### PR TITLE
Pass active surface through ms::SurfaceObserver

### DIFF
--- a/include/server/mir/scene/null_surface_observer.h
+++ b/include/server/mir/scene/null_surface_observer.h
@@ -31,23 +31,29 @@ public:
     NullSurfaceObserver() = default;
     virtual ~NullSurfaceObserver() = default;
 
-    void attrib_changed(MirWindowAttrib attrib, int value) override;
-    void resized_to(geometry::Size const& size) override;
-    void moved_to(geometry::Point const& top_left) override;
-    void hidden_set_to(bool hide) override;
-    void frame_posted(int frames_available, geometry::Size const& size) override;
-    void alpha_set_to(float alpha) override;
-    void orientation_set_to(MirOrientation orientation) override;
-    void transformation_set_to(glm::mat4 const& t) override;
-    void cursor_image_set_to(graphics::CursorImage const& image) override;
-    void reception_mode_set_to(input::InputReceptionMode mode) override;
-    void client_surface_close_requested() override;
-    void keymap_changed(MirInputDeviceId id, std::string const& model, std::string const& layout, std::string const& variant, std::string const& options) override;
-    void renamed(char const* name) override;
-    void cursor_image_removed() override;
-    void placed_relative(geometry::Rectangle const& placement) override;
-    void input_consumed(MirEvent const* event) override;
-    void start_drag_and_drop(std::vector<uint8_t> const& handle) override;
+    void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) override;
+    void resized_to(Surface const* surf, geometry::Size const& size) override;
+    void moved_to(Surface const* surf, geometry::Point const& top_left) override;
+    void hidden_set_to(Surface const* surf, bool hide) override;
+    void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) override;
+    void alpha_set_to(Surface const* surf, float alpha) override;
+    void orientation_set_to(Surface const* surf, MirOrientation orientation) override;
+    void transformation_set_to(Surface const* surf, glm::mat4 const& t) override;
+    void cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image) override;
+    void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) override;
+    void client_surface_close_requested(Surface const* surf) override;
+    void keymap_changed(
+        Surface const* surf,
+        MirInputDeviceId id,
+        std::string const& model,
+        std::string const& layout,
+        std::string const& variant,
+        std::string const& options) override;
+    void renamed(Surface const* surf, char const* name) override;
+    void cursor_image_removed(Surface const* surf) override;
+    void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
+    void input_consumed(Surface const* surf, MirEvent const* event) override;
+    void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
 
 protected:
     NullSurfaceObserver(NullSurfaceObserver const&) = delete;

--- a/include/server/mir/scene/surface_observer.h
+++ b/include/server/mir/scene/surface_observer.h
@@ -43,27 +43,34 @@ class CursorImage;
 
 namespace scene
 {
+class Surface;
+
 class SurfaceObserver
 {
 public:
-    virtual void attrib_changed(MirWindowAttrib attrib, int value) = 0;
-    virtual void resized_to(geometry::Size const& size) = 0;
-    virtual void moved_to(geometry::Point const& top_left) = 0;
-    virtual void hidden_set_to(bool hide) = 0;
-    virtual void frame_posted(int frames_available, geometry::Size const& size) = 0;
-    virtual void alpha_set_to(float alpha) = 0;
-    virtual void orientation_set_to(MirOrientation orientation) = 0;
-    virtual void transformation_set_to(glm::mat4 const& t) = 0;
-    virtual void reception_mode_set_to(input::InputReceptionMode mode) = 0;
-    virtual void cursor_image_set_to(graphics::CursorImage const& image) = 0;
-    virtual void client_surface_close_requested() = 0;
-    virtual void keymap_changed(MirInputDeviceId id, std::string const& model, std::string const& layout,
-                                std::string const& variant, std::string const& options) = 0;
-    virtual void renamed(char const* name) = 0;
-    virtual void cursor_image_removed() = 0;
-    virtual void placed_relative(geometry::Rectangle const& placement) = 0;
-    virtual void input_consumed(MirEvent const* event) = 0;
-    virtual void start_drag_and_drop(std::vector<uint8_t> const& handle) = 0;
+    virtual void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) = 0;
+    virtual void resized_to(Surface const* surf, geometry::Size const& size) = 0;
+    virtual void moved_to(Surface const* surf, geometry::Point const& top_left) = 0;
+    virtual void hidden_set_to(Surface const* surf, bool hide) = 0;
+    virtual void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) = 0;
+    virtual void alpha_set_to(Surface const* surf, float alpha) = 0;
+    virtual void orientation_set_to(Surface const* surf, MirOrientation orientation) = 0;
+    virtual void transformation_set_to(Surface const* surf, glm::mat4 const& t) = 0;
+    virtual void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) = 0;
+    virtual void cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image) = 0;
+    virtual void client_surface_close_requested(Surface const* surf) = 0;
+    virtual void keymap_changed(
+        Surface const* surf,
+        MirInputDeviceId id,
+        std::string const& model,
+        std::string const& layout,
+        std::string const& variant,
+        std::string const& options) = 0;
+    virtual void renamed(Surface const* surf, char const* name) = 0;
+    virtual void cursor_image_removed(Surface const* surf) = 0;
+    virtual void placed_relative(Surface const* surf, geometry::Rectangle const& placement) = 0;
+    virtual void input_consumed(Surface const* surf, MirEvent const* event) = 0;
+    virtual void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) = 0;
 
 protected:
     SurfaceObserver() = default;

--- a/include/server/mir/shell/surface_ready_observer.h
+++ b/include/server/mir/shell/surface_ready_observer.h
@@ -47,7 +47,7 @@ public:
     ~SurfaceReadyObserver();
 
 private:
-    void frame_posted(int, geometry::Size const&) override;
+    void frame_posted(scene::Surface const* surf, int, geometry::Size const&) override;
 
     ActivateFunction const activate;
     std::weak_ptr<scene::Session> const session;

--- a/src/include/server/mir/scene/surface_event_source.h
+++ b/src/include/server/mir/scene/surface_event_source.h
@@ -42,16 +42,21 @@ public:
         OutputPropertiesCache const& outputs,
         std::shared_ptr<frontend::EventSink> const& event_sink);
 
-    void attrib_changed(MirWindowAttrib attrib, int value) override;
-    void resized_to(geometry::Size const& size) override;
-    void moved_to(geometry::Point const& top_left) override;
-    void orientation_set_to(MirOrientation orientation) override;
-    void client_surface_close_requested() override;
-    void keymap_changed(MirInputDeviceId id, std::string const& model, std::string const& layout,
-                        std::string const& variant, std::string const& options) override;
-    void placed_relative(geometry::Rectangle const& placement) override;
-    void input_consumed(MirEvent const* event) override;
-    void start_drag_and_drop(std::vector<uint8_t> const& handle) override;
+    void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) override;
+    void resized_to(Surface const* surf, geometry::Size const& size) override;
+    void moved_to(Surface const* surf, geometry::Point const& top_left) override;
+    void orientation_set_to(Surface const* surf, MirOrientation orientation) override;
+    void client_surface_close_requested(Surface const* surf) override;
+    void keymap_changed(
+        Surface const* surf,
+        MirInputDeviceId id,
+        std::string const& model,
+        std::string const& layout,
+        std::string const& variant,
+        std::string const& options) override;
+    void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
+    void input_consumed(Surface const* surf, MirEvent const* event) override;
+    void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
 
 private:
     frontend::SurfaceId const id;

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -34,24 +34,29 @@ public:
     using BasicObservers<SurfaceObserver>::remove;
     using BasicObservers<SurfaceObserver>::for_each;
 
