### PR TITLE
mf::BufferStream: Don't pretend to be a scene::Surface.

### DIFF
--- a/include/server/mir/frontend/buffer_stream.h
+++ b/include/server/mir/frontend/buffer_stream.h
@@ -32,10 +32,6 @@ namespace graphics
 class Buffer;
 struct BufferProperties;
 }
-namespace scene
-{
-class SurfaceObserver;
-}
 
 namespace frontend
 {
@@ -48,9 +44,9 @@ public:
     virtual void submit_buffer(std::shared_ptr<graphics::Buffer> const& buffer) = 0;
     virtual void resize(geometry::Size const& size) = 0;
 
-    virtual void add_observer(std::shared_ptr<scene::SurfaceObserver> const& observer) = 0;
-    virtual void remove_observer(std::weak_ptr<scene::SurfaceObserver> const& observer) = 0;
-    
+    virtual void set_frame_posted_callback(
+        std::function<void(geometry::Size const&)> const& callback) = 0;
+
     virtual void with_most_recent_buffer_do(
         std::function<void(graphics::Buffer&)> const& exec) = 0;
 

--- a/src/server/compositor/stream.h
+++ b/src/server/compositor/stream.h
@@ -45,8 +45,8 @@ public:
     void submit_buffer(std::shared_ptr<graphics::Buffer> const& buffer) override;
     void with_most_recent_buffer_do(std::function<void(graphics::Buffer&)> const& exec) override;
     MirPixelFormat pixel_format() const override;
-    void add_observer(std::shared_ptr<scene::SurfaceObserver> const& observer) override;
-    void remove_observer(std::weak_ptr<scene::SurfaceObserver> const& observer) override;
+    void set_frame_posted_callback(
+        std::function<void(geometry::Size const&)> const& callback) override;
     std::shared_ptr<graphics::Buffer>
         lock_compositor_buffer(void const* user_id) override;
     geometry::Size stream_size() override;
@@ -70,7 +70,8 @@ private:
     MirPixelFormat pf;
     bool first_frame_posted;
 
-    scene::SurfaceObservers observers;
+    std::mutex callback_mutex;
+    std::function<void(geometry::Size const&)> frame_callback;
 };
 }
 }

--- a/src/server/frontend/CMakeLists.txt
+++ b/src/server/frontend/CMakeLists.txt
@@ -34,6 +34,7 @@ set(
   session_mediator_observer_multiplexer.cpp
   session_mediator_observer_multiplexer.h
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/frontend/shell.h
+  ${PROJECT_SOURCE_DIR}/include/server/mir/frontend/buffer_stream.h
 )
 
 add_subdirectory(wayland)

--- a/tests/include/mir/test/doubles/mock_buffer_stream.h
+++ b/tests/include/mir/test/doubles/mock_buffer_stream.h
@@ -59,8 +59,7 @@ struct MockBufferStream : public compositor::BufferStream
     MOCK_METHOD1(release_client_buffer, void(graphics::Buffer*));
     MOCK_METHOD1(lock_compositor_buffer,
                  std::shared_ptr<graphics::Buffer>(void const*));
-    MOCK_METHOD1(add_observer, void(std::shared_ptr<scene::SurfaceObserver> const&));
-    MOCK_METHOD1(remove_observer, void(std::weak_ptr<scene::SurfaceObserver> const&));
+    MOCK_METHOD1(set_frame_posted_callback, void(std::function<void(geometry::Size const&)> const&));
 
     MOCK_METHOD0(get_stream_pixel_format, MirPixelFormat());
     MOCK_METHOD0(stream_size, geometry::Size());

--- a/tests/include/mir/test/doubles/stub_buffer_stream.h
+++ b/tests/include/mir/test/doubles/stub_buffer_stream.h
@@ -76,8 +76,7 @@ public:
         fn(*stub_compositor_buffer);
     }
     MirPixelFormat pixel_format() const override { return mir_pixel_format_abgr_8888; }
-    void add_observer(std::shared_ptr<scene::SurfaceObserver> const&) override {}
-    void remove_observer(std::weak_ptr<scene::SurfaceObserver> const&) override {}
+    void set_frame_posted_callback(std::function<void(geometry::Size const&)> const&) override {}
     bool has_submitted_buffer() const override { return true; }
     void set_scale(float) override {}
 

--- a/tests/unit-tests/compositor/test_stream.cpp
+++ b/tests/unit-tests/compositor/test_stream.cpp
@@ -140,25 +140,24 @@ TEST_F(Stream, tracks_has_buffer)
     EXPECT_TRUE(stream.has_submitted_buffer());
 }
 
-TEST_F(Stream, calls_observers_after_scheduling_on_submissions)
+TEST_F(Stream, calls_frame_callback_after_scheduling_on_submissions)
 {
-    auto observer = std::make_shared<MockSurfaceObserver>();
-    EXPECT_CALL(*observer, frame_posted(1, initial_size));
-    stream.add_observer(observer);
+    int frame_count{0};
+    stream.set_frame_posted_callback([&frame_count](auto) { ++frame_count;});
     stream.submit_buffer(buffers[0]);
-    stream.remove_observer(observer);
+    stream.set_frame_posted_callback([](auto) {});
     stream.submit_buffer(buffers[0]);
+    EXPECT_THAT(frame_count, Eq(1));
 }
 
