### PR TITLE
SessionListener: Add buffer_stream_{created,destroyed} observers.

### DIFF
--- a/include/server/mir/scene/null_session_listener.h
+++ b/include/server/mir/scene/null_session_listener.h
@@ -39,6 +39,8 @@ public:
     void surface_created(Session&, std::shared_ptr<Surface> const&) override {}
     void destroying_surface(Session&, std::shared_ptr<Surface> const&) override {}
 
+    void buffer_stream_created(Session&, std::shared_ptr<frontend::BufferStream> const&) override {}
+    void buffer_stream_destroyed(Session&, std::shared_ptr<frontend::BufferStream> const&) override {}
 protected:
     NullSessionListener(const NullSessionListener&) = delete;
     NullSessionListener& operator=(const NullSessionListener&) = delete;

--- a/include/server/mir/scene/session_listener.h
+++ b/include/server/mir/scene/session_listener.h
@@ -23,6 +23,10 @@
 
 namespace mir
 {
+namespace frontend
+{
+class BufferStream;
+}
 namespace scene
 {
 class Surface;
@@ -38,6 +42,13 @@ public:
 
     virtual void surface_created(Session& session, std::shared_ptr<Surface> const& surface) = 0;
     virtual void destroying_surface(Session& session, std::shared_ptr<Surface> const& surface) = 0;
+
+    virtual void buffer_stream_created(
+        Session& session,
+        std::shared_ptr<frontend::BufferStream> const& stream) = 0;
+    virtual void buffer_stream_destroyed(
+        Session& session,
+        std::shared_ptr<frontend::BufferStream> const& stream) = 0;
 
 protected:
     SessionListener() = default;

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -371,7 +371,8 @@ mf::BufferStreamId ms::ApplicationSession::create_buffer_stream(mg::BufferProper
 {
     auto const id = static_cast<mf::BufferStreamId>(next_id().as_value());
     auto stream = buffer_stream_factory->create_buffer_stream(id, props);
-    
+    session_listener->buffer_stream_created(*this, stream);
+
     std::unique_lock<std::mutex> lock(surfaces_and_streams_mutex);
     streams[id] = stream;
     return id;
@@ -384,6 +385,7 @@ void ms::ApplicationSession::destroy_buffer_stream(mf::BufferStreamId id)
     if (stream_it == streams.end())
         BOOST_THROW_EXCEPTION(std::runtime_error("cannot destroy stream: Invalid BufferStreamId"));
 
+    session_listener->buffer_stream_destroyed(*this, stream_it->second);
     streams.erase(stream_it);
 }
 

--- a/src/server/scene/session_manager.cpp
+++ b/src/server/scene/session_manager.cpp
@@ -78,6 +78,14 @@ struct ms::SessionManager::SessionObservers : mir::Executor, mir::ObserverMultip
     {
         for_each_observer(&SessionListener::destroying_surface, std::ref(session), surface);
     }
+    void buffer_stream_created(Session& session, std::shared_ptr<mf::BufferStream> const& stream) override
+    {
+        for_each_observer(&SessionListener::buffer_stream_created, std::ref(session), stream);
+    }
+    void buffer_stream_destroyed(Session& session, std::shared_ptr<mf::BufferStream> const& stream) override
+    {
+        for_each_observer(&SessionListener::buffer_stream_destroyed, std::ref(session), stream);
+    }
 };
 
 ms::SessionManager::SessionManager(

--- a/tests/include/mir/test/doubles/mock_session_listener.h
+++ b/tests/include/mir/test/doubles/mock_session_listener.h
@@ -41,6 +41,9 @@ struct MockSessionListener : public scene::SessionListener
 
     MOCK_METHOD2(surface_created, void(scene::Session&, std::shared_ptr<scene::Surface> const&));
     MOCK_METHOD2(destroying_surface, void(scene::Session&, std::shared_ptr<scene::Surface> const&));
+
+    MOCK_METHOD2(buffer_stream_created, void(scene::Session&, std::shared_ptr<frontend::BufferStream> const&));
+    MOCK_METHOD2(buffer_stream_destroyed, void(scene::Session&, std::shared_ptr<frontend::BufferStream> const&));
 };
 
 }


### PR DESCRIPTION
These parallel the surface creation/destruction observers, and are needed by
wlcs to correlate Mir objects with their Wayland counterparts.