### PR TITLE
wayland_client: Calculate buffer size correctly. 

### DIFF
--- a/examples/wayland_client.c
+++ b/examples/wayland_client.c
@@ -378,7 +378,7 @@ int main()
 
     for (int i = 0; i < 4; ++i)
     {
-        ctx->buffers[i].buffer = wl_shm_pool_create_buffer(shm_pool, 0, 400, 400, 400, WL_SHM_FORMAT_ARGB8888);
+        ctx->buffers[i].buffer = wl_shm_pool_create_buffer(shm_pool, 0, 400, 400, 400*4, WL_SHM_FORMAT_ARGB8888);
         ctx->buffers[i].available = true;
         wl_buffer_add_listener(ctx->buffers[i].buffer, &buffer_listener, ctx);
     }

--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -493,12 +493,12 @@ private:
           size_{wl_shm_buffer_get_width(this->buffer), wl_shm_buffer_get_height(this->buffer)},
           stride_{wl_shm_buffer_get_stride(this->buffer)},
           format_{wl_format_to_mir_format(wl_shm_buffer_get_format(this->buffer))},
-          data{std::make_unique<uint8_t[]>(size_.height.as_int() * stride_.as_int() * MIR_BYTES_PER_PIXEL(format_))},
+          data{std::make_unique<uint8_t[]>(size_.height.as_int() * stride_.as_int())},
           consumed{false},
           on_consumed{std::move(on_consumed)}
     {
         wl_shm_buffer_begin_access(this->buffer);
-        std::memcpy(data.get(), wl_shm_buffer_get_data(this->buffer), size_.height.as_int() * stride_.as_int() * MIR_BYTES_PER_PIXEL(format_));
+        std::memcpy(data.get(), wl_shm_buffer_get_data(this->buffer), size_.height.as_int() * stride_.as_int());
         wl_shm_buffer_end_access(this->buffer);
     }
 


### PR DESCRIPTION
wayland_client: Calculate buffer size correctly.

We were setting the stride incorrectly in wayland_client, it is documented as the number of
bytes and we were using the number of pixels.

This resulted in the GL driver attempting to access outside the bounds of the data array,
and a segfault.

Fixes #78 (better) and #94 