### PR TITLE
Tidy up smoke test script (again)

### DIFF
--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -60,5 +60,5 @@ while [ ! -e "${socket}" ]; do echo "waiting for ${socket}"; sleep 1 ;done
 
 unset QT_QPA_PLATFORMTHEME
 MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=mir QT_QPA_PLATFORM=${qt_qpa_platform} SDL_VIDEODRIVER=wayland WAYLAND_DISPLAY=${wayland_display} dbus-run-session -- ${launcher}
-killall ${bindir}${miral_server}
+killall ${bindir}${miral_server} || killall ${bindir}${miral_server}.bin
 

--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -9,7 +9,7 @@ if [ -n "${MIR_SOCKET}" ]
 then
   if [ ! -e "${MIR_SOCKET}" ]
   then
-    echo "Error: Host endpoint '${MIR_SOCKET}' does not exists"; exit 1
+    echo "Error: Host endpoint '${MIR_SOCKET}' does not exist"; exit 1
   fi
   hostsocket='--host-socket ${MIR_SOCKET}'
 fi

--- a/examples/miral-shell/miral-desktop.sh
+++ b/examples/miral-shell/miral-desktop.sh
@@ -57,5 +57,5 @@ while [ ! -e "${socket}" ]; do echo "waiting for ${socket}"; sleep 1 ;done
 
 unset QT_QPA_PLATFORMTHEME
 MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=mir QT_QPA_PLATFORM=${qt_qpa_platform} SDL_VIDEODRIVER=wayland WAYLAND_DISPLAY=${wayland_display} dbus-run-session -- ${launcher}
-sudo killall ${bindir}${miral_server}
+sudo killall ${bindir}${miral_server} || sudo killall ${bindir}${miral_server}.bin
 

--- a/tools/mir-smoke-test-runner.sh
+++ b/tools/mir-smoke-test-runner.sh
@@ -5,18 +5,18 @@ date --utc --iso-8601=seconds | xargs echo "[timestamp] Start time :"
 
 mir_rc=0
 timeout=3
+wayland_display="mir-smoke-test"
+options="--wayland-socket-name=${wayland_display} --test-timeout=${timeout}"
 
 if [ -v MIR_SOCKET ]
 then
   if [ ! -e "${MIR_SOCKET}" ]
   then
-    echo "Error: Host endpoint '${MIR_SOCKET}' does not exists"; exit 1
+    echo "Error: Host endpoint '${MIR_SOCKET}' does not exist"; exit 1
   fi
-  export MIR_SERVER_HOST_SOCKET=${MIR_SOCKET}
+  options="${options} --host-socket ${MIR_SOCKET}"
 fi
 
-export WAYLAND_DISPLAY=mir-smoke-test
-export MIR_SERVER_WAYLAND_SOCKET_NAME=${WAYLAND_DISPLAY}
 root="$( dirname "${BASH_SOURCE[0]}" )"
 
 client_list=`find ${root} -name mir_demo_client_* | grep -v bin$ | sed s?${root}/??`
@@ -27,8 +27,8 @@ echo "I: client_list=" ${client_list}
 for client in ${client_list}; do
     echo running client ${client}
     date --utc --iso-8601=seconds | xargs echo "[timestamp] Start :" ${client}
-    echo ${root}/mir_demo_server --test-timeout=${timeout} --test-client ${root}/${client}
-    if   ${root}/mir_demo_server --test-timeout=${timeout} --test-client ${root}/${client}
+    echo WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client ${root}/${client}
+    if   WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client ${root}/${client}
     then
       echo "I: [PASSED]" ${root}/${client}
     else

--- a/tools/mir-smoke-test-runner.sh
+++ b/tools/mir-smoke-test-runner.sh
@@ -5,9 +5,18 @@ date --utc --iso-8601=seconds | xargs echo "[timestamp] Start time :"
 
 mir_rc=0
 timeout=3
-WAYLAND_DESKTOP=mir-smoke-test
-MIR_SERVER_WAYLAND_SOCKET=${WAYLAND_DESKTOP}
 
+if [ -v MIR_SOCKET ]
+then
+  if [ ! -e "${MIR_SOCKET}" ]
+  then
+    echo "Error: Host endpoint '${MIR_SOCKET}' does not exists"; exit 1
+  fi
+  export MIR_SERVER_HOST_SOCKET=${MIR_SOCKET}
+fi
+
+export WAYLAND_DISPLAY=mir-smoke-test
+export MIR_SERVER_WAYLAND_SOCKET_NAME=${WAYLAND_DISPLAY}
 root="$( dirname "${BASH_SOURCE[0]}" )"
 
 client_list=`find ${root} -name mir_demo_client_* | grep -v bin$ | sed s?${root}/??`


### PR DESCRIPTION
Specify WAYLAND_DISPLAY to avoid clashing with desktop. If available, use $MIR_SOCKET as host socket.