### PR TITLE
Test (and fix) SeatObserver

### DIFF
--- a/include/platform/mir/input/input_sink.h
+++ b/include/platform/mir/input/input_sink.h
@@ -61,7 +61,7 @@ class InputSink
 public:
     InputSink() = default;
     virtual ~InputSink() = default;
-    virtual void handle_input(MirEvent& event) = 0;
+    virtual void handle_input(std::shared_ptr<MirEvent> const& event) = 0;
     /**!
      * Obtain the bounding rectangle of the destination area for this input sink
      */

--- a/include/server/mir/input/input_dispatcher.h
+++ b/include/server/mir/input/input_dispatcher.h
@@ -20,6 +20,7 @@
 #define MIR_INPUT_INPUT_DISPATCHER_H
 
 #include <chrono>
+#include <memory>
 
 #include "mir_toolkit/event.h"
 
@@ -38,7 +39,7 @@ namespace input
 class InputDispatcher
 {
 public:
-    virtual bool dispatch(MirEvent const& event) = 0;
+    virtual bool dispatch(std::shared_ptr<MirEvent const> const& event) = 0;
 
     virtual void start() = 0;
     virtual void stop() = 0;

--- a/include/server/mir/input/seat_observer.h
+++ b/include/server/mir/input/seat_observer.h
@@ -43,7 +43,6 @@ public:
     virtual void seat_add_device(uint64_t id) = 0;
     virtual void seat_remove_device(uint64_t id) = 0;
     virtual void seat_dispatch_event(std::shared_ptr<MirEvent const> const& event) = 0;
-    virtual void seat_get_rectangle_for(uint64_t id, geometry::Rectangle const& out_rect) = 0;
     virtual void seat_set_key_state(uint64_t id, std::vector<uint32_t> const& scan_codes) = 0;
     virtual void seat_set_pointer_state(uint64_t id, unsigned buttons) = 0;
     virtual void seat_set_cursor_position(float cursor_x, float cursor_y) = 0;

--- a/include/server/mir/input/seat_observer.h
+++ b/include/server/mir/input/seat_observer.h
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 class MirEvent;
 
@@ -41,7 +42,7 @@ public:
     
     virtual void seat_add_device(uint64_t id) = 0;
     virtual void seat_remove_device(uint64_t id) = 0;
-    virtual void seat_dispatch_event(MirEvent const* event) = 0;
+    virtual void seat_dispatch_event(std::shared_ptr<MirEvent const> const& event) = 0;
     virtual void seat_get_rectangle_for(uint64_t id, geometry::Rectangle const& out_rect) = 0;
     virtual void seat_set_key_state(uint64_t id, std::vector<uint32_t> const& scan_codes) = 0;
     virtual void seat_set_pointer_state(uint64_t id, unsigned buttons) = 0;

--- a/include/test/mir/test/doubles/mock_input_dispatcher.h
+++ b/include/test/mir/test/doubles/mock_input_dispatcher.h
@@ -31,7 +31,7 @@ namespace doubles
 
 struct MockInputDispatcher : public mir::input::InputDispatcher
 {
-    MOCK_METHOD1(dispatch, bool(MirEvent const&));
+    MOCK_METHOD1(dispatch, bool(std::shared_ptr<MirEvent const> const&));
     MOCK_METHOD0(start, void());
     MOCK_METHOD0(stop, void());
 };

--- a/include/test/mir/test/doubles/mock_seat_report.h
+++ b/include/test/mir/test/doubles/mock_seat_report.h
@@ -36,7 +36,7 @@ class MockSeatObserver : public input::SeatObserver
 public:
     MOCK_METHOD1(seat_add_device, void(uint64_t /*id*/));
     MOCK_METHOD1(seat_remove_device, void(uint64_t /*id*/));
-    MOCK_METHOD1(seat_dispatch_event, void(MirEvent const* /*event*/));
+    MOCK_METHOD1(seat_dispatch_event, void(std::shared_ptr<MirEvent const> const& /*event*/));
     MOCK_METHOD2(seat_get_rectangle_for, void(uint64_t /*id*/, geometry::Rectangle const& /*out_rect*/));
     MOCK_METHOD2(seat_set_key_state, void(uint64_t /*id*/, std::vector<uint32_t> const& /*scan_codes*/));
     MOCK_METHOD2(seat_set_pointer_state, void(uint64_t /*id*/, unsigned /*buttons*/));

--- a/include/test/mir/test/event_matchers.h
+++ b/include/test/mir/test/event_matchers.h
@@ -27,6 +27,8 @@
 #include <xkbcommon/xkbcommon.h>
 #include <xkbcommon/xkbcommon-keysyms.h>
 
+#include <memory>
+
 #include <gmock/gmock.h>
 
 
@@ -49,6 +51,11 @@ inline MirEvent const* to_address(MirEvent const* event)
 inline MirEvent const* to_address(MirEvent const& event)
 {
     return &event;
+}
+
+inline MirEvent const* to_address(std::shared_ptr<MirEvent const> const& event)
+{
+    return event.get();
 }
 
 inline MirEvent const& to_ref(MirEvent const* event)

--- a/include/test/mir_test_framework/fake_input_device.h
+++ b/include/test/mir_test_framework/fake_input_device.h
@@ -23,6 +23,7 @@
 #include "mir/test/event_factory.h"
 #include <chrono>
 #include <functional>
+#include <vector>
 
 namespace mir
 {
@@ -60,6 +61,7 @@ public:
     virtual void emit_touch_sequence(std::function<mir::input::synthesis::TouchParameters(int)> const& generate_parameters,
                                      int count,
                                      std::chrono::duration<double> delay) = 0;
+    virtual void emit_key_state(std::vector<uint32_t> const& scan_codes) = 0;
     virtual void on_new_configuration_do(std::function<void(mir::input::InputDevice const& device)> callback) = 0;
 
     FakeInputDevice(FakeInputDevice const&) = delete;

--- a/src/include/server/mir/input/seat.h
+++ b/src/include/server/mir/input/seat.h
@@ -42,7 +42,7 @@ public:
     virtual ~Seat() = default;
     virtual void add_device(Device const& device) = 0;
     virtual void remove_device(Device const& device) = 0;
-    virtual void dispatch_event(MirEvent& event) = 0;
+    virtual void dispatch_event(std::shared_ptr<MirEvent> const& event) = 0;
     virtual EventUPtr create_device_state() = 0;
 
     virtual void set_key_state(Device const& dev, std::vector<uint32_t> const& scan_codes) = 0;

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -30,6 +30,8 @@ set(MIR_PLATFORM_REFERENCES ${MIR_PLATFORM_REFERENCES} PARENT_SCOPE)
 
 add_library(mirplatform SHARED
   ${MIR_PLATFORM_OBJECTS}
+
+  ${PROJECT_SOURCE_DIR}/include/platform/mir/input/input_sink.h
 )
 
 target_link_libraries(mirplatform

--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -147,19 +147,19 @@ void mie::LibInputDevice::process_event(libinput_event* event)
         switch(libinput_event_get_type(event))
         {
         case LIBINPUT_EVENT_KEYBOARD_KEY:
-            sink->handle_input(*convert_event(libinput_event_get_keyboard_event(event)));
+            sink->handle_input(convert_event(libinput_event_get_keyboard_event(event)));
             break;
         case LIBINPUT_EVENT_POINTER_MOTION:
-            sink->handle_input(*convert_motion_event(libinput_event_get_pointer_event(event)));
+            sink->handle_input(convert_motion_event(libinput_event_get_pointer_event(event)));
             break;
         case LIBINPUT_EVENT_POINTER_MOTION_ABSOLUTE:
-            sink->handle_input(*convert_absolute_motion_event(libinput_event_get_pointer_event(event)));
+            sink->handle_input(convert_absolute_motion_event(libinput_event_get_pointer_event(event)));
             break;
         case LIBINPUT_EVENT_POINTER_BUTTON:
-            sink->handle_input(*convert_button_event(libinput_event_get_pointer_event(event)));
+            sink->handle_input(convert_button_event(libinput_event_get_pointer_event(event)));
             break;
         case LIBINPUT_EVENT_POINTER_AXIS:
-            sink->handle_input(*convert_axis_event(libinput_event_get_pointer_event(event)));
+            sink->handle_input(convert_axis_event(libinput_event_get_pointer_event(event)));
             break;
         // touch events are processed as a batch of changes over all touch pointts
         case LIBINPUT_EVENT_TOUCH_DOWN:
@@ -177,7 +177,7 @@ void mie::LibInputDevice::process_event(libinput_event* event)
         case LIBINPUT_EVENT_TOUCH_FRAME:
             if (is_output_active())
             {
-                sink->handle_input(*convert_touch_frame(libinput_event_get_touch_event(event)));
+                sink->handle_input(convert_touch_frame(libinput_event_get_touch_event(event)));
             }
             break;
         default:

--- a/src/platforms/mesa/server/x11/input/input_device.cpp
+++ b/src/platforms/mesa/server/x11/input/input_device.cpp
@@ -141,7 +141,7 @@ bool mix::XInputDevice::started() const
 void mix::XInputDevice::key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code)
 {
     sink->handle_input(
-        *builder->key_event(
+        builder->key_event(
             event_time,
             mir_keyboard_action_down,
             key_sym,
@@ -154,7 +154,7 @@ void mix::XInputDevice::key_press(std::chrono::nanoseconds event_time, xkb_keysy
 void mix::XInputDevice::key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code)
 {
     sink->handle_input(
-        *builder->key_event(
+        builder->key_event(
             event_time,
             mir_keyboard_action_up,
             key_sym,
@@ -175,7 +175,7 @@ void mix::XInputDevice::pointer_press(std::chrono::nanoseconds event_time, int b
     auto const movement = pos - pointer_pos;
     pointer_pos = pos;
     sink->handle_input(
-        *builder->pointer_event(
+        builder->pointer_event(
             event_time,
             mir_pointer_action_button_down,
             button_state,
@@ -196,7 +196,7 @@ void mix::XInputDevice::pointer_release(std::chrono::nanoseconds event_time, int
     auto const movement = pos - pointer_pos;
     pointer_pos = pos;
     sink->handle_input(
-        *builder->pointer_event(
+        builder->pointer_event(
             event_time,
             mir_pointer_action_button_up,
             button_state,
@@ -216,7 +216,7 @@ void mix::XInputDevice::pointer_motion(std::chrono::nanoseconds event_time, mir:
     auto const movement = pos - pointer_pos;
     pointer_pos = pos;
     sink->handle_input(
-        *builder->pointer_event(
+        builder->pointer_event(
             event_time,
             mir_pointer_action_motion,
             button_state,

--- a/src/server/graphics/nested/input_platform.cpp
+++ b/src/server/graphics/nested/input_platform.cpp
@@ -81,7 +81,7 @@ private:
 void Postman::do_work()
 {
     while (auto const event = next_event())
-        destination->handle_input(*event);
+        destination->handle_input(event);
 }
 
 std::shared_ptr<MirEvent> Postman::next_event()
@@ -429,7 +429,7 @@ void mgn::InputPlatform::start()
                     auto device_state_event = front->builder->device_state_event(
                         mir_input_device_state_event_pointer_axis(device_state, mir_pointer_axis_x),
                         mir_input_device_state_event_pointer_axis(device_state, mir_pointer_axis_y));
-                    front->destination->handle_input(*device_state_event);
+                    front->destination->handle_input(std::move(device_state_event));
                 }
             }
         });

--- a/src/server/input/CMakeLists.txt
+++ b/src/server/input/CMakeLists.txt
@@ -24,6 +24,9 @@ set(
   vt_filter.cpp
   seat_observer_multiplexer.cpp
   seat_observer_multiplexer.h
+  ${PROJECT_SOURCE_DIR}/include/server/mir/input/seat_observer.h
+  ${PROJECT_SOURCE_DIR}/include/server/mir/input/input_dispatcher.h
+  ${PROJECT_SOURCE_DIR}/src/include/server/mir/input/seat.h
 )
 
 add_library(

--- a/src/server/input/basic_seat.cpp
+++ b/src/server/input/basic_seat.cpp
@@ -172,7 +172,7 @@ void mi::BasicSeat::remove_device(input::Device const& device)
     input_state_tracker.remove_device(device.id());
 }
 
-void mi::BasicSeat::dispatch_event(MirEvent& event)
+void mi::BasicSeat::dispatch_event(std::shared_ptr<MirEvent> const& event)
 {
     input_state_tracker.dispatch(event);
 }

--- a/src/server/input/basic_seat.h
+++ b/src/server/input/basic_seat.h
@@ -59,7 +59,7 @@ public:
     // Seat methods:
     void add_device(Device const& device) override;
     void remove_device(Device const& device) override;
-    void dispatch_event(MirEvent& event) override;
+    void dispatch_event(std::shared_ptr<MirEvent> const& event) override;
     geometry::Rectangle bounding_rectangle() const override;
     input::OutputInfo output_info(uint32_t output_id) const override;
     EventUPtr create_device_state() override;

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -278,9 +278,9 @@ MirInputDeviceId mi::DefaultInputDeviceHub::RegisteredDevice::id()
     return device_id;
 }
 
-void mi::DefaultInputDeviceHub::RegisteredDevice::handle_input(MirEvent& event)
+void mi::DefaultInputDeviceHub::RegisteredDevice::handle_input(std::shared_ptr<MirEvent> const& event)
 {
-    auto type = mir_event_get_type(&event);
+    auto type = mir_event_get_type(event.get());
 
     if (type != mir_event_type_input &&
         type != mir_event_type_input_device_state)

--- a/src/server/input/default_input_device_hub.h
+++ b/src/server/input/default_input_device_hub.h
@@ -125,7 +125,7 @@ private:
                          std::shared_ptr<dispatch::ActionQueue> const& multiplexer,
                          std::shared_ptr<cookie::Authority> const& cookie_authority,
                          std::shared_ptr<DefaultDevice> const& handle);
-        void handle_input(MirEvent& event) override;
+        void handle_input(std::shared_ptr<MirEvent> const& event) override;
         geometry::Rectangle bounding_rectangle() const override;
         input::OutputInfo output_info(uint32_t output_id) const override;
         bool device_matches(std::shared_ptr<InputDevice> const& dev) const;

--- a/src/server/input/event_filter_chain_dispatcher.cpp
+++ b/src/server/input/event_filter_chain_dispatcher.cpp
@@ -62,9 +62,9 @@ void mi::EventFilterChainDispatcher::prepend(std::shared_ptr<EventFilter> const&
     filters.insert(filters.begin(), filter);
 }
 
-bool mi::EventFilterChainDispatcher::dispatch(MirEvent const& event)
+bool mi::EventFilterChainDispatcher::dispatch(std::shared_ptr<MirEvent const> const& event)
 {
-    if (!handle(event))
+    if (!handle(*event))
         return next_dispatcher->dispatch(event);
     return true;
 }

--- a/src/server/input/event_filter_chain_dispatcher.h
+++ b/src/server/input/event_filter_chain_dispatcher.h
@@ -43,7 +43,7 @@ public:
     void prepend(std::shared_ptr<EventFilter> const& filter) override;
 
     // InputDispatcher
-    bool dispatch(MirEvent const& event) override;
+    bool dispatch(std::shared_ptr<MirEvent const> const& event) override;
     void start() override;
     void stop() override;
     

--- a/src/server/input/key_repeat_dispatcher.cpp
+++ b/src/server/input/key_repeat_dispatcher.cpp
@@ -110,16 +110,16 @@ mi::KeyRepeatDispatcher::KeyboardState& mi::KeyRepeatDispatcher::ensure_state_fo
     return repeat_state_by_device[id];
 }
 
-bool mi::KeyRepeatDispatcher::dispatch(MirEvent const& event)
+bool mi::KeyRepeatDispatcher::dispatch(std::shared_ptr<MirEvent const> const& event)
 {
     if (!repeat_enabled) // if we made this mutable we'd need a guard
     {
 	return next_dispatcher->dispatch(event);
     }
 
-    if (mir_event_get_type(&event) == mir_event_type_input)
+    if (mir_event_get_type(event.get()) == mir_event_type_input)
     {
-        auto iev = mir_event_get_input_event(&event);
+        auto iev = mir_event_get_input_event(event.get());
         if (mir_input_event_get_type(iev) != mir_input_event_type_key)
             return next_dispatcher->dispatch(event);
         auto device_id = mir_input_event_get_device_id(iev);
@@ -170,7 +170,7 @@ bool mi::KeyRepeatDispatcher::handle_key_input(MirInputDeviceId id, MirKeyboardE
                      key_code,
                      scan_code,
                      modifiers);
-                 next_dispatcher->dispatch(*new_event);
+                 next_dispatcher->dispatch(std::move(new_event));
              };
 
         auto it = device_state.repeat_alarms_by_scancode.find(scan_code);

--- a/src/server/input/key_repeat_dispatcher.h
+++ b/src/server/input/key_repeat_dispatcher.h
@@ -54,7 +54,7 @@ public:
                         bool disable_repeat_on_touchscreen);
 
     // InputDispatcher
-    bool dispatch(MirEvent const& event) override;
+    bool dispatch(std::shared_ptr<MirEvent const> const& event) override;
     void start() override;
     void stop() override;
 

--- a/src/server/input/null_input_dispatcher.cpp
+++ b/src/server/input/null_input_dispatcher.cpp
@@ -16,11 +16,12 @@
  * Authored by: Andreas Pokorny <andreas.pokorny@canonical.com>
  */
 
+#include <boost/asio/detail/shared_ptr.hpp>
 #include "null_input_dispatcher.h"
 
 namespace mi = mir::input;
 
-bool mi::NullInputDispatcher::dispatch(MirEvent const& /*event*/)
+bool mi::NullInputDispatcher::dispatch(std::shared_ptr<MirEvent const> const& /*event*/)
 {
     return true;
 }

--- a/src/server/input/null_input_dispatcher.h
+++ b/src/server/input/null_input_dispatcher.h
@@ -29,7 +29,7 @@ namespace input
 class NullInputDispatcher : public mir::input::InputDispatcher
 {
 public:
-    bool dispatch(MirEvent const& event) override;
+    bool dispatch(std::shared_ptr<MirEvent const> const& event) override;
 
     void start() override;
     void stop() override;

--- a/src/server/input/seat_input_device_tracker.cpp
+++ b/src/server/input/seat_input_device_tracker.cpp
@@ -108,7 +108,11 @@ void mi::SeatInputDeviceTracker::dispatch(MirEvent &event)
     }
 
     dispatcher->dispatch(event);
-    observer->seat_dispatch_event(&event);
+    observer->seat_dispatch_event(
+        std::shared_ptr<MirEvent const>(
+            mir_event_ref(&event),
+            &mir_event_unref
+        ));
 }
 
 bool mi::SeatInputDeviceTracker::filter_input_event(MirInputEvent const* event)

--- a/src/server/input/seat_input_device_tracker.cpp
+++ b/src/server/input/seat_input_device_tracker.cpp
@@ -85,34 +85,30 @@ void mi::SeatInputDeviceTracker::remove_device(MirInputDeviceId id)
     observer->seat_remove_device(id);
 }
 
-void mi::SeatInputDeviceTracker::dispatch(MirEvent &event)
+void mi::SeatInputDeviceTracker::dispatch(std::shared_ptr<MirEvent> const& event)
 {
-    if (mir_event_get_type(&event) == mir_event_type_input)
+    if (mir_event_get_type(event.get()) == mir_event_type_input)
     {
         std::lock_guard<std::mutex> lock(device_state_mutex);
 
-        auto input_event = mir_event_get_input_event(&event);
+        auto input_event = mir_event_get_input_event(event.get());
 
         if (filter_input_event(input_event))
             return;
 
         update_seat_properties(input_event);
 
-        key_mapper->map_event(event);
+        key_mapper->map_event(*event);
 
         if (mir_input_event_type_pointer == mir_input_event_get_type(input_event))
         {
-            mev::set_cursor_position(event, cursor_x, cursor_y);
-            mev::set_button_state(event, buttons);
+            mev::set_cursor_position(*event, cursor_x, cursor_y);
+            mev::set_button_state(*event, buttons);
         }
     }
 
     dispatcher->dispatch(event);
-    observer->seat_dispatch_event(
-        std::shared_ptr<MirEvent const>(
-            mir_event_ref(&event),
-            &mir_event_unref
-        ));
+    observer->seat_dispatch_event(event);
 }
 
 bool mi::SeatInputDeviceTracker::filter_input_event(MirInputEvent const* event)

--- a/src/server/input/seat_input_device_tracker.h
+++ b/src/server/input/seat_input_device_tracker.h
@@ -64,7 +64,7 @@ public:
     void add_device(MirInputDeviceId);
     void remove_device(MirInputDeviceId);
 
-    void dispatch(MirEvent & event);
+    void dispatch(std::shared_ptr<MirEvent> const& event);
 
     MirPointerButtons button_state() const;
     geometry::Point cursor_position() const;

--- a/src/server/input/seat_observer_multiplexer.cpp
+++ b/src/server/input/seat_observer_multiplexer.cpp
@@ -31,7 +31,7 @@ void mi::SeatObserverMultiplexer::seat_add_device(uint64_t id)
 
 void mi::SeatObserverMultiplexer::seat_remove_device(uint64_t id)
 {
-    for_each_observer(&mi::SeatObserver::seat_add_device, id);
+    for_each_observer(&mi::SeatObserver::seat_remove_device, id);
 }
 
 void mi::SeatObserverMultiplexer::seat_dispatch_event(MirEvent const* event)

--- a/src/server/input/seat_observer_multiplexer.cpp
+++ b/src/server/input/seat_observer_multiplexer.cpp
@@ -40,13 +40,6 @@ void mi::SeatObserverMultiplexer::seat_dispatch_event(
     for_each_observer(&mi::SeatObserver::seat_dispatch_event, event);
 }
 
-void mi::SeatObserverMultiplexer::seat_get_rectangle_for(
-    uint64_t id,
-    geom::Rectangle const& out_rect)
-{
-    for_each_observer(&mi::SeatObserver::seat_get_rectangle_for, id, out_rect);
-}
-
 void mi::SeatObserverMultiplexer::seat_set_key_state(uint64_t id, std::vector<uint32_t> const& scan_codes)
 {
     for_each_observer(&mi::SeatObserver::seat_set_key_state, id, scan_codes);

--- a/src/server/input/seat_observer_multiplexer.cpp
+++ b/src/server/input/seat_observer_multiplexer.cpp
@@ -34,7 +34,8 @@ void mi::SeatObserverMultiplexer::seat_remove_device(uint64_t id)
     for_each_observer(&mi::SeatObserver::seat_remove_device, id);
 }
 
-void mi::SeatObserverMultiplexer::seat_dispatch_event(MirEvent const* event)
+void mi::SeatObserverMultiplexer::seat_dispatch_event(
+    std::shared_ptr<MirEvent const> const& event)
 {
     for_each_observer(&mi::SeatObserver::seat_dispatch_event, event);
 }

--- a/src/server/input/seat_observer_multiplexer.h
+++ b/src/server/input/seat_observer_multiplexer.h
@@ -39,8 +39,6 @@ public:
 
     void seat_dispatch_event(std::shared_ptr<MirEvent const> const& event) override;
 
-    void seat_get_rectangle_for(uint64_t id, geometry::Rectangle const& out_rect) override;
-
     void seat_set_key_state(uint64_t id, std::vector<uint32_t> const& scan_codes) override;
 
     void seat_set_pointer_state(uint64_t id, unsigned buttons) override;

--- a/src/server/input/seat_observer_multiplexer.h
+++ b/src/server/input/seat_observer_multiplexer.h
@@ -37,7 +37,7 @@ public:
 
     void seat_remove_device(uint64_t id) override;
 
-    void seat_dispatch_event(MirEvent const* event) override;
+    void seat_dispatch_event(std::shared_ptr<MirEvent const> const& event) override;
 
     void seat_get_rectangle_for(uint64_t id, geometry::Rectangle const& out_rect) override;
 

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -416,21 +416,21 @@ bool mi::SurfaceInputDispatcher::dispatch_touch(MirInputDeviceId id, MirEvent co
     return false;
 }
 
-bool mi::SurfaceInputDispatcher::dispatch(MirEvent const& event)
+bool mi::SurfaceInputDispatcher::dispatch(std::shared_ptr<MirEvent const> const& event)
 {
-    if (mir_event_get_type(&event) != mir_event_type_input)
+    if (mir_event_get_type(event.get()) != mir_event_type_input)
         BOOST_THROW_EXCEPTION(std::logic_error("InputDispatcher got an unexpected event type"));
     
-    auto iev = mir_event_get_input_event(&event);
+    auto iev = mir_event_get_input_event(event.get());
     auto id = mir_input_event_get_device_id(iev);
     switch (mir_input_event_get_type(iev))
     {
     case mir_input_event_type_key:
-        return dispatch_key(&event);
+        return dispatch_key(event.get());
     case mir_input_event_type_touch:
-        return dispatch_touch(id, &event);
+        return dispatch_touch(id, event.get());
     case mir_input_event_type_pointer:
-        return dispatch_pointer(id, &event);
+        return dispatch_pointer(id, event.get());
     default:
         BOOST_THROW_EXCEPTION(std::logic_error("InputDispatcher got an input event of unknown type"));
     }

--- a/src/server/input/surface_input_dispatcher.h
+++ b/src/server/input/surface_input_dispatcher.h
@@ -47,7 +47,7 @@ public:
     ~SurfaceInputDispatcher();
 
     // mir::input::InputDispatcher
-    bool dispatch(MirEvent const& event) override;
+    bool dispatch(std::shared_ptr<MirEvent const> const& event) override;
     void start() override;
     void stop() override;
 

--- a/src/server/report/logging/seat_report.cpp
+++ b/src/server/report/logging/seat_report.cpp
@@ -77,7 +77,7 @@ void mrl::SeatReport::seat_remove_device(uint64_t id)
     log->log(ml::Severity::informational, ss.str(), component);
 }
 
-void mrl::SeatReport::seat_dispatch_event(MirEvent const* event)
+void mrl::SeatReport::seat_dispatch_event(std::shared_ptr<MirEvent const> const& event)
 {
     std::stringstream ss;
     ss << "Dispatch event"

--- a/src/server/report/logging/seat_report.cpp
+++ b/src/server/report/logging/seat_report.cpp
@@ -86,16 +86,6 @@ void mrl::SeatReport::seat_dispatch_event(std::shared_ptr<MirEvent const> const&
     log->log(ml::Severity::informational, ss.str(), component);
 }
 
-void mrl::SeatReport::seat_get_rectangle_for(uint64_t id, geometry::Rectangle const& out_rect)
-{
-    std::stringstream ss;
-    ss << "Get rectangle for"
-       << " device_id=" << id
-       << " out_rect=" << out_rect;
-
-    log->log(ml::Severity::informational, ss.str(), component);
-}
-
 void mrl::SeatReport::seat_set_key_state(uint64_t id, std::vector<uint32_t> const& scan_codes)
 {
     std::stringstream ss;

--- a/src/server/report/logging/seat_report.h
+++ b/src/server/report/logging/seat_report.h
@@ -48,7 +48,7 @@ public:
 
     virtual void seat_add_device(uint64_t id) override;
     virtual void seat_remove_device(uint64_t id) override;
-    virtual void seat_dispatch_event(MirEvent const* event) override;
+    virtual void seat_dispatch_event(std::shared_ptr<MirEvent const> const& event) override;
     virtual void seat_get_rectangle_for(uint64_t id, geometry::Rectangle const& out_rect) override;
     virtual void seat_set_key_state(uint64_t id, std::vector<uint32_t> const& scan_codes) override;
     virtual void seat_set_pointer_state(uint64_t id, unsigned buttons) override;

--- a/src/server/report/logging/seat_report.h
+++ b/src/server/report/logging/seat_report.h
@@ -49,7 +49,6 @@ public:
     virtual void seat_add_device(uint64_t id) override;
     virtual void seat_remove_device(uint64_t id) override;
     virtual void seat_dispatch_event(std::shared_ptr<MirEvent const> const& event) override;
-    virtual void seat_get_rectangle_for(uint64_t id, geometry::Rectangle const& out_rect) override;
     virtual void seat_set_key_state(uint64_t id, std::vector<uint32_t> const& scan_codes) override;
     virtual void seat_set_pointer_state(uint64_t id, unsigned buttons) override;
     virtual void seat_set_cursor_position(float cursor_x, float cursor_y) override;

--- a/src/server/report/null/seat_report.cpp
+++ b/src/server/report/null/seat_report.cpp
@@ -33,10 +33,6 @@ void mrn::SeatReport::seat_dispatch_event(std::shared_ptr<MirEvent const> const&
 {
 }
 
-void mrn::SeatReport::seat_get_rectangle_for(uint64_t /*id*/, geometry::Rectangle const& /*out_rect*/)
-{
-}
-
 void mrn::SeatReport::seat_set_key_state(uint64_t /*id*/, std::vector<uint32_t> const& /*scan_codes*/)
 {
 }

--- a/src/server/report/null/seat_report.cpp
+++ b/src/server/report/null/seat_report.cpp
@@ -29,7 +29,7 @@ void mrn::SeatReport::seat_remove_device(uint64_t /*id*/)
 {
 }
 
-void mrn::SeatReport::seat_dispatch_event(MirEvent const* /*event*/)
+void mrn::SeatReport::seat_dispatch_event(std::shared_ptr<MirEvent const> const& /*event*/)
 {
 }
 

--- a/src/server/report/null/seat_report.h
+++ b/src/server/report/null/seat_report.h
@@ -34,7 +34,7 @@ class SeatReport : public input::SeatObserver
 public:
     virtual void seat_add_device(uint64_t id) override;
     virtual void seat_remove_device(uint64_t id) override;
-    virtual void seat_dispatch_event(MirEvent const* event) override;
+    virtual void seat_dispatch_event(std::shared_ptr<MirEvent const> const& event) override;
     virtual void seat_get_rectangle_for(uint64_t id, geometry::Rectangle const& out_rect) override;
     virtual void seat_set_key_state(uint64_t id, std::vector<uint32_t> const& scan_codes) override;
     virtual void seat_set_pointer_state(uint64_t id, unsigned buttons) override;

--- a/src/server/report/null/seat_report.h
+++ b/src/server/report/null/seat_report.h
@@ -35,7 +35,6 @@ public:
     virtual void seat_add_device(uint64_t id) override;
     virtual void seat_remove_device(uint64_t id) override;
     virtual void seat_dispatch_event(std::shared_ptr<MirEvent const> const& event) override;
-    virtual void seat_get_rectangle_for(uint64_t id, geometry::Rectangle const& out_rect) override;
     virtual void seat_set_key_state(uint64_t id, std::vector<uint32_t> const& scan_codes) override;
     virtual void seat_set_pointer_state(uint64_t id, unsigned buttons) override;
     virtual void seat_set_cursor_position(float cursor_x, float cursor_y) override;

--- a/tests/acceptance-tests/CMakeLists.txt
+++ b/tests/acceptance-tests/CMakeLists.txt
@@ -68,6 +68,7 @@ set(
   test_presentation_chain.cpp
   test_render_surface.cpp
   test_buffer_stream_arrangement1.cpp
+  test_seat_report.cpp
 )
 
 if (MIR_TEST_PLATFORM STREQUAL "mesa-kms" OR MIR_TEST_PLATFORM STREQUAL "mesa-x11")

--- a/tests/acceptance-tests/test_seat_report.cpp
+++ b/tests/acceptance-tests/test_seat_report.cpp
@@ -65,7 +65,7 @@ class NullSeatListener : public mi::SeatObserver
 public:
     void seat_add_device(uint64_t /*id*/) override {}
     void seat_remove_device(uint64_t /*id*/) override {}
-    void seat_dispatch_event(MirEvent const* /*event*/) override {}
+    void seat_dispatch_event(std::shared_ptr<MirEvent const> const& /*event*/) override {}
 
     void seat_get_rectangle_for(
         uint64_t /*id*/,
@@ -248,11 +248,11 @@ TEST_F(TestSeatReport, dispatch_event_received)
         {
         }
 
-        void seat_dispatch_event(MirEvent const* event) override
+        void seat_dispatch_event(std::shared_ptr<MirEvent const> const& event) override
         {
-            if (mir_event_get_type(event) == mir_event_type_input)
+            if (mir_event_get_type(event.get()) == mir_event_type_input)
             {
-                auto iev = mir_event_get_input_event(event);
+                auto iev = mir_event_get_input_event(event.get());
                 if (mir_input_event_get_type(iev) == mir_input_event_type_pointer)
                 {
                     auto pointer = mir_input_event_get_pointer_event(iev);

--- a/tests/acceptance-tests/test_seat_report.cpp
+++ b/tests/acceptance-tests/test_seat_report.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2017 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#include "mir/input/input_device_info.h"
+#include "mir/input/keymap.h"
+#include "mir/input/mir_touchpad_config.h"
+#include "mir/input/mir_input_config.h"
+#include "mir/input/input_device.h"
+#include "mir/input/device.h"
+#include "mir/input/touchscreen_settings.h"
+
+#include "mir_test_framework/stub_server_platform_factory.h"
+#include "mir_test_framework/headless_in_process_server.h"
+#include "mir_test_framework/fake_input_device.h"
+#include "mir/test/signal.h"
+#include "mir/test/event_matchers.h"
+#include "mir/test/event_factory.h"
+
+#include "mir/input/input_device_observer.h"
+#include "mir/input/input_device_hub.h"
+#include "mir/input/seat_observer.h"
+#include "mir/observer_registrar.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <linux/input.h>
+
+#include <condition_variable>
+#include <unordered_map>
+#include <chrono>
+#include <atomic>
+#include <mutex>
+
+namespace mi = mir::input;
+namespace mt = mir::test;
+namespace mis = mir::input::synthesis;
+namespace mtf = mir_test_framework;
+namespace geom = mir::geometry;
+
+using namespace std::chrono_literals;
+using namespace testing;
+
+using TestSeatReport = mtf::HeadlessInProcessServer;
+
+namespace
+{
+class NullSeatListener : public mi::SeatObserver
+{
+public:
+    void seat_add_device(uint64_t /*id*/) override {}
+    void seat_remove_device(uint64_t /*id*/) override {}
+    void seat_dispatch_event(MirEvent const* /*event*/) override {}
+
+    void seat_get_rectangle_for(
+        uint64_t /*id*/,
+        geom::Rectangle const& /*out_rect*/) override
+    {
+    }
+
+    void seat_set_key_state(
+        uint64_t /*id*/,
+        std::vector<uint32_t> const& /*scan_codes*/) override
+    {
+    }
+
+    void seat_set_pointer_state(uint64_t /*id*/, unsigned /*buttons*/) override {}
+    void seat_set_cursor_position(float /*cursor_x*/, float /*cursor_y*/) override {}
+    void seat_set_confinement_region_called(geom::Rectangles const& /*regions*/) override {}
+    void seat_reset_confinement_regions() override {}
+};
+}
+
+TEST_F(TestSeatReport, add_device_received)
+{
+    class DeviceAddListener : public NullSeatListener
+    {
+    public:
+        DeviceAddListener(size_t expected_devices)
+            : expected_devices{expected_devices}
+        {
+        }
+
+        void seat_add_device(uint64_t id) override
+        {
+            seen_ids.push_back(id);
+            if (seen_ids.size() == expected_devices)
+            {
+                seen_expected_devices.raise();
+            }
+        }
+
+        std::vector<uint64_t> wait_for_devices()
+        {
+            seen_expected_devices.wait_for(30s);
+            return std::move(seen_ids);
+        }
+    private:
+        size_t const expected_devices;
+        std::vector<uint64_t> seen_ids;
+        mt::Signal seen_expected_devices;
+    };
+
+    auto listener = std::make_shared<DeviceAddListener>(3);
+    server.the_seat_observer_registrar()->register_interest(listener);
+
+    auto constexpr mouse_name = "mouse";
+    auto constexpr mouse_uid = "some-sort-of-uid";
+    auto fake_pointer = mtf::add_fake_input_device(
+        mi::InputDeviceInfo{mouse_name, mouse_uid, mi::DeviceCapability::pointer});
+
+    auto constexpr touch_name = "touchscreen";
+    auto constexpr touch_uid = "Bottle Rocket";
+    auto fake_touch = mtf::add_fake_input_device(
+        mi::InputDeviceInfo{touch_name, touch_uid, mi::DeviceCapability::touchscreen});
+
+    auto constexpr keyboard_name = "keybored";
+    auto constexpr keyboard_uid = "Panther Dash";
+    auto fake_keyboard = mtf::add_fake_input_device(
+        mi::InputDeviceInfo{
+            keyboard_name,
+            keyboard_uid,
+            mi::DeviceCapability::alpha_numeric | mi::DeviceCapability::keyboard});
+
+    auto device_ids_seen = listener->wait_for_devices();
+    std::vector<uint64_t> devices;
+
+    server.the_input_device_hub()->for_each_input_device(
+        [&devices](mi::Device const& device)
+        {
+            devices.push_back(device.id());
+        });
+
+    EXPECT_THAT(device_ids_seen, ContainerEq(devices));
+}

--- a/tests/acceptance-tests/test_seat_report.cpp
+++ b/tests/acceptance-tests/test_seat_report.cpp
@@ -67,12 +67,6 @@ public:
     void seat_remove_device(uint64_t /*id*/) override {}
     void seat_dispatch_event(std::shared_ptr<MirEvent const> const& /*event*/) override {}
 
-    void seat_get_rectangle_for(
-        uint64_t /*id*/,
-        geom::Rectangle const& /*out_rect*/) override
-    {
-    }
-
     void seat_set_key_state(
         uint64_t /*id*/,
         std::vector<uint32_t> const& /*scan_codes*/) override

--- a/tests/acceptance-tests/test_seat_report.cpp
+++ b/tests/acceptance-tests/test_seat_report.cpp
@@ -222,7 +222,7 @@ public:
     bool wait_for_expected_devices(std::chrono::duration<Period, Ratio> timeout)
     {
         return seen_expected_devices.wait_for(timeout);
-    };
+    }
 private:
     size_t const expected_devices;
     size_t devices_seen{0};

--- a/tests/include/mir/test/doubles/mock_input_seat.h
+++ b/tests/include/mir/test/doubles/mock_input_seat.h
@@ -36,7 +36,7 @@ struct MockInputSeat : input::Seat
 {
     MOCK_METHOD1(add_device, void(input::Device const& device));
     MOCK_METHOD1(remove_device, void(input::Device const& device));
-    MOCK_METHOD1(dispatch_event, void(MirEvent& event));
+    MOCK_METHOD1(dispatch_event, void(std::shared_ptr<MirEvent> const& event));
     MOCK_METHOD0(create_device_state, mir::EventUPtr());
     MOCK_METHOD2(set_key_state, void(input::Device const&, std::vector<uint32_t> const&));
     MOCK_METHOD2(set_pointer_state, void (input::Device const&, MirPointerButtons));

--- a/tests/include/mir/test/doubles/mock_input_sink.h
+++ b/tests/include/mir/test/doubles/mock_input_sink.h
@@ -32,7 +32,7 @@ namespace doubles
 
 struct MockInputSink : mir::input::InputSink
 {
-    MOCK_METHOD1(handle_input, void(MirEvent&));
+    MOCK_METHOD1(handle_input, void(std::shared_ptr<MirEvent> const&));
     MOCK_METHOD1(confine_pointer, void(mir::geometry::Point&));
     MOCK_CONST_METHOD0(bounding_rectangle, mir::geometry::Rectangle());
     MOCK_CONST_METHOD1(output_info, mir::input::OutputInfo(uint32_t));

--- a/tests/integration-tests/input/test_single_seat_setup.cpp
+++ b/tests/integration-tests/input/test_single_seat_setup.cpp
@@ -202,7 +202,7 @@ TEST_F(SingleSeatInputDeviceHubSetup, input_sink_posts_events_to_input_dispatche
 
     EXPECT_CALL(mock_dispatcher, dispatch(AllOf(mt::InputDeviceIdMatches(handle->id()), mt::MirKeyboardEventMatches(event.get()))));
 
-    sink->handle_input(*event);
+    sink->handle_input(std::move(event));
 }
 
 TEST_F(SingleSeatInputDeviceHubSetup, forwards_touch_spots_to_visualizer)
@@ -241,10 +241,10 @@ TEST_F(SingleSeatInputDeviceHubSetup, forwards_touch_spots_to_visualizer)
     EXPECT_CALL(mock_visualizer, visualize_touches(ElementsAreArray({Spot{{70,30}, 50}})));
     EXPECT_CALL(mock_visualizer, visualize_touches(ElementsAreArray(std::vector<Spot>())));
 
-    sink->handle_input(*touch_event_1);
-    sink->handle_input(*touch_event_2);
-    sink->handle_input(*touch_event_3);
-    sink->handle_input(*touch_event_4);
+    sink->handle_input(std::move(touch_event_1));
+    sink->handle_input(std::move(touch_event_2));
+    sink->handle_input(std::move(touch_event_3));
+    sink->handle_input(std::move(touch_event_4));
 }
 
 TEST_F(SingleSeatInputDeviceHubSetup, tracks_pointer_position)
@@ -260,11 +260,11 @@ TEST_F(SingleSeatInputDeviceHubSetup, tracks_pointer_position)
 
     hub.add_device(mt::fake_shared(device));
     sink->handle_input(
-        *builder->pointer_event(arbitrary_timestamp, mir_pointer_action_motion, 0, 0.0f, 0.0f, 10.0f, 10.0f));
+        builder->pointer_event(arbitrary_timestamp, mir_pointer_action_motion, 0, 0.0f, 0.0f, 10.0f, 10.0f));
     sink->handle_input(
-        *builder->pointer_event(arbitrary_timestamp, mir_pointer_action_motion, 0, 0.0f, 0.0f, 10.0f, 10.0f));
+        builder->pointer_event(arbitrary_timestamp, mir_pointer_action_motion, 0, 0.0f, 0.0f, 10.0f, 10.0f));
     sink->handle_input(
-        *builder->pointer_event(arbitrary_timestamp, mir_pointer_action_motion, 0, 0.0f, 0.0f, -10.0f, 10.0f));
+        builder->pointer_event(arbitrary_timestamp, mir_pointer_action_motion, 0, 0.0f, 0.0f, -10.0f, 10.0f));
 }
 
 TEST_F(SingleSeatInputDeviceHubSetup, confines_pointer_movement)
@@ -280,9 +280,9 @@ TEST_F(SingleSeatInputDeviceHubSetup, confines_pointer_movement)
     hub.add_device(mt::fake_shared(device));
 
     sink->handle_input(
-        *builder->pointer_event(arbitrary_timestamp, mir_pointer_action_motion, 0, 0.0f, 0.0f, 10.0f, 20.0f));
+        builder->pointer_event(arbitrary_timestamp, mir_pointer_action_motion, 0, 0.0f, 0.0f, 10.0f, 20.0f));
     sink->handle_input(
-        *builder->pointer_event(arbitrary_timestamp, mir_pointer_action_motion, 0, 0.0f, 0.0f, 10.0f, 10.0f));
+        builder->pointer_event(arbitrary_timestamp, mir_pointer_action_motion, 0, 0.0f, 0.0f, 10.0f, 10.0f));
 }
 
 TEST_F(SingleSeatInputDeviceHubSetup, forwards_pointer_updates_to_cursor_listener)
@@ -298,7 +298,7 @@ TEST_F(SingleSeatInputDeviceHubSetup, forwards_pointer_updates_to_cursor_listene
 
     EXPECT_CALL(mock_cursor_listener, cursor_moved_to(move_x, move_y)).Times(1);
 
-    sink->handle_input(*event);
+    sink->handle_input(std::move(event));
 }
 
 TEST_F(SingleSeatInputDeviceHubSetup, forwards_pointer_settings_to_input_device)
@@ -359,8 +359,8 @@ TEST_F(SingleSeatInputDeviceHubSetup, input_sink_tracks_modifier)
     EXPECT_CALL(mock_dispatcher, dispatch(mt::KeyWithModifiers(shift_left)));
     EXPECT_CALL(mock_dispatcher, dispatch(mt::KeyWithModifiers(mir_input_event_modifier_none)));
 
-    key_board_sink->handle_input(*shift_down);
-    key_board_sink->handle_input(*shift_up);
+    key_board_sink->handle_input(std::move(shift_down));
+    key_board_sink->handle_input(std::move(shift_up));
 }
 
 TEST_F(SingleSeatInputDeviceHubSetup, input_sink_unifies_modifier_state_accross_devices)
@@ -395,8 +395,8 @@ TEST_F(SingleSeatInputDeviceHubSetup, input_sink_unifies_modifier_state_accross_
     EXPECT_CALL(mock_dispatcher, dispatch(mt::KeyWithModifiers(r_alt_modifier)));
     EXPECT_CALL(mock_dispatcher, dispatch(mt::PointerEventWithModifiers(r_alt_modifier)));
 
-    key_board_sink->handle_input(*key);
-    mouse_sink->handle_input(*motion);
+    key_board_sink->handle_input(std::move(key));
+    mouse_sink->handle_input(std::move(motion));
 
     EXPECT_THAT(key_handle->id(), Ne(mouse_handle->id()));
 }
@@ -450,11 +450,11 @@ TEST_F(SingleSeatInputDeviceHubSetup, input_sink_reduces_modifier_state_accross_
     EXPECT_CALL(mock_dispatcher, dispatch(mt::KeyWithModifiers(mir_input_event_modifier_none)));
     EXPECT_CALL(mock_dispatcher, dispatch(mt::PointerEventWithModifiers(r_alt_modifier)));
 
-    key_board_sink_1->handle_input(*alt_down);
-    key_board_sink_2->handle_input(*ctrl_down);
-    mouse_sink->handle_input(*motion_1);
-    key_board_sink_2->handle_input(*ctrl_up);
-    mouse_sink->handle_input(*motion_2);
+    key_board_sink_1->handle_input(std::move(alt_down));
+    key_board_sink_2->handle_input(std::move(ctrl_down));
+    mouse_sink->handle_input(std::move(motion_1));
+    key_board_sink_2->handle_input(std::move(ctrl_up));
+    mouse_sink->handle_input(std::move(motion_2));
 
     EXPECT_THAT(key_handle_1->id(), Ne(key_handle_2->id()));
 }
@@ -483,9 +483,9 @@ TEST_F(SingleSeatInputDeviceHubSetup, tracks_a_single_cursor_position_from_multi
     EXPECT_CALL(mock_cursor_listener, cursor_moved_to(41, 10));
     EXPECT_CALL(mock_cursor_listener, cursor_moved_to(43, 20));
 
-    mouse_sink_1->handle_input(*motion_1);
-    mouse_sink_2->handle_input(*motion_2);
-    mouse_sink_1->handle_input(*motion_3);
+    mouse_sink_1->handle_input(std::move(motion_1));
+    mouse_sink_2->handle_input(std::move(motion_2));
+    mouse_sink_1->handle_input(std::move(motion_3));
 }
 
 TEST_F(SingleSeatInputDeviceHubSetup, tracks_a_single_button_state_from_multiple_pointing_devices)
@@ -518,10 +518,10 @@ TEST_F(SingleSeatInputDeviceHubSetup, tracks_a_single_button_state_from_multiple
     EXPECT_CALL(mock_dispatcher, dispatch(mt::ButtonsUp(x, y, mir_pointer_button_secondary)));
     EXPECT_CALL(mock_dispatcher, dispatch(mt::ButtonsUp(x, y, no_buttons)));
 
-    mouse_sink_1->handle_input(*motion_1);
-    mouse_sink_2->handle_input(*motion_2);
-    mouse_sink_1->handle_input(*motion_3);
-    mouse_sink_1->handle_input(*motion_4);
+    mouse_sink_1->handle_input(std::move(motion_1));
+    mouse_sink_2->handle_input(std::move(motion_2));
+    mouse_sink_1->handle_input(std::move(motion_3));
+    mouse_sink_1->handle_input(std::move(motion_4));
 }
 
 TEST_F(SingleSeatInputDeviceHubSetup, input_device_changes_sent_to_session)

--- a/tests/mir_test_framework/fake_input_device_impl.cpp
+++ b/tests/mir_test_framework/fake_input_device_impl.cpp
@@ -110,6 +110,15 @@ void mtf::FakeInputDeviceImpl::emit_touch_sequence(std::function<mir::input::syn
         });
 }
 
+void mtf::FakeInputDeviceImpl::emit_key_state(std::vector<uint32_t> const& key_syms)
+{
+    queue->enqueue(
+        [this, key_syms]()
+        {
+            device->emit_key_state(key_syms);
+        });
+}
+
 void mtf::FakeInputDeviceImpl::on_new_configuration_do(std::function<void(mir::input::InputDevice const& device)> callback)
 {
     device->set_apply_settings_callback(callback);
@@ -233,6 +242,11 @@ void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::TouchPa
 
         sink->handle_input(std::move(touch_event));
     }
+}
+
+void mtf::FakeInputDeviceImpl::InputDevice::emit_key_state(std::vector<uint32_t> const& scan_codes)
+{
+    sink->key_state(scan_codes);
 }
 
 mir::optional_value<mi::PointerSettings> mtf::FakeInputDeviceImpl::InputDevice::get_pointer_settings() const

--- a/tests/mir_test_framework/fake_input_device_impl.cpp
+++ b/tests/mir_test_framework/fake_input_device_impl.cpp
@@ -147,7 +147,7 @@ void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::KeyPara
 
     if (!sink)
         BOOST_THROW_EXCEPTION(std::runtime_error("Device is not started."));
-    sink->handle_input(*key_event);
+    sink->handle_input(std::move(key_event));
 }
 
 void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::ButtonParameters const& button)
@@ -165,7 +165,7 @@ void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::ButtonP
 
     if (!sink)
         BOOST_THROW_EXCEPTION(std::runtime_error("Device is not started."));
-    sink->handle_input(*button_event);
+    sink->handle_input(std::move(button_event));
 }
 
 MirPointerAction mtf::FakeInputDeviceImpl::InputDevice::update_buttons(synthesis::EventAction action, MirPointerButton button)
@@ -204,7 +204,7 @@ void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::MotionP
                                                 rel_x,
                                                 rel_y);
 
-    sink->handle_input(*pointer_event);
+    sink->handle_input(std::move(pointer_event));
 }
 
 void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::TouchParameters const& touch)
@@ -231,7 +231,7 @@ void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::TouchPa
             event_time,
             {{MirTouchId{1}, touch_action, mir_touch_tooltype_finger, abs_x, abs_y, 1.0f, 8.0f, 5.0f, 0.0f}});
 
-        sink->handle_input(*touch_event);
+        sink->handle_input(std::move(touch_event));
     }
 }
 

--- a/tests/mir_test_framework/fake_input_device_impl.h
+++ b/tests/mir_test_framework/fake_input_device_impl.h
@@ -29,6 +29,7 @@
 
 #include <mutex>
 #include <functional>
+#include <vector>
 
 namespace mir
 {
@@ -57,6 +58,7 @@ public:
     void emit_touch_sequence(std::function<mir::input::synthesis::TouchParameters(int)> const& event_generator,
                              int count,
                              std::chrono::duration<double> delay) override;
+    void emit_key_state(std::vector<uint32_t> const& key_syms) override;
     virtual void on_new_configuration_do(std::function<void(mir::input::InputDevice const& device)> callback) override;
 
 private:
@@ -73,6 +75,8 @@ private:
         void synthesize_events(mir::input::synthesis::ButtonParameters const& button);
         void synthesize_events(mir::input::synthesis::MotionParameters const& motion);
         void synthesize_events(mir::input::synthesis::TouchParameters const& touch);
+
+        void emit_key_state(std::vector<uint32_t> const& scan_codes);
         mir::input::InputDeviceInfo get_device_info() override
         {
             return info;

--- a/tests/unit-tests/input/test_key_repeat_dispatcher.cpp
+++ b/tests/unit-tests/input/test_key_repeat_dispatcher.cpp
@@ -184,11 +184,11 @@ TEST_F(KeyRepeatDispatcher, schedules_alarm_to_repeat_key_down)
     EXPECT_CALL(*mock_next_dispatcher, dispatch(mt::KeyUpEvent())).Times(1);
 
     // Schedule the repeat
-    dispatcher.dispatch(*a_key_down_event());
+    dispatcher.dispatch(a_key_down_event());
     // Trigger the repeat
     alarm_function();
     // Trigger the cancel
-    dispatcher.dispatch(*a_key_up_event());
+    dispatcher.dispatch(a_key_up_event());
 }
 
 TEST_F(KeyRepeatDispatcher, stops_repeat_on_device_removal)
@@ -207,7 +207,7 @@ TEST_F(KeyRepeatDispatcher, stops_repeat_on_device_removal)
     EXPECT_CALL(*mock_alarm, reschedule_in(repeat_delay)).Times(1).WillOnce(Return(true));
     ON_CALL(*mock_alarm, cancel()).WillByDefault(Invoke([&](){alarm_canceled = true; return true;}));
 
-    dispatcher.dispatch(*a_key_down_event());
+    dispatcher.dispatch(a_key_down_event());
 
     alarm_function();
     Mock::VerifyAndClearExpectations(mock_alarm); // mock_alarm will be deleted after this
@@ -223,7 +223,7 @@ TEST_F(KeyRepeatDispatcherOnArale, no_repeat_alarm_on_mtk_tpd)
     EXPECT_CALL(*mock_next_dispatcher, dispatch(mt::KeyRepeatEvent())).Times(0);
 
     add_mtk_tpd();
-    dispatcher.dispatch(*mtk_key_down_event());
+    dispatcher.dispatch(mtk_key_down_event());
 }
 
 TEST_F(KeyRepeatDispatcherOnArale, repeat_for_regular_keys)
@@ -240,6 +240,6 @@ TEST_F(KeyRepeatDispatcherOnArale, repeat_for_regular_keys)
     EXPECT_CALL(*mock_next_dispatcher, dispatch(mt::KeyRepeatEvent())).Times(1);
 
     add_mtk_tpd();
-    dispatcher.dispatch(*a_key_down_event());
+    dispatcher.dispatch(a_key_down_event());
     alarm_function();
 }

--- a/tests/unit-tests/input/test_surface_input_dispatcher.cpp
+++ b/tests/unit-tests/input/test_surface_input_dispatcher.cpp
@@ -269,7 +269,7 @@ TEST_F(SurfaceInputDispatcher, key_event_delivered_to_focused_surface)
     dispatcher.start();
 
     dispatcher.set_focus(surface);
-    EXPECT_TRUE(dispatcher.dispatch(*event));
+    EXPECT_TRUE(dispatcher.dispatch(std::move(event)));
 }
 
 TEST_F(SurfaceInputDispatcher, key_event_dropped_if_no_surface_focused)
