### PR TITLE
Install mir_wlcs_tests with the rest of the tests

### DIFF
--- a/debian/mir-test-tools.install
+++ b/debian/mir-test-tools.install
@@ -11,6 +11,7 @@ usr/bin/mir_client_startup_performance_test
 usr/bin/mir_privileged_tests
 usr/bin/mir_test_reload_protobuf
 usr/bin/mir_test_client_*
+usr/bin/mir_wlcs_tests
 usr/lib/*/mir/tools/libmirclientlttng.so
 usr/lib/*/mir/tools/libmirserverlttng.so
 usr/lib/*/mir/server-platform/graphics-dummy.so


### PR DESCRIPTION
This fixes¹ the package builds, which are complaining that we don't install mir_wlcs_tests anywhere.

¹: Well, should fix ☺