### PR TITLE
moved surface code from wayland_connector.cpp to wl_surface.cpp

### DIFF
--- a/src/server/frontend/wayland/CMakeLists.txt
+++ b/src/server/frontend/wayland/CMakeLists.txt
@@ -12,6 +12,7 @@ set(
   null_event_sink.cpp           null_event_sink.h
   basic_surface_event_sink.cpp  basic_surface_event_sink.h
   output_manager.cpp            output_manager.h
+  wl_mir_window.cpp             wl_mir_window.h
   wl_surface.cpp                wl_surface.h
 )
 

--- a/src/server/frontend/wayland/CMakeLists.txt
+++ b/src/server/frontend/wayland/CMakeLists.txt
@@ -12,6 +12,7 @@ set(
   null_event_sink.cpp           null_event_sink.h
   basic_surface_event_sink.cpp  basic_surface_event_sink.h
   output_manager.cpp            output_manager.h
+  wl_surface.cpp                wl_surface.h
 )
 
 add_library(

--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -18,9 +18,9 @@
 
 #include "wayland_connector.h"
 
+#include "wayland_utils.h"
 #include "wl_mir_window.h"
 #include "wl_surface.h"
-
 #include "basic_surface_event_sink.h"
 #include "null_event_sink.h"
 #include "output_manager.h"
@@ -222,7 +222,7 @@ std::shared_ptr<mf::BufferStream> create_buffer_stream(mf::Session& session)
 */
 }
 
