### PR TITLE
fix-handling-of-set_window_geometry

### DIFF
--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -590,6 +590,7 @@ public:
                 auto const serial = wl_display_next_serial(display);
                 auto const event = mir_event_get_input_event(ev);
                 auto const pointer_event = mir_input_event_get_pointer_event(event);
+                auto const buffer_offset = WlSurface::from(target)->buffer_offset;
 
                 switch(mir_pointer_event_action(pointer_event))
                 {
@@ -630,8 +631,8 @@ public:
                             resource,
                             serial,
                             target,
-                            wl_fixed_from_double(mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_x)),
-                            wl_fixed_from_double(mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_y)));
+                            wl_fixed_from_double(mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_x)-buffer_offset.dx.as_int()),
+                            wl_fixed_from_double(mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_y)-buffer_offset.dy.as_int()));
                         break;
                     }
                     case mir_pointer_action_leave:
@@ -644,8 +645,8 @@ public:
                     }
                     case mir_pointer_action_motion:
                     {
-                        auto x = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_x);
-                        auto y = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_y);
+                        auto x = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_x)-buffer_offset.dx.as_int();
+                        auto y = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_y)-buffer_offset.dy.as_int();
                         auto vscroll = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_vscroll);
                         auto hscroll = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_hscroll);
 
@@ -752,6 +753,7 @@ public:
 
                 auto const input_ev = mir_event_get_input_event(ev);
                 auto const touch_ev = mir_input_event_get_touch_event(input_ev);
+                auto const buffer_offset = WlSurface::from(target)->buffer_offset;
 
                 for (auto i = 0u; i < mir_touch_event_point_count(touch_ev); ++i)
                 {
@@ -760,11 +762,11 @@ public:
                     auto const x = mir_touch_event_axis_value(
                         touch_ev,
                         i,
-                        mir_touch_axis_x);
+                        mir_touch_axis_x)-buffer_offset.dx.as_int();
                     auto const y = mir_touch_event_axis_value(
                         touch_ev,
                         i,
-                        mir_touch_axis_y);
+                        mir_touch_axis_y)-buffer_offset.dy.as_int();
 
                     switch (action)
                     {
@@ -1683,7 +1685,7 @@ struct XdgSurfaceV6 : wayland::XdgSurfaceV6, WlAbstractMirWindow
 
     void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) override
     {
-        buffer_offset = geom::Displacement{-x, -y};
+        WlSurface::from(surface)->buffer_offset = geom::Displacement{-x, -y};
         window_size = geom::Size{width, height};
     }
 

--- a/src/server/frontend/wayland/wayland_connector.cpp
+++ b/src/server/frontend/wayland/wayland_connector.cpp
@@ -1683,16 +1683,8 @@ struct XdgSurfaceV6 : wayland::XdgSurfaceV6, WlAbstractMirWindow
 
     void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) override
     {
-        geom::Rectangle const input_region{{x, y}, {width, height}};
-
-        if (surface_id.as_value())
-        {
-            spec().input_shape = {input_region};
-        }
-        else
-        {
-            params->input_shape = {input_region};
-        }
+        buffer_offset = geom::Displacement{-x, -y};
+        window_size = geom::Size{width, height};
     }
 
     void ack_configure(uint32_t serial) override

--- a/src/server/frontend/wayland/wl_mir_window.cpp
+++ b/src/server/frontend/wayland/wl_mir_window.cpp
@@ -123,7 +123,7 @@ void WlAbstractMirWindow::commit()
     if (params->size == geometry::Size{})
         params->size = latest_window_size;
 
-    params->streams = std::move(std::vector<shell::StreamSpecification>{{mir_surface->stream_id, buffer_offset, {}}});
+    params->streams = std::move(std::vector<shell::StreamSpecification>{{mir_surface->stream_id, mir_surface->buffer_offset, {}}});
 
     surface_id = shell->create_surface(session, *params, sink);
     mir_surface->surface_id = surface_id;

--- a/src/server/frontend/wayland/wl_mir_window.h
+++ b/src/server/frontend/wayland/wl_mir_window.h
@@ -20,7 +20,9 @@
 #define WL_MIR_WINDOW_H
 
 #include "mir/frontend/surface_id.h"
+#include "mir/geometry/displacement.h"
 #include "mir/geometry/size.h"
+#include "mir/optional_value.h"
 
 #include <memory>
 