@@ -281,7 +281,7 @@ TEST_F(SurfaceInputDispatcher, key_event_dropped_if_no_surface_focused)
     dispatcher.start();
 
     FakeKeyboard keyboard;
-    EXPECT_FALSE(dispatcher.dispatch(*keyboard.press()));
+    EXPECT_FALSE(dispatcher.dispatch(keyboard.press()));
 }
 
 TEST_F(SurfaceInputDispatcher, pointer_motion_delivered_to_client_under_pointer)
@@ -298,8 +298,8 @@ TEST_F(SurfaceInputDispatcher, pointer_motion_delivered_to_client_under_pointer)
 
     dispatcher.start();
 
-    EXPECT_TRUE(dispatcher.dispatch(*pointer.move_to({1, 0})));
-    EXPECT_TRUE(dispatcher.dispatch(*pointer.move_to({5, 0})));
+    EXPECT_TRUE(dispatcher.dispatch(pointer.move_to({1, 0})));
+    EXPECT_TRUE(dispatcher.dispatch(pointer.move_to({5, 0})));
 }
 
 TEST_F(SurfaceInputDispatcher, pointer_delivered_only_to_top_surface)
@@ -315,9 +315,9 @@ TEST_F(SurfaceInputDispatcher, pointer_delivered_only_to_top_surface)
 
     dispatcher.start();
 
