### PR TITLE
Restore Fedora 27 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
   - SYSTEM=ubuntu-16.04 VARIANT=arm64
   - SYSTEM=ubuntu-17.10 VARIANT=amd64
   - SYSTEM=ubuntu-devel VARIANT=clang
-#  - SYSTEM=fedora-27 VARIANT=amd64
+  - SYSTEM=fedora-27 VARIANT=amd64
 
 before_install:
 - mkdir -p ${SPREAD_PATH}


### PR DESCRIPTION
glm has now been updated to work with the recently updated g++