### PR TITLE
bors: increase CI timeout

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,3 @@
 status = [ "continuous-integration/travis-ci/push" ]
 block-labels = [ "no-merge" ]
+timeout-sec = 12000


### PR DESCRIPTION
We only have a single node available at the moment, so sometimes it's
busy.