### PR TITLE
Allow Window movement to be initiated by Wayland clients (Fixes #61)

### DIFF
--- a/examples/miral-shell/floating_window_manager.cpp
+++ b/examples/miral-shell/floating_window_manager.cpp
@@ -812,3 +812,13 @@ void FloatingWindowManagerPolicy::handle_modify_window(WindowInfo& window_info, 
     CanonicalWindowManagerPolicy::handle_modify_window(window_info, mods);
 }
 
+void FloatingWindowManagerPolicy::handle_request_drag_and_drop(WindowInfo& window_info)
+{
+    puts((std::string{"FloatingWindowManagerPolicy::handle_request_drag_and_drop("} + window_info.name() + ")").c_str());
+}
+
+void FloatingWindowManagerPolicy::handle_request_move(WindowInfo& window_info, MirInputEvent const* /*input_event*/)
+{
+    puts((std::string{"FloatingWindowManagerPolicy::handle_request_move("} + window_info.name() + ")").c_str());
+}
+

--- a/examples/miral-shell/floating_window_manager.h
+++ b/examples/miral-shell/floating_window_manager.h
@@ -102,6 +102,8 @@ private:
 
     Point old_cursor{};
 
+    bool csd_move = false;
+    unsigned csd_modifiers = 0;
     bool resizing = false;
     bool left_resize = false;
     bool top_resize  = false;

--- a/examples/miral-shell/floating_window_manager.h
+++ b/examples/miral-shell/floating_window_manager.h
@@ -20,6 +20,7 @@
 #define MIRAL_SHELL_FLOATING_WINDOW_MANAGER_H
 
 #include <miral/canonical_window_manager.h>
+#include <miral/window_management_policy_addendum2.h>
 #include <miral/window_management_policy_addendum3.h>
 #include <miral/workspace_policy.h>
 
@@ -36,7 +37,8 @@ using namespace mir::geometry;
 class DecorationProvider;
 
 class FloatingWindowManagerPolicy : public miral::CanonicalWindowManagerPolicy,
-    public miral::WorkspacePolicy, public miral::WindowManagementPolicyAddendum3
+    public miral::WorkspacePolicy, public miral::WindowManagementPolicyAddendum3,
+    public miral::WindowManagementPolicyAddendum2
 {
 public:
     FloatingWindowManagerPolicy(
@@ -76,6 +78,13 @@ public:
     void advise_delete_window(miral::WindowInfo const& window_info) override;
 
     void handle_modify_window(miral::WindowInfo& window_info, miral::WindowSpecification const& modifications) override;
+    /** @} */
+
+    /** @name support for CSD invoked sizing and movement
+     *  @{ */
+    void handle_request_drag_and_drop(miral::WindowInfo& window_info) override;
+
+    void handle_request_move(miral::WindowInfo& window_info, MirInputEvent const* input_event) override;
     /** @} */
 
 protected:

--- a/examples/miral-shell/floating_window_manager.h
+++ b/examples/miral-shell/floating_window_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Canonical Ltd.
+ * Copyright © 2016-2018 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as

--- a/examples/miral-shell/floating_window_manager.h
+++ b/examples/miral-shell/floating_window_manager.h
@@ -102,8 +102,8 @@ private:
 
     Point old_cursor{};
 
-    bool csd_move = false;
-    unsigned csd_modifiers = 0;
+    bool moving = false;
+    unsigned move_modifiers = 0;
     bool resizing = false;
     bool left_resize = false;
     bool top_resize  = false;

--- a/src/server/frontend/wayland/basic_surface_event_sink.cpp
+++ b/src/server/frontend/wayland/basic_surface_event_sink.cpp
@@ -33,6 +33,11 @@ void mf::BasicSurfaceEventSink::handle_event(MirEvent const& event)
     case mir_event_type_input:
     {
         auto input_event = mir_event_get_input_event(&event);
+
+        // Remember the timestamp of any events "signed" with a cookie
+        if (mir_input_event_has_cookie(input_event))
+            timestamp = mir_input_event_get_event_time(input_event);
+
         switch (mir_input_event_get_type(input_event))
         {
         case mir_input_event_type_key:

--- a/src/server/frontend/wayland/basic_surface_event_sink.h
+++ b/src/server/frontend/wayland/basic_surface_event_sink.h
@@ -64,6 +64,11 @@ public:
         this->window_size = window_size;
     }
 
+    auto latest_timestamp() const -> uint64_t
+    {
+        return timestamp;
+    }
+
     virtual void send_resize(geometry::Size const& new_size) const = 0;
 
 protected:
@@ -72,6 +77,7 @@ protected:
     wl_resource* const target;
     wl_resource* const event_sink;
     std::atomic<geometry::Size> window_size;
+    std::atomic<int64_t> timestamp{0};
 };
 }
 }

--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -1730,6 +1730,13 @@ protected:
 
     void move(struct wl_resource* /*seat*/, uint32_t /*serial*/) override
     {
+        if (surface_id.as_value())
+        {
+            if (auto session = session_for_client(client))
+            {
+                shell->request_operation(session, surface_id, sink->latest_timestamp(), Shell::UserRequest::move);
+            }
+        }
     }
 
     void resize(struct wl_resource* /*seat*/, uint32_t /*serial*/, uint32_t /*edges*/) override
@@ -1877,11 +1884,7 @@ struct XdgToplevelV6 : wayland::XdgToplevelV6
         // TODO
     }
 
-    void move(struct wl_resource* seat, uint32_t serial) override
-    {
-        (void)seat, (void)serial;
-        // TODO
-    }
+    void move(struct wl_resource* seat, uint32_t serial) override;
 
     void resize(struct wl_resource* seat, uint32_t serial, uint32_t edges) override
     {
@@ -2067,6 +2070,7 @@ struct XdgSurfaceV6 : wayland::XdgSurfaceV6, WlAbstractMirWindow
 
     void set_parent(optional_value<SurfaceId> parent_id);
     void set_title(std::string const& title);
+    void move(struct wl_resource* seat, uint32_t serial);
     void set_max_size(int32_t width, int32_t height);
     void set_min_size(int32_t width, int32_t height);
     void set_maximized();
@@ -2108,6 +2112,16 @@ void XdgSurfaceV6::set_title(std::string const& title)
     }
 }
 
+void XdgSurfaceV6::move(struct wl_resource* /*seat*/, uint32_t /*serial*/)
+{
+    if (surface_id.as_value())
+    {
+        if (auto session = session_for_client(client))
+        {
+            shell->request_operation(session, surface_id, sink->latest_timestamp(), Shell::UserRequest::move);
+        }
+    }
+}
 
 void XdgSurfaceV6::set_parent(optional_value<SurfaceId> parent_id)
 {
@@ -2208,6 +2222,11 @@ void XdgToplevelV6::set_parent(std::experimental::optional<struct wl_resource*> 
 void XdgToplevelV6::set_title(std::string const& title)
 {
     self->set_title(title);
+}
+
+void XdgToplevelV6::move(struct wl_resource* seat, uint32_t serial)
+{
+    self->move(seat, serial);
 }
 
 void XdgToplevelV6::set_max_size(int32_t width, int32_t height)


### PR DESCRIPTION
1. Connects up Wayland move() requests with the CSD move support.
2. Implements move in the "floating" window manager
3. Consolidates the move logic

NB GTK apps on *Artful* don't work with this but Qt apps and weston-terminal do.
(On Bionic, Fedora 27 and rawhide GTK apps seem fine.)