### PR TITLE
Add NO_AT_BRIDGE=1 to client environment.

### DIFF
--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -51,6 +51,6 @@ sh -c "${bindir}${miral_server} $* ${hostsocket} --file ${socket} --wayland-sock
 while [ ! -e "${socket}" ]; do echo "waiting for ${socket}"; sleep 1 ;done
 
 unset QT_QPA_PLATFORMTHEME
-MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=wayland,mir QT_QPA_PLATFORM=wayland SDL_VIDEODRIVER=wayland WAYLAND_DISPLAY=${wayland_display} dbus-run-session -- ${launcher}
+MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=wayland,mir QT_QPA_PLATFORM=wayland SDL_VIDEODRIVER=wayland WAYLAND_DISPLAY=${wayland_display} NO_AT_BRIDGE=1 dbus-run-session -- ${launcher}
 killall ${bindir}${miral_server} || killall ${bindir}${miral_server}.bin
 

--- a/examples/miral-shell/miral-desktop.sh
+++ b/examples/miral-shell/miral-desktop.sh
@@ -46,6 +46,6 @@ sudo --background --preserve-env sh -c "${bindir}${miral_server} --wayland-socke
 while [ ! -e "${socket}" ]; do echo "waiting for ${socket}"; sleep 1 ;done
 
 unset QT_QPA_PLATFORMTHEME
-MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=wayland,mir QT_QPA_PLATFORM=wayland SDL_VIDEODRIVER=wayland WAYLAND_DISPLAY=${wayland_display} dbus-run-session -- ${launcher}
+MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=wayland,mir QT_QPA_PLATFORM=wayland SDL_VIDEODRIVER=wayland WAYLAND_DISPLAY=${wayland_display} NO_AT_BRIDGE=1 dbus-run-session -- ${launcher}
 sudo killall ${bindir}${miral_server} || sudo killall ${bindir}${miral_server}.bin
 

--- a/examples/miral-shell/miral-run.sh
+++ b/examples/miral-shell/miral-run.sh
@@ -28,4 +28,4 @@ then extras='--app-id com.canonical.miral.Terminal'
 fi
 unset QT_QPA_PLATFORMTHEME
 
-MIR_SOCKET=${mir_socket} WAYLAND_DISPLAY=${wayland_socket} XDG_SESSION_TYPE=mir GDK_BACKEND=wayland,mir QT_QPA_PLATFORM=wayland SDL_VIDEODRIVER=wayland "$@" ${extras}&
+MIR_SOCKET=${mir_socket} WAYLAND_DISPLAY=${wayland_socket} XDG_SESSION_TYPE=mir GDK_BACKEND=wayland,mir QT_QPA_PLATFORM=wayland SDL_VIDEODRIVER=wayland NO_AT_BRIDGE=1 "$@" ${extras}&

--- a/examples/miral-shell/miral-xrun.sh
+++ b/examples/miral-shell/miral-xrun.sh
@@ -83,5 +83,5 @@ done
 
 MIR_SOCKET=${mir_socket} WAYLAND_DISPLAY=${wayland_display} ${x11_server} ${x11_server_args} :${port} & pid=$!
 while [ ! -e "/tmp/.X11-unix/X${port}" ]; do echo "waiting for DISPLAY=:${port}"; sleep 1 ;done
-DISPLAY=:${port} "$@"
+DISPLAY=:${port} NO_AT_BRIDGE=1 "$@"
 kill ${pid}


### PR DESCRIPTION
This prevents annoying delays when starting GTK applications followed by

WARNING **: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files 