### PR TITLE
Don't crap out if we can't bind to wayland display

### DIFF
--- a/src/platforms/mesa/server/buffer_allocator.cpp
+++ b/src/platforms/mesa/server/buffer_allocator.cpp
@@ -561,7 +561,7 @@ void mgm::BufferAllocator::bind_display(wl_display* display)
 
     if (egl_extensions->wayland->eglBindWaylandDisplayWL(dpy, display) == EGL_FALSE)
     {
-        mir::log_error("Failed to bind Wayland display");
+        mir::log_warning("Failed to bind Wayland display");
         return;
     }
     else

--- a/src/platforms/mesa/server/buffer_allocator.cpp
+++ b/src/platforms/mesa/server/buffer_allocator.cpp
@@ -561,7 +561,8 @@ void mgm::BufferAllocator::bind_display(wl_display* display)
 
     if (egl_extensions->wayland->eglBindWaylandDisplayWL(dpy, display) == EGL_FALSE)
     {
-        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to bind Wayland display"));
+        mir::log_error("Failed to bind Wayland display");
+        return;
     }
     else
     {


### PR DESCRIPTION
Without this mir will not run with proprietary nividia drivers using the
X platform.

Wayland is sure to not work, but it's better then not working at all.