### PR TITLE
Fix link errors encountered on rawhide

### DIFF
--- a/tests/integration-tests/CMakeLists.txt
+++ b/tests/integration-tests/CMakeLists.txt
@@ -57,13 +57,14 @@ add_dependencies(mir_integration_tests GMock)
 target_link_libraries(
   mir_integration_tests
 
+  mirclient-static
+  mirclientlttng-static
+
   mir-test-static
   mir-test-framework-static
   mir-test-doubles-static
   mirclient-debug-extension
-  mirclient-static
   mirdraw
-  mirclientlttng-static
 
   mircommon
 

--- a/tests/integration-tests/graphics/mesa/CMakeLists.txt
+++ b/tests/integration-tests/graphics/mesa/CMakeLists.txt
@@ -5,9 +5,6 @@ if (MIR_BUILD_PLATFORM_MESA_KMS)
     mir_add_wrapped_executable(
       mir_integration_tests_mesa-kms
       ${CMAKE_CURRENT_SOURCE_DIR}/test_buffer_integration.cpp
-      ${MIR_SERVER_OBJECTS}
-      ${MIR_PLATFORM_OBJECTS}
-      $<TARGET_OBJECTS:mirplatformgraphicsmesakmsobjects>
     )
 
     add_dependencies(mir_integration_tests_mesa-kms GMock)
@@ -41,9 +38,6 @@ if (MIR_BUILD_PLATFORM_MESA_X11)
     mir_add_wrapped_executable(
       mir_integration_tests_mesa-x11
       ${CMAKE_CURRENT_SOURCE_DIR}/test_buffer_integration.cpp
-      ${MIR_SERVER_OBJECTS}
-      ${MIR_PLATFORM_OBJECTS}
-      $<TARGET_OBJECTS:mirplatformgraphicsmesax11objects>
       $<TARGET_OBJECTS:mirplatformservermesax11sharedresources>
     )
 

--- a/tests/unit-tests/platforms/mesa/kms/CMakeLists.txt
+++ b/tests/unit-tests/platforms/mesa/kms/CMakeLists.txt
@@ -33,7 +33,8 @@ target_link_libraries(
   mir-test-doubles-static
   mir-test-doubles-platform-static
   mirsharedmesaservercommon-static
-  mircommon
+
+  server_platform_common
 
   ${DRM_LDFLAGS} ${DRM_LIBRARIES}
 )

--- a/tests/unit-tests/platforms/mesa/x11/CMakeLists.txt
+++ b/tests/unit-tests/platforms/mesa/x11/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(
   mir-test-doubles-static
   mir-test-doubles-platform-static
   mirsharedmesaservercommon-static
+  server_platform_common
 )
 
 if (MIR_RUN_UNIT_TESTS)


### PR DESCRIPTION
Fix rawhide linking for mir_unit_tests_mesa-kms

(To reproduce enable MIR_LINK_TIME_OPTIMIZATION but DON'T enable MIR_USE_LD_GOLD)