### PR TITLE
csd-resize

### DIFF
--- a/examples/miral-shell/floating_window_manager.cpp
+++ b/examples/miral-shell/floating_window_manager.cpp
@@ -90,7 +90,7 @@ bool FloatingWindowManagerPolicy::handle_pointer_event(MirPointerEvent const* ev
                     auto const top_left = csd_resize_window.top_left();
                     Rectangle const old_pos{top_left, csd_resize_window.size()};
 
-                    auto movement = cursor-old_cursor;
+                    auto movement = cursor - old_cursor;
 
                     auto new_width = old_pos.size.width;
                     auto new_height = old_pos.size.height;

--- a/examples/miral-shell/floating_window_manager.h
+++ b/examples/miral-shell/floating_window_manager.h
@@ -22,8 +22,8 @@
 #include <miral/canonical_window_manager.h>
 #include <miral/window_management_policy_addendum2.h>
 #include <miral/window_management_policy_addendum3.h>
+#include <miral/window_management_policy_addendum4.h>
 #include <miral/workspace_policy.h>
-
 
 #include "spinner/splash.h"
 
@@ -38,7 +38,7 @@ class DecorationProvider;
 
 class FloatingWindowManagerPolicy : public miral::CanonicalWindowManagerPolicy,
     public miral::WorkspacePolicy, public miral::WindowManagementPolicyAddendum3,
-    public miral::WindowManagementPolicyAddendum2
+    public miral::WindowManagementPolicyAddendum2, public miral::WindowManagementPolicyAddendum4
 {
 public:
     FloatingWindowManagerPolicy(
@@ -85,6 +85,9 @@ public:
     void handle_request_drag_and_drop(miral::WindowInfo& window_info) override;
 
     void handle_request_move(miral::WindowInfo& window_info, MirInputEvent const* input_event) override;
+
+    void handle_request_resize(
+        miral::WindowInfo& window_info, MirInputEvent const* input_event, MirResizeEdge edge) override;
     /** @} */
 
 protected:
@@ -113,6 +116,10 @@ private:
     int old_touch_pinch_width = 0;
     int old_touch_pinch_height = 0;
     bool pinching = false;
+
+    bool csd_resizing = false;
+    MirResizeEdge csd_resize_edge = mir_resize_edge_none;
+    miral::Window csd_resize_window;
 
     SpinnerSplash const spinner;
 

--- a/include/client/mir_toolkit/mir_window.h
+++ b/include/client/mir_toolkit/mir_window.h
@@ -747,6 +747,15 @@ void mir_window_raise(MirWindow* window, MirCookie const* cookie);
 void mir_window_request_user_move(MirWindow* window, MirCookie const* cookie);
 
 /**
+ * Informs the window manager that the user is resizing the window.
+ *
+ * \param [in] window  The window to resize
+ * \param [in] cookie  A cookie instance obtained from an input event.
+ *                     An invalid cookie will terminate the client connection.
+ */
+void mir_window_request_user_resize(MirWindow* window, MirCookie const* cookie);
+
+/**
  * Get the type (purpose) of a window.
  *   \param [in] window   The window to query
  *   \return              The type of the window

--- a/include/client/mir_toolkit/mir_window.h
+++ b/include/client/mir_toolkit/mir_window.h
@@ -750,10 +750,11 @@ void mir_window_request_user_move(MirWindow* window, MirCookie const* cookie);
  * Informs the window manager that the user is resizing the window.
  *
  * \param [in] window  The window to resize
+ * \param [in/ edge    The edge being dragged
  * \param [in] cookie  A cookie instance obtained from an input event.
  *                     An invalid cookie will terminate the client connection.
  */
-void mir_window_request_user_resize(MirWindow* window, MirCookie const* cookie);
+void mir_window_request_user_resize(MirWindow* window, MirResizeEdge edge, MirCookie const* cookie);
 
 /**
  * Get the type (purpose) of a window.

--- a/include/core/mir_toolkit/common.h
+++ b/include/core/mir_toolkit/common.h
@@ -399,6 +399,26 @@ typedef enum MirPlacementHints
     mir_placement_hints_resize_any = mir_placement_hints_resize_x|mir_placement_hints_resize_y,
 } MirPlacementHints;
 
+
+/**
+ * Hints for resizing a window.
+ *
+ * These values are used to indicate which edge(s) of a surface
+ * is being dragged in a resize operation.
+ */
+typedef enum MirResizeEdge
+{
+    mir_resize_edge_none      = 0,
+    mir_resize_edge_west      = 1 << 0,
+    mir_resize_edge_east      = 1 << 1,
+    mir_resize_edge_north     = 1 << 2,
+    mir_resize_edge_south     = 1 << 3,
+    mir_resize_edge_northwest = mir_resize_edge_north | mir_resize_edge_west,
+    mir_resize_edge_northeast = mir_resize_edge_north | mir_resize_edge_east,
+    mir_resize_edge_southwest = mir_resize_edge_south | mir_resize_edge_west,
+    mir_resize_edge_southeast = mir_resize_edge_south | mir_resize_edge_east
+} MirResizeEdge;
+
 /**
  * Form factor associated with a physical output
  */

--- a/include/miral/miral/window_management_policy_addendum4.h
+++ b/include/miral/miral/window_management_policy_addendum4.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#ifndef MIRAL_WINDOW_MANAGEMENT_ADDENDUM4_H
+#define MIRAL_WINDOW_MANAGEMENT_ADDENDUM4_H
+
+#include <mir_toolkit/client_types.h>
+#include <mir_toolkit/mir_version_number.h>
+
+namespace miral
+{
+struct WindowInfo;
+
+/**
+ *  Handle additional client requests.
+ *
+ *  \note This interface is intended to be implemented by a WindowManagementPolicy
+ *  implementation, we can't add these functions directly to that interface without
+ *  breaking ABI (the vtab could be incompatible).
+ *  When initializing the window manager this interface will be detected by
+ *  dynamic_cast and registered accordingly.
+ */
+class WindowManagementPolicyAddendum4
+{
+public:
+/** @name handle requests originating from the client
+ * The policy is expected to update the model as appropriate
+ *  @{ */
+    /** request from client to initiate resize
+     * \note the request has already been validated against the requesting event
+     *
+     * @param window_info   the window
+     * @param input_event   the requesting event
+     * @param edge          the edge(s) being dragged
+     */
+    virtual void handle_request_resize(WindowInfo& window_info, MirInputEvent const* input_event, MirResizeEdge edge) = 0;
+/** @} */
+
+    virtual ~WindowManagementPolicyAddendum4() = default;
+    WindowManagementPolicyAddendum4() = default;
+    WindowManagementPolicyAddendum4(WindowManagementPolicyAddendum4 const&) = delete;
+    WindowManagementPolicyAddendum4& operator=(WindowManagementPolicyAddendum4 const&) = delete;
+};
+#if MIRAL_VERSION >= MIR_VERSION_NUMBER(2, 0, 0)
+#error "We've presumably broken ABI - please roll this interface into WindowManagementPolicy"
+#endif
+}
+
+#endif //MIRAL_WINDOW_MANAGEMENT_ADDENDUM4_H

--- a/include/server/mir/shell/abstract_shell.h
+++ b/include/server/mir/shell/abstract_shell.h
@@ -92,6 +92,12 @@ public:
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp) override;
 
+    void request_resize(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<scene::Surface> const& surface,
+        uint64_t timestamp,
+        MirResizeEdge edge) override;
+
     std::shared_ptr<scene::PromptSession> start_prompt_session_for(
         std::shared_ptr<scene::Session> const& session,
         scene::PromptSessionCreationParameters const& params) override;

--- a/include/server/mir/shell/shell.h
+++ b/include/server/mir/shell/shell.h
@@ -109,6 +109,13 @@ public:
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp) = 0;
+
+    virtual void request_resize(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<scene::Surface> const& surface,
+        uint64_t timestamp,
+        MirResizeEdge edge) = 0;
+
 /** @} */
 };
 }