-TEST_F(Stream, calls_observers_call_doesnt_hold_lock)
+TEST_F(Stream, frame_callback_is_called_without_scheduling_lock)
 {
-    auto observer = std::make_shared<MockSurfaceObserver>();
-    EXPECT_CALL(*observer, frame_posted(1,_))
-        .WillOnce(InvokeWithoutArgs([&]{
+    stream.set_frame_posted_callback(
+        [this](auto)
+        {
             EXPECT_THAT(stream.buffers_ready_for_compositor(this), Eq(1));
             EXPECT_TRUE(stream.has_submitted_buffer());
-        }));
-    stream.add_observer(observer);
+        });
     stream.submit_buffer(buffers[0]);
 }
 
@@ -191,9 +190,7 @@ TEST_F(Stream, forces_a_new_buffer_when_told_to_drop_buffers)
 
 TEST_F(Stream, throws_on_nullptr_submissions)
 {
-    auto observer = std::make_shared<MockSurfaceObserver>();
-    EXPECT_CALL(*observer, frame_posted(_,_)).Times(0);
-    stream.add_observer(observer);
+    stream.set_frame_posted_callback([](auto) { FAIL() << "frame-posted should not be called on null buffer"; });
     EXPECT_THROW({
         stream.submit_buffer(nullptr);
     }, std::invalid_argument);

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -820,51 +820,44 @@ TEST_F(BasicSurfaceTest, can_set_streams_not_containing_originally_created_with_
     EXPECT_THAT(renderables.size(), Eq(2));
 }
 
-TEST_F(BasicSurfaceTest, stream_observers_are_added_and_removed_appropriately)
+TEST_F(BasicSurfaceTest, registers_frame_callbacks_on_construction)
 {
     using namespace testing;
 
-    surface.add_observer(observer);
+    auto buffer_stream0 = std::make_shared<NiceMock<mtd::MockBufferStream>>();
+    auto buffer_stream1 = std::make_shared<NiceMock<mtd::MockBufferStream>>();
+    std::list<ms::StreamInfo> streams = {
+        { buffer_stream0, {0,0}, {} },
+        { buffer_stream1, {0,0}, {} }
+    };
+
+    EXPECT_CALL(*buffer_stream0, set_frame_posted_callback(_));
+    EXPECT_CALL(*buffer_stream1, set_frame_posted_callback(_));
+
+    ms::BasicSurface child{
+        name,
+        geom::Rectangle{{0,0}, {100,100}},
+        std::weak_ptr<ms::Surface>{},
+        mir_pointer_unconfined,
+        streams,
+        std::shared_ptr<mg::CursorImage>(),
+        report};
+}
+
+TEST_F(BasicSurfaceTest, registers_frame_callbacks_on_set_streams)
+{
+    using namespace testing;
 
     auto buffer_stream0 = std::make_shared<NiceMock<mtd::MockBufferStream>>();
     auto buffer_stream1 = std::make_shared<NiceMock<mtd::MockBufferStream>>();
-
-
-    Sequence seq0;
-    EXPECT_CALL(*buffer_stream0, add_observer(_))
-        .InSequence(seq0);
-    EXPECT_CALL(*buffer_stream0, remove_observer(_))
-        .InSequence(seq0);
-    EXPECT_CALL(*buffer_stream0, add_observer(_))
-        .InSequence(seq0);
-    EXPECT_CALL(*buffer_stream0, remove_observer(_))
-        .InSequence(seq0);
-    EXPECT_CALL(*buffer_stream0, add_observer(_))
-        .InSequence(seq0);
-
-    Sequence seq1;
-    EXPECT_CALL(*buffer_stream1, add_observer(_))
-        .InSequence(seq1);
-    EXPECT_CALL(*buffer_stream1, remove_observer(_))
-        .InSequence(seq1);
-    EXPECT_CALL(*buffer_stream1, add_observer(_))
-        .InSequence(seq1);
-    EXPECT_CALL(*buffer_stream1, remove_observer(_))
-        .InSequence(seq1);
-
     std::list<ms::StreamInfo> streams = {
         { buffer_stream0, {0,0}, {} },
-        { buffer_stream1, {0,0}, {} },
+        { buffer_stream1, {0,0}, {} }
     };
-    surface.set_streams(streams);
 
-    streams = { { buffer_stream0, {0,0}, {} } };
-    surface.set_streams(streams);
+    EXPECT_CALL(*buffer_stream0, set_frame_posted_callback(_));
+    EXPECT_CALL(*buffer_stream1, set_frame_posted_callback(_));
 
-    streams = { { buffer_stream1, {0,0}, {} } };
-    surface.set_streams(streams);
-
-    streams = { { buffer_stream0, {0,0}, {} } };
     surface.set_streams(streams);
 }
 


### PR DESCRIPTION
mf::BufferStream::{add,remove}_observer(ms::SurfaceObserver) exists as an implementation detail
of BasicSurface, which needs to provide the SurfaceObserver::frame_posted observable.

Rather than pass the whole SurfaceObserver down to the BufferStream, just add a callback
to run on buffer submition to the BufferStream.

If need be this can be switched out to a full BufferStreamObserver, but it is not currently
needed.