### PR TITLE
fix-handling-of-set_window_geometry

### DIFF
--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -1683,16 +1683,8 @@ struct XdgSurfaceV6 : wayland::XdgSurfaceV6, WlAbstractMirWindow
 
     void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) override
     {
-        geom::Rectangle const input_region{{x, y}, {width, height}};
-
-        if (surface_id.as_value())
-        {
-            spec().input_shape = {input_region};
-        }
-        else
-        {
-            params->input_shape = {input_region};
-        }
+        buffer_offset = geom::Displacement{-x, -y};
+        window_size = geom::Size{width, height};
     }
 
     void ack_configure(uint32_t serial) override

--- a/src/server/frontend/wayland/wl_mir_window.h
+++ b/src/server/frontend/wayland/wl_mir_window.h
@@ -20,7 +20,9 @@
 #define WL_MIR_WINDOW_H
 
 #include "mir/frontend/surface_id.h"
+#include "mir/geometry/displacement.h"
 #include "mir/geometry/size.h"
+#include "mir/optional_value.h"
 
 #include <memory>
 
@@ -70,6 +72,8 @@ protected:
 
     std::unique_ptr<scene::SurfaceCreationParameters> const params;
     SurfaceId surface_id;
+    optional_value<geometry::Size> window_size;
+    geometry::Displacement buffer_offset;
 
     shell::SurfaceSpecification& spec();
 


### PR DESCRIPTION
Improves xdg-shell support.

Drag resizing of xdg-shell clients works on F27 and Artful (with some flickering)

On bionic there are some remaining issues:

Qt apps hang after resize (pre-existing)
GTK apps crash on interaction (pre-existing)
weston-terminal seems happy.