-    EXPECT_TRUE(dispatcher.dispatch(*pointer.move_to({1, 0})));
+    EXPECT_TRUE(dispatcher.dispatch(pointer.move_to({1, 0})));
     scene.remove_surface(top_surface);
-    EXPECT_TRUE(dispatcher.dispatch(*pointer.move_to({1, 0})));
+    EXPECT_TRUE(dispatcher.dispatch(pointer.move_to({1, 0})));
 }
 
 TEST_F(SurfaceInputDispatcher, pointer_may_move_between_adjacent_surfaces)
@@ -337,9 +337,9 @@ TEST_F(SurfaceInputDispatcher, pointer_may_move_between_adjacent_surfaces)
 
     dispatcher.start();
 
-    EXPECT_TRUE(dispatcher.dispatch(*pointer.move_to({1, 1})));
-    EXPECT_TRUE(dispatcher.dispatch(*pointer.move_to({6, 6})));
-    EXPECT_TRUE(dispatcher.dispatch(*pointer.move_to({11, 11})));
+    EXPECT_TRUE(dispatcher.dispatch(pointer.move_to({1, 1})));
+    EXPECT_TRUE(dispatcher.dispatch(pointer.move_to({6, 6})));
+    EXPECT_TRUE(dispatcher.dispatch(pointer.move_to({11, 11})));
 }
 
 // We test that a client will receive pointer events following a button down