--- a/include/server/mir/shell/shell_wrapper.h
+++ b/include/server/mir/shell/shell_wrapper.h
@@ -95,6 +95,12 @@ public:
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp) override;
 
+    void request_resize(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<scene::Surface> const& surface,
+        uint64_t timestamp,
+        MirResizeEdge edge) override;
+
     void add_display(geometry::Rectangle const& area) override;
     void remove_display(geometry::Rectangle const& area) override;
 

--- a/include/server/mir/shell/system_compositor_window_manager.h
+++ b/include/server/mir/shell/system_compositor_window_manager.h
@@ -105,6 +105,12 @@ private:
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp) override;
 
+    void handle_request_resize(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<scene::Surface> const& surface,
+        uint64_t timestamp,
+        MirResizeEdge edge) override;
+
     int set_surface_attribute(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,

--- a/include/server/mir/shell/window_manager.h
+++ b/include/server/mir/shell/window_manager.h
@@ -86,6 +86,12 @@ public:
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp) = 0;
 
+    virtual void handle_request_resize(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<scene::Surface> const& surface,
+        uint64_t timestamp,
+        MirResizeEdge edge) = 0;
+
     virtual ~WindowManager() = default;
     WindowManager() = default;
     WindowManager(WindowManager const&) = delete;

--- a/include/test/mir/test/doubles/mock_window_manager.h
+++ b/include/test/mir/test/doubles/mock_window_manager.h
@@ -60,6 +60,7 @@ struct MockWindowManager : shell::WindowManager
     MOCK_METHOD3(handle_raise_surface, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, uint64_t));
     MOCK_METHOD3(handle_request_drag_and_drop, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, uint64_t));
     MOCK_METHOD3(handle_request_move, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, uint64_t));