-    void attrib_changed(MirWindowAttrib attrib, int value) override;
-    void resized_to(geometry::Size const& size) override;
-    void moved_to(geometry::Point const& top_left) override;
-    void hidden_set_to(bool hide) override;
-    void frame_posted(int frames_available, geometry::Size const& size) override;
-    void alpha_set_to(float alpha) override;
-    void orientation_set_to(MirOrientation orientation) override;
-    void transformation_set_to(glm::mat4 const& t) override;
-    void reception_mode_set_to(input::InputReceptionMode mode) override;
-    void cursor_image_set_to(graphics::CursorImage const& image) override;
-    void client_surface_close_requested() override;
-    void keymap_changed(MirInputDeviceId id, std::string const& model, std::string const& layout,
-                        std::string const& variant, std::string const& options) override;
-    void renamed(char const*) override;
-    void cursor_image_removed() override;
-    void placed_relative(geometry::Rectangle const& placement) override;
-    void input_consumed(MirEvent const* event) override;
-    void start_drag_and_drop(std::vector<uint8_t> const& handle) override;
+    void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) override;
+    void resized_to(Surface const* surf, geometry::Size const& size) override;
+    void moved_to(Surface const* surf, geometry::Point const& top_left) override;
+    void hidden_set_to(Surface const* surf, bool hide) override;
+    void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) override;
+    void alpha_set_to(Surface const* surf, float alpha) override;
+    void orientation_set_to(Surface const* surf, MirOrientation orientation) override;
+    void transformation_set_to(Surface const* surf, glm::mat4 const& t) override;
+    void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) override;
+    void cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image) override;
+    void client_surface_close_requested(Surface const* surf) override;
+    void keymap_changed(
+        Surface const* surf,
+        MirInputDeviceId id,
+        std::string const& model,
+        std::string const& layout,
+        std::string const& variant,
+        std::string const& options) override;
+    void renamed(Surface const* surf, char const*) override;
+    void cursor_image_removed(Surface const* surf) override;
+    void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
+    void input_consumed(Surface const* surf, MirEvent const* event) override;
+    void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
 };
 
 }

--- a/src/server/input/cursor_controller.cpp
+++ b/src/server/input/cursor_controller.cpp
@@ -44,23 +44,23 @@ struct UpdateCursorOnSurfaceChanges : ms::NullSurfaceObserver
     {
     }
 
-    void attrib_changed(MirWindowAttrib, int) override
+    void attrib_changed(ms::Surface const*, MirWindowAttrib, int) override
     {
         // Attribute changing alone wont trigger a cursor update
     }
-    void resized_to(geom::Size const&) override
+    void resized_to(ms::Surface const*, geom::Size const&) override
     {
         cursor_controller->update_cursor_image();
     }
-    void moved_to(geom::Point const&) override
+    void moved_to(ms::Surface const*, geom::Point const&) override
     {
         cursor_controller->update_cursor_image();
     }
-    void hidden_set_to(bool) override
+    void hidden_set_to(ms::Surface const*, bool) override
     {
         cursor_controller->update_cursor_image();
     }
-    void frame_posted(int, geom::Size const&) override
+    void frame_posted(ms::Surface const*, int, geom::Size const&) override
     {
         // The first frame posted will trigger a cursor update, since it
         // changes the visibility status of the surface, and can thus affect
@@ -71,31 +71,31 @@ struct UpdateCursorOnSurfaceChanges : ms::NullSurfaceObserver
             cursor_controller->update_cursor_image();
         }
     }
-    void alpha_set_to(float) override
+    void alpha_set_to(ms::Surface const*, float) override
     {
         cursor_controller->update_cursor_image();
     }
-    void transformation_set_to(glm::mat4 const&) override
+    void transformation_set_to(ms::Surface const*, glm::mat4 const&) override
     {
         cursor_controller->update_cursor_image();
     }
-    void reception_mode_set_to(mi::InputReceptionMode) override
+    void reception_mode_set_to(ms::Surface const*, mi::InputReceptionMode) override
     {
         cursor_controller->update_cursor_image();
     }
-    void cursor_image_set_to(mg::CursorImage const&) override
+    void cursor_image_set_to(ms::Surface const*, const mir::graphics::CursorImage&) override
     {
         cursor_controller->update_cursor_image();
     }
-    void cursor_image_removed() override
+    void cursor_image_removed(ms::Surface const*) override
     {
         cursor_controller->update_cursor_image();
     }
-    void orientation_set_to(MirOrientation /* orientation */) override
+    void orientation_set_to(ms::Surface const*, MirOrientation) override
     {
         // No need to update cursor for orientation property change alone.
     }
-    void client_surface_close_requested() override
+    void client_surface_close_requested(ms::Surface const*) override
     {
         // No need to update cursor for client close requests
     }

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -89,56 +89,57 @@ private:
         {
         }
 
-        void attrib_changed(MirWindowAttrib /*attrib*/, int /*value*/) override
+        void attrib_changed(ms::Surface const*, MirWindowAttrib /*attrib*/, int /*value*/) override
         {
             // TODO: Do we need to listen to visibility events?
         }
 
-        void resized_to(mir::geometry::Size const& /*size*/) override
+        void resized_to(ms::Surface const*, mir::geometry::Size const& /*size*/) override
         {
             dispatch->on_surface_resized();
         }
 
-        void moved_to(mir::geometry::Point const& /*top_left*/) override
+        void moved_to(ms::Surface const*, mir::geometry::Point const& /*top_left*/) override
         {
             dispatch->on_surface_moved(this_surface);
         }
 
-        void hidden_set_to(bool /*hide*/) override
+        void hidden_set_to(ms::Surface const*, bool /*hide*/) override
         {
             // TODO: Do we need to listen to this?
         }
 
-        void frame_posted(int, mir::geometry::Size const&) override
+        void frame_posted(ms::Surface const*, int, mir::geometry::Size const&) override
         {
         }
 
-        void alpha_set_to(float) override
+        void alpha_set_to(ms::Surface const*, float) override
         {
         }
 
-        void orientation_set_to(MirOrientation) override
+        void orientation_set_to(ms::Surface const*, MirOrientation) override
         {
         }
 
-        void transformation_set_to(glm::mat4 const&) override
+        void transformation_set_to(ms::Surface const*, glm::mat4 const&) override
         {
             // TODO: Do we need to listen to this?
         }
 
-        void reception_mode_set_to(mir::input::InputReceptionMode) override
+        void reception_mode_set_to(ms::Surface const*, mir::input::InputReceptionMode) override
         {
         }
 
-        void cursor_image_set_to(mir::graphics::CursorImage const&) override
+        void cursor_image_set_to(ms::Surface const*, mir::graphics::CursorImage const&) override
         {
         }
 
-        void client_surface_close_requested() override
+        void client_surface_close_requested(ms::Surface const*) override
         {
         }
 
         void keymap_changed(
+                ms::Surface const*,
                 MirInputDeviceId,
                 std::string const&,
                 std::string const&,
@@ -147,23 +148,23 @@ private:
         {
         }
 
-        void renamed(char const*) override
+        void renamed(ms::Surface const*, char const*) override
         {
         }
 
-        void cursor_image_removed() override
+        void cursor_image_removed(ms::Surface const*) override
         {
         }
 
-        void placed_relative(mir::geometry::Rectangle const&) override
+        void placed_relative(ms::Surface const*, mir::geometry::Rectangle const&) override
         {
         }
 
-        void input_consumed(MirEvent const*) override
+        void input_consumed(ms::Surface const*, MirEvent const*) override
         {
         }
 
-        void start_drag_and_drop(std::vector<uint8_t> const&) override
+        void start_drag_and_drop(ms::Surface const*, std::vector<uint8_t> const&) override
         {
         }
 

--- a/src/server/scene/CMakeLists.txt
+++ b/src/server/scene/CMakeLists.txt
@@ -34,4 +34,5 @@ ADD_LIBRARY(
   output_properties_cache.cpp
   output_properties_cache.h
   application_not_responding_detector_wrapper.cpp
+  ${CMAKE_SOURCE_DIR}/include/server/mir/scene/surface_observer.h
 )

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -161,7 +161,7 @@ mf::SurfaceId ms::ApplicationSession::create_surface(
         default_content_map[id] = stream_id;
     }
 
-    observer->moved_to(surface->top_left());
+    observer->moved_to(surface.get(), surface->top_left());
 
     session_listener->surface_created(*this, surface);
     return id;

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -47,107 +47,110 @@ namespace mf = mir::frontend;
 namespace geom = mir::geometry;
 namespace mrs = mir::renderer::software;
 
-void ms::SurfaceObservers::attrib_changed(MirWindowAttrib attrib, int value)
+void ms::SurfaceObservers::attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->attrib_changed(attrib, value); });
+        { observer->attrib_changed(surf, attrib, value); });
 }
 
