### PR TITLE
changed code that autogenerates globals to facilitate refactoring WlSeat

### DIFF
--- a/src/server/frontend/wayland/basic_surface_event_sink.cpp
+++ b/src/server/frontend/wayland/basic_surface_event_sink.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "basic_surface_event_sink.h"
+#include "wl_seat.h"
 
 namespace mf = mir::frontend;
 

--- a/src/server/frontend/wayland/basic_surface_event_sink.h
+++ b/src/server/frontend/wayland/basic_surface_event_sink.h
@@ -32,23 +32,13 @@ namespace mir
 {
 namespace frontend
 {
-class BasicWlSeat
-{
-public:
-    virtual ~BasicWlSeat() = default;
 
-    virtual void handle_pointer_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const = 0;
-    virtual void handle_keyboard_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const = 0;
-    virtual void handle_touch_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const = 0;
-    virtual void handle_event(wl_client* client, MirKeymapEvent const* keymap_event, wl_resource* target) const = 0;
-    virtual void handle_event(wl_client* client, MirWindowEvent const* window_event, wl_resource* target) const = 0;
-    virtual void spawn(std::function<void()>&& work) = 0;
-};
+class WlSeat;
 
 class BasicSurfaceEventSink : public NullEventSink
 {
 public:
-    BasicSurfaceEventSink(BasicWlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink)
+    BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink)
         : seat{seat},
         client{client},
         target{target},
@@ -72,7 +62,7 @@ public:
     virtual void send_resize(geometry::Size const& new_size) const = 0;
 
 protected:
-    BasicWlSeat* const seat;
+    WlSeat* const seat;
     wl_client* const client;
     wl_resource* const target;
     wl_resource* const event_sink;

--- a/src/server/frontend/wayland/wl_seat.h
+++ b/src/server/frontend/wayland/wl_seat.h
@@ -19,13 +19,15 @@
 #ifndef MIR_FRONTEND_WL_SEAT_H
 #define MIR_FRONTEND_WL_SEAT_H
 
-#include "basic_surface_event_sink.h"
+#include "core_generated_interfaces.h"
 
 #include <unordered_map>
 
-// from <wayland-server-core.h>
-struct wl_client;
-struct wl_resource;
+// from "mir_toolkit/events/event.h"
+struct MirInputEvent;
+struct MirSurfaceEvent;
+typedef struct MirSurfaceEvent MirWindowEvent;
+struct MirKeymapEvent;
 
 namespace mir
 {
@@ -46,7 +48,7 @@ class WlPointer;
 class WlKeyboard;
 class WlTouch;
 
-class WlSeat : public BasicWlSeat
+class WlSeat : public wayland::Seat
 {
 public:
     WlSeat(
@@ -57,13 +59,13 @@ public:
 
     ~WlSeat();
 
-    void handle_pointer_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const override;
-    void handle_keyboard_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const override;
-    void handle_touch_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const override;
-    void handle_event(wl_client* client, MirKeymapEvent const* keymap_event, wl_resource* target) const override;
-    void handle_event(wl_client* client, MirWindowEvent const* window_event, wl_resource* target) const override;
+    void handle_pointer_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const;
+    void handle_keyboard_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const;
+    void handle_touch_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const;
+    void handle_event(wl_client* client, MirKeymapEvent const* keymap_event, wl_resource* target) const;
+    void handle_event(wl_client* client, MirWindowEvent const* window_event, wl_resource* target) const;
 
-    void spawn(std::function<void()>&& work) override;
+    void spawn(std::function<void()>&& work);
 
 private:
     class ConfigObserver;
@@ -80,14 +82,11 @@ private:
 
     std::shared_ptr<mir::Executor> const executor;
 
-    static void bind(struct wl_client* client, void* data, uint32_t version, uint32_t id);
-    static void get_pointer(wl_client* client, wl_resource* resource, uint32_t id);
-    static void get_keyboard(wl_client* client, wl_resource* resource, uint32_t id);
-    static void get_touch(wl_client* client, wl_resource* resource, uint32_t id);
-    static void release(struct wl_client* /*client*/, struct wl_resource* us);
-
-    wl_global* const global;
-    static struct wl_seat_interface const vtable;
+    void bind(wl_client* client, wl_resource* resource) override;
+    void get_pointer(wl_client* client, wl_resource* resource, uint32_t id) override;
+    void get_keyboard(wl_client* client, wl_resource* resource, uint32_t id) override;
+    void get_touch(wl_client* client, wl_resource* resource, uint32_t id) override;
+    void release(struct wl_client* /*client*/, struct wl_resource* us) override;
 };
 }
 }


### PR DESCRIPTION
- Renamed bind() to bind_thunk()
- Created a virtual bind() function (not pure virtual, empty by default) that can be overridden by globals and is called after an instance is created (WlSeat needed this)
- Call wl_global_destroy() in the destructor of global wayland objects (and store a pointer to the wl_global to allow this)
- Refactored WlSeat to use the improved generated class instead of rolling its own wayland vtable.