+    MOCK_METHOD4(handle_request_resize, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, uint64_t, MirResizeEdge));
 
     MOCK_METHOD4(set_surface_attribute,
         int(std::shared_ptr<scene::Session> const& session,

--- a/src/client/mir_surface.cpp
+++ b/src/client/mir_surface.cpp
@@ -593,9 +593,9 @@ void MirSurface::request_user_move(MirCookie const* cookie)
     request_operation(cookie, mp::RequestOperation::USER_MOVE);
 }
 
-void MirSurface::request_user_resize(MirCookie const* cookie)
+void MirSurface::request_user_resize(MirResizeEdge edge, MirCookie const* cookie)
 {
-    request_operation(cookie, mp::RequestOperation::USER_RESIZE);
+    request_operation(cookie, mp::RequestOperation::USER_RESIZE, edge);
 }
 
 void MirSurface::request_drag_and_drop(MirCookie const* cookie)
@@ -604,6 +604,11 @@ void MirSurface::request_drag_and_drop(MirCookie const* cookie)
 }
 
 void MirSurface::request_operation(MirCookie const* cookie, mir::protobuf::RequestOperation operation) const
+{
+    request_operation(cookie, operation, mir::optional_value<uint32_t>{});
+}
+
+void MirSurface::request_operation(MirCookie const* cookie, mir::protobuf::RequestOperation operation, mir::optional_value<uint32_t> hint) const
 {
     mir::protobuf::RequestWithAuthority request;
     request.set_operation(operation);
@@ -614,6 +619,9 @@ void MirSurface::request_operation(MirCookie const* cookie, mir::protobuf::Reque
     auto const event_authority = request.mutable_authority();
 
     event_authority->set_cookie(cookie->cookie().data(), cookie->size());
+
+    if (hint.is_set())
+        request.set_hint(hint.value());
 
     server->request_operation(
         &request,

--- a/src/client/mir_surface.cpp
+++ b/src/client/mir_surface.cpp
@@ -593,6 +593,11 @@ void MirSurface::request_user_move(MirCookie const* cookie)
     request_operation(cookie, mp::RequestOperation::USER_MOVE);
 }
 
+void MirSurface::request_user_resize(MirCookie const* cookie)
+{
+    request_operation(cookie, mp::RequestOperation::USER_RESIZE);
+}
+
 void MirSurface::request_drag_and_drop(MirCookie const* cookie)
 {
     request_operation(cookie, mp::RequestOperation::START_DRAG_AND_DROP);

--- a/src/client/mir_surface.h
+++ b/src/client/mir_surface.h
@@ -201,6 +201,7 @@ public:
 
     void raise_surface(MirCookie const* cookie);
     void request_user_move(MirCookie const* cookie);
+    void request_user_resize(MirCookie const* cookie);
     void request_drag_and_drop(MirCookie const* cookie);
     void set_drag_and_drop_start_handler(std::function<void(MirWindowEvent const*)> const& callback);
 

--- a/src/client/mir_surface.h
+++ b/src/client/mir_surface.h
@@ -201,7 +201,7 @@ public:
 
     void raise_surface(MirCookie const* cookie);
     void request_user_move(MirCookie const* cookie);
-    void request_user_resize(MirCookie const* cookie);
+    void request_user_resize(MirResizeEdge edge, MirCookie const* cookie);
     void request_drag_and_drop(MirCookie const* cookie);
     void set_drag_and_drop_start_handler(std::function<void(MirWindowEvent const*)> const& callback);
 
@@ -233,6 +233,7 @@ private:
     void on_cursor_configured();
     void acquired_persistent_id(MirWindowIdCallback callback, void* context);
     void request_operation(MirCookie const* cookie, mir::protobuf::RequestOperation operation) const;
+    void request_operation(MirCookie const* cookie, mir::protobuf::RequestOperation operation, mir::optional_value<uint32_t> hint) const;
 
     mir::client::rpc::DisplayServer* const server{nullptr};
     mir::client::rpc::DisplayServerDebug* const debug{nullptr};

--- a/src/client/mir_surface_api.cpp
+++ b/src/client/mir_surface_api.cpp
@@ -731,13 +731,13 @@ void mir_window_request_user_move(MirWindow* window, MirCookie const* cookie)
     }
 }
 
-void mir_window_request_user_resize(MirWindow* window, MirCookie const* cookie)
+void mir_window_request_user_resize(MirWindow* window, MirResizeEdge edge, MirCookie const* cookie)
 {
     mir::require(mir_window_is_valid(window));
 
     try
     {
-        window->request_user_resize(cookie);
+        window->request_user_resize(edge, cookie);
     }
     catch (std::exception const& ex)
     {

--- a/src/client/mir_surface_api.cpp
+++ b/src/client/mir_surface_api.cpp
@@ -731,6 +731,20 @@ void mir_window_request_user_move(MirWindow* window, MirCookie const* cookie)
     }
 }
 
+void mir_window_request_user_resize(MirWindow* window, MirCookie const* cookie)
+{
+    mir::require(mir_window_is_valid(window));
+
+    try
+    {
+        window->request_user_resize(cookie);
+    }
+    catch (std::exception const& ex)
+    {
+        MIR_LOG_UNCAUGHT_EXCEPTION(ex);
+    }
+}
+
 MirWindowType mir_window_get_type(MirWindow* window)
 {
     MirWindowType type = mir_window_type_normal;

--- a/src/include/server/mir/frontend/shell.h
+++ b/src/include/server/mir/frontend/shell.h
@@ -20,6 +20,7 @@
 #define MIR_FRONTEND_SHELL_H_
 
 #include "mir/frontend/surface_id.h"
+#include "mir/optional_value.h"
 #include "mir_toolkit/common.h"
 
 #include <sys/types.h>
@@ -87,12 +88,22 @@ public:
         drag_and_drop,
         move,
         activate,
+        resize,
     };
 
     virtual void request_operation(
         std::shared_ptr<Session> const& session,
         SurfaceId surface_id, uint64_t timestamp,
-        UserRequest request) = 0;
+        UserRequest request,
+        optional_value<uint32_t> hint) = 0;
+
+    void request_operation(
+        std::shared_ptr<Session> const& session,
+        SurfaceId surface_id, uint64_t timestamp,
+        UserRequest request)
+    {
+        request_operation(session, surface_id, timestamp, request, optional_value<uint32_t>{});
+    }
 
 protected:
     Shell() = default;

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(miral SHARED
     window_manager_tools.cpp            ${miral_include}/miral/window_manager_tools.h
                                         ${miral_include}/miral/window_management_policy_addendum2.h
                                         ${miral_include}/miral/window_management_policy_addendum3.h
+                                        ${miral_include}/miral/window_management_policy_addendum4.h
                                         window_info_defaults.h
 )
 

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -405,7 +405,6 @@ void miral::BasicWindowManager::handle_raise_surface(
         policy->handle_raise_window(info_for(surface));
 }
 