-void ms::SurfaceObservers::resized_to(geometry::Size const& size)
+void ms::SurfaceObservers::resized_to(Surface const* surf, geometry::Size const& size)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->resized_to(size); });
+        { observer->resized_to(surf, size); });
 }
 
-void ms::SurfaceObservers::moved_to(geometry::Point const& top_left)
+void ms::SurfaceObservers::moved_to(Surface const* surf, geometry::Point const& top_left)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->moved_to(top_left); });
+        { observer->moved_to(surf, top_left); });
 }
 
-void ms::SurfaceObservers::hidden_set_to(bool hide)
+void ms::SurfaceObservers::hidden_set_to(Surface const* surf, bool hide)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->hidden_set_to(hide); });
+        { observer->hidden_set_to(surf, hide); });
 }
 
-void ms::SurfaceObservers::frame_posted(int frames_available, geometry::Size const& size)
+void ms::SurfaceObservers::frame_posted(Surface const* surf, int frames_available, geometry::Size const& size)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->frame_posted(frames_available, size); });
+        { observer->frame_posted(surf, frames_available, size); });
 }
 
-void ms::SurfaceObservers::alpha_set_to(float alpha)
+void ms::SurfaceObservers::alpha_set_to(Surface const* surf, float alpha)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->alpha_set_to(alpha); });
+        { observer->alpha_set_to(surf, alpha); });
 }
 
-void ms::SurfaceObservers::orientation_set_to(MirOrientation orientation)
+void ms::SurfaceObservers::orientation_set_to(Surface const* surf, MirOrientation orientation)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->orientation_set_to(orientation); });
+        { observer->orientation_set_to(surf, orientation); });
 }
 
-void ms::SurfaceObservers::transformation_set_to(glm::mat4 const& t)
+void ms::SurfaceObservers::transformation_set_to(Surface const* surf, glm::mat4 const& t)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->transformation_set_to(t); });
+        { observer->transformation_set_to(surf, t); });
 }
 
-void ms::SurfaceObservers::cursor_image_set_to(mg::CursorImage const& image)
+void ms::SurfaceObservers::cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->cursor_image_set_to(image); });
+        { observer->cursor_image_set_to(surf, image); });
 }
 
-void ms::SurfaceObservers::reception_mode_set_to(mi::InputReceptionMode mode)
+void ms::SurfaceObservers::reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->reception_mode_set_to(mode); });
+        { observer->reception_mode_set_to(surf, mode); });
 }
 
-void ms::SurfaceObservers::client_surface_close_requested()
+void ms::SurfaceObservers::client_surface_close_requested(Surface const* surf)
 {
-    for_each([](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->client_surface_close_requested(); });
+    for_each([&surf](std::shared_ptr<SurfaceObserver> const& observer)
+        { observer->client_surface_close_requested(surf); });
 }
 
-void ms::SurfaceObservers::keymap_changed(MirInputDeviceId id, std::string const& model, std::string const& layout,
-                                          std::string const& variant, std::string const& options)
-{
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->keymap_changed(id, model, layout, variant, options); });
-}
-
-void ms::SurfaceObservers::renamed(char const* name)
-{
-    for_each([name](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->renamed(name); });
-}
-
-void ms::SurfaceObservers::cursor_image_removed()
-{
-    for_each([](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->cursor_image_removed(); });
-}
-
-void ms::SurfaceObservers::placed_relative(geometry::Rectangle const& placement)
+void ms::SurfaceObservers::keymap_changed(
+    Surface const* surf, MirInputDeviceId id, std::string const& model,
+    std::string const& layout,
+    std::string const& variant,
+    std::string const& options)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-                 { observer->placed_relative(placement); });
+        { observer->keymap_changed(surf, id, model, layout, variant, options); });
 }
 
-void ms::SurfaceObservers::input_consumed(MirEvent const* event)
+void ms::SurfaceObservers::renamed(Surface const* surf, char const* name)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-                 { observer->input_consumed(event); });
+    for_each([&surf, name](std::shared_ptr<SurfaceObserver> const& observer)
+        { observer->renamed(surf, name); });
 }
 
-void ms::SurfaceObservers::start_drag_and_drop(std::vector<uint8_t> const& handle)
+void ms::SurfaceObservers::cursor_image_removed(Surface const* surf)
+{
+    for_each([&surf](std::shared_ptr<SurfaceObserver> const& observer)
+        { observer->cursor_image_removed(surf); });
+}
+
+void ms::SurfaceObservers::placed_relative(Surface const* surf, geometry::Rectangle const& placement)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-                 { observer->start_drag_and_drop(handle); });
+                 { observer->placed_relative(surf, placement); });
+}
+
+void ms::SurfaceObservers::input_consumed(Surface const* surf, MirEvent const* event)
+{
+    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
+                 { observer->input_consumed(surf, event); });
+}
+
+void ms::SurfaceObservers::start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle)
+{
+    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
+                 { observer->start_drag_and_drop(surf, handle); });
 }
 
 
@@ -248,7 +251,7 @@ ms::BasicSurface::BasicSurface(
         layer.stream->set_frame_posted_callback(
             [this](auto const& size)
             {
-                observers.frame_posted(1, size);
+                observers.frame_posted(this, 1, size);
             });
     }
     report->surface_created(this, surface_name);
@@ -282,7 +285,7 @@ void ms::BasicSurface::move_to(geometry::Point const& top_left)
         std::unique_lock<std::mutex> lk(guard);
         surface_rect.top_left = top_left;
     }
-    observers.moved_to(top_left);
+    observers.moved_to(this, top_left);
 }
 
 void ms::BasicSurface::set_hidden(bool hide)
@@ -291,7 +294,7 @@ void ms::BasicSurface::set_hidden(bool hide)
         std::unique_lock<std::mutex> lk(guard);
         hidden = hide;
     }
-    observers.hidden_set_to(hide);
+    observers.hidden_set_to(this, hide);
 }
 
 mir::geometry::Size ms::BasicSurface::size() const
@@ -339,7 +342,7 @@ void ms::BasicSurface::resize(geom::Size const& desired_size)
         std::unique_lock<std::mutex> lock(guard);
         surface_rect.size = new_size;
     }
-    observers.resized_to(new_size);
+    observers.resized_to(this, new_size);
 }
 
 geom::Point ms::BasicSurface::top_left() const
@@ -386,12 +389,12 @@ void ms::BasicSurface::set_alpha(float alpha)
         std::unique_lock<std::mutex> lk(guard);
         surface_alpha = alpha;
     }
-    observers.alpha_set_to(alpha);
+    observers.alpha_set_to(this, alpha);
 }
 
 void ms::BasicSurface::set_orientation(MirOrientation orientation)
 {
-    observers.orientation_set_to(orientation);
+    observers.orientation_set_to(this, orientation);
 }
 
 void ms::BasicSurface::set_transformation(glm::mat4 const& t)
@@ -400,7 +403,7 @@ void ms::BasicSurface::set_transformation(glm::mat4 const& t)
         std::unique_lock<std::mutex> lk(guard);
         transformation_matrix = t;
     }
-    observers.transformation_set_to(t);
+    observers.transformation_set_to(this, t);
 }
 
 bool ms::BasicSurface::visible() const
@@ -428,7 +431,7 @@ void ms::BasicSurface::set_reception_mode(mi::InputReceptionMode mode)
         std::lock_guard<std::mutex> lk(guard);
         input_mode = mode;
     }
-    observers.reception_mode_set_to(mode);
+    observers.reception_mode_set_to(this, mode);
 }
 
 MirWindowType ms::BasicSurface::type() const
@@ -452,7 +455,7 @@ MirWindowType ms::BasicSurface::set_type(MirWindowType t)
         type_ = t;
         lg.unlock();
 
-        observers.attrib_changed(mir_window_attrib_type, type_);
+        observers.attrib_changed(this, mir_window_attrib_type, type_);
     }
 
     return t;
@@ -474,7 +477,7 @@ MirWindowState ms::BasicSurface::set_state(MirWindowState s)
     {
         state_ = s;
         lg.unlock();
-        observers.attrib_changed(mir_window_attrib_state, s);
+        observers.attrib_changed(this, mir_window_attrib_state, s);
     }
 
     return s;
