### PR TITLE
more-wayland-core-fixes

### DIFF
--- a/examples/miral-shell/miral-desktop.sh
+++ b/examples/miral-shell/miral-desktop.sh
@@ -40,9 +40,8 @@ if [ -e "${XDG_RUNTIME_DIR}/${wayland_display}" ]; then echo "Error: wayland end
 vt_login_session=$(who -u | grep tty${vt} | grep ${USER} | wc -l)
 if [ "${vt_login_session}" == "0" ]; then echo "Error: please log into tty${vt} first"; exit 1 ;fi
 
-sudo ls >> /dev/null
 oldvt=$(sudo fgconsole)
-sudo sh -c "LD_LIBRARY_PATH=${LD_LIBRARY_PATH} XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR} ${bindir}${miral_server} --wayland-socket-name ${wayland_display} --vt ${vt} --arw-file --file ${socket} $*; chvt ${oldvt}"&
+sudo --background --preserve-env sh -c "${bindir}${miral_server} --wayland-socket-name ${wayland_display} --vt ${vt} --arw-file --file ${socket} $*; chvt ${oldvt}"
 
 while [ ! -e "${socket}" ]; do echo "waiting for ${socket}"; sleep 1 ;done
 

--- a/src/server/frontend/wayland/CMakeLists.txt
+++ b/src/server/frontend/wayland/CMakeLists.txt
@@ -3,8 +3,8 @@ set(
 
   core_generated_interfaces.h
   wayland_default_configuration.cpp
-  wayland_connector.cpp
-)
+  wayland_connector.cpp wayland_connector.h
+  wlshmbuffer.cpp       wlshmbuffer.h)
 
 add_library(
   mirfrontend-wayland OBJECT

--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -64,7 +64,6 @@
 #include <xkbcommon/xkbcommon.h>
 #include <linux/input.h>
 #include <algorithm>
-#include <iostream>
 #include <mir/log.h>
 #include <cstring>
 #include <deque>
@@ -77,6 +76,7 @@
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include "mir/anonymous_shm_file.h"
+#include "wlshmbuffer.h"
 
 namespace mf = mir::frontend;
 namespace mg = mir::graphics;
@@ -117,57 +117,6 @@ private:
 
 namespace
 {
-bool get_gl_pixel_format(
-    MirPixelFormat mir_format,
-    GLenum& gl_format,
-    GLenum& gl_type)
-{
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-    GLenum const argb = GL_BGRA_EXT;
-    GLenum const abgr = GL_RGBA;
-#elif __BYTE_ORDER == __BIG_ENDIAN
-    // TODO: Big endian support
-GLenum const argb = GL_INVALID_ENUM;
-GLenum const abgr = GL_INVALID_ENUM;
-//GLenum const rgba = GL_RGBA;
-//GLenum const bgra = GL_BGRA_EXT;
-#endif
-
-    static const struct
-    {
-        MirPixelFormat mir_format;
-        GLenum gl_format, gl_type;
-    } mapping[mir_pixel_formats] =
-        {
-            {mir_pixel_format_invalid,   GL_INVALID_ENUM, GL_INVALID_ENUM},
-            {mir_pixel_format_abgr_8888, abgr,            GL_UNSIGNED_BYTE},
-            {mir_pixel_format_xbgr_8888, abgr,            GL_UNSIGNED_BYTE},
-            {mir_pixel_format_argb_8888, argb,            GL_UNSIGNED_BYTE},
-            {mir_pixel_format_xrgb_8888, argb,            GL_UNSIGNED_BYTE},
-            {mir_pixel_format_bgr_888,   GL_INVALID_ENUM, GL_INVALID_ENUM},
-            {mir_pixel_format_rgb_888,   GL_RGB,          GL_UNSIGNED_BYTE},
-            {mir_pixel_format_rgb_565,   GL_RGB,          GL_UNSIGNED_SHORT_5_6_5},
-            {mir_pixel_format_rgba_5551, GL_RGBA,         GL_UNSIGNED_SHORT_5_5_5_1},
-            {mir_pixel_format_rgba_4444, GL_RGBA,         GL_UNSIGNED_SHORT_4_4_4_4},
-        };
-
-    if (mir_format > mir_pixel_format_invalid &&
-        mir_format < mir_pixel_formats &&
-        mapping[mir_format].mir_format == mir_format) // just a sanity check
-    {
-        gl_format = mapping[mir_format].gl_format;
-        gl_type = mapping[mir_format].gl_type;
-    }
-    else
-    {
-        gl_format = GL_INVALID_ENUM;
-        gl_type = GL_INVALID_ENUM;
-    }
-
-    return gl_format != GL_INVALID_ENUM && gl_type != GL_INVALID_ENUM;
-}
-
-
 struct ClientPrivate
 {
     ClientPrivate(std::shared_ptr<mf::Session> const& session, mf::Shell& shell)
@@ -310,44 +259,6 @@ std::shared_ptr<mf::BufferStream> create_buffer_stream(mf::Session& session)
     return session.get_buffer_stream(id);
 }
 */
-MirPixelFormat wl_format_to_mir_format(uint32_t format)
-{
-    switch (format)
-    {
-        case WL_SHM_FORMAT_ARGB8888:
-            return mir_pixel_format_argb_8888;
-        case WL_SHM_FORMAT_XRGB8888:
-            return mir_pixel_format_xrgb_8888;
-        case WL_SHM_FORMAT_RGBA4444:
-            return mir_pixel_format_rgba_4444;
-        case WL_SHM_FORMAT_RGBA5551:
-            return mir_pixel_format_rgba_5551;
-        case WL_SHM_FORMAT_RGB565:
-            return mir_pixel_format_rgb_565;
-        case WL_SHM_FORMAT_RGB888:
-            return mir_pixel_format_rgb_888;
-        case WL_SHM_FORMAT_BGR888:
-            return mir_pixel_format_bgr_888;
-        case WL_SHM_FORMAT_XBGR8888:
-            return mir_pixel_format_xbgr_8888;
-        case WL_SHM_FORMAT_ABGR8888:
-            return mir_pixel_format_abgr_8888;
-        default:
-            return mir_pixel_format_invalid;
-    }
-}
-
-wl_shm_buffer* shm_buffer_from_resource_checked(wl_resource* resource)
-{
-    auto const buffer = wl_shm_buffer_get(resource);
-    if (!buffer)
-    {
-        BOOST_THROW_EXCEPTION((std::logic_error{"Tried to create WlShmBuffer from non-shm resource"}));
-    }
-
-    return buffer;
-}
-
 template<typename Callable>
 auto run_unless(std::shared_ptr<bool> const& condition, Callable&& callable)
 {
@@ -361,223 +272,6 @@ auto run_unless(std::shared_ptr<bool> const& condition, Callable&& callable)
         };
 }
 }
