### PR TITLE
no-more-qtubuntu

### DIFF
--- a/doc/getting_and_using_mir.md
+++ b/doc/getting_and_using_mir.md
@@ -27,8 +27,8 @@ To remove the PPA from your system:
 
 You can install the Mir examples along with the Mir graphics drivers as follows:
 
-    $ sudo apt install mir-demos qterminal
-    $ sudo apt install mir-graphics-drivers-desktop qtubuntu-desktop
+    $ sudo apt install mir-demos qterminal qtwayland5
+    $ sudo apt install mir-graphics-drivers-desktop
 
 ## Getting Mir examples on Fedora
 

--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -45,20 +45,12 @@ if [ "${bindir}" != "" ]; then bindir="${bindir}/"; fi
 if [ -e "${socket}" ]; then echo "Error: session endpoint '${socket}' already exists"; exit 1 ;fi
 if [ -e "${XDG_RUNTIME_DIR}/${wayland_display}" ]; then echo "Error: wayland endpoint '${wayland_display}' already exists"; exit 1 ;fi
 
-qt_qpa_platform=ubuntumirclient
-qtubuntu_desktop_installed=$(apt list qtubuntu-desktop 2>/dev/null | grep installed | wc -l)
-if [ "${qtubuntu_desktop_installed}" == "0" ]
-then
-    echo "** Warning ** defaulting to Wayland backend for Qt"
-    echo "For the best experience install qtubuntu-desktop - run \"sudo apt install qtubuntu-desktop\""
-    qt_qpa_platform=wayland
-fi
 
 sh -c "${bindir}${miral_server} $* ${hostsocket} --file ${socket} --wayland-socket-name ${wayland_display} --desktop_file_hint=miral-shell.desktop"&
 
 while [ ! -e "${socket}" ]; do echo "waiting for ${socket}"; sleep 1 ;done
 
 unset QT_QPA_PLATFORMTHEME
-MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=mir QT_QPA_PLATFORM=${qt_qpa_platform} SDL_VIDEODRIVER=wayland WAYLAND_DISPLAY=${wayland_display} dbus-run-session -- ${launcher}
+MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=mir QT_QPA_PLATFORM=wayland SDL_VIDEODRIVER=wayland WAYLAND_DISPLAY=${wayland_display} dbus-run-session -- ${launcher}
 killall ${bindir}${miral_server} || killall ${bindir}${miral_server}.bin
 

--- a/examples/miral-shell/miral-desktop.sh
+++ b/examples/miral-shell/miral-desktop.sh
@@ -37,15 +37,6 @@ if [ "${bindir}" != "" ]; then bindir="${bindir}/"; fi
 if [ -e "${socket}" ]; then echo "Error: session endpoint '${socket}' already exists"; exit 1 ;fi
 if [ -e "${XDG_RUNTIME_DIR}/${wayland_display}" ]; then echo "Error: wayland endpoint '${wayland_display}' already exists"; exit 1 ;fi
 
-qt_qpa_platform=ubuntumirclient
-qtubuntu_desktop_installed=$(apt list qtubuntu-desktop 2>/dev/null | grep installed | wc -l)
-if [ "${qtubuntu_desktop_installed}" == "0" ]
-then
-    echo "** Warning ** defaulting to Wayland backend for Qt"
-    echo "For the best experience install qtubuntu-desktop - run \"sudo apt install qtubuntu-desktop\""
-    qt_qpa_platform=wayland
-fi
-
 vt_login_session=$(who -u | grep tty${vt} | grep ${USER} | wc -l)
 if [ "${vt_login_session}" == "0" ]; then echo "Error: please log into tty${vt} first"; exit 1 ;fi
 
@@ -56,6 +47,6 @@ sudo sh -c "LD_LIBRARY_PATH=${LD_LIBRARY_PATH} XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR
 while [ ! -e "${socket}" ]; do echo "waiting for ${socket}"; sleep 1 ;done
 
 unset QT_QPA_PLATFORMTHEME
-MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=mir QT_QPA_PLATFORM=${qt_qpa_platform} SDL_VIDEODRIVER=wayland WAYLAND_DISPLAY=${wayland_display} dbus-run-session -- ${launcher}
+MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=mir QT_QPA_PLATFORM=wayland SDL_VIDEODRIVER=wayland WAYLAND_DISPLAY=${wayland_display} dbus-run-session -- ${launcher}
 sudo killall ${bindir}${miral_server} || sudo killall ${bindir}${miral_server}.bin
 

--- a/examples/miral-shell/miral-run.sh
+++ b/examples/miral-shell/miral-run.sh
@@ -28,14 +28,4 @@ then extras='--app-id com.canonical.miral.Terminal'
 fi
 unset QT_QPA_PLATFORMTHEME
 
-qt_qpa_platform=ubuntumirclient
-qtubuntu_desktop_installed=$(apt list qtubuntu-desktop
- 2>/dev/null | grep installed | wc -l)
-if [ "${qtubuntu_desktop_installed}" == "0" ]
-then
-    echo "** Warning ** defaulting to Wayland backend for Qt"
-    echo "For the best experience install qtubuntu-desktop - run \"sudo apt install qtubuntu-desktop\""
-    qt_qpa_platform=wayland
-fi
-
-MIR_SOCKET=${mir_socket} WAYLAND_DISPLAY=${wayland_socket} XDG_SESSION_TYPE=mir GDK_BACKEND=mir QT_QPA_PLATFORM=${qt_qpa_platform} SDL_VIDEODRIVER=wayland "$@" ${extras}&
+MIR_SOCKET=${mir_socket} WAYLAND_DISPLAY=${wayland_socket} XDG_SESSION_TYPE=mir GDK_BACKEND=mir QT_QPA_PLATFORM=wayland SDL_VIDEODRIVER=wayland "$@" ${extras}&

--- a/src/miral/runner.cpp
+++ b/src/miral/runner.cpp
@@ -101,7 +101,7 @@ void launch_startup_app(std::string socket_file, std::string app)
 
         setenv("MIR_SOCKET", socket_file.c_str(),  true);   // configure Mir socket
         setenv("GDK_BACKEND", "mir", true);                 // configure GTK to use Mir
-        setenv("QT_QPA_PLATFORM", "ubuntumirclient", true); // configure Qt to use Mir
+        setenv("QT_QPA_PLATFORM", "wayland", true);         // configure Qt to use Mir
         unsetenv("QT_QPA_PLATFORMTHEME");                   // Discourage Qt from unsupported theme
         setenv("SDL_VIDEODRIVER", "wayland", true);         // configure SDL to use Wayland
 

--- a/src/utils/run.cpp
+++ b/src/utils/run.cpp
@@ -83,7 +83,7 @@ try
 
     unsetenv("DISPLAY");                                // Discourage toolkits from using X11
     setenv("GDK_BACKEND", "mir", true);                 // configure GTK to use Mir
-    setenv("QT_QPA_PLATFORM", "ubuntumirclient", true); // configure Qt to use Mir
+    setenv("QT_QPA_PLATFORM", "wayland", true);         // configure Qt to use Mir
     unsetenv("QT_QPA_PLATFORMTHEME");                   // Discourage Qt from unsupported theme
     setenv("SDL_VIDEODRIVER", "wayland", true);         // configure SDL to use Wayland
 


### PR DESCRIPTION
Stop using qtubuntu when launching Qt applications and use wayland instead. (Plus fix some resulting issues seen on Fedora 27 and Artful)