### PR TITLE
Don't extend the life of the main loop after server shuts down (Fixes #88)

### DIFF
--- a/src/miral/runner.cpp
+++ b/src/miral/runner.cpp
@@ -213,10 +213,9 @@ try
         // ensuring that the server has really and fully started.
         auto const main_loop = server->the_main_loop();
         main_loop->enqueue(this, start_callback);
-
-        server->run();
     }
 
+    server->run();
 
     return server->exited_normally() ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
Work items in the main loop should be allowed to die before the server objects they reference.