### PR TITLE
benchmarks: Use standard options to install perf framework on non-Debian

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -28,7 +28,12 @@ target_link_libraries(benchmark_multiplexing_dispatchable
 # Note: We need to write \$ENV{DESTDIR} (note the \$) to make
 # CMake replace the DESTDIR variable at installation time rather
 # than configuration time
-install(CODE "execute_process(COMMAND python3 mir_perf_framework_setup.py install -f --prefix=${CMAKE_INSTALL_PREFIX} --root=\$ENV{DESTDIR} --install-layout=deb --no-compile WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})")
+if (EXISTS "/etc/debian_version")
+  # Debian requires special options, since they do a custom layout and things...
+  install(CODE "execute_process(COMMAND python3 mir_perf_framework_setup.py install -f --prefix=${CMAKE_INSTALL_PREFIX} --root=\$ENV{DESTDIR} --install-layout=deb --no-compile WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})")
+else()
+  install(CODE "execute_process(COMMAND python3 mir_perf_framework_setup.py install -O1 -f --prefix=${CMAKE_INSTALL_PREFIX} --root=\$ENV{DESTDIR} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})")
+endif()
 
 set(MIR_PERF_SCRIPTS
   key_event_latency.py


### PR DESCRIPTION
The usage of Debian-specific options broke the build for Fedora.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>