### PR TITLE
Fix unregistration of ms::SurfaceObservers in SurfaceInputDispatcher

### DIFF
--- a/src/server/input/surface_input_dispatcher.h
+++ b/src/server/input/surface_input_dispatcher.h
@@ -73,7 +73,7 @@ private:
 
     void surface_removed(scene::Surface* surface);
 
-    void surface_moved(scene::Surface* moved_surface);
+    void surface_moved(scene::Surface const* moved_surface);
     void surface_resized();
 
     // Look in to homognizing index on KeyInputState and PointerInputState (wrt to device id)


### PR DESCRIPTION
While this doesn't currently cause us any problems, its the sort of thing that will plausibly do so in the future.