@@ -364,9 +364,9 @@ TEST_F(SurfaceInputDispatcher, gestures_persist_over_button_down)
     
     dispatcher.start();
 
-    EXPECT_TRUE(dispatcher.dispatch(*ev_1));
-    EXPECT_TRUE(dispatcher.dispatch(*ev_2));
-    EXPECT_TRUE(dispatcher.dispatch(*ev_3));
+    EXPECT_TRUE(dispatcher.dispatch(std::move(ev_1)));
+    EXPECT_TRUE(dispatcher.dispatch(std::move(ev_2)));
+    EXPECT_TRUE(dispatcher.dispatch(std::move(ev_3)));
 }
 
 TEST_F(SurfaceInputDispatcher, pointer_gestures_may_transfer_over_buttons)
@@ -393,11 +393,11 @@ TEST_F(SurfaceInputDispatcher, pointer_gestures_may_transfer_over_buttons)
 
     dispatcher.start();
 
-    EXPECT_TRUE(dispatcher.dispatch(*ev_1));
-    EXPECT_TRUE(dispatcher.dispatch(*ev_2));
-    EXPECT_TRUE(dispatcher.dispatch(*ev_3));
-    EXPECT_TRUE(dispatcher.dispatch(*ev_4));
-    EXPECT_TRUE(dispatcher.dispatch(*ev_5));
+    EXPECT_TRUE(dispatcher.dispatch(std::move(ev_1)));
+    EXPECT_TRUE(dispatcher.dispatch(std::move(ev_2)));
+    EXPECT_TRUE(dispatcher.dispatch(std::move(ev_3)));
+    EXPECT_TRUE(dispatcher.dispatch(std::move(ev_4)));
+    EXPECT_TRUE(dispatcher.dispatch(std::move(ev_5)));
 }
 
 TEST_F(SurfaceInputDispatcher, pointer_gesture_target_may_vanish_and_the_situation_remains_hunky_dorey)
