### PR TITLE
Wayland check SessionAuthorizer::connection_is_allowed on client connection

### DIFF
--- a/src/server/frontend/wayland/wayland_connector.h
+++ b/src/server/frontend/wayland/wayland_connector.h
@@ -49,6 +49,7 @@ class OutputManager;
 
 class Shell;
 class DisplayChanger;
+class SessionAuthorizer;
 
 class WaylandConnector : public Connector
 {
@@ -59,6 +60,7 @@ public:
         DisplayChanger& display_config,
         std::shared_ptr<input::InputDeviceHub> const& input_hub,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
+        std::shared_ptr<SessionAuthorizer> const& session_authorizer,
         bool arw_socket);
 
     ~WaylandConnector() override;

--- a/src/server/frontend/wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend/wayland/wayland_default_configuration.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<mf::Connector>
                 *the_frontend_display_changer(),
                 the_input_device_hub(),
                 the_buffer_allocator(),
+                the_session_authorizer(),
                 arw_socket);
         });
 }
-


### PR DESCRIPTION
Wayland check SessionAuthorizer::connection_is_allowed on client connection, this is needed for unity8 to accept wayland applications. 