### PR TITLE
mtf::FakeInputDevice: Add the ability to synthesise the event time.

### DIFF
--- a/include/test/mir/test/event_factory.h
+++ b/include/test/mir/test/event_factory.h
@@ -21,6 +21,9 @@
 
 #include "mir/geometry/point.h"
 
+#include <experimental/optional>
+#include <chrono>
+
 namespace mir
 {
 namespace input
@@ -70,10 +73,12 @@ public:
     MotionParameters();
     MotionParameters& from_device(int device_id);
     MotionParameters& with_movement(int rel_x, int rel_y);
+    MotionParameters& with_event_time(std::chrono::nanoseconds time);
 
     int device_id;
     int rel_x;
     int rel_y;
+    std::experimental::optional<std::chrono::nanoseconds> event_time;
 };
 MotionParameters a_pointer_event();
 

--- a/tests/mir_test/event_factory.cpp
+++ b/tests/mir_test/event_factory.cpp
@@ -110,6 +110,12 @@ mis::MotionParameters& mis::MotionParameters::with_movement(int new_rel_x, int n
     return *this;
 }
 
+mis::MotionParameters& mis::MotionParameters::with_event_time(std::chrono::nanoseconds event_time)
+{
+    this->event_time = event_time;
+    return *this;
+}
+
 mis::MotionParameters mis::a_pointer_event()
 {
     return mis::MotionParameters();

--- a/tests/mir_test_framework/fake_input_device_impl.cpp
+++ b/tests/mir_test_framework/fake_input_device_impl.cpp
@@ -196,8 +196,9 @@ void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::MotionP
     if (!sink)
         BOOST_THROW_EXCEPTION(std::runtime_error("Device is not started."));
 
-    auto event_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        std::chrono::steady_clock::now().time_since_epoch());
+    auto event_time = pointer.event_time.value_or(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch()));
     // constant scaling is used here to simplify checking for the
     // expected results. Default settings of the device lead to no
     // scaling at all.


### PR DESCRIPTION
For pointer motion events, at least for now.