@@ -417,10 +417,10 @@ TEST_F(SurfaceInputDispatcher, pointer_gesture_target_may_vanish_and_the_situati
 
     dispatcher.start();
 
-    EXPECT_TRUE(dispatcher.dispatch(*ev_1));
+    EXPECT_TRUE(dispatcher.dispatch(std::move(ev_1)));
     scene.remove_surface(surface);
-    EXPECT_FALSE(dispatcher.dispatch(*ev_2));
-    EXPECT_TRUE(dispatcher.dispatch(*ev_3));
+    EXPECT_FALSE(dispatcher.dispatch(std::move(ev_2)));
+    EXPECT_TRUE(dispatcher.dispatch(std::move(ev_3)));
 }
 
 TEST_F(SurfaceInputDispatcher, touch_delivered_to_surface)
@@ -434,8 +434,8 @@ TEST_F(SurfaceInputDispatcher, touch_delivered_to_surface)
     dispatcher.start();
 
     FakeToucher toucher;
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.touch_at({1,1})));
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.release_at({1,1})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.touch_at({1,1})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.release_at({1,1})));
 }
 
 TEST_F(SurfaceInputDispatcher, touch_delivered_only_to_top_surface)
@@ -452,8 +452,8 @@ TEST_F(SurfaceInputDispatcher, touch_delivered_only_to_top_surface)
     dispatcher.start();
 
     FakeToucher toucher;
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.touch_at({1,1})));
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.release_at({2,2})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.touch_at({1,1})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.release_at({2,2})));
 }
 
 TEST_F(SurfaceInputDispatcher, gestures_persist_over_touch_down)