-#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(0, 27, 0)
 void miral::BasicWindowManager::handle_request_drag_and_drop(
     std::shared_ptr<mir::scene::Session> const& /*session*/,
     std::shared_ptr<mir::scene::Surface> const& surface,
@@ -427,7 +426,16 @@ void miral::BasicWindowManager::handle_request_move(
         policy2->handle_request_move(info_for(surface), mir_event_get_input_event(last_input_event));
     }
 }
-#endif
+
+void miral::BasicWindowManager::handle_request_resize(
+    std::shared_ptr<mir::scene::Session> const& session,
+    std::shared_ptr<mir::scene::Surface> const& surface,
+    uint64_t timestamp,
+    MirResizeEdge edge)
+{
+    (void)session, (void)surface, (void)timestamp, (void)edge;
+    // TODO{arg}
+}
 
 int miral::BasicWindowManager::set_surface_attribute(
     std::shared_ptr<scene::Session> const& /*application*/,

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -109,7 +109,6 @@ public:
         std::shared_ptr<mir::scene::Surface> const& surface,
         uint64_t timestamp) override;
 
-#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(0, 27, 0)
     void handle_request_drag_and_drop(
         std::shared_ptr<mir::scene::Session> const& session,
         std::shared_ptr<mir::scene::Surface> const& surface,
@@ -119,7 +118,12 @@ public:
         std::shared_ptr<mir::scene::Session> const& session,
         std::shared_ptr<mir::scene::Surface> const& surface,
         uint64_t timestamp) override;
