### PR TITLE
travis: disable Ubuntu 17.10 based tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ env:
   matrix:
   - SYSTEM=ubuntu-16.04 VARIANT=amd64
   - SYSTEM=ubuntu-16.04 VARIANT=arm64
-  - SYSTEM=ubuntu-17.10 VARIANT=amd64
-  - SYSTEM=ubuntu-devel VARIANT=clang
+#  - SYSTEM=ubuntu-17.10 VARIANT=amd64
+#  - SYSTEM=ubuntu-devel VARIANT=clang
   - SYSTEM=fedora-27 VARIANT=amd64
   - SYSTEM=fedora-rawhide VARIANT=amd64
 


### PR DESCRIPTION
Linode stopped listing ubuntu-17.10 images, hopefully temporarily?