@@ -470,9 +470,9 @@ TEST_F(SurfaceInputDispatcher, gestures_persist_over_touch_down)
     dispatcher.start();
     
     FakeToucher toucher;
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.touch_at({0, 0})));
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.move_to({2, 2})));
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.release_at({2, 2})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.touch_at({0, 0})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.move_to({2, 2})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.release_at({2, 2})));
 }
 
 TEST_F(SurfaceInputDispatcher, touch_target_switches_on_finger_down)
@@ -490,9 +490,9 @@ TEST_F(SurfaceInputDispatcher, touch_target_switches_on_finger_down)
     dispatcher.start();
     
     FakeToucher toucher;
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.touch_at({0, 0})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.touch_at({0, 0})));
     // Note: No touch release event produced
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.touch_at({5, 5})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.touch_at({5, 5})));
 }
 
 TEST_F(SurfaceInputDispatcher, touch_target_switches_on_fingers_down)
@@ -509,9 +509,9 @@ TEST_F(SurfaceInputDispatcher, touch_target_switches_on_fingers_down)
     dispatcher.start();
 
     FakeToucher toucher;
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.touch_at({0, 0})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.touch_at({0, 0})));
     // Note: No touch release event produced
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.touches_at({5, 5}, {6, 6})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.touches_at({5, 5}, {6, 6})));
 }
 
 TEST_F(SurfaceInputDispatcher, touch_gestures_terminated_by_release_all_touches)
