### PR TITLE
Add Server::run_on_wayland_display().

### DIFF
--- a/include/server/mir/server.h
+++ b/include/server/mir/server.h
@@ -26,6 +26,9 @@
 #include <memory>
 #include <vector>
 
+
+struct wl_display;
+
 namespace mir
 {
 template<class Observer>
@@ -458,6 +461,8 @@ public:
     /// Get a file descriptor that can be used to connect a Wayland client
     /// It can be passed to another process, or used with wl_display_connect_to_fd()
     auto open_wayland_client_socket() -> Fd;
+
+    void run_on_wayland_display(std::function<void(wl_display*)> const& functor);
 /** @} */
 
 private:

--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -2329,3 +2329,10 @@ int mf::WaylandConnector::client_socket_fd(
 {
     return -1;
 }
+
+void mf::WaylandConnector::run_on_wayland_display(std::function<void(wl_display*)> const& functor)
+{
+    auto executor = WaylandExecutor::executor_for_event_loop(wl_display_get_event_loop(display.get()));
+
+    executor->spawn([display_ref = display.get(), functor]() { functor(display_ref); });
+}

--- a/src/server/frontend/wayland/wayland_connector.h
+++ b/src/server/frontend/wayland/wayland_connector.h
@@ -71,6 +71,7 @@ public:
     int client_socket_fd(
         std::function<void(std::shared_ptr<Session> const& session)> const& connect_handler) const override;
 
+    void run_on_wayland_display(std::function<void(wl_display*)> const& functor);
 private:
     std::unique_ptr<wl_display, void(*)(wl_display*)> const display;
     mir::Fd const pause_signal;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -40,6 +40,8 @@
 #include "mir/graphics/renderable.h"
 #include "mir/renderer/renderer_factory.h"
 
+#include "frontend/wayland/wayland_connector.h"
+
 #include <iostream>
 
 namespace mo = mir::options;
@@ -474,6 +476,15 @@ auto mir::Server::open_wayland_client_socket() -> Fd
         return Fd{config->the_wayland_connector()->client_socket_fd()};
 
     BOOST_THROW_EXCEPTION(std::logic_error("Cannot open connection when not running"));
+}
+
+void mir::Server::run_on_wayland_display(std::function<void(wl_display*)> const& functor)
+{
+    if (auto const config = self->server_config)
+    {
+        std::dynamic_pointer_cast<mir::frontend::WaylandConnector>(config->the_wayland_connector())
+            ->run_on_wayland_display(functor);
+    }
 }
 
 auto mir::Server::open_client_socket(ConnectHandler const& connect_handler) -> Fd


### PR DESCRIPTION
This lets code access the wl_display* in the Wayland event-loop thread context.
This is useful for shells which wish to expose additional Wayland extensions,
or for other parts of Mir which require more visibility into the Wayland context.