### PR TITLE
Explicitly initialise glm::mat? identity matricies.

### DIFF
--- a/examples/server_example_adorning_compositor.cpp
+++ b/examples/server_example_adorning_compositor.cpp
@@ -127,7 +127,7 @@ bool renderable_is_occluded(
     mir::geometry::Rectangle const& area,
     std::vector<mir::geometry::Rectangle>& coverage)
 {
-    static glm::mat4 const identity;
+    static glm::mat4 const identity{};
     static mir::geometry::Rectangle const empty{};
 
     if (renderable.transformation() != identity)

--- a/include/platform/mir/graphics/transformation.h
+++ b/include/platform/mir/graphics/transformation.h
@@ -39,7 +39,7 @@ inline glm::mat2 transformation(MirOrientation ori)
 
 inline glm::mat2 transformation(MirMirrorMode mode)
 {
-    glm::mat2 mat;
+    glm::mat2 mat{};
     if (mode == mir_mirror_mode_horizontal)
         mat[0][0] = -1;
     else if (mode == mir_mirror_mode_vertical)

--- a/src/platforms/mesa/server/kms/bypass.cpp
+++ b/src/platforms/mesa/server/kms/bypass.cpp
@@ -25,7 +25,8 @@ namespace mgm = mir::graphics::mesa;
 
 mgm::BypassMatch::BypassMatch(geometry::Rectangle const& rect)
     : view_area(rect),
-      bypass_is_feasible(true)
+      bypass_is_feasible(true),
+      identity()
 {
 }
 

--- a/src/platforms/mesa/server/kms/display_buffer.cpp
+++ b/src/platforms/mesa/server/kms/display_buffer.cpp
@@ -581,7 +581,7 @@ void mgm::DisplayBuffer::set_transformation(glm::mat2 const& t, geometry::Rectan
 
 bool mgm::DisplayBuffer::overlay(RenderableList const& renderable_list)
 {
-    glm::mat2 static const no_transformation;
+    glm::mat2 static const no_transformation{};
     if (transform == no_transformation &&
        (bypass_option == mgm::BypassOption::allowed))
     {

--- a/src/server/compositor/occlusion.cpp
+++ b/src/server/compositor/occlusion.cpp
@@ -34,7 +34,7 @@ bool renderable_is_occluded(
     Rectangle const& area,
     std::vector<Rectangle>& coverage)
 {
-    static glm::mat4 const identity;
+    static glm::mat4 const identity{};
     static Rectangle const empty{};
 
     if (renderable.transformation() != identity)

--- a/src/server/graphics/nested/display_buffer.cpp
+++ b/src/server/graphics/nested/display_buffer.cpp
@@ -74,7 +74,8 @@ mgn::detail::DisplayBuffer::DisplayBuffer(
     area{best_output.extents()},
     egl_surface{egl_display, host_stream->egl_native_window(), egl_config},
     passthrough_option(option),
-    content{BackingContent::stream}
+    content{BackingContent::stream},
+    identity()
 {
     host_surface->set_event_handler(event_thunk, this);
 }

--- a/tests/unit-tests/compositor/test_default_display_buffer_compositor.cpp
+++ b/tests/unit-tests/compositor/test_default_display_buffer_compositor.cpp
@@ -51,7 +51,7 @@ namespace mtd = mir::test::doubles;
 namespace
 {
 
-glm::mat2 const no_transformation;
+glm::mat2 const no_transformation{};
 
 struct StubSceneElement : mc::SceneElement
 {


### PR DESCRIPTION
glm::mat4 has a perfectly acceptable default constructor so this should be unnecessary
but GCC 7.3.0 in bionic-proposed warns about this.