### PR TITLE
Don't leave outstanding work on the SessionMediator "executor" when closing down

### DIFF
--- a/src/server/frontend/default_ipc_factory.cpp
+++ b/src/server/frontend/default_ipc_factory.cpp
@@ -31,6 +31,7 @@
 #include "mir/cookie/authority.h"
 #include "mir/executor.h"
 #include "mir/signal_blocker.h"
+#include "mir/thread_name.h"
 
 #include <deque>
 
@@ -51,6 +52,7 @@ public:
 
     void do_work() noexcept
     {
+        mir::set_thread_name("IPC Executor");
         std::unique_lock<std::mutex> lock{queue_mutex};
         for(;;)
         {

--- a/tests/acceptance-tests/test_nested_input.cpp
+++ b/tests/acceptance-tests/test_nested_input.cpp
@@ -625,6 +625,7 @@ TEST_F(NestedInput, pressed_keys_on_vt_switch_are_forgotten)
     }
 
     display.trigger_pause();
+    std::this_thread::sleep_for(100ms); // This is a frig to allow work queues to empty
     display.trigger_resume();
 
     // The expectations above are abused to set up the test conditions,
@@ -639,5 +640,4 @@ TEST_F(NestedInput, pressed_keys_on_vt_switch_are_forgotten)
 
     fake_keyboard->emit_event(mis::a_key_down_event().of_scancode(KEY_A));
     EXPECT_TRUE(keys_without_modifier_received.wait_for(10s));
-    std::this_thread::sleep_for(100ms);
 }

--- a/tests/unit-tests/frontend/test_session_mediator.cpp
+++ b/tests/unit-tests/frontend/test_session_mediator.cpp
@@ -1383,6 +1383,8 @@ TEST_F(SessionMediator, buffer_releases_are_sent_from_specified_executor)
     EXPECT_CALL(executor, spawn_thunk(_)).Times(1);
 
     mediator.submit_buffer(&submit_request, &null, null_callback.get());
+
+    Mock::VerifyAndClearExpectations(&executor);
 }
 
 namespace


### PR DESCRIPTION
This fixes another failure mode of NestedInput* tests.

Best seen intermittently with NestedInput.pressed_keys_on_vt_switch_are_forgotten: 

`    $rm core;stress -c 4 -t 200&while cmake-build-debug/bin/mir_acceptance_tests --logging on --gtest_filter=NestedInput.pressed_keys_on_vt_switch_are_forgotten; do :; done`

When the servers are shut down the static ThreadExecutor in src/server/frontend/default_ipc_factory.cpp is "quiesced" but it can still be running tasks where the nested server "talks" to the host connection to release buffers and/or the connection after both servers have existed.

This also fixes the intermittent failures in `NestedInput.on_input_device_state_nested_server_emits_input_device_state`

Also important is a test that hung intermittently using the first version of this PR: `NestedServer.given_client_set_display_configuration_when_monitor_unplugs_client_can_set_display_configuration`