@@ -525,9 +525,9 @@ TEST_F(SurfaceInputDispatcher, touch_gestures_terminated_by_release_all_touches)
     dispatcher.start();
 
     FakeToucher toucher;
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.touches_at({5, 5}, {6, 6})));
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.releases_at({5, 5}, {6, 6})));
-    EXPECT_FALSE(dispatcher.dispatch(*toucher.move_to({5, 6})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.touches_at({5, 5}, {6, 6})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.releases_at({5, 5}, {6, 6})));
+    EXPECT_FALSE(dispatcher.dispatch(toucher.move_to({5, 6})));
 }
 
 TEST_F(SurfaceInputDispatcher, touch_gesture_target_may_vanish_but_things_continue_to_function_as_intended)
@@ -542,8 +542,8 @@ TEST_F(SurfaceInputDispatcher, touch_gesture_target_may_vanish_but_things_contin
     dispatcher.start();
     
     FakeToucher toucher;
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.touch_at({0, 0})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.touch_at({0, 0})));
     scene.remove_surface(surface_2);
-    EXPECT_FALSE(dispatcher.dispatch(*toucher.release_at({0, 0})));
-    EXPECT_TRUE(dispatcher.dispatch(*toucher.touch_at({0, 0})));
+    EXPECT_FALSE(dispatcher.dispatch(toucher.release_at({0, 0})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.touch_at({0, 0})));
 }


### PR DESCRIPTION
We did not have any end-to-end tests for mi::SeatObserver. Add some, and then fix the problems they found. And then remove the entirely unused method.

This does not test all the observer methods; more tests can be added later.