### PR TITLE
Add missing GMock dependencies for performance_tests

### DIFF
--- a/tests/performance-tests/CMakeLists.txt
+++ b/tests/performance-tests/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 mir_add_wrapped_executable(mir_glmark2_performance_test
   test_glmark2-es2-mir.cpp
 )
-add_dependencies(mir_glmark2_performance_test GMock)
+
 target_link_libraries(mir_glmark2_performance_test
   mir-test-assist
 )
@@ -39,3 +39,6 @@ target_link_libraries(mir_client_startup_performance_test
   mir-test-assist
 )
 
+add_dependencies(mir_glmark2_performance_test GMock)
+add_dependencies(mir_compositor_performance_test GMock)
+add_dependencies(mir_client_startup_performance_test GMock)


### PR DESCRIPTION
Both mir_client_startup_performance_test and mir_compositor_performance_test does not depend on GMock, this results in a build race condition between the tests and GMock.

This results in build failure on UBports arm node (64 cores)  since the tests get built before GMock is done.