-
-class WlShmBuffer :
-    public mg::BufferBasic,
-    public mg::NativeBufferBase,
-    public mir::renderer::gl::TextureSource,
-    public mir::renderer::software::PixelSource
-{
-public:
-    ~WlShmBuffer()
-    {
-        std::lock_guard<std::mutex> lock{*buffer_mutex};
-        if (buffer)
-        {
-            wl_resource_queue_event(resource, WL_BUFFER_RELEASE);
-        }
-    }
-
-    static std::shared_ptr<graphics::Buffer> mir_buffer_from_wl_buffer(
-        wl_resource* buffer,
-        std::function<void()>&& on_consumed)
-    {
-        std::shared_ptr<WlShmBuffer> mir_buffer;
-        DestructionShim* shim;
-
-        if (auto notifier = wl_resource_get_destroy_listener(buffer, &on_buffer_destroyed))
-        {
-            // We've already constructed a shim for this buffer, update it.
-            shim = wl_container_of(notifier, shim, destruction_listener);
-
-            if (!(mir_buffer = shim->associated_buffer.lock()))
-            {
-                /*
-                 * We've seen this wl_buffer before, but all the WlShmBuffers associated with it
-                 * have been destroyed.
-                 *
-                 * Recreate a new WlShmBuffer to track the new compositor lifetime.
-                 */
-                mir_buffer = std::shared_ptr<WlShmBuffer>{new WlShmBuffer{buffer, std::move(on_consumed)}};
-                shim->associated_buffer = mir_buffer;
-            }
-        }
-        else
-        {
-            mir_buffer = std::shared_ptr<WlShmBuffer>{new WlShmBuffer{buffer, std::move(on_consumed)}};
-            shim = new DestructionShim;
-            shim->destruction_listener.notify = &on_buffer_destroyed;
-            shim->associated_buffer = mir_buffer;
-
-            wl_resource_add_destroy_listener(buffer, &shim->destruction_listener);
-        }
-
-        mir_buffer->buffer_mutex = shim->mutex;
-        return mir_buffer;
-    }
-
-    std::shared_ptr<graphics::NativeBuffer> native_buffer_handle() const override
-    {
-        return nullptr;
-    }
-
-    geometry::Size size() const override
-    {
-        return size_;
-    }
-
-    MirPixelFormat pixel_format() const override
-    {
-        return format_;
-    }
-
-    graphics::NativeBufferBase *native_buffer_base() override
-    {
-        return this;
-    }
-
-    void gl_bind_to_texture() override
-    {
-        GLenum format, type;
-
-        if (get_gl_pixel_format(
-            format_,
-            format,
-            type))
-        {
-            /*
-             * All existing Mir logic assumes that strides are whole multiples of
-             * pixels. And OpenGL defaults to expecting strides are multiples of
-             * 4 bytes. These assumptions used to be compatible when we only had
-             * 4-byte pixels but now we support 2/3-byte pixels we need to be more
-             * careful...
-             */
-            glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-
-            read(
-               [this, format, type](unsigned char const* pixels)
-               {
-                   auto const size = this->size();
-                   glTexImage2D(GL_TEXTURE_2D, 0, format,
-                                size.width.as_int(), size.height.as_int(),
-                                0, format, type, pixels);
-               });
-        }
-    }
-
-    void bind() override
-    {
-        gl_bind_to_texture();
-    }
-
-    void secure_for_render() override
-    {
-    }
-
-    void write(unsigned char const *pixels, size_t size) override
-    {
-        std::lock_guard<std::mutex> lock{*buffer_mutex};
-        wl_shm_buffer_begin_access(buffer);
-        auto data = wl_shm_buffer_get_data(buffer);
-        ::memcpy(data, pixels, size);
-        wl_shm_buffer_end_access(buffer);
-    }
-
-    void read(std::function<void(unsigned char const *)> const &do_with_pixels) override
-    {
-        std::lock_guard<std::mutex> lock{*buffer_mutex};
-        if (!buffer)
-        {
-            mir::log_warning("Attempt to read from WlShmBuffer after the wl_buffer has been destroyed");
-            return;
-        }
-
-        if (!consumed)
-        {
-            on_consumed();
-            consumed = true;
-        }
-
-        do_with_pixels(static_cast<unsigned char const*>(data.get()));
-    }
-
-    geometry::Stride stride() const override
-    {
-        return stride_;
-    }
-
-private:
-    WlShmBuffer(
-        wl_resource* buffer,
-        std::function<void()>&& on_consumed)
-        : buffer{shm_buffer_from_resource_checked(buffer)},
-          resource{buffer},
-          size_{wl_shm_buffer_get_width(this->buffer), wl_shm_buffer_get_height(this->buffer)},
-          stride_{wl_shm_buffer_get_stride(this->buffer)},
-          format_{wl_format_to_mir_format(wl_shm_buffer_get_format(this->buffer))},
-          data{std::make_unique<uint8_t[]>(size_.height.as_int() * stride_.as_int())},
-          consumed{false},
-          on_consumed{std::move(on_consumed)}
-    {
-        if (stride_.as_int() < size_.width.as_int() * MIR_BYTES_PER_PIXEL(format_))
-        {
-            wl_resource_post_error(
-                resource,
-                WL_SHM_ERROR_INVALID_STRIDE,
-                "Stride (%u) is less than width × bytes per pixel (%u×%u). "
-                "Did you accidentally specify stride in pixels?",
-                stride_.as_int(), size_.width.as_int(), MIR_BYTES_PER_PIXEL(format_));
-
-            BOOST_THROW_EXCEPTION((
-                std::runtime_error{"Buffer has invalid stride"}));
-        }
-
-        wl_shm_buffer_begin_access(this->buffer);
-        std::memcpy(data.get(), wl_shm_buffer_get_data(this->buffer), size_.height.as_int() * stride_.as_int());
-        wl_shm_buffer_end_access(this->buffer);
-    }
-
-    static void on_buffer_destroyed(wl_listener* listener, void*)
-    {
-        static_assert(
-            std::is_standard_layout<DestructionShim>::value,
-            "DestructionShim must be Standard Layout for wl_container_of to be defined behaviour");
-
-        DestructionShim* shim;
-        shim = wl_container_of(listener, shim, destruction_listener);
-
-        {
-            std::lock_guard<std::mutex> lock{*shim->mutex};
-            if (auto mir_buffer = shim->associated_buffer.lock())
-            {
-                mir_buffer->buffer = nullptr;
-            }
-        }
-
-        delete shim;
-    }
-
-    struct DestructionShim
-    {
-        std::shared_ptr<std::mutex> const mutex = std::make_shared<std::mutex>();
-        std::weak_ptr<WlShmBuffer> associated_buffer;
-        wl_listener destruction_listener;
-    };
-
-    std::shared_ptr<std::mutex> buffer_mutex;
-
-    wl_shm_buffer* buffer;
-    wl_resource* const resource;
-
-    geom::Size const size_;
-    geom::Stride const stride_;
-    MirPixelFormat const format_;
-
-    std::unique_ptr<uint8_t[]> const data;
-
-    bool consumed;
-    std::function<void()> on_consumed;
-};
 
 struct WlMirWindow
 {

--- a/src/server/frontend/wayland/wlshmbuffer.cpp
+++ b/src/server/frontend/wayland/wlshmbuffer.cpp
@@ -1,0 +1,305 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by:
+ *   Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ *   Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "wlshmbuffer.h"
+
+#include <mir/log.h>
+
+#include <wayland-server-protocol.h>
+
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+
+#include <boost/throw_exception.hpp>
+
+#include <cstring>
+
+namespace
+{
+wl_shm_buffer* shm_buffer_from_resource_checked(wl_resource* resource)
+{
+    auto const buffer = wl_shm_buffer_get(resource);
+    if (!buffer)
+    {
+        BOOST_THROW_EXCEPTION((std::logic_error{"Tried to create WlShmBuffer from non-shm resource"}));
+    }
+
+    return buffer;
+}
+
+MirPixelFormat wl_format_to_mir_format(uint32_t format)
+{
+    switch (format)
+    {
+        case WL_SHM_FORMAT_ARGB8888:
+            return mir_pixel_format_argb_8888;
+        case WL_SHM_FORMAT_XRGB8888:
+            return mir_pixel_format_xrgb_8888;
+        case WL_SHM_FORMAT_RGBA4444:
+            return mir_pixel_format_rgba_4444;
+        case WL_SHM_FORMAT_RGBA5551:
+            return mir_pixel_format_rgba_5551;
+        case WL_SHM_FORMAT_RGB565:
+            return mir_pixel_format_rgb_565;
+        case WL_SHM_FORMAT_RGB888:
+            return mir_pixel_format_rgb_888;
+        case WL_SHM_FORMAT_BGR888:
+            return mir_pixel_format_bgr_888;
+        case WL_SHM_FORMAT_XBGR8888:
+            return mir_pixel_format_xbgr_8888;
+        case WL_SHM_FORMAT_ABGR8888:
+            return mir_pixel_format_abgr_8888;
+        default:
+            return mir_pixel_format_invalid;
+    }
+}
+
+bool get_gl_pixel_format(
+    MirPixelFormat mir_format,
+    GLenum& gl_format,
+    GLenum& gl_type)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    GLenum const argb = GL_BGRA_EXT;
+    GLenum const abgr = GL_RGBA;
+#elif __BYTE_ORDER == __BIG_ENDIAN
+    // TODO: Big endian support
+GLenum const argb = GL_INVALID_ENUM;
+GLenum const abgr = GL_INVALID_ENUM;
+//GLenum const rgba = GL_RGBA;
+//GLenum const bgra = GL_BGRA_EXT;
+#endif
+
+    static const struct
+    {
+        MirPixelFormat mir_format;
+        GLenum gl_format, gl_type;
+    } mapping[mir_pixel_formats] =
+        {
+            {mir_pixel_format_invalid,   GL_INVALID_ENUM, GL_INVALID_ENUM},
+            {mir_pixel_format_abgr_8888, abgr,            GL_UNSIGNED_BYTE},
+            {mir_pixel_format_xbgr_8888, abgr,            GL_UNSIGNED_BYTE},
+            {mir_pixel_format_argb_8888, argb,            GL_UNSIGNED_BYTE},
+            {mir_pixel_format_xrgb_8888, argb,            GL_UNSIGNED_BYTE},
+            {mir_pixel_format_bgr_888,   GL_INVALID_ENUM, GL_INVALID_ENUM},
+            {mir_pixel_format_rgb_888,   GL_RGB,          GL_UNSIGNED_BYTE},
+            {mir_pixel_format_rgb_565,   GL_RGB,          GL_UNSIGNED_SHORT_5_6_5},
+            {mir_pixel_format_rgba_5551, GL_RGBA,         GL_UNSIGNED_SHORT_5_5_5_1},
+            {mir_pixel_format_rgba_4444, GL_RGBA,         GL_UNSIGNED_SHORT_4_4_4_4},
+        };
+
+    if (mir_format > mir_pixel_format_invalid &&
+        mir_format < mir_pixel_formats &&
+        mapping[mir_format].mir_format == mir_format) // just a sanity check
+    {
+        gl_format = mapping[mir_format].gl_format;
+        gl_type = mapping[mir_format].gl_type;
+    }
+    else
+    {
+        gl_format = GL_INVALID_ENUM;
+        gl_type = GL_INVALID_ENUM;
+    }
+
+    return gl_format != GL_INVALID_ENUM && gl_type != GL_INVALID_ENUM;
+}
+}
+
+namespace mf = mir::frontend;
+namespace mg = mir::graphics;
+using namespace mir::geometry;
+
+mf::WlShmBuffer::~WlShmBuffer()
+{
+    std::lock_guard <std::mutex> lock{*buffer_mutex};
+    if (buffer) {
+        wl_resource_queue_event(resource, WL_BUFFER_RELEASE);
+    }
+}
+
+std::shared_ptr<mg::Buffer> mf::WlShmBuffer::mir_buffer_from_wl_buffer(
+    wl_resource *buffer,
+    std::function<void()> &&on_consumed)
+{
+    std::shared_ptr <WlShmBuffer> mir_buffer;
+    DestructionShim *shim;
+
+    if (auto notifier = wl_resource_get_destroy_listener(buffer, &on_buffer_destroyed)) {
+        // We've already constructed a shim for this buffer, update it.
+        shim = wl_container_of(notifier, shim, destruction_listener);
+
+        if (!(mir_buffer = shim->associated_buffer.lock())) {
+            /*
+             * We've seen this wl_buffer before, but all the WlShmBuffers associated with it
+             * have been destroyed.
+             *
+             * Recreate a new WlShmBuffer to track the new compositor lifetime.
+             */
+            mir_buffer = std::shared_ptr < WlShmBuffer > {new WlShmBuffer{buffer, std::move(on_consumed)}};
+            shim->associated_buffer = mir_buffer;
+        }
+    } else {
+        mir_buffer = std::shared_ptr < WlShmBuffer > {new WlShmBuffer{buffer, std::move(on_consumed)}};
+        shim = new DestructionShim;
+        shim->destruction_listener.notify = &on_buffer_destroyed;
+        shim->associated_buffer = mir_buffer;
+
+        wl_resource_add_destroy_listener(buffer, &shim->destruction_listener);
+    }
+
+    mir_buffer->buffer_mutex = shim->mutex;
+    return mir_buffer;
+}
+
+std::shared_ptr <mg::NativeBuffer> mf::WlShmBuffer::native_buffer_handle() const
+{
+    return nullptr;
+}
+
+Size mf::WlShmBuffer::size() const
+{
+    return size_;
+}
+
+MirPixelFormat mf::WlShmBuffer::pixel_format() const
+{
+    return format_;
+}
+
+mg::NativeBufferBase* mf::WlShmBuffer::native_buffer_base()
+{
+    return this;
+}
+
+void mf::WlShmBuffer::gl_bind_to_texture()
+{
+    GLenum format, type;
+
+    if (get_gl_pixel_format(
+        format_,
+        format,
+        type)) {
+        /*
+         * All existing Mir logic assumes that strides are whole multiples of
+         * pixels. And OpenGL defaults to expecting strides are multiples of
+         * 4 bytes. These assumptions used to be compatible when we only had
+         * 4-byte pixels but now we support 2/3-byte pixels we need to be more
+         * careful...
+         */
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+        read(
+            [this, format, type](unsigned char const *pixels)
+            {
+                auto const size = this->size();
+                glTexImage2D(GL_TEXTURE_2D, 0, format,
+                             size.width.as_int(), size.height.as_int(),
+                             0, format, type, pixels);
+            });
+    }
+}
+
+void mf::WlShmBuffer::bind()
+{
+    gl_bind_to_texture();
+}
+
+void mf::WlShmBuffer::secure_for_render()
+{
+}
+
+void mf::WlShmBuffer::write(unsigned char const *pixels, size_t size)
+{
+    std::lock_guard <std::mutex> lock{*buffer_mutex};
+    wl_shm_buffer_begin_access(buffer);
+    auto data = wl_shm_buffer_get_data(buffer);
+    ::memcpy(data, pixels, size);
+    wl_shm_buffer_end_access(buffer);
+}
+
+void mf::WlShmBuffer::read(std::function<void(unsigned char const *)> const &do_with_pixels)
+{
+    std::lock_guard <std::mutex> lock{*buffer_mutex};
+    if (!buffer) {
+        log_warning("Attempt to read from WlShmBuffer after the wl_buffer has been destroyed");
+        return;
+    }
+
+    if (!consumed) {
+        on_consumed();
+        consumed = true;
+    }
+
+    do_with_pixels(static_cast<unsigned char const *>(data.get()));
+}
+
+Stride mf::WlShmBuffer::stride() const
+{
+    return stride_;
+}
+
+mf::WlShmBuffer::WlShmBuffer(
+    wl_resource *buffer,
+    std::function<void()> &&on_consumed)
+    :
+    buffer{shm_buffer_from_resource_checked(buffer)},
+    resource{buffer},
+    size_{wl_shm_buffer_get_width(this->buffer), wl_shm_buffer_get_height(this->buffer)},
+    stride_{wl_shm_buffer_get_stride(this->buffer)},
+    format_{wl_format_to_mir_format(wl_shm_buffer_get_format(this->buffer))},
+    data{std::make_unique<uint8_t[]>(size_.height.as_int() * stride_.as_int())},
+    consumed{false},
+    on_consumed{std::move(on_consumed)}
+{
+    if (stride_.as_int() < size_.width.as_int() * MIR_BYTES_PER_PIXEL(format_)) {
+        wl_resource_post_error(
+            resource,
+            WL_SHM_ERROR_INVALID_STRIDE,
+            "Stride (%u) is less than width × bytes per pixel (%u×%u). "
+                "Did you accidentally specify stride in pixels?",
+            stride_.as_int(), size_.width.as_int(), MIR_BYTES_PER_PIXEL(format_));
+
+        BOOST_THROW_EXCEPTION((
+                                  std::runtime_error{"Buffer has invalid stride"}));
+    }
+
+    wl_shm_buffer_begin_access(this->buffer);
+    std::memcpy(data.get(), wl_shm_buffer_get_data(this->buffer), size_.height.as_int() * stride_.as_int());
+    wl_shm_buffer_end_access(this->buffer);
+}
+
+void mf::WlShmBuffer::on_buffer_destroyed(wl_listener *listener, void *)
+{
+    static_assert(
+        std::is_standard_layout<DestructionShim>::value,
+        "DestructionShim must be Standard Layout for wl_container_of to be defined behaviour");
+
+    DestructionShim *shim;
+    shim = wl_container_of(listener, shim, destruction_listener);
+
+    {
+        std::lock_guard <std::mutex> lock{*shim->mutex};
+        if (auto mir_buffer = shim->associated_buffer.lock()) {
+            mir_buffer->buffer = nullptr;
+        }
+    }
+
+    delete shim;
+}

