### PR TITLE
KMS platform - fallback if crtc mode invalid

### DIFF
--- a/src/platforms/mesa/server/kms/real_kms_output.cpp
+++ b/src/platforms/mesa/server/kms/real_kms_output.cpp
@@ -578,7 +578,7 @@ void mgm::RealKMSOutput::update_from_hardware_state(
 
     /* Fallback for VMWare which fails to specify a matching current mode (bug:1661295) */
     if (current_mode_index == invalid_mode_index) {
-        for (int m = 0; m < connector->count_modes; m++) {
+        for (int m = 0; m != connector->count_modes; ++m) {
             drmModeModeInfo &mode_info = connector->modes[m];
 
             if (strcmp(mode_info.name, "preferred") == 0)
@@ -586,9 +586,10 @@ void mgm::RealKMSOutput::update_from_hardware_state(
         }
     }
 
-    if (current_mode_index == invalid_mode_index)
+    if (current_mode_index == invalid_mode_index) {
         mir::log_warning(
-            "Unable to determine the current mode.");
+            "Unable to determine the current display mode.");
+    }
 
     output.type = type;
     output.modes = modes;

--- a/src/platforms/mesa/server/kms/real_kms_output.cpp
+++ b/src/platforms/mesa/server/kms/real_kms_output.cpp
@@ -576,6 +576,20 @@ void mgm::RealKMSOutput::update_from_hardware_state(
             preferred_mode_index = m;
     }
 
+    /* Fallback for VMWare which fails to specify a matching current mode (bug:1661295) */
+    if (current_mode_index == invalid_mode_index) {
+        for (int m = 0; m < connector->count_modes; m++) {
+            drmModeModeInfo &mode_info = connector->modes[m];
+
+            if (strcmp(mode_info.name, "preferred") == 0)
+                current_mode_index = m;
+        }
+    }
+
+    if (current_mode_index == invalid_mode_index)
+        mir::log_warning(
+            "Unable to determine the current mode.");
+
     output.type = type;
     output.modes = modes;
     output.preferred_mode_index = preferred_mode_index;


### PR DESCRIPTION
If the current mode advertised by the crtc does not exist in the list of modes, fall back to using the mode named "preferred" as current mode. Some VMs specify this.

Fixes nested server run on VMWare: https://bugs.launchpad.net/mir/+bug/1661295