### PR TITLE
WlPointer: Initialise last coördinate values to 0.

### DIFF
--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -947,7 +947,7 @@ private:
     std::shared_ptr<bool> const destroyed;
 
     MirPointerButtons last_set{0};
-    float last_x, last_y, last_vscroll, last_hscroll;
+    float last_x{0}, last_y{0}, last_vscroll{0}, last_hscroll{0};
 
     void set_cursor(uint32_t serial, std::experimental::optional<wl_resource*> const& surface, int32_t hotspot_x, int32_t hotspot_y) override;
     void release() override;


### PR DESCRIPTION
Otherwise they'll have essentially random values, and we'll send an unnecessary wl_pointer.axis event.
This isn't too harmful for real clients, but it kills the wlcs tests because we don't have an axis
event handler set up!