--- a/src/server/frontend/wayland/wlshmbuffer.h
+++ b/src/server/frontend/wayland/wlshmbuffer.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by:
+ *   Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef MIR_FRONTEND_WLSHMBUFFER_H_
+#define MIR_FRONTEND_WLSHMBUFFER_H_
+
+#include <mir/graphics/buffer_basic.h>
+#include <mir/renderer/gl/texture_source.h>
+#include <mir/renderer/sw/pixel_source.h>
+
+#include <wayland-server-core.h>
+
+#include <functional>
+#include <mutex>
+#include <string>
+
+namespace mir
+{
+namespace frontend
+{
+
+class WlShmBuffer :
+    public graphics::BufferBasic,
+    public graphics::NativeBufferBase,
+    public renderer::gl::TextureSource,
+    public renderer::software::PixelSource
+{
+public:
+    ~WlShmBuffer();
+
+    static std::shared_ptr <graphics::Buffer> mir_buffer_from_wl_buffer(
+        wl_resource *buffer,
+        std::function<void()> &&on_consumed);
+
+    std::shared_ptr <graphics::NativeBuffer> native_buffer_handle() const override;
+
+    geometry::Size size() const override;
+
+    MirPixelFormat pixel_format() const override;
+
+    graphics::NativeBufferBase *native_buffer_base() override;
+
+    void gl_bind_to_texture() override;
+
+    void bind() override;
+
+    void secure_for_render() override;
+
+    void write(unsigned char const *pixels, size_t size) override;
+
+    void read(std::function<void(unsigned char const *)> const &do_with_pixels) override;
+
+    geometry::Stride stride() const override;
+
+private:
+    WlShmBuffer(
+        wl_resource *buffer,
+        std::function<void()> &&on_consumed);
+
+    static void on_buffer_destroyed(wl_listener *listener, void *);
+
+    struct DestructionShim
+    {
+        std::shared_ptr <std::mutex> const mutex = std::make_shared<std::mutex>();
+        std::weak_ptr <WlShmBuffer> associated_buffer;
+        wl_listener destruction_listener;
+    };
+
+    std::shared_ptr <std::mutex> buffer_mutex;
+
+    wl_shm_buffer *buffer;
+    wl_resource *const resource;
+
+    geometry::Size const size_;
+    geometry::Stride const stride_;
+    MirPixelFormat const format_;
+
+    std::unique_ptr<uint8_t[]> const data;
+
+    bool consumed;
+    std::function<void()> on_consumed;
+};
+}
+}
+
+#endif


### PR DESCRIPTION
Fixes crash when events are targeted at a destroyed window.

Also includes some useful cherry-picks from the xdg-shell work.