### PR TITLE
benchmarks: Configure mir-perf-framework with the Mir version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .project
+benchmarks/mir_perf_framework_setup.py
 include/server/mir/version.h
 include/client/mir_toolkit/version.h
 include/miral/version.h

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -25,6 +25,9 @@ target_link_libraries(benchmark_multiplexing_dispatchable
   mircommon
 )
 
+# Configure the version in the setup.py
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mir_perf_framework_setup.py.in ${CMAKE_CURRENT_SOURCE_DIR}/mir_perf_framework_setup.py @ONLY)
+
 # Note: We need to write \$ENV{DESTDIR} (note the \$) to make
 # CMake replace the DESTDIR variable at installation time rather
 # than configuration time

--- a/benchmarks/mir_perf_framework_setup.py.in
+++ b/benchmarks/mir_perf_framework_setup.py.in
@@ -1,5 +1,5 @@
 from distutils.core import setup
 
 setup(name='mir_perf_framework',
-      version='0.1',
+      version='@MIR_VERSION@',
       packages=['mir_perf_framework'])


### PR DESCRIPTION
mir-perf-framework is released alongside the rest of Mir, so it should be versioned in the same manner.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>