-#endif
+
+    void handle_request_resize(
+        std::shared_ptr<mir::scene::Session> const& session,
+        std::shared_ptr<mir::scene::Surface> const& surface,
+        uint64_t timestamp,
+        MirResizeEdge edge) override;
 
     int set_surface_attribute(
         std::shared_ptr<mir::scene::Session> const& /*application*/,

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -51,6 +51,7 @@ namespace miral
 class WorkspacePolicy;
 class WindowManagementPolicyAddendum2;
 class WindowManagementPolicyAddendum3;
+class WindowManagementPolicyAddendum4;
 class DisplayConfigurationListeners;
 
 using mir::shell::SurfaceSet;
@@ -216,6 +217,7 @@ private:
     WorkspacePolicy* const workspace_policy;
     WindowManagementPolicyAddendum2* const policy2;
     WindowManagementPolicyAddendum3* const policy3;
+    WindowManagementPolicyAddendum4* const policy4;
 
     std::mutex mutex;
     SessionInfoMap app_info;

--- a/src/protobuf/mir_protobuf.proto
+++ b/src/protobuf/mir_protobuf.proto
@@ -465,6 +465,7 @@ message RequestWithAuthority {
   required Cookie authority = 1;
   required SurfaceId surface_id = 2;
   required RequestOperation operation = 3;
+  optional uint32 hint = 4;
 }
 
 message InputDevices {

--- a/src/protobuf/mir_protobuf.proto
+++ b/src/protobuf/mir_protobuf.proto
@@ -458,6 +458,7 @@ enum RequestOperation {
   START_DRAG_AND_DROP = 1;
   MAKE_ACTIVE = 2;
   USER_MOVE = 3;
+  USER_RESIZE = 4;
 }
 
 message RequestWithAuthority {

--- a/src/server/frontend/session_mediator.cpp
+++ b/src/server/frontend/session_mediator.cpp
@@ -1324,6 +1324,13 @@ void mir::frontend::SessionMediator::request_operation(
             Shell::UserRequest::move);
         break;
 
+    case mir::protobuf::RequestOperation::USER_RESIZE:
+        shell->request_operation(
+            session, mf::SurfaceId{surface_id.value()},
+            cookie_ptr->timestamp(),
+            Shell::UserRequest::resize);
+        break;
+
     default:
         break;
     }

--- a/src/server/frontend/shell_wrapper.cpp
+++ b/src/server/frontend/shell_wrapper.cpp
@@ -100,7 +100,11 @@ int mf::ShellWrapper::get_surface_attribute(
 }
 
 void mf::ShellWrapper::request_operation(
-    std::shared_ptr<Session> const& session, SurfaceId surface_id, uint64_t timestamp, UserRequest request)
+    std::shared_ptr<Session> const& session,
+    SurfaceId surface_id,
+    uint64_t timestamp,
+    UserRequest request,
+    optional_value <uint32_t> hint)
 {
-    wrapped->request_operation(session, surface_id, timestamp, request);
+    wrapped->request_operation(session, surface_id, timestamp, request, hint);
 }

--- a/src/server/frontend/shell_wrapper.h
+++ b/src/server/frontend/shell_wrapper.h
@@ -79,7 +79,8 @@ public:
         std::shared_ptr<Session> const& session,
         SurfaceId surface_id,
         uint64_t timestamp,
-        UserRequest request) override;
+        UserRequest request,
+        optional_value <uint32_t> hint) override;
 
 protected:
     std::shared_ptr<Shell> const wrapped;