@@ -496,7 +499,7 @@ int ms::BasicSurface::set_swap_interval(int interval)
             info.stream->allow_framedropping(allow_dropping);
 
         lg.unlock();
-        observers.attrib_changed(mir_window_attrib_swapinterval, interval);
+        observers.attrib_changed(this, mir_window_attrib_swapinterval, interval);
     }
 
     return interval;
@@ -516,7 +519,7 @@ MirWindowFocusState ms::BasicSurface::set_focus_state(MirWindowFocusState new_st
         focus_ = new_state;
 
         lg.unlock();
-        observers.attrib_changed(mir_window_attrib_focus, new_state);
+        observers.attrib_changed(this, mir_window_attrib_focus, new_state);
     }
 
     return new_state;
@@ -535,7 +538,7 @@ MirOrientationMode ms::BasicSurface::set_preferred_orientation(MirOrientationMod
         pref_orientation_mode = new_orientation_mode;
         lg.unlock();
 
-        observers.attrib_changed(mir_window_attrib_preferred_orientation, new_orientation_mode);
+        observers.attrib_changed(this, mir_window_attrib_preferred_orientation, new_orientation_mode);
     }
 
     return new_orientation_mode;
@@ -611,9 +614,9 @@ void ms::BasicSurface::set_cursor_image(std::shared_ptr<mg::CursorImage> const& 
     }
 
     if (image)
-        observers.cursor_image_set_to(*image);
+        observers.cursor_image_set_to(this, *image);
     else
-        observers.cursor_image_removed();
+        observers.cursor_image_removed(this);
 }
 
 std::shared_ptr<mg::CursorImage> ms::BasicSurface::cursor_image() const
@@ -677,7 +680,7 @@ void ms::BasicSurface::set_cursor_from_buffer(mg::Buffer& buffer, geom::Displace
         std::unique_lock<std::mutex> lock(guard);
         cursor_image_ = image;
     }
-    observers.cursor_image_set_to(*image);
+    observers.cursor_image_set_to(this, *image);
 }
 
 // In order to set the cursor image from a buffer stream, we use an adapter pattern,
@@ -695,7 +698,7 @@ void ms::BasicSurface::set_cursor_stream(std::shared_ptr<mf::BufferStream> const
 
 void ms::BasicSurface::request_client_surface_close()
 {
-    observers.client_surface_close_requested();
+    observers.client_surface_close_requested(this);
 }
 
 int ms::BasicSurface::dpi() const
@@ -716,7 +719,7 @@ int ms::BasicSurface::set_dpi(int new_dpi)
     {
         dpi_ = new_dpi;
         lg.unlock();
-        observers.attrib_changed(mir_window_attrib_dpi, new_dpi);
+        observers.attrib_changed(this, mir_window_attrib_dpi, new_dpi);
     }
 
     return new_dpi;
@@ -740,7 +743,7 @@ MirWindowVisibility ms::BasicSurface::set_visibility(MirWindowVisibility new_vis
             for (auto& info : layers)
                 info.stream->drop_old_buffers();
         }
-        observers.attrib_changed(mir_window_attrib_visibility, visibility_);
+        observers.attrib_changed(this, mir_window_attrib_visibility, visibility_);
     }
 
     return new_visibility;
@@ -839,13 +842,13 @@ int ms::BasicSurface::buffers_ready_for_compositor(void const* id) const
 
 void ms::BasicSurface::consume(MirEvent const* event)
 {
-    observers.input_consumed(event);
+    observers.input_consumed(this, event);
 }
 
 void ms::BasicSurface::set_keymap(MirInputDeviceId id, std::string const& model, std::string const& layout,
                                   std::string const& variant, std::string const& options)
 {
-    observers.keymap_changed(id, model, layout, variant, options);
+    observers.keymap_changed(this, id, model, layout, variant, options);
 }
 
 void ms::BasicSurface::rename(std::string const& title)
@@ -853,7 +856,7 @@ void ms::BasicSurface::rename(std::string const& title)
     if (surface_name != title)
     {
         surface_name = title;
-        observers.renamed(surface_name.c_str());
+        observers.renamed(this, surface_name.c_str());
     }
 }
 
@@ -870,10 +873,10 @@ void ms::BasicSurface::set_streams(std::list<scene::StreamInfo> const& s)
             layer.stream->set_frame_posted_callback(
                 [this](auto const& size)
                 {
-                    observers.frame_posted(1, size);
+                    observers.frame_posted(this, 1, size);
                 });
     }
-    observers.moved_to(surface_rect.top_left);
+    observers.moved_to(this, surface_rect.top_left);
 }
 
 mg::RenderableList ms::BasicSurface::generate_renderables(mc::CompositorID id) const
@@ -911,10 +914,10 @@ MirPointerConfinementState ms::BasicSurface::confine_pointer_state() const
 
 void ms::BasicSurface::placed_relative(geometry::Rectangle const& placement)
 {
-    observers.placed_relative(placement);
+    observers.placed_relative(this, placement);
 }
 
 void mir::scene::BasicSurface::start_drag_and_drop(std::vector<uint8_t> const& handle)
 {
-    observers.start_drag_and_drop(handle);
+    observers.start_drag_and_drop(this, handle);
 }

--- a/src/server/scene/legacy_scene_change_notification.cpp
+++ b/src/server/scene/legacy_scene_change_notification.cpp
@@ -57,8 +57,8 @@ public:
         std::function<void(int frames, mir::geometry::Rectangle const& damage)> const& damage_notify_change,
         ms::Surface* surface);
 
-    void moved_to(mir::geometry::Point const& /*top_left*/) override;
-    void frame_posted(int frames_available, mir::geometry::Size const& size) override;
+    void moved_to(ms::Surface const* surf, const mir::geometry::Point&) override;
+    void frame_posted(ms::Surface const* surf, int frames_available, const mir::geometry::Size& size) override;
 
 private:
     mir::geometry::Point top_left;
@@ -75,13 +75,13 @@ NonLegacySurfaceChangeNotification::NonLegacySurfaceChangeNotification(
     top_left = surface->top_left();
 }
 
-void NonLegacySurfaceChangeNotification::moved_to(mir::geometry::Point const& top_left)
+void NonLegacySurfaceChangeNotification::moved_to(ms::Surface const* surf, const mir::geometry::Point& top_left)
 {
     this->top_left = top_left;
-    ms::LegacySurfaceChangeNotification::moved_to(top_left);
+    ms::LegacySurfaceChangeNotification::moved_to(surf, top_left);
 }
 
