### PR TITLE
[travis] disable fedora builds for now and use IPv4 in spread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
   - SYSTEM=ubuntu-16.04 VARIANT=arm64
   - SYSTEM=ubuntu-17.10 VARIANT=amd64
   - SYSTEM=ubuntu-devel VARIANT=clang
-  - SYSTEM=fedora-27 VARIANT=amd64
+#  - SYSTEM=fedora-27 VARIANT=amd64
 
 before_install:
 - mkdir -p ${SPREAD_PATH}

--- a/spread.yaml
+++ b/spread.yaml
@@ -32,6 +32,20 @@ environment:
     VALGRIND: 0
     VALGRIND/valgrind: 1
 
+prepare: |
+    # NOTE: This part of the code needs to be in spread.yaml as it runs before
+    # the rest of the source code (including the tests/lib directory) is
+    # around. The purpose of this code is to fix some connectivity issues and
+    # then apply the delta of the git repository.
+    # apt update is hanging on security.ubuntu.com with IPv6, prefer IPv4 over IPv6
+    cat <<EOF > /etc/gai.conf
+    precedence  ::1/128       50
+    precedence  ::/0          40
+    precedence  2002::/16     30
+    precedence ::/96          20
+    precedence ::ffff:0:0/96 100
+    EOF
+
 suites:
     spread/build/:
         summary: Build Mir


### PR DESCRIPTION
glm-devel didn't get an update along with gcc:

https://bugzilla.redhat.com/show_bug.cgi?id=1542941