-std::shared_ptr<mir::frontend::Session> session_for_client(wl_client* client)
+std::shared_ptr<mir::frontend::Session> get_session(wl_client* client)
 {
     auto listener = wl_client_get_destroy_listener(client, &cleanup_private);
 
@@ -1229,7 +1229,7 @@ protected:
         int32_t y,
         uint32_t flags) override
     {
-        auto const session = session_for_client(client);
+        auto const session = get_session(client);
         auto& parent_surface = *WlSurface::from(parent);
 
         if (surface_id.as_value())
@@ -1292,7 +1292,7 @@ protected:
         int32_t y,
         uint32_t flags) override
     {
-        auto const session = session_for_client(client);
+        auto const session = get_session(client);
         auto& parent_surface = *WlSurface::from(parent);
 
         if (surface_id.as_value())
@@ -1365,7 +1365,7 @@ protected:
     {
         if (surface_id.as_value())
         {
-            if (auto session = session_for_client(client))
+            if (auto session = get_session(client))
             {
                 shell->request_operation(session, surface_id, sink->latest_timestamp(), Shell::UserRequest::move);
             }
@@ -1663,7 +1663,7 @@ struct XdgSurfaceV6 : wayland::XdgSurfaceV6, WlAbstractMirWindow
         auto* tmp = wl_resource_get_user_data(positioner);
         auto const* const pos =  static_cast<XdgPositionerV6*>(static_cast<wayland::XdgPositionerV6*>(tmp));
 
-        auto const session = session_for_client(client);
+        auto const session = get_session(client);
         auto& parent_surface = *get_xdgsurface(parent);
 
         params->type = mir_window_type_freestyle;
@@ -1749,7 +1749,7 @@ void XdgSurfaceV6::move(struct wl_resource* /*seat*/, uint32_t /*serial*/)
 {
     if (surface_id.as_value())
     {
-        if (auto session = session_for_client(client))
+        if (auto session = get_session(client))
         {
             shell->request_operation(session, surface_id, sink->latest_timestamp(), Shell::UserRequest::move);
         }

--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -18,6 +18,8 @@
 
 #include "wayland_connector.h"
 
+#include "wl_surface.h"
+
 #include "basic_surface_event_sink.h"
 #include "null_event_sink.h"
 #include "output_manager.h"
@@ -87,6 +89,18 @@ namespace mir
 {
 namespace frontend
 {
+struct NullWlMirWindow : WlMirWindow
+{
+    void new_buffer_size(mir::geometry::Size const& ) {}
+    void commit() {}
+    void visiblity(bool ) {}
+    void destroy() {}
+
+    static NullWlMirWindow instance;
+} NullWlMirWindow::instance;
+
+WlMirWindow * const nullWlMirWindowPtr = &NullWlMirWindow::instance;
+
 namespace
 {
 struct ClientPrivate
@@ -130,16 +144,6 @@ ClientPrivate* private_from_listener(wl_listener* listener)
 void cleanup_private(wl_listener* listener, void* /*data*/)
 {
     delete private_from_listener(listener);
-}
-
-std::shared_ptr<mf::Session> session_for_client(wl_client* client)
-{
-    auto listener = wl_client_get_destroy_listener(client, &cleanup_private);
-
-    if (listener)
-        return private_from_listener(listener)->session;
-
-    return nullptr;
 }
 
 std::shared_ptr<ms::Surface> get_surface_for_id(std::shared_ptr<mf::Session> const& session, mf::SurfaceId surface_id)
@@ -231,252 +235,16 @@ std::shared_ptr<mf::BufferStream> create_buffer_stream(mf::Session& session)
     return session.get_buffer_stream(id);
 }
 */
-template<typename Callable>
-auto run_unless(std::shared_ptr<bool> const& condition, Callable&& callable)
-{
-    return
-        [callable = std::move(callable), condition]()
-        {
-            if (*condition)
-                return;
-
-            callable();
-        };
-}
 }
 
-struct WlMirWindow
+std::shared_ptr<mir::frontend::Session> session_for_client(wl_client* client)
 {
-    virtual void new_buffer_size(geometry::Size const& buffer_size) = 0;
-    virtual void commit() = 0;
-    virtual void visiblity(bool visible) = 0;
-    virtual void destroy() = 0;
-    virtual ~WlMirWindow() = default;
-};
+    auto listener = wl_client_get_destroy_listener(client, &cleanup_private);
 
-struct NullWlMirWindow : WlMirWindow
-{
-    void new_buffer_size(geom::Size const& ) {}
-    void commit() {}
-    void visiblity(bool ) {}
-    void destroy() {}
-} nullwlmirwindow;
+    if (listener)
+        return private_from_listener(listener)->session;
 
-class WlSurface : public wayland::Surface
-{
-public:
-    WlSurface(
-        wl_client* client,
-        wl_resource* parent,
-        uint32_t id,
-        std::shared_ptr<mir::Executor> const& executor,
-        std::shared_ptr<mg::WaylandAllocator> const& allocator)
-        : Surface(client, parent, id),
-          allocator{allocator},
-          executor{executor},
-          pending_buffer{nullptr},
-          pending_frames{std::make_shared<std::vector<wl_resource*>>()},
-          destroyed{std::make_shared<bool>(false)}
-    {
-        auto session = session_for_client(client);
-        mg::BufferProperties const props{
-            geom::Size{geom::Width{0}, geom::Height{0}},
-            mir_pixel_format_invalid,
-            mg::BufferUsage::undefined
-        };
-
-        stream_id = session->create_buffer_stream(props);
-        stream = session->get_buffer_stream(stream_id);
-
-        // wl_surface is specified to act in mailbox mode
-        stream->allow_framedropping(true);
-    }
-
-    ~WlSurface()
-    {
-        *destroyed = true;
-        if (auto session = session_for_client(client))
-            session->destroy_buffer_stream(stream_id);
-    }
-
-    void set_role(WlMirWindow* role_)
-    {
-        role = role_;
-    }
-
-    mf::BufferStreamId stream_id;
-    std::shared_ptr<mf::BufferStream> stream;
-    mf::SurfaceId surface_id;       // ID of any associated surface
-
-    std::shared_ptr<bool> destroyed_flag() const
-    {
-        return destroyed;
-    }
-
-private:
-    std::shared_ptr<mg::WaylandAllocator> const allocator;
-    std::shared_ptr<mir::Executor> const executor;
-
-    WlMirWindow* role = &nullwlmirwindow;
-
-    wl_resource* pending_buffer;
-    std::shared_ptr<std::vector<wl_resource*>> const pending_frames;
-    std::shared_ptr<bool> const destroyed;
-
-    void destroy();
-    void attach(std::experimental::optional<wl_resource*> const& buffer, int32_t x, int32_t y);
-    void damage(int32_t x, int32_t y, int32_t width, int32_t height);
-    void frame(uint32_t callback);
-    void set_opaque_region(std::experimental::optional<wl_resource*> const& region);
-    void set_input_region(std::experimental::optional<wl_resource*> const& region);
-    void commit();
-    void damage_buffer(int32_t x, int32_t y, int32_t width, int32_t height);
-    void set_buffer_transform(int32_t transform);
-    void set_buffer_scale(int32_t scale);
-};
-
-WlSurface* get_wlsurface(wl_resource* surface)
-{
-    auto* tmp = wl_resource_get_user_data(surface);
-    return static_cast<WlSurface*>(static_cast<wayland::Surface*>(tmp));
-}
-
-void WlSurface::destroy()
-{
-    *destroyed = true;
-    role->destroy();
-    wl_resource_destroy(resource);
-}
-
-void WlSurface::attach(std::experimental::optional<wl_resource*> const& buffer, int32_t x, int32_t y)
-{
-    if (x != 0 || y != 0)
-    {
-        mir::log_warning("Client requested unimplemented non-zero attach offset. Rendering will be incorrect.");
-    }
-
-    role->visiblity(!!buffer);
-
-    pending_buffer = buffer.value_or(nullptr);
-}
-
-void WlSurface::damage(int32_t x, int32_t y, int32_t width, int32_t height)
-{
-    (void)x;
-    (void)y;
-    (void)width;
-    (void)height;
-    // This isn't essential, but could enable optimizations
-}
-
-void WlSurface::damage_buffer(int32_t x, int32_t y, int32_t width, int32_t height)
-{
-    (void)x;
-    (void)y;
-    (void)width;
-    (void)height;
-    // This isn't essential, but could enable optimizations
-}
-
-void WlSurface::frame(uint32_t callback)
-{
-    pending_frames->emplace_back(
-        wl_resource_create(client, &wl_callback_interface, 1, callback));
-}
-
-void WlSurface::set_opaque_region(const std::experimental::optional<wl_resource*>& region)
-{
-    (void)region;
-}
-
-void WlSurface::set_input_region(const std::experimental::optional<wl_resource*>& region)
-{
-    (void)region;
-}
-
-void WlSurface::commit()
-{
-    if (pending_buffer)
-    {
-        auto send_frame_notifications =
-            [executor = executor, frames = pending_frames, destroyed = destroyed]()
-            {
-                executor->spawn(run_unless(
-                    destroyed,
-                    [frames]()
-                    {
-                        /*
-                         * There is no synchronisation required here -
-                         * This is run on the WaylandExecutor, and is guaranteed to run on the
-                         * wl_event_loop's thread.
-                         *
-                         * The only other accessors of WlSurface are also on the wl_event_loop,
-                         * so this is guaranteed not to be reentrant.
-                         */
-                        for (auto frame : *frames)
-                        {
-                            wl_callback_send_done(frame, 0);
-                            wl_resource_destroy(frame);
-                        }
-                        frames->clear();
-                    }));
-            };
-
-        std::shared_ptr<mg::Buffer> mir_buffer;
-
-        if (wl_shm_buffer_get(pending_buffer))
-        {
-            mir_buffer = WlShmBuffer::mir_buffer_from_wl_buffer(
-                pending_buffer,
-                std::move(send_frame_notifications));
-        }
-        else
-        {
-            auto release_buffer = [executor = executor, buffer = pending_buffer, destroyed = destroyed]()
-                {
-                    executor->spawn(run_unless(
-                        destroyed,
-                        [buffer](){ wl_resource_queue_event(buffer, WL_BUFFER_RELEASE); }));
-                };
-
-            mir_buffer = allocator->buffer_from_resource(
-                    pending_buffer,
-                    std::move(send_frame_notifications),
-                    std::move(release_buffer));
-        }
-
-        /*
-         * This is technically incorrect - the resize and submit_buffer *should* be atomic,
-         * but are not, so a client in the process of resizing can have buffers rendered at
-         * an unexpected size.
-         *
-         * It should be good enough for now, though.
-         *
-         * TODO: Provide a mg::Buffer::logical_size() to do this properly.
-         */
-        stream->resize(mir_buffer->size());
-        role->new_buffer_size(mir_buffer->size());
-        role->commit();
-        stream->submit_buffer(mir_buffer);
-
-        pending_buffer = nullptr;
-    }
-    else
-    {
-        role->commit();
-    }
-}
-
-void WlSurface::set_buffer_transform(int32_t transform)
-{
-    (void)transform;
-    // TODO
-}
-
-void WlSurface::set_buffer_scale(int32_t scale)
-{
-    (void)scale;
-    // TODO
+    return nullptr;
 }
 
 class WlCompositor : public wayland::Compositor
@@ -624,7 +392,7 @@ public:
                 destroyed,
                 [
                     target = target,
-                    target_window_destroyed = get_wlsurface(target)->destroyed_flag(),
+                    target_window_destroyed = WlSurface::from(target)->destroyed_flag(),
                     focussed = mir_window_event_get_attribute_value(event),
                     this
                 ]()
@@ -827,7 +595,7 @@ public:
             [
                 ev = mcl::Event{mir_input_event_get_event(event)},
                 target,
-                target_window_destroyed = get_wlsurface(target)->destroyed_flag(),
+                target_window_destroyed = WlSurface::from(target)->destroyed_flag(),
                 this
             ]()
             {
@@ -990,7 +758,7 @@ public:
             [
                 ev = mcl::Event{mir_input_event_get_event(event)},
                 target = target,
-                target_window_destroyed = get_wlsurface(target)->destroyed_flag(),
+                target_window_destroyed = WlSurface::from(target)->destroyed_flag(),
                 this
             ]()
             {
@@ -1511,7 +1279,7 @@ private:
         if (latest_buffer_size == geom::Size{})
             return;
 
-        auto* const mir_surface = get_wlsurface(surface);
+        auto* const mir_surface = WlSurface::from(surface);
         if (params.size == geom::Size{}) params.size = latest_buffer_size;
         params.content_id = mir_surface->stream_id;
         surface_id = shell->create_surface(session, params, sink);
@@ -1568,8 +1336,8 @@ public:
 
     ~WlShellSurface() override
     {
-        auto* const mir_surface = get_wlsurface(surface);
-        mir_surface->set_role(&nullwlmirwindow);
+        auto* const mir_surface = WlSurface::from(surface);
+        mir_surface->set_role(nullWlMirWindowPtr);
     }
 
 protected:
@@ -1580,7 +1348,7 @@ protected:
 
     void set_toplevel() override
     {
-        auto* const mir_surface = get_wlsurface(surface);
+        auto* const mir_surface = WlSurface::from(surface);
 
         mir_surface->set_role(this);
     }
@@ -1592,7 +1360,7 @@ protected:
         uint32_t flags) override
     {
         auto const session = session_for_client(client);
-        auto& parent_surface = *get_wlsurface(parent);
+        auto& parent_surface = *WlSurface::from(parent);
 
         if (surface_id.as_value())
         {
@@ -1617,7 +1385,7 @@ protected:
             params.aux_rect_placement_offset_x = 0;
             params.aux_rect_placement_offset_y = 0;
 
-            auto* const mir_surface = get_wlsurface(surface);
+            auto* const mir_surface = WlSurface::from(surface);
             mir_surface->set_role(this);
         }
     }
@@ -1655,7 +1423,7 @@ protected:
         uint32_t flags) override
     {
         auto const session = session_for_client(client);
-        auto& parent_surface = *get_wlsurface(parent);
+        auto& parent_surface = *WlSurface::from(parent);
 
         if (surface_id.as_value())
         {
@@ -1681,7 +1449,7 @@ protected:
             params.aux_rect_placement_offset_x = 0;
             params.aux_rect_placement_offset_y = 0;
 
-            auto* const mir_surface = get_wlsurface(surface);
+            auto* const mir_surface = WlSurface::from(surface);
             mir_surface->set_role(this);
         }
     }
@@ -2004,8 +1772,8 @@ struct XdgSurfaceV6 : wayland::XdgSurfaceV6, WlAbstractMirWindow
 
     ~XdgSurfaceV6() override
     {
-        auto* const mir_surface = get_wlsurface(surface);
-        mir_surface->set_role(&nullwlmirwindow);
+        auto* const mir_surface = WlSurface::from(surface);
+        mir_surface->set_role(nullWlMirWindowPtr);
     }
 
     void destroy() override
@@ -2016,7 +1784,7 @@ struct XdgSurfaceV6 : wayland::XdgSurfaceV6, WlAbstractMirWindow
     void get_toplevel(uint32_t id) override
     {
         new XdgToplevelV6{client, parent, id, shell, this};
-        auto* const mir_surface = get_wlsurface(surface);
+        auto* const mir_surface = WlSurface::from(surface);
         mir_surface->set_role(this);
     }
 
@@ -2039,7 +1807,7 @@ struct XdgSurfaceV6 : wayland::XdgSurfaceV6, WlAbstractMirWindow
         params.placement_hints = mir_placement_hints_slide_any;
 
         new XdgPopupV6{client, parent, id};
-        auto* const mir_surface = get_wlsurface(surface);
+        auto* const mir_surface = WlSurface::from(surface);
         mir_surface->set_role(this);
     }
 

--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -89,17 +89,18 @@ namespace mir
 {
 namespace frontend
 {
+
+namespace
+{
 struct NullWlMirWindow : WlMirWindow
 {
     void new_buffer_size(mir::geometry::Size const& ) {}
     void commit() {}
     void visiblity(bool ) {}
     void destroy() {}
-
-    static NullWlMirWindow instance;
-} NullWlMirWindow::instance;
-
-WlMirWindow * const nullWlMirWindowPtr = &NullWlMirWindow::instance;
+} null_wl_mir_window_instance;
+}
+WlMirWindow* const null_wl_mir_window_ptr = &null_wl_mir_window_instance;
 
 namespace
 {
@@ -1337,7 +1338,7 @@ public:
     ~WlShellSurface() override
     {
         auto* const mir_surface = WlSurface::from(surface);
-        mir_surface->set_role(nullWlMirWindowPtr);
+        mir_surface->set_role(null_wl_mir_window_ptr);
     }
 
 protected:
@@ -1773,7 +1774,7 @@ struct XdgSurfaceV6 : wayland::XdgSurfaceV6, WlAbstractMirWindow
     ~XdgSurfaceV6() override
     {
         auto* const mir_surface = WlSurface::from(surface);
-        mir_surface->set_role(nullWlMirWindowPtr);
+        mir_surface->set_role(null_wl_mir_window_ptr);
     }
 
     void destroy() override

--- a/src/server/frontend/wayland/wayland_connector.h
+++ b/src/server/frontend/wayland/wayland_connector.h
@@ -56,21 +56,6 @@ class DisplayChanger;
 class SessionAuthorizer;
 class DataDeviceManager;
 
-template<typename Callable>
-inline auto run_unless(std::shared_ptr<bool> const& condition, Callable&& callable)
-{
-    return
-        [callable = std::move(callable), condition]()
-        {
-            if (*condition)
-                return;
-
-            callable();
-        };
-}
-
-std::shared_ptr<mir::frontend::Session> session_for_client(wl_client* client);
-
 class WaylandConnector : public Connector
 {
 public:

--- a/src/server/frontend/wayland/wayland_connector.h
+++ b/src/server/frontend/wayland/wayland_connector.h
@@ -71,15 +71,6 @@ inline auto run_unless(std::shared_ptr<bool> const& condition, Callable&& callab
 
 std::shared_ptr<mir::frontend::Session> session_for_client(wl_client* client);
 
-struct WlMirWindow
-{
-    virtual void new_buffer_size(geometry::Size const& buffer_size) = 0;
-    virtual void commit() = 0;
-    virtual void visiblity(bool visible) = 0;
-    virtual void destroy() = 0;
-    virtual ~WlMirWindow() = default;
-} extern * const null_wl_mir_window_ptr;
-
 class WaylandConnector : public Connector
 {
 public:

--- a/src/server/frontend/wayland/wayland_connector.h
+++ b/src/server/frontend/wayland/wayland_connector.h
@@ -78,7 +78,7 @@ struct WlMirWindow
     virtual void visiblity(bool visible) = 0;
     virtual void destroy() = 0;
     virtual ~WlMirWindow() = default;
-} extern * const nullWlMirWindowPtr;
+} extern * const null_wl_mir_window_ptr;
 
 class WaylandConnector : public Connector
 {

--- a/src/server/frontend/wayland/wayland_utils.h
+++ b/src/server/frontend/wayland/wayland_utils.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015-2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef WAYLAND_UTILS_H
+#define WAYLAND_UTILS_H
+
+#include "wayland_utils.h"
+
+#include <memory>
+
+class wl_client;
+
+namespace mir
+{
+namespace frontend
+{
+class Session;
+
+template<typename Callable>
+inline auto run_unless(std::shared_ptr<bool> const& condition, Callable&& callable)
+{
+    return [callable = std::move(callable), condition]()
+        {
+            if (*condition)
+                return;
+            callable();
+        };
+}
+
+std::shared_ptr<frontend::Session> get_session(wl_client* client);
+
+}
+}
+
+#endif // WAYLAND_UTILS_H

--- a/src/server/frontend/wayland/wl_mir_window.cpp
+++ b/src/server/frontend/wayland/wl_mir_window.cpp
@@ -18,7 +18,7 @@
 
 #include "wl_mir_window.h"
 
-#include "wayland_connector.h"
+#include "wayland_utils.h"
 #include "wl_surface.h"
 #include "basic_surface_event_sink.h"
 
@@ -73,7 +73,7 @@ WlAbstractMirWindow::~WlAbstractMirWindow()
     *destroyed = true;
     if (surface_id.as_value())
     {
-        if (auto session = session_for_client(client))
+        if (auto session = get_session(client))
         {
             shell->destroy_surface(session, surface_id);
         }
@@ -92,7 +92,7 @@ shell::SurfaceSpecification& WlAbstractMirWindow::spec()
 
 void WlAbstractMirWindow::commit()
 {
-    auto const session = session_for_client(client);
+    auto const session = get_session(client);
 
     if (surface_id.as_value())
     {
@@ -147,7 +147,7 @@ void WlAbstractMirWindow::visiblity(bool visible)
     if (!surface_id.as_value())
         return;
 
-    auto const session = session_for_client(client);
+    auto const session = get_session(client);
 
     if (get_surface_for_id(session, surface_id)->visible() == visible)
         return;

--- a/src/server/frontend/wayland/wl_mir_window.cpp
+++ b/src/server/frontend/wayland/wl_mir_window.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2015-2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#include "wl_mir_window.h"
+
+#include "wayland_connector.h"
+#include "wl_surface.h"
+#include "basic_surface_event_sink.h"
+
+#include "mir/frontend/shell.h"
+#include "mir/frontend/session.h"
+#include "mir/frontend/event_sink.h"
+
+#include "mir/scene/surface.h"
+#include "mir/scene/surface_creation_parameters.h"
+
+namespace mir
+{
+namespace frontend
+{
+
+namespace
+{
+class NullWlMirWindow : public WlMirWindow
+{
+public:
+    void new_buffer_size(geometry::Size const& /*buffer_size*/) {}
+    void commit() {}
+    void visiblity(bool /*visible*/) {}
+    void destroy() {}
+} null_wl_mir_window_instance;
+}
+
+WlMirWindow* const null_wl_mir_window_ptr = &null_wl_mir_window_instance;
+
+namespace
+{
+std::shared_ptr<scene::Surface> get_surface_for_id(std::shared_ptr<Session> const& session, SurfaceId surface_id)
+{
+    return std::dynamic_pointer_cast<scene::Surface>(session->get_surface(surface_id));
+}
+}
+
+WlAbstractMirWindow::WlAbstractMirWindow(wl_client* client, wl_resource* surface, wl_resource* event_sink,
+    std::shared_ptr<Shell> const& shell)
+        : destroyed{std::make_shared<bool>(false)},
+          client{client},
+          surface{surface},
+          event_sink{event_sink},
+          shell{shell},
+          params{std::make_unique<scene::SurfaceCreationParameters>(
+              scene::SurfaceCreationParameters().of_type(mir_window_type_freestyle))}
+{
+}
+
+WlAbstractMirWindow::~WlAbstractMirWindow()
+{
+    *destroyed = true;
+    if (surface_id.as_value())
+    {
+        if (auto session = session_for_client(client))
+        {
+            shell->destroy_surface(session, surface_id);
+        }
+
+        surface_id = {};
+    }
+}
+
+shell::SurfaceSpecification& WlAbstractMirWindow::spec()
+{
+    if (!pending_changes)
+        pending_changes = std::make_unique<shell::SurfaceSpecification>();
+
+    return *pending_changes;
+}
+
+void WlAbstractMirWindow::commit()
+{
+    auto const session = session_for_client(client);
+
+    if (surface_id.as_value())
+    {
+        auto const surface = get_surface_for_id(session, surface_id);
+
+        if (surface->size() != latest_buffer_size)
+        {
+            sink->latest_resize(latest_buffer_size);
+            auto& new_size_spec = spec();
+            new_size_spec.width = latest_buffer_size.width;
+            new_size_spec.height = latest_buffer_size.height;
+        }
+
+        if (pending_changes)
+            shell->modify_surface(session, surface_id, *pending_changes);
+
+        pending_changes.reset();
+        return;
+    }
+
+    // Until we've seen a buffer we don't create a surface
+    if (latest_buffer_size == geometry::Size{})
+        return;
+
+    auto* const mir_surface = WlSurface::from(surface);
+    if (params->size == geometry::Size{})
+        params->size = latest_buffer_size;
+    params->content_id = mir_surface->stream_id;
+    surface_id = shell->create_surface(session, *params, sink);
+    mir_surface->surface_id = surface_id;
+
+    // The shell isn't guaranteed to respect the requested size
+    auto const window = session->get_surface(surface_id);
+    sink->send_resize(window->client_size());
+}
+
+void WlAbstractMirWindow::new_buffer_size(geometry::Size const& buffer_size)
+{
+    latest_buffer_size = buffer_size;
+
+    // Sometimes, when using xdg-shell, qterminal creates an insanely tall buffer
+    if (latest_buffer_size.height > geometry::Height{10000})
+    {
+        log_warning("Insane buffer height sanitized: latest_buffer_size.height = %d (was %d)",
+                1000, latest_buffer_size.height.as_int());
+        latest_buffer_size.height = geometry::Height{1000};
+    }
+}
+
+void WlAbstractMirWindow::visiblity(bool visible)
+{
+    if (!surface_id.as_value())
+        return;
+
+    auto const session = session_for_client(client);
+
+    if (get_surface_for_id(session, surface_id)->visible() == visible)
+        return;
+
+    spec().state = visible ? mir_window_state_restored : mir_window_state_hidden;
+}
+
+}
+}

--- a/src/server/frontend/wayland/wl_mir_window.h
+++ b/src/server/frontend/wayland/wl_mir_window.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015-2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef WL_MIR_WINDOW_H
+#define WL_MIR_WINDOW_H
+
+#include "mir/frontend/surface_id.h"
+#include "mir/geometry/size.h"
+
+#include <memory>
+
+struct wl_client;
+struct wl_resource;
+
+namespace mir
+{
+namespace scene
+{
+class SurfaceCreationParameters;
+}
+namespace shell
+{
+class SurfaceSpecification;
+}
+namespace frontend
+{
+class Shell;
+class BasicSurfaceEventSink;
+
+class WlMirWindow
+{
+public:
+    virtual void new_buffer_size(geometry::Size const& buffer_size) = 0;
+    virtual void commit() = 0;
+    virtual void visiblity(bool visible) = 0;
+    virtual void destroy() = 0;
+    virtual ~WlMirWindow() = default;
+} extern * const null_wl_mir_window_ptr;
+
+class WlAbstractMirWindow : public WlMirWindow
+{
+public:
+    WlAbstractMirWindow(wl_client* client, wl_resource* surface, wl_resource* event_sink,
+        std::shared_ptr<frontend::Shell> const& shell);
+
+    ~WlAbstractMirWindow() override;
+
+protected:
+    std::shared_ptr<bool> const destroyed;
+    wl_client* const client;
+    wl_resource* const surface;
+    wl_resource* const event_sink;
+    std::shared_ptr<frontend::Shell> const shell;
+    std::shared_ptr<BasicSurfaceEventSink> sink;
+
+    std::unique_ptr<scene::SurfaceCreationParameters> const params;
+    SurfaceId surface_id;
+
+    shell::SurfaceSpecification& spec();
+
+private:
+    geometry::Size latest_buffer_size;
+    std::unique_ptr<shell::SurfaceSpecification> pending_changes;
+
+    void commit() override;
+    void new_buffer_size(geometry::Size const& buffer_size) override;
+    void visiblity(bool visible) override;
+};
+
+}
+}
+
+#endif // WL_MIR_WINDOW_H

--- a/src/server/frontend/wayland/wl_surface.cpp
+++ b/src/server/frontend/wayland/wl_surface.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ *              William Wold <william.wold@canonical.com>
+ */
+
+#include "wl_surface.h"
+
+#include "core_generated_interfaces.h"
+#include "wayland_connector.h"
+#include "wlshmbuffer.h"
+
+#include "mir/graphics/buffer_properties.h"
+#include "mir/frontend/session.h"
+#include "mir/compositor/buffer_stream.h"
+#include "mir/executor.h"
+#include "mir/graphics/wayland_allocator.h"
+
+namespace mir
+{
+namespace frontend
+{
+
+WlSurface::WlSurface(
+    wl_client* client,
+    wl_resource* parent,
+    uint32_t id,
+    std::shared_ptr<Executor> const& executor,
+    std::shared_ptr<graphics::WaylandAllocator> const& allocator)
+    : Surface(client, parent, id),
+        allocator{allocator},
+        executor{executor},
+        role{nullWlMirWindowPtr},
+        pending_buffer{nullptr},
+        pending_frames{std::make_shared<std::vector<wl_resource*>>()},
+        destroyed{std::make_shared<bool>(false)}
+{
+    auto session = session_for_client(client);
+    graphics::BufferProperties const props{
+        geometry::Size{geometry::Width{0}, geometry::Height{0}},
+        mir_pixel_format_invalid,
+        graphics::BufferUsage::undefined
+    };
+
+    stream_id = session->create_buffer_stream(props);
+    stream = session->get_buffer_stream(stream_id);
+
+    // wl_surface is specified to act in mailbox mode
+    stream->allow_framedropping(true);
+}
+
+WlSurface::~WlSurface()
+{
+    *destroyed = true;
+    if (auto session = session_for_client(client))
+        session->destroy_buffer_stream(stream_id);
+}
+
+void WlSurface::set_role(WlMirWindow* role_)
+{
+    role = role_;
+}
+
+std::shared_ptr<bool> WlSurface::destroyed_flag() const
+{
+    return destroyed;
+}
+
+WlSurface* WlSurface::from(wl_resource* resource)
+{
+    void* raw_surface = wl_resource_get_user_data(resource);
+    return static_cast<WlSurface*>(static_cast<wayland::Surface*>(raw_surface));
+}
+
+void WlSurface::destroy()
+{
+    *destroyed = true;
+    role->destroy();
+    wl_resource_destroy(resource);
+}
+
+void WlSurface::attach(std::experimental::optional<wl_resource*> const& buffer, int32_t x, int32_t y)
+{
+    if (x != 0 || y != 0)
+    {
+        mir::log_warning("Client requested unimplemented non-zero attach offset. Rendering will be incorrect.");
+    }
+
+    role->visiblity(!!buffer);
+
+    pending_buffer = buffer.value_or(nullptr);
+}
+
+void WlSurface::damage(int32_t x, int32_t y, int32_t width, int32_t height)
+{
+    (void)x;
+    (void)y;
+    (void)width;
+    (void)height;
+    // This isn't essential, but could enable optimizations
+}
+
+void WlSurface::damage_buffer(int32_t x, int32_t y, int32_t width, int32_t height)
+{
+    (void)x;
+    (void)y;
+    (void)width;
+    (void)height;
+    // This isn't essential, but could enable optimizations
+}
+
+void WlSurface::frame(uint32_t callback)
+{
+    pending_frames->emplace_back(
+        wl_resource_create(client, &wl_callback_interface, 1, callback));
+}
+
+void WlSurface::set_opaque_region(const std::experimental::optional<wl_resource*>& region)
+{
+    (void)region;
+}
+
+void WlSurface::set_input_region(const std::experimental::optional<wl_resource*>& region)
+{
+    (void)region;
+}
+
+void WlSurface::commit()
+{
+    if (pending_buffer)
+    {
+        auto send_frame_notifications =
+            [executor = executor, frames = pending_frames, destroyed = destroyed]()
+            {
+                executor->spawn(run_unless(
+                    destroyed,
+                    [frames]()
+                    {
+                        /*
+                         * There is no synchronisation required here -
+                         * This is run on the WaylandExecutor, and is guaranteed to run on the
+                         * wl_event_loop's thread.
+                         *
+                         * The only other accessors of WlSurface are also on the wl_event_loop,
+                         * so this is guaranteed not to be reentrant.
+                         */
+                        for (auto frame : *frames)
+                        {
+                            wl_callback_send_done(frame, 0);
+                            wl_resource_destroy(frame);
+                        }
+                        frames->clear();
+                    }));
+            };
+
+        std::shared_ptr<graphics::Buffer> mir_buffer;
+
+        if (wl_shm_buffer_get(pending_buffer))
+        {
+            mir_buffer = WlShmBuffer::mir_buffer_from_wl_buffer(
+                pending_buffer,
+                std::move(send_frame_notifications));
+        }
+        else
+        {
+            auto release_buffer = [executor = executor, buffer = pending_buffer, destroyed = destroyed]()
+                {
+                    executor->spawn(run_unless(
+                        destroyed,
+                        [buffer](){ wl_resource_queue_event(buffer, WL_BUFFER_RELEASE); }));
+                };
+
+            mir_buffer = allocator->buffer_from_resource(
+                    pending_buffer,
+                    std::move(send_frame_notifications),
+                    std::move(release_buffer));
+        }
+
+        /*
+         * This is technically incorrect - the resize and submit_buffer *should* be atomic,
+         * but are not, so a client in the process of resizing can have buffers rendered at
+         * an unexpected size.
+         *
+         * It should be good enough for now, though.
+         *
+         * TODO: Provide a mg::Buffer::logical_size() to do this properly.
+         */
+        stream->resize(mir_buffer->size());
+        role->new_buffer_size(mir_buffer->size());
+        role->commit();
+        stream->submit_buffer(mir_buffer);
+
+        pending_buffer = nullptr;
+    }
+    else
+    {
+        role->commit();
+    }
+}
+
+void WlSurface::set_buffer_transform(int32_t transform)
+{
+    (void)transform;
+    // TODO
+}
+
+void WlSurface::set_buffer_scale(int32_t scale)
+{
+    (void)scale;
+    // TODO
+}
+
+}
+}

--- a/src/server/frontend/wayland/wl_surface.cpp
+++ b/src/server/frontend/wayland/wl_surface.cpp
@@ -20,6 +20,7 @@
 #include "wl_surface.h"
 
 #include "core_generated_interfaces.h"
+#include "wl_mir_window.h"
 #include "wayland_connector.h"
 #include "wlshmbuffer.h"
 

--- a/src/server/frontend/wayland/wl_surface.cpp
+++ b/src/server/frontend/wayland/wl_surface.cpp
@@ -19,9 +19,9 @@
 
 #include "wl_surface.h"
 
+#include "wayland_utils.h"
 #include "core_generated_interfaces.h"
 #include "wl_mir_window.h"
-#include "wayland_connector.h"
 #include "wlshmbuffer.h"
 
 #include "mir/graphics/buffer_properties.h"
@@ -49,7 +49,7 @@ WlSurface::WlSurface(
         pending_frames{std::make_shared<std::vector<wl_resource*>>()},
         destroyed{std::make_shared<bool>(false)}
 {
-    auto session = session_for_client(client);
+    auto session = get_session(client);
     graphics::BufferProperties const props{
         geometry::Size{geometry::Width{0}, geometry::Height{0}},
         mir_pixel_format_invalid,
@@ -66,7 +66,7 @@ WlSurface::WlSurface(
 WlSurface::~WlSurface()
 {
     *destroyed = true;
-    if (auto session = session_for_client(client))
+    if (auto session = get_session(client))
         session->destroy_buffer_stream(stream_id);
 }
 

--- a/src/server/frontend/wayland/wl_surface.cpp
+++ b/src/server/frontend/wayland/wl_surface.cpp
@@ -43,7 +43,7 @@ WlSurface::WlSurface(
     : Surface(client, parent, id),
         allocator{allocator},
         executor{executor},
-        role{nullWlMirWindowPtr},
+        role{null_wl_mir_window_ptr},
         pending_buffer{nullptr},
         pending_frames{std::make_shared<std::vector<wl_resource*>>()},
         destroyed{std::make_shared<bool>(false)}
@@ -128,12 +128,12 @@ void WlSurface::frame(uint32_t callback)
         wl_resource_create(client, &wl_callback_interface, 1, callback));
 }
 
-void WlSurface::set_opaque_region(const std::experimental::optional<wl_resource*>& region)
+void WlSurface::set_opaque_region(std::experimental::optional<wl_resource*> const& region)
 {
     (void)region;
 }
 
-void WlSurface::set_input_region(const std::experimental::optional<wl_resource*>& region)
+void WlSurface::set_input_region(std::experimental::optional<wl_resource*> const& region)
 {
     (void)region;
 }

--- a/src/server/frontend/wayland/wl_surface.h
+++ b/src/server/frontend/wayland/wl_surface.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ *              William Wold <william.wold@canonical.com>
+ */
+
+#ifndef WL_SURFACE_H
+#define WL_SURFACE_H
+
+#include "core_generated_interfaces.h"
+
+#include "mir/frontend/buffer_stream_id.h"
+#include "mir/frontend/surface_id.h"
+
+#include <vector>
+
+namespace mir
+{
+class Executor;
+
+namespace graphics
+{
+class WaylandAllocator;
+}
+
+namespace frontend
+{
+class BufferStream;
+struct WlMirWindow;
+
+class WlSurface : public wayland::Surface
+{
+public:
+    WlSurface(wl_client* client,
+              wl_resource* parent,
+              uint32_t id,
+              const std::shared_ptr< mir::Executor >& executor,
+              const std::shared_ptr< mir::graphics::WaylandAllocator >& allocator);
+
+    ~WlSurface();
+
+    void set_role(WlMirWindow* role_);
+
+    mir::frontend::BufferStreamId stream_id;
+    std::shared_ptr<mir::frontend::BufferStream> stream;
+    mir::frontend::SurfaceId surface_id;       // ID of any associated surface
+
+    std::shared_ptr<bool> destroyed_flag() const;
+
+    static WlSurface* from(wl_resource* resource);
+
+private:
+    std::shared_ptr<mir::graphics::WaylandAllocator> const allocator;
+    std::shared_ptr<mir::Executor> const executor;
+
+    WlMirWindow* role;
+
+    wl_resource* pending_buffer;
+    std::shared_ptr<std::vector<wl_resource*>> const pending_frames;
+    std::shared_ptr<bool> const destroyed;
+
+    void destroy();
+    void attach(std::experimental::optional<wl_resource*> const& buffer, int32_t x, int32_t y);
+    void damage(int32_t x, int32_t y, int32_t width, int32_t height);
+    void frame(uint32_t callback);
+    void set_opaque_region(std::experimental::optional<wl_resource*> const& region);
+    void set_input_region(std::experimental::optional<wl_resource*> const& region);
+    void commit();
+    void damage_buffer(int32_t x, int32_t y, int32_t width, int32_t height);
+    void set_buffer_transform(int32_t transform);
+    void set_buffer_scale(int32_t scale);
+};
+}
+}
+
+#endif // WL_SURFACE_H

--- a/src/server/frontend/wayland/wl_surface.h
+++ b/src/server/frontend/wayland/wl_surface.h
@@ -47,8 +47,8 @@ public:
     WlSurface(wl_client* client,
               wl_resource* parent,
               uint32_t id,
-              const std::shared_ptr< mir::Executor >& executor,
-              const std::shared_ptr< mir::graphics::WaylandAllocator >& allocator);
+              std::shared_ptr<mir::Executor> const& executor,
+              std::shared_ptr<mir::graphics::WaylandAllocator> const& allocator);
 
     ~WlSurface();
 


### PR DESCRIPTION
Some changes of note:
- renamed `get_wlsurface(resource)` to `WlSurface::from(resource)`
- `nullWlMirWindow;` is now `nullWlMirWindowPtr` (and the `NullWlMirWindow` type is not exposed)