-void NonLegacySurfaceChangeNotification::frame_posted(int frames_available, mir::geometry::Size const& size)
+void NonLegacySurfaceChangeNotification::frame_posted(ms::Surface const*, int frames_available, const mir::geometry::Size& size)
 {
     mir::geometry::Rectangle const update_region{top_left, size};
     damage_notify_change(frames_available, update_region);

--- a/src/server/scene/legacy_surface_change_notification.cpp
+++ b/src/server/scene/legacy_surface_change_notification.cpp
@@ -31,84 +31,85 @@ ms::LegacySurfaceChangeNotification::LegacySurfaceChangeNotification(
 {
 }
 
-void ms::LegacySurfaceChangeNotification::resized_to(geom::Size const& /*size*/)
+void ms::LegacySurfaceChangeNotification::resized_to(Surface const*, geometry::Size const&)
 {
     notify_scene_change();
 }
 
-void ms::LegacySurfaceChangeNotification::moved_to(geom::Point const& /*top_left*/)
+void ms::LegacySurfaceChangeNotification::moved_to(Surface const*, geometry::Point const&)
 {
     notify_scene_change();
 }
 
-void ms::LegacySurfaceChangeNotification::hidden_set_to(bool /*hide*/)
+void ms::LegacySurfaceChangeNotification::hidden_set_to(Surface const*, bool)
 {
     notify_scene_change();
 }
 
-void ms::LegacySurfaceChangeNotification::frame_posted(int frames_available, geom::Size const& /* size */)
+void ms::LegacySurfaceChangeNotification::frame_posted(Surface const*, int frames_available, geometry::Size const&)
 {
     notify_buffer_change(frames_available);
 }
 
-void ms::LegacySurfaceChangeNotification::alpha_set_to(float /*alpha*/)
+void ms::LegacySurfaceChangeNotification::alpha_set_to(Surface const*, float)
 {
     notify_scene_change();
 }
 
 // An orientation change alone is not enough to trigger recomposition.
-void ms::LegacySurfaceChangeNotification::orientation_set_to(MirOrientation /*orientation*/)
+void ms::LegacySurfaceChangeNotification::orientation_set_to(Surface const*, MirOrientation)
 {
 }
 
-void ms::LegacySurfaceChangeNotification::transformation_set_to(glm::mat4 const& /*t*/)
+void ms::LegacySurfaceChangeNotification::transformation_set_to(Surface const*, glm::mat4 const&)
 {
     notify_scene_change();
 }
 
 // An attrib change alone is not enough to trigger recomposition.
-void ms::LegacySurfaceChangeNotification::attrib_changed(MirWindowAttrib /* attrib */, int /* value */)
+void ms::LegacySurfaceChangeNotification::attrib_changed(Surface const*, MirWindowAttrib, int)
 {
 }
 
 // Cursor image change request is not enough to trigger recomposition.
-void ms::LegacySurfaceChangeNotification::cursor_image_set_to(mg::CursorImage const& /* image */)
+void ms::LegacySurfaceChangeNotification::cursor_image_set_to(Surface const*, graphics::CursorImage const&)
 {
 }
 
-void ms::LegacySurfaceChangeNotification::cursor_image_removed()
+void ms::LegacySurfaceChangeNotification::cursor_image_removed(Surface const*)
 {
 }
 
-void ms::LegacySurfaceChangeNotification::placed_relative(geometry::Rectangle const& /*placement*/)
+void ms::LegacySurfaceChangeNotification::placed_relative(Surface const*, geometry::Rectangle const&)
 {
 }
 
-void ms::LegacySurfaceChangeNotification::reception_mode_set_to(mi::InputReceptionMode /*mode*/)
+void ms::LegacySurfaceChangeNotification::reception_mode_set_to(Surface const*, input::InputReceptionMode)
 {
     notify_scene_change();
 }
 
 // A client close request is not enough to trigger recomposition.
-void ms::LegacySurfaceChangeNotification::client_surface_close_requested()
+void ms::LegacySurfaceChangeNotification::client_surface_close_requested(Surface const*)
 {
 }
 
 // A keymap change is not enough to trigger recomposition
-void ms::LegacySurfaceChangeNotification::keymap_changed(MirInputDeviceId, std::string const&, std::string const&,
-                                                         std::string const&, std::string const&)
+void ms::LegacySurfaceChangeNotification::keymap_changed(Surface const*, MirInputDeviceId, std::string const&,
+                                                         std::string const&, std::string const&,
+                                                         std::string const&)
 {
 }
 
-void ms::LegacySurfaceChangeNotification::renamed(char const*)
+void ms::LegacySurfaceChangeNotification::renamed(Surface const*, char const*)
 {
     notify_scene_change();
 }
 
-void ms::LegacySurfaceChangeNotification::input_consumed(MirEvent const*)
+void ms::LegacySurfaceChangeNotification::input_consumed(Surface const*, MirEvent const*)
 {
 }
 
-void ms::LegacySurfaceChangeNotification::start_drag_and_drop(std::vector<uint8_t> const& /*handle*/)
+void ms::LegacySurfaceChangeNotification::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&)
 {
 }

--- a/src/server/scene/legacy_surface_change_notification.h
+++ b/src/server/scene/legacy_surface_change_notification.h
@@ -34,24 +34,29 @@ public:
         std::function<void()> const& notify_scene_change,
         std::function<void(int)> const& notify_buffer_change);
 
-    void resized_to(geometry::Size const& /*size*/) override;
-    void moved_to(geometry::Point const& /*top_left*/) override;
-    void hidden_set_to(bool /*hide*/) override;
-    void frame_posted(int frames_available, geometry::Size const& size) override;
-    void alpha_set_to(float /*alpha*/) override;
-    void orientation_set_to(MirOrientation orientation) override;
-    void transformation_set_to(glm::mat4 const& /*t*/) override;
-    void attrib_changed(MirWindowAttrib, int) override;
-    void reception_mode_set_to(input::InputReceptionMode mode) override;
-    void cursor_image_set_to(graphics::CursorImage const& image) override;
-    void client_surface_close_requested() override;
-    void keymap_changed(MirInputDeviceId id, std::string const& model, std::string const& layout,
-                        std::string const& variant, std::string const& options) override;
-    void renamed(char const*) override;
-    void cursor_image_removed() override;
-    void placed_relative(geometry::Rectangle const& placement) override;
-    void input_consumed(MirEvent const* event) override;
-    void start_drag_and_drop(std::vector<uint8_t> const& handle) override;
+    void resized_to(Surface const* surf, geometry::Size const&) override;
+    void moved_to(Surface const* surf, geometry::Point const&) override;
+    void hidden_set_to(Surface const* surf, bool) override;
+    void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) override;
+    void alpha_set_to(Surface const* surf, float) override;
+    void orientation_set_to(Surface const* surf, MirOrientation orientation) override;
+    void transformation_set_to(Surface const* surf, glm::mat4 const&) override;
+    void attrib_changed(Surface const* surf, MirWindowAttrib, int) override;
+    void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) override;
+    void cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image) override;
+    void client_surface_close_requested(Surface const* surf) override;
+    void keymap_changed(
+        Surface const* surf,
+        MirInputDeviceId id,
+        std::string const& model,
+        std::string const& layout,
+        std::string const& variant,
+        std::string const& options) override;
+    void renamed(Surface const* surf, char const*) override;
+    void cursor_image_removed(Surface const* surf) override;
+    void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
+    void input_consumed(Surface const* surf, MirEvent const* event) override;
+    void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
 
 private:
     std::function<void()> const notify_scene_change;

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -21,24 +21,26 @@
 namespace ms = mir::scene;
 namespace mg = mir::graphics;
 
-void ms::NullSurfaceObserver::attrib_changed(MirWindowAttrib /*attrib*/, int /*value*/) {}
-void ms::NullSurfaceObserver::resized_to(geometry::Size const& /*size*/) {}
-void ms::NullSurfaceObserver::moved_to(geometry::Point const& /*top_left*/) {}
-void ms::NullSurfaceObserver::hidden_set_to(bool /*hide*/) {}
-void ms::NullSurfaceObserver::frame_posted(int /*frames_available*/, geometry::Size const& /* size */) {}
-void ms::NullSurfaceObserver::alpha_set_to(float /*alpha*/) {}
-void ms::NullSurfaceObserver::orientation_set_to(MirOrientation /*orientation*/) {}
-void ms::NullSurfaceObserver::transformation_set_to(glm::mat4 const& /*t*/) {}
-void ms::NullSurfaceObserver::reception_mode_set_to(input::InputReceptionMode /*mode*/) {}
-void ms::NullSurfaceObserver::cursor_image_set_to(mg::CursorImage const& /*image*/) {}
-void ms::NullSurfaceObserver::client_surface_close_requested() {}
-void ms::NullSurfaceObserver::keymap_changed(MirInputDeviceId /* id */, std::string const& /*model*/,
-                                             std::string const& /*layout*/, std::string const& /*variant*/,
-                                             std::string const& /**/)
-{
-}
-void ms::NullSurfaceObserver::renamed(char const*) {}
-void ms::NullSurfaceObserver::cursor_image_removed() {}
-void ms::NullSurfaceObserver::placed_relative(geometry::Rectangle const& /*placement*/)  {}
-void ms::NullSurfaceObserver::input_consumed(MirEvent const* /*event*/)  {}
-void ms::NullSurfaceObserver::start_drag_and_drop(std::vector<uint8_t> const& /*handle*/)  {}
+void ms::NullSurfaceObserver::attrib_changed(Surface const*, MirWindowAttrib, int) {}
+void ms::NullSurfaceObserver::resized_to(Surface const*, geometry::Size const&) {}
+void ms::NullSurfaceObserver::moved_to(Surface const*, geometry::Point const&) {}
+void ms::NullSurfaceObserver::hidden_set_to(Surface const*, bool) {}
+void ms::NullSurfaceObserver::frame_posted(Surface const*, int, geometry::Size const&) {}
+void ms::NullSurfaceObserver::alpha_set_to(Surface const*, float) {}
+void ms::NullSurfaceObserver::orientation_set_to(Surface const*, MirOrientation) {}
+void ms::NullSurfaceObserver::transformation_set_to(Surface const*, glm::mat4 const&) {}
+void ms::NullSurfaceObserver::reception_mode_set_to(Surface const*, input::InputReceptionMode) {}
+void ms::NullSurfaceObserver::cursor_image_set_to(Surface const*, graphics::CursorImage const&) {}
+void ms::NullSurfaceObserver::client_surface_close_requested(Surface const*) {}
+void ms::NullSurfaceObserver::keymap_changed(
+    Surface const*,
+    MirInputDeviceId,
+    std::string const&,
+    std::string const&,
+    std::string const&,
+    std::string const&) {}
+void ms::NullSurfaceObserver::renamed(Surface const*, char const*) {}
+void ms::NullSurfaceObserver::cursor_image_removed(Surface const*) {}
+void ms::NullSurfaceObserver::placed_relative(Surface const*, geometry::Rectangle const&) {}
+void ms::NullSurfaceObserver::input_consumed(Surface const*, MirEvent const*) {}
+void ms::NullSurfaceObserver::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&) {}

