### PR TITLE
Add mir-smoke-test-runner to mir-test-tools

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -294,6 +294,11 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends},
          ${shlibs:Depends},
 Recommends: mir-demos,
+            xmir,
+            xwayland,
+            glmark2-es2,
+            glmark2-es2-mir,
+            glmark2-es2-wayland
 Description: Display Server for Ubuntu - stress tests and other test tools
  Mir is a display server running on linux systems, with a focus on efficiency,
  robust operation and a well-defined driver model.

--- a/debian/mir-test-tools.install
+++ b/debian/mir-test-tools.install
@@ -9,6 +9,7 @@ usr/bin/mir_privileged_tests
 usr/bin/mir_test_reload_protobuf
 usr/bin/mir_test_client_*
 usr/bin/mir_wlcs_tests
+usr/bin/mir-smoke-test-runner
 usr/lib/*/mir/tools/libmirclientlttng.so
 usr/lib/*/mir/tools/libmirserverlttng.so
 usr/lib/*/mir/server-platform/graphics-dummy.so

--- a/tests/performance-tests/CMakeLists.txt
+++ b/tests/performance-tests/CMakeLists.txt
@@ -20,3 +20,11 @@ target_link_libraries(mir_performance_tests
 )
 
 add_dependencies(mir_performance_tests GMock)
+
+add_custom_target(mir-smoke-test-runner ALL
+    cp ${PROJECT_SOURCE_DIR}/tools/mir-smoke-test-runner.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir-smoke-test-runner
+)
+
+install(PROGRAMS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir-smoke-test-runner
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+)


### PR DESCRIPTION
Make the mir-smoke-test-runner script available for manual testing