--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -1376,7 +1376,7 @@ protected:
     {
         if (surface_id.as_value())
         {
-            if (auto session = session_for_client(client))
+            if (auto session = get_session(client))
             {
                 MirResizeEdge edge = mir_resize_edge_none;
 
@@ -1808,7 +1808,7 @@ void XdgSurfaceV6::resize(struct wl_resource* /*seat*/, uint32_t /*serial*/, uin
 {
     if (surface_id.as_value())
     {
-        if (auto session = session_for_client(client))
+        if (auto session = get_session(client))
         {
             MirResizeEdge edge = mir_resize_edge_none;
 

--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -1736,6 +1736,23 @@ protected:
 
     void resize(struct wl_resource* /*seat*/, uint32_t /*serial*/, uint32_t /*edges*/) override
     {
+        //    <enum name="resize" bitfield="true">
+        //      <description summary="edge values for resizing">
+        //	These values are used to indicate which edge of a surface
+        //	is being dragged in a resize operation. The server may
+        //	use this information to adapt its behavior, e.g. choose
+        //	an appropriate cursor image.
+        //      </description>
+        //      <entry name="none" value="0" summary="no edge"/>
+        //      <entry name="top" value="1" summary="top edge"/>
+        //      <entry name="bottom" value="2" summary="bottom edge"/>
+        //      <entry name="left" value="4" summary="left edge"/>
+        //      <entry name="top_left" value="5" summary="top and left edges"/>
+        //      <entry name="bottom_left" value="6" summary="bottom and left edges"/>
+        //      <entry name="right" value="8" summary="right edge"/>
+        //      <entry name="top_right" value="9" summary="top and right edges"/>
+        //      <entry name="bottom_right" value="10" summary="bottom and right edges"/>
+        //    </enum>
     }
 
     void set_class(std::string const& /*class_*/) override
@@ -1883,6 +1900,21 @@ struct XdgToplevelV6 : wayland::XdgToplevelV6
 
     void resize(struct wl_resource* seat, uint32_t serial, uint32_t edges) override
     {
+        //    <enum name="resize_edge">
+        //      <description summary="edge values for resizing">
+        //	These values are used to indicate which edge of a surface
+        //	is being dragged in a resize operation.
+        //      </description>
+        //      <entry name="none" value="0"/>
+        //      <entry name="top" value="1"/>
+        //      <entry name="bottom" value="2"/>
+        //      <entry name="left" value="4"/>
+        //      <entry name="top_left" value="5"/>
+        //      <entry name="bottom_left" value="6"/>
+        //      <entry name="right" value="8"/>
+        //      <entry name="top_right" value="9"/>
+        //      <entry name="bottom_right" value="10"/>
+        //    </enum>
         (void)seat, (void)serial, (void)edges;
         // TODO
     }

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -274,6 +274,15 @@ void msh::AbstractShell::request_move(
     window_manager->handle_request_move(session, surface, timestamp);
 }
 
+void msh::AbstractShell::request_resize(
+    std::shared_ptr<scene::Session> const& session,
+    std::shared_ptr<scene::Surface> const& surface,
+    uint64_t timestamp,
+    MirResizeEdge edge)
+{
+    window_manager->handle_request_resize(session, surface, timestamp, edge);
+}
+
 void msh::AbstractShell::focus_next_session()
 {
     std::unique_lock<std::mutex> lock(focus_mutex);

--- a/src/server/shell/frontend_shell.cpp
+++ b/src/server/shell/frontend_shell.cpp
@@ -152,7 +152,8 @@ void msh::FrontendShell::request_operation(
     std::shared_ptr<mf::Session> const& session,
     mf::SurfaceId surface_id,
     uint64_t timestamp,
-    UserRequest request)
+    UserRequest request,
+    optional_value <uint32_t> hint)
 {
     auto const scene_session = std::dynamic_pointer_cast<ms::Session>(session);
     auto const surface = scene_session->surface(surface_id);
@@ -173,6 +174,12 @@ void msh::FrontendShell::request_operation(
 
     case UserRequest::move:
         wrapped->request_move(scene_session, surface, timestamp);
+        break;
+
+    case UserRequest::resize:
+        if (!hint.is_set())
+            BOOST_THROW_EXCEPTION(std::logic_error("Resize request must identify edge(s)"));
+        wrapped->request_resize(scene_session, surface, timestamp, MirResizeEdge(hint.value()));
         break;
 
     default:

--- a/src/server/shell/frontend_shell.h
+++ b/src/server/shell/frontend_shell.h
@@ -91,7 +91,8 @@ struct FrontendShell : mf::Shell
         std::shared_ptr<mf::Session> const& session,
         mf::SurfaceId surface_id,
         uint64_t timestamp,
-        UserRequest request) override;
+        UserRequest request,
+        optional_value <uint32_t> hint) override;
 };
 }
 }

--- a/src/server/shell/shell_wrapper.cpp
+++ b/src/server/shell/shell_wrapper.cpp
@@ -136,6 +136,15 @@ void msh::ShellWrapper::request_move(
     wrapped->request_move(session, surface, timestamp);
 }
 
+void msh::ShellWrapper::request_resize(
+    std::shared_ptr<scene::Session> const& session,
+    std::shared_ptr<scene::Surface> const& surface,
+    uint64_t timestamp,
+    MirResizeEdge edge)
+{
+    wrapped->request_resize(session, surface, timestamp, edge);
+}
+
 void msh::ShellWrapper::add_display(geometry::Rectangle const& area)
 {
     wrapped->add_display(area);

--- a/src/server/shell/system_compositor_window_manager.cpp
+++ b/src/server/shell/system_compositor_window_manager.cpp
@@ -215,3 +215,11 @@ void msh::SystemCompositorWindowManager::handle_request_move(
     uint64_t /*timestamp*/)
 {
 }
+
+void msh::SystemCompositorWindowManager::handle_request_resize(
+    std::shared_ptr<scene::Session> const& /*session*/,
+    std::shared_ptr<scene::Surface> const& /*surface*/,
+    uint64_t /*timestamp*/,
+    MirResizeEdge /*edge*/)
+{
+}

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1,4 +1,4 @@
-MIR_SERVER_1.0 {
+MIR_SERVER_0.31 {
  global:
   extern "C++" {
 # Symbols not yet picked up by script
@@ -178,6 +178,7 @@ MIR_SERVER_1.0 {
     mir::Server::get_options*;
     mir::Server::open_client_socket*;
     mir::Server::open_prompt_socket*;
+    mir::Server::open_wayland_client_socket*;
     mir::Server::override_the_application_not_responding_detector*;
     mir::Server::override_the_compositor*;
     mir::Server::override_the_cookie_authority*;
@@ -354,6 +355,7 @@ MIR_SERVER_1.0 {
     mir::shell::ShellWrapper::remove_display*;
     mir::shell::ShellWrapper::request_drag_and_drop*;
     mir::shell::ShellWrapper::request_move*;
+    mir::shell::ShellWrapper::request_resize*;
     mir::shell::ShellWrapper::set_drag_and_drop_handle*;
     mir::shell::ShellWrapper::set_focus_to*;
     mir::shell::ShellWrapper::set_surface_attribute*;
@@ -391,6 +393,7 @@ MIR_SERVER_1.0 {
     mir::shell::SystemCompositorWindowManager::handle_raise_surface*;
     mir::shell::SystemCompositorWindowManager::handle_request_drag_and_drop*;
     mir::shell::SystemCompositorWindowManager::handle_request_move*;
+    mir::shell::SystemCompositorWindowManager::handle_request_resize*;
     mir::shell::SystemCompositorWindowManager::handle_touch_event*;
     mir::shell::SystemCompositorWindowManager::modify_surface*;
     mir::shell::SystemCompositorWindowManager::on_session_added*;
@@ -569,6 +572,7 @@ MIR_SERVER_1.0 {
     non-virtual?thunk?to?mir::shell::ShellWrapper::remove_display*;
     non-virtual?thunk?to?mir::shell::ShellWrapper::request_drag_and_drop*;
     non-virtual?thunk?to?mir::shell::ShellWrapper::request_move*;
+    non-virtual?thunk?to?mir::shell::ShellWrapper::request_resize*;
     non-virtual?thunk?to?mir::shell::ShellWrapper::set_drag_and_drop_handle*;
     non-virtual?thunk?to?mir::shell::ShellWrapper::set_focus_to*;
     non-virtual?thunk?to?mir::shell::ShellWrapper::set_surface_attribute*;
@@ -589,6 +593,7 @@ MIR_SERVER_1.0 {
     non-virtual?thunk?to?mir::shell::SystemCompositorWindowManager::handle_raise_surface*;
     non-virtual?thunk?to?mir::shell::SystemCompositorWindowManager::handle_request_drag_and_drop*;
     non-virtual?thunk?to?mir::shell::SystemCompositorWindowManager::handle_request_move*;
+    non-virtual?thunk?to?mir::shell::SystemCompositorWindowManager::handle_request_resize*;
     non-virtual?thunk?to?mir::shell::SystemCompositorWindowManager::handle_touch_event*;
     non-virtual?thunk?to?mir::shell::SystemCompositorWindowManager::modify_surface*;
     non-virtual?thunk?to?mir::shell::SystemCompositorWindowManager::on_session_added*;
@@ -819,15 +824,8 @@ MIR_SERVER_1.0 {
  local: *;
 };
 
-MIR_SERVER_0.29 {
- global:
-  extern "C++" {
-    mir::Server::open_wayland_client_socket*;
-  };
-} MIR_SERVER_1.0;
-
-# these symbols are needed by the "throwback" tests and mir_proving_server but are not intended to be public
-MIR_SERVER_DETAIL_FOR_TESTING_1.0 {
+# these symbols are needed by the "throwback" tests but are not intended to be public
+MIR_SERVER_DETAIL_FOR_TESTING_0.31 {
  global:
   extern "C++" {
     mir::DefaultServerConfiguration::clock*;
@@ -936,4 +934,4 @@ MIR_SERVER_DETAIL_FOR_TESTING_1.0 {
 
     mir::run_mir*;
   };
-} MIR_SERVER_1.0;
+} MIR_SERVER_0.31;

--- a/tests/acceptance-tests/client_mediated_user_gestures.cpp
+++ b/tests/acceptance-tests/client_mediated_user_gestures.cpp
@@ -270,6 +270,14 @@ auto ClientMediatedUserGestures::user_initiates_gesture() -> Cookie
 }
 }
 
+// TODO extend this test when server side implemented
+TEST_F(ClientMediatedUserGestures, when_client_initiates_resize_nothing_bad_happens)
+{
+    auto const cookie = user_initiates_gesture();
+
+    mir_window_request_user_resize(window, cookie);
+}
+
 TEST_F(ClientMediatedUserGestures, when_user_initiates_gesture_client_receives_cookie)
 {
     auto const cookie = user_initiates_gesture();

--- a/tests/acceptance-tests/client_mediated_user_gestures.cpp
+++ b/tests/acceptance-tests/client_mediated_user_gestures.cpp
@@ -275,7 +275,7 @@ TEST_F(ClientMediatedUserGestures, when_client_initiates_resize_nothing_bad_happ
 {
     auto const cookie = user_initiates_gesture();
 
-    mir_window_request_user_resize(window, cookie);
+    mir_window_request_user_resize(window, mir_resize_edge_east, cookie);
 }
 
 TEST_F(ClientMediatedUserGestures, when_user_initiates_gesture_client_receives_cookie)

--- a/tests/include/mir/shell/basic_window_manager.h
+++ b/tests/include/mir/shell/basic_window_manager.h
@@ -182,6 +182,12 @@ public:
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp) override;
 
+    void handle_request_resize(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<scene::Surface> const& surface,
+        uint64_t timestamp,
+        MirResizeEdge edge) override;
+
     int set_surface_attribute(
         std::shared_ptr<scene::Session> const& /*session*/,
         std::shared_ptr<scene::Surface> const& surface,

--- a/tests/include/mir/test/doubles/mock_shell.h
+++ b/tests/include/mir/test/doubles/mock_shell.h
@@ -73,8 +73,8 @@ struct MockShell : public frontend::Shell
     MOCK_METHOD3(raise_surface, void(std::shared_ptr<frontend::Session> const& session,
         frontend::SurfaceId surface_id, uint64_t timestamp));
 
-    MOCK_METHOD4(request_operation, void(std::shared_ptr<frontend::Session> const &session,
-        frontend::SurfaceId surface_id, uint64_t timestamp, UserRequest request));
+    MOCK_METHOD5(request_operation, void(std::shared_ptr<frontend::Session> const &session,
+        frontend::SurfaceId surface_id, uint64_t timestamp, UserRequest request, optional_value<uint32_t> hint));
 };
 
 }

--- a/tests/mir_test_framework/basic_window_manager.cpp
+++ b/tests/mir_test_framework/basic_window_manager.cpp
@@ -166,6 +166,14 @@ void msh::BasicWindowManager::handle_request_move(
     }
 }
 
+void msh::BasicWindowManager::handle_request_resize(
+    std::shared_ptr<scene::Session> const& /*session*/,
+    std::shared_ptr<scene::Surface> const& /*surface*/,
+    uint64_t /*timestamp*/,
+    MirResizeEdge /*edge*/)
+{
+}
+
 int msh::BasicWindowManager::set_surface_attribute(
     std::shared_ptr<scene::Session> const& /*session*/,
     std::shared_ptr<scene::Surface> const& surface,

--- a/tests/miral/client_mediated_gestures.cpp
+++ b/tests/miral/client_mediated_gestures.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Canonical Ltd.
+ * Copyright © 2017-2018 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -24,6 +24,7 @@
 #include <mir_toolkit/mir_blob.h>
 
 #include <miral/window_management_policy_addendum2.h>
+#include <miral/window_management_policy_addendum4.h>
 
 #include <mir/geometry/displacement.h>
 #include <mir/input/input_device_info.h>
@@ -54,7 +55,8 @@ using mir::client::Cookie;
 namespace
 {
 struct MockWindowManagementPolicy : mir_test_framework::CanonicalWindowManagerPolicy,
-                                    miral::WindowManagementPolicyAddendum2
+                                    miral::WindowManagementPolicyAddendum2,
+                                    miral::WindowManagementPolicyAddendum4
 {
     MockWindowManagementPolicy(
         miral::WindowManagerTools const& tools,
@@ -66,6 +68,7 @@ struct MockWindowManagementPolicy : mir_test_framework::CanonicalWindowManagerPo
 
     MOCK_METHOD2(handle_request_move, void(miral::WindowInfo&, MirInputEvent const*));
     MOCK_METHOD1(handle_request_drag_and_drop, void(miral::WindowInfo&));
+    MOCK_METHOD3(handle_request_resize, void(miral::WindowInfo&, MirInputEvent const*, MirResizeEdge));
 };
 
 struct MouseMoverAndFaker
@@ -273,6 +276,17 @@ TEST_F(ClientMediatedUserGestures, when_client_initiates_move_window_manager_han
     EXPECT_CALL(*mock_wm_policy, handle_request_move(_, _)).WillOnce(InvokeWithoutArgs([&]{ have_request.raise(); }));
 
     mir_window_request_user_move(window, cookie);
+
+    EXPECT_THAT(have_request.wait_for(receive_event_timeout), Eq(true));
+}
+
+TEST_F(ClientMediatedUserGestures, when_client_initiates_resize_window_manager_handles_request)
+{
+    auto const cookie = user_initiates_gesture();
+    Signal have_request;
+    EXPECT_CALL(*mock_wm_policy, handle_request_resize(_, _, _)).WillOnce(InvokeWithoutArgs([&]{ have_request.raise(); }));
+
+    mir_window_request_user_resize(window, mir_resize_edge_east, cookie);
 
     EXPECT_THAT(have_request.wait_for(receive_event_timeout), Eq(true));
 }


### PR DESCRIPTION
Initial pass at CSD initiated resize.

Note that this runs into issues with apps that use XdgSurfaceV6::set_window_geometry() (gnome apps, weston-terminal).

I'll be proposing a fix for our mishandling of XdgSurfaceV6::set_window_geometry() separately.