--- a/src/server/scene/surface_event_source.cpp
+++ b/src/server/scene/surface_event_source.cpp
@@ -44,12 +44,12 @@ ms::SurfaceEventSource::SurfaceEventSource(
 {
 }
 
-void ms::SurfaceEventSource::resized_to(geom::Size const& size)
+void ms::SurfaceEventSource::resized_to(Surface const*, geometry::Size const& size)
 {
     event_sink->handle_event(*mev::make_event(id, size));
 }
 
-void ms::SurfaceEventSource::moved_to(geom::Point const& top_left)
+void ms::SurfaceEventSource::moved_to(Surface const*, geometry::Point const& top_left)
 {
     auto new_output_properties = outputs.properties_for(geom::Rectangle{top_left, surface.size()});
     if (new_output_properties && (new_output_properties != last_output.lock()))
@@ -66,43 +66,45 @@ void ms::SurfaceEventSource::moved_to(geom::Point const& top_left)
     }
 }
 
-void ms::SurfaceEventSource::attrib_changed(MirWindowAttrib attrib, int value)
+void ms::SurfaceEventSource::attrib_changed(Surface const*, MirWindowAttrib attrib, int value)
 {
     event_sink->handle_event(*mev::make_event(id, attrib, value));
 }
 
-void ms::SurfaceEventSource::orientation_set_to(MirOrientation orientation)
+void ms::SurfaceEventSource::orientation_set_to(Surface const*, MirOrientation orientation)
 {
     event_sink->handle_event(*mev::make_event(id, orientation));
 }
 
-void ms::SurfaceEventSource::client_surface_close_requested()
+void ms::SurfaceEventSource::client_surface_close_requested(Surface const*)
 {
     event_sink->handle_event(*mev::make_event(id));
 }
 
-void ms::SurfaceEventSource::keymap_changed(MirInputDeviceId device_id,
-                                            std::string const& model,
-                                            std::string const& layout,
-                                            std::string const& variant,
-                                            std::string const& options)
+void ms::SurfaceEventSource::keymap_changed(
+    Surface const*,
+    MirInputDeviceId device_id,
+    std::string const& model,
+    std::string const& layout,
+    std::string const& variant,
+    std::string const& options)
 {
     event_sink->handle_event(*mev::make_event(id, device_id, model, layout, variant, options));
 }
 
-void ms::SurfaceEventSource::placed_relative(geometry::Rectangle const& placement)
+void ms::SurfaceEventSource::placed_relative(Surface const*, geometry::Rectangle const& placement)
 {
     event_sink->handle_event(*mev::make_event(id, placement));
 }
 
-void ms::SurfaceEventSource::input_consumed(MirEvent const* event)
+void ms::SurfaceEventSource::input_consumed(Surface const*, MirEvent const* event)
 {
     auto ev = mev::clone_event(*event);
     mev::set_window_id(*ev, id.as_value());
     event_sink->handle_event(*ev);
 }
 
-void ms::SurfaceEventSource::start_drag_and_drop(std::vector<uint8_t> const& handle)
+void ms::SurfaceEventSource::start_drag_and_drop(Surface const*, std::vector<uint8_t> const& handle)
 {
     event_sink->handle_event(*mev::make_start_drag_and_drop_event(id, handle));
 }

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -46,12 +46,12 @@ struct UpdateConfinementOnSurfaceChanges : ms::NullSurfaceObserver
     {
     }
 
-    void resized_to(geom::Size const& /*size*/) override
+    void resized_to(ms::Surface const*, geom::Size const& /*size*/) override
     {
         update_confinement_region();
     }
 
-    void moved_to(geom::Point const& /*top_left*/) override
+    void moved_to(ms::Surface const*, geom::Point const& /*top_left*/) override
     {
         update_confinement_region();
     }