@@ -70,6 +72,8 @@ protected:
 
     std::unique_ptr<scene::SurfaceCreationParameters> const params;
     SurfaceId surface_id;
+    optional_value<geometry::Size> window_size;
+    geometry::Displacement buffer_offset;
 
     shell::SurfaceSpecification& spec();
 

--- a/src/server/frontend/wayland/wl_mir_window.h
+++ b/src/server/frontend/wayland/wl_mir_window.h
@@ -73,7 +73,6 @@ protected:
     std::unique_ptr<scene::SurfaceCreationParameters> const params;
     SurfaceId surface_id;
     optional_value<geometry::Size> window_size;
-    geometry::Displacement buffer_offset;
 
     shell::SurfaceSpecification& spec();
 

--- a/src/server/frontend/wayland/wl_pointer.cpp
+++ b/src/server/frontend/wayland/wl_pointer.cpp
@@ -65,6 +65,7 @@ void mf::WlPointer::handle_event(MirInputEvent const* event, wl_resource* target
             auto const serial = wl_display_next_serial(display);
             auto const event = mir_event_get_input_event(ev);
             auto const pointer_event = mir_input_event_get_pointer_event(event);
+            auto const buffer_offset = WlSurface::from(target)->buffer_offset;
 
             switch(mir_pointer_event_action(pointer_event))
             {
@@ -105,8 +106,8 @@ void mf::WlPointer::handle_event(MirInputEvent const* event, wl_resource* target
                         resource,
                         serial,
                         target,
-                        wl_fixed_from_double(mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_x)),
-                        wl_fixed_from_double(mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_y)));
+                        wl_fixed_from_double(mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_x)-buffer_offset.dx.as_int()),
+                        wl_fixed_from_double(mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_y)-buffer_offset.dy.as_int()));
                     break;
                 }
                 case mir_pointer_action_leave:
@@ -119,8 +120,8 @@ void mf::WlPointer::handle_event(MirInputEvent const* event, wl_resource* target
                 }
                 case mir_pointer_action_motion:
                 {
-                    auto x = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_x);
-                    auto y = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_y);
+                    auto x = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_x)-buffer_offset.dx.as_int();
+                    auto y = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_y)-buffer_offset.dy.as_int();
                     auto vscroll = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_vscroll);
                     auto hscroll = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_hscroll);
 

--- a/src/server/frontend/wayland/wl_surface.h
+++ b/src/server/frontend/wayland/wl_surface.h
@@ -24,6 +24,7 @@
 
 #include "mir/frontend/buffer_stream_id.h"
 #include "mir/frontend/surface_id.h"
+#include <mir/geometry/displacement.h>
 
 #include <vector>
 
@@ -55,6 +56,7 @@ public:
     void set_role(WlMirWindow* role_);
 
     mir::frontend::BufferStreamId stream_id;
+    geometry::Displacement buffer_offset;
     std::shared_ptr<mir::frontend::BufferStream> stream;
     mir::frontend::SurfaceId surface_id;       // ID of any associated surface
 

--- a/src/server/frontend/wayland/wl_touch.cpp
+++ b/src/server/frontend/wayland/wl_touch.cpp
@@ -61,6 +61,7 @@ void mf::WlTouch::handle_event(MirInputEvent const* event, wl_resource* target)
 
             auto const input_ev = mir_event_get_input_event(ev);
             auto const touch_ev = mir_input_event_get_touch_event(input_ev);
+            auto const buffer_offset = WlSurface::from(target)->buffer_offset;
 
             for (auto i = 0u; i < mir_touch_event_point_count(touch_ev); ++i)
             {
@@ -69,11 +70,11 @@ void mf::WlTouch::handle_event(MirInputEvent const* event, wl_resource* target)
                 auto const x = mir_touch_event_axis_value(
                     touch_ev,
                     i,
-                    mir_touch_axis_x);
+                    mir_touch_axis_x) - buffer_offset.dx.as_int();
                 auto const y = mir_touch_event_axis_value(
                     touch_ev,
                     i,
-                    mir_touch_axis_y);
+                    mir_touch_axis_y) - buffer_offset.dy.as_int();
 
                 switch (action)
                 {


### PR DESCRIPTION
Improves experimental xdg-shell support.

Drag resizing of xdg-shell clients works on F27 and Artful (with some flickering)

On bionic weston-terminal seems happy. But there are some remaining issues:

Qt apps hang after resize (pre-existing)
GTK apps crash on interaction (pre-existing)
