### PR TITLE
Add git submodule steps in getting involved guide

### DIFF
--- a/doc/getting_involved_in_mir.md
+++ b/doc/getting_involved_in_mir.md
@@ -23,8 +23,7 @@ With these installed you can checkout Mir and get the remaining dependencies:
 
     $ git clone https://github.com/MirServer/mir.git
     $ cd mir
-    $ git submodule init
-    $ git submodule update
+    $ git submodule update --init --recursive
     $ mk-build-deps -i -s sudo
 
 ### On Fedora
@@ -43,8 +42,7 @@ With these installed you can checkout Mir:
 
     $ git clone https://github.com/MirServer/mir.git
     $ cd mir
-    $ git submodule init
-    $ git submodule update
+    $ git submodule update --init --recursive
 
 Building Mir
 ------------

--- a/doc/getting_involved_in_mir.md
+++ b/doc/getting_involved_in_mir.md
@@ -43,6 +43,8 @@ With these installed you can checkout Mir:
 
     $ git clone https://github.com/MirServer/mir.git
     $ cd mir
+    $ git submodule init
+    $ git submodule update
 
 Building Mir
 ------------

--- a/doc/getting_involved_in_mir.md
+++ b/doc/getting_involved_in_mir.md
@@ -23,6 +23,8 @@ With these installed you can checkout Mir and get the remaining dependencies:
 
     $ git clone https://github.com/MirServer/mir.git
     $ cd mir
+    $ git submodule init
+    $ git submodule update
     $ mk-build-deps -i -s sudo
 
 ### On Fedora


### PR DESCRIPTION
Attempting to follow the "Getting involved in mir" guide leads to
an error when cmake looks for wlcs and can't find it. This commit
adds the git commands to fetch the wlcs repo so that the build
works.

Fixes #42