--- a/src/server/shell/surface_ready_observer.cpp
+++ b/src/server/shell/surface_ready_observer.cpp
@@ -35,7 +35,7 @@ msh::SurfaceReadyObserver::SurfaceReadyObserver(
 msh::SurfaceReadyObserver::~SurfaceReadyObserver()
     = default;
 
-void msh::SurfaceReadyObserver::frame_posted(int, mir::geometry::Size const&)
+void msh::SurfaceReadyObserver::frame_posted(ms::Surface const*, int, geometry::Size const&)
 {
     if (auto const s = surface.lock())
     {

--- a/tests/acceptance-tests/test_confined_pointer.cpp
+++ b/tests/acceptance-tests/test_confined_pointer.cpp
@@ -55,7 +55,7 @@ int const surface_height = 100;
 
 struct MockSurfaceObserver : public ms::NullSurfaceObserver
 {
-    MOCK_METHOD1(resized_to, void(geom::Size const&));
+    MOCK_METHOD2(resized_to, void(ms::Surface const*, geom::Size const&));
 };
 }
 
@@ -263,7 +263,7 @@ TEST_F(PointerConfinement, test_we_update_our_confined_region_on_a_resize)
     latest_shell_surface()->add_observer(fake);
 
     geom::Size new_size = {surface_width * 2, surface_height};
-    EXPECT_CALL(surface_observer, resized_to(new_size)).Times(1);
+    EXPECT_CALL(surface_observer, resized_to(_, new_size)).Times(1);
 
     geom::Rectangles confinement_region{{{0, 0}, new_size}};
     EXPECT_CALL(*mock_seat_observer, seat_set_confinement_region_called(mt::RectanglesMatches(confinement_region)))

--- a/tests/acceptance-tests/test_nested_mir.cpp
+++ b/tests/acceptance-tests/test_nested_mir.cpp
@@ -234,8 +234,8 @@ struct MockDisplay : mtd::FakeDisplay
 
 struct StubSurfaceObserver : msc::NullSurfaceObserver
 {
-    void cursor_image_set_to(mg::CursorImage const&) override {}
-    void cursor_image_removed() override
+    void cursor_image_set_to(msc::Surface const*, mg::CursorImage const&) override {}
+    void cursor_image_removed(msc::Surface const*) override
     {
         std::unique_lock<decltype(mutex)> lk(mutex);
         removed = true;

--- a/tests/acceptance-tests/test_surface_modifications.cpp
+++ b/tests/acceptance-tests/test_surface_modifications.cpp
@@ -46,9 +46,9 @@ namespace
 class MockSurfaceObserver : public ms::NullSurfaceObserver
 {
 public:
-    MOCK_METHOD1(renamed, void(char const*));
-    MOCK_METHOD1(resized_to, void(Size const& size));
-    MOCK_METHOD1(hidden_set_to, void(bool));
+    MOCK_METHOD2(renamed, void(ms::Surface const*, char const*));
+    MOCK_METHOD2(resized_to, void(ms::Surface const*, Size const& size));
+    MOCK_METHOD2(hidden_set_to, void(ms::Surface const*, bool));
 };
 
 struct SurfaceModifications : mtf::ConnectedClientWithAWindow
@@ -123,7 +123,7 @@ struct SurfaceModifications : mtf::ConnectedClientWithAWindow
 
         auto const new_title = __PRETTY_FUNCTION__;
 
-        EXPECT_CALL(surface_observer, renamed(StrEq(new_title))).
+        EXPECT_CALL(surface_observer, renamed(_, StrEq(new_title))).
             WillOnce(InvokeWithoutArgs([&]{ server_ready.raise(); }));
 
         apply_changes([&](MirWindowSpec* spec)
@@ -192,7 +192,7 @@ TEST_F(SurfaceModifications, surface_spec_name_is_notified)
 {
     auto const new_title = __PRETTY_FUNCTION__;
 
-    EXPECT_CALL(surface_observer, renamed(StrEq(new_title)));
+    EXPECT_CALL(surface_observer, renamed(_, StrEq(new_title)));
 
     apply_changes([&](MirWindowSpec* spec)
         {
@@ -205,7 +205,7 @@ TEST_F(SurfaceModifications, surface_spec_resize_is_notified)
     auto const new_width = 5;
     auto const new_height = 7;
 
-    EXPECT_CALL(surface_observer, resized_to(Size{new_width, new_height}));
+    EXPECT_CALL(surface_observer, resized_to(_, Size{new_width, new_height}));
 
     apply_changes([&](MirWindowSpec* spec)
         {
@@ -218,7 +218,7 @@ TEST_F(SurfaceModifications, surface_spec_change_width_is_notified)
 {
     auto const new_width = 11;
 
-    EXPECT_CALL(surface_observer, resized_to(WidthEq(new_width)));
+    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(new_width)));
 
     apply_changes([&](MirWindowSpec* spec)
         {
@@ -230,7 +230,7 @@ TEST_F(SurfaceModifications, surface_spec_change_height_is_notified)
 {
     auto const new_height = 13;
 
-    EXPECT_CALL(surface_observer, resized_to(HeightEq(new_height)));
+    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(new_height)));
 
     apply_changes([&](MirWindowSpec* spec)
         {
@@ -252,7 +252,7 @@ TEST_F(SurfaceModifications, surface_spec_min_width_is_respected)
     auto const shell_surface = this->shell_surface.lock();
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(WidthEq(min_width)));
+    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(min_width)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(shell_surface->top_left());
@@ -272,7 +272,7 @@ TEST_F(SurfaceModifications, surface_spec_min_height_is_respected)
     auto const shell_surface = this->shell_surface.lock();
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(HeightEq(min_height)));
+    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(min_height)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(shell_surface->top_left());
@@ -292,7 +292,7 @@ TEST_F(SurfaceModifications, surface_spec_max_width_is_respected)
     auto const shell_surface = this->shell_surface.lock();
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(WidthEq(max_width)));
+    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(max_width)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(max_width));
@@ -312,7 +312,7 @@ TEST_F(SurfaceModifications, surface_spec_max_height_is_respected)
     auto const shell_surface = this->shell_surface.lock();
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(HeightEq(max_height)));
+    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(max_height)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(max_height));
@@ -333,7 +333,7 @@ TEST_F(SurfaceModifications, surface_spec_width_inc_is_respected)
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).WillOnce(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(16));
@@ -358,7 +358,7 @@ TEST_F(SurfaceModifications, surface_spec_with_min_width_and_width_inc_is_respec
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).WillOnce(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(16));
@@ -381,7 +381,7 @@ TEST_F(SurfaceModifications, surface_spec_height_inc_is_respected)
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).WillOnce(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(16));
@@ -406,7 +406,7 @@ TEST_F(SurfaceModifications, surface_spec_with_min_height_and_height_inc_is_resp
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).WillOnce(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(16));
@@ -431,7 +431,7 @@ TEST_F(SurfaceModifications, surface_spec_with_min_aspect_ratio_is_respected)
     auto const bottom_left = shell_surface->input_bounds().bottom_left() + Displacement{1,-1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).WillOnce(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_left);
@@ -456,7 +456,7 @@ TEST_F(SurfaceModifications, surface_spec_with_max_aspect_ratio_is_respected)
     auto const top_right = shell_surface->input_bounds().top_right() - Displacement{1,-1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).WillOnce(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(top_right);
@@ -476,7 +476,7 @@ TEST_F(SurfaceModifications, surface_spec_with_fixed_aspect_ratio_and_size_range
     auto const height_inc = 7;
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).Times(AnyNumber()).WillRepeatedly(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).Times(AnyNumber()).WillRepeatedly(SaveArg<1>(&actual));
 
     apply_changes([&](MirWindowSpec* spec)
           {
@@ -528,7 +528,7 @@ TEST_F(SurfaceModifications, surface_spec_state_affects_surface_visibility)
 {
     auto const new_state = mir_window_state_hidden;
 
-    EXPECT_CALL(surface_observer, hidden_set_to(true));
+    EXPECT_CALL(surface_observer, hidden_set_to(_, true));
 
     apply_changes([&](MirWindowSpec* spec)
         {
@@ -541,8 +541,8 @@ TEST_P(SurfaceSpecStateCase, set_state_affects_surface_visibility)
     auto const initial_state = GetParam().from;
     auto const new_state = GetParam().to;
 
-    EXPECT_CALL(surface_observer, hidden_set_to(is_visible(initial_state)));
-    EXPECT_CALL(surface_observer, hidden_set_to(is_visible(new_state)));
+    EXPECT_CALL(surface_observer, hidden_set_to(_, is_visible(initial_state)));
+    EXPECT_CALL(surface_observer, hidden_set_to(_, is_visible(new_state)));
 
     apply_changes([&](MirWindowSpec* spec)
         {
@@ -577,9 +577,9 @@ TEST_P(SurfaceStateCase, set_state_affects_surface_visibility)
     mt::Signal received_initial_state;
     mt::Signal received_new_state;
 
-    EXPECT_CALL(surface_observer, hidden_set_to(is_visible(initial_state)))
+    EXPECT_CALL(surface_observer, hidden_set_to(_, is_visible(initial_state)))
         .WillOnce(InvokeWithoutArgs([&]{ received_initial_state.raise(); }));
-    EXPECT_CALL(surface_observer, hidden_set_to(is_visible(new_state)))
+    EXPECT_CALL(surface_observer, hidden_set_to(_, is_visible(new_state)))
         .WillOnce(InvokeWithoutArgs([&]{ received_new_state.raise(); }));
 
     mir_window_set_state(window, initial_state);

--- a/tests/acceptance-tests/test_surface_morphing.cpp
+++ b/tests/acceptance-tests/test_surface_morphing.cpp
@@ -56,8 +56,8 @@ private:
 class MockSurfaceObserver : public ms::NullSurfaceObserver
 {
 public:
-    MOCK_METHOD1(renamed, void(char const*));
-    MOCK_METHOD2(attrib_changed, void(MirWindowAttrib attrib, int value));
+    MOCK_METHOD2(renamed, void(ms::Surface const*, char const*));
+    MOCK_METHOD3(attrib_changed, void(ms::Surface const*, MirWindowAttrib attrib, int value));
 };
 
 struct SurfaceMorphing : mtf::ConnectedClientHeadlessServer
@@ -128,7 +128,7 @@ struct SurfaceMorphing : mtf::ConnectedClientHeadlessServer
     {
         auto const new_title = __PRETTY_FUNCTION__;
 
-        EXPECT_CALL(surface_observer, renamed(StrEq(new_title))).
+        EXPECT_CALL(surface_observer, renamed(_, StrEq(new_title))).
             WillOnce(InvokeWithoutArgs([&]{ change_observed(); }));
 
         change_surface(window, [&](MirWindowSpec* spec)
@@ -190,7 +190,7 @@ TEST_P(TargetWithoutParent, not_setting_parent_succeeds)
 
     latest_shell_surface()->add_observer(mt::fake_shared(surface_observer));
 
-    EXPECT_CALL(surface_observer, attrib_changed(mir_window_attrib_type, new_type)).
+    EXPECT_CALL(surface_observer, attrib_changed(_, mir_window_attrib_type, new_type)).
         WillOnce(InvokeWithoutArgs([&] { change_observed(); }));
 
     change_surface(window, [&](MirWindowSpec* spec)
@@ -230,7 +230,7 @@ TEST_P(TargetWithoutParent, setting_parent_fails)
 
     latest_shell_surface()->add_observer(mt::fake_shared(surface_observer));
 
-    EXPECT_CALL(surface_observer, attrib_changed(mir_window_attrib_type, new_type)).
+    EXPECT_CALL(surface_observer, attrib_changed(_, mir_window_attrib_type, new_type)).
         Times(0);
 
     change_surface(window, [&](MirWindowSpec* spec)
@@ -277,7 +277,7 @@ TEST_P(TargetNeedingParent, setting_parent_succeeds)
 
     latest_shell_surface()->add_observer(mt::fake_shared(surface_observer));
 
-    EXPECT_CALL(surface_observer, attrib_changed(mir_window_attrib_type, new_type)).
+    EXPECT_CALL(surface_observer, attrib_changed(_, mir_window_attrib_type, new_type)).
         WillOnce(InvokeWithoutArgs([&] { change_observed(); }));
 
     change_surface(window, [&](MirWindowSpec* spec)
@@ -306,7 +306,7 @@ TEST_P(TargetNeedingParent, not_setting_parent_fails)
 
     latest_shell_surface()->add_observer(mt::fake_shared(surface_observer));
 
-    EXPECT_CALL(surface_observer, attrib_changed(mir_window_attrib_type, new_type)).
+    EXPECT_CALL(surface_observer, attrib_changed(_, mir_window_attrib_type, new_type)).
         Times(0);
 
     change_surface(window, [&](MirWindowSpec* spec)
@@ -352,7 +352,7 @@ TEST_P(TargetMayHaveParent, setting_parent_succeeds)
 
     latest_shell_surface()->add_observer(mt::fake_shared(surface_observer));
 
-    EXPECT_CALL(surface_observer, attrib_changed(mir_window_attrib_type, new_type)).
+    EXPECT_CALL(surface_observer, attrib_changed(_, mir_window_attrib_type, new_type)).
         WillOnce(InvokeWithoutArgs([&] { change_observed(); }));
 
     change_surface(window, [&](MirWindowSpec* spec)
@@ -393,7 +393,7 @@ TEST_P(TargetMayHaveParent, not_setting_parent_succeeds)
 
     latest_shell_surface()->add_observer(mt::fake_shared(surface_observer));
 
-    EXPECT_CALL(surface_observer, attrib_changed(mir_window_attrib_type, new_type)).
+    EXPECT_CALL(surface_observer, attrib_changed(_, mir_window_attrib_type, new_type)).
     WillOnce(InvokeWithoutArgs([&] { change_observed(); }));
 
 

--- a/tests/acceptance-tests/test_surface_specification.cpp
+++ b/tests/acceptance-tests/test_surface_specification.cpp
@@ -47,9 +47,9 @@ namespace
     class MockSurfaceObserver : public ms::NullSurfaceObserver
     {
     public:
-        MOCK_METHOD1(renamed, void(char const*));
-        MOCK_METHOD2(attrib_changed, void(MirWindowAttrib attrib, int value));
-        MOCK_METHOD1(resized_to, void(Size const& size));
+        MOCK_METHOD2(renamed, void(ms::Surface const*, char const*));
+        MOCK_METHOD3(attrib_changed, void(ms::Surface const*, MirWindowAttrib attrib, int value));
+        MOCK_METHOD2(resized_to, void(ms::Surface const*, Size const& size));
     };
 
     struct SurfaceSpecification : mtf::ConnectedClientHeadlessServer
@@ -153,7 +153,7 @@ namespace
         {
             auto const new_title = __PRETTY_FUNCTION__;
 
-            EXPECT_CALL(surface_observer, renamed(StrEq(new_title))).
+            EXPECT_CALL(surface_observer, renamed(_, StrEq(new_title))).
                     WillOnce(InvokeWithoutArgs([&]{ change_observed(); }));
 
             signal_change.reset();
@@ -226,7 +226,7 @@ TEST_F(SurfaceSpecification, surface_spec_min_width_is_respected)
 
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(WidthEq(min_width)));
+    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(min_width)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(shell_surface->top_left());
@@ -254,7 +254,7 @@ TEST_F(SurfaceSpecification, surface_spec_min_height_is_respected)
 
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(HeightEq(min_height)));
+    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(min_height)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(shell_surface->top_left());
@@ -282,7 +282,7 @@ TEST_F(SurfaceSpecification, surface_spec_max_width_is_respected)
 
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(WidthEq(max_width)));
+    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(max_width)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(max_width));
@@ -310,7 +310,7 @@ TEST_F(SurfaceSpecification, surface_spec_max_height_is_respected)
 
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(HeightEq(max_height)));
+    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(max_height)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(max_height));
@@ -339,7 +339,7 @@ TEST_F(SurfaceSpecification, surface_spec_width_inc_is_respected)
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).WillOnce(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(16));
@@ -372,7 +372,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_min_width_and_width_inc_is_respec
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).WillOnce(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(16));
@@ -403,7 +403,7 @@ TEST_F(SurfaceSpecification, surface_spec_height_inc_is_respected)
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).WillOnce(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(16));
@@ -436,7 +436,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_min_height_and_height_inc_is_resp
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).WillOnce(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(16));
@@ -469,7 +469,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_min_aspect_ratio_is_respected)
     auto const bottom_left = shell_surface->input_bounds().bottom_left() + Displacement{1,-1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).WillOnce(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_left);
@@ -502,7 +502,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_max_aspect_ratio_is_respected)
     auto const top_right = shell_surface->input_bounds().top_right() - Displacement{1,-1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).WillOnce(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(top_right);
@@ -553,7 +553,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_fixed_aspect_ratio_and_size_range
     shell_surface->add_observer(mt::fake_shared(surface_observer));
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_)).Times(AnyNumber()).WillRepeatedly(SaveArg<0>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _)).Times(AnyNumber()).WillRepeatedly(SaveArg<1>(&actual));
 
     for (int delta = 1; delta != 20; ++delta)
     {

--- a/tests/integration-tests/test_stale_frames.cpp
+++ b/tests/integration-tests/test_stale_frames.cpp
@@ -125,7 +125,7 @@ public:
     {
     }
 
-    void frame_posted(int count, geom::Size const&) override
+    void frame_posted(mir::scene::Surface const*, int count, geom::Size const&) override
     {
         cb(count);
     }

--- a/tests/unit-tests/input/test_cursor_controller.cpp
+++ b/tests/unit-tests/input/test_cursor_controller.cpp
@@ -145,7 +145,7 @@ struct StubInputSurface : public mtd::StubSceneSurface
         {
             std::unique_lock<decltype(observer_guard)> lk(observer_guard);
             for (auto o : observers)
-                o->cursor_image_set_to(*image);
+                o->cursor_image_set_to(this, *image);
         }
     }
 
@@ -169,7 +169,7 @@ struct StubInputSurface : public mtd::StubSceneSurface
     {
         for (auto observer : observers)
         {
-            observer->frame_posted(1, geom::Size{0,0});
+            observer->frame_posted(this, 1, geom::Size{0, 0});
         }
     }
 

--- a/tests/unit-tests/scene/test_legacy_scene_change_notification.cpp
+++ b/tests/unit-tests/scene/test_legacy_scene_change_notification.cpp
@@ -95,7 +95,7 @@ TEST_F(LegacySceneChangeNotificationTest, observes_surface_changes)
 
     ms::LegacySceneChangeNotification observer(scene_change_callback, buffer_change_callback);
     observer.surface_added(&surface);
-    surface_observer->frame_posted(buffer_num, mir::geometry::Size{0,0});
+    surface_observer->frame_posted(&surface, buffer_num, mir::geometry::Size{0, 0});
 }
 
 TEST_F(LegacySceneChangeNotificationTest, redraws_on_rename)
@@ -111,7 +111,7 @@ TEST_F(LegacySceneChangeNotificationTest, redraws_on_rename)
     ms::LegacySceneChangeNotification observer(scene_change_callback,
                                                buffer_change_callback);
     observer.surface_added(&surface);
-    surface_observer->renamed("Something New");
+    surface_observer->renamed(&surface, "Something New");
 }
 
 TEST_F(LegacySceneChangeNotificationTest, destroying_observer_unregisters_surface_observers)


### PR DESCRIPTION
This is useful when a component wants to monitor many (or all)
of the ms::Surfaces in the scene.