### PR TITLE
Explicitly initialise glm matricies, take 2.

### DIFF
--- a/examples/server_example_adorning_compositor.cpp
+++ b/examples/server_example_adorning_compositor.cpp
@@ -127,7 +127,7 @@ bool renderable_is_occluded(
     mir::geometry::Rectangle const& area,
     std::vector<mir::geometry::Rectangle>& coverage)
 {
-    static glm::mat4 const identity{};
+    static glm::mat4 const identity(1);
     static mir::geometry::Rectangle const empty{};
 
     if (renderable.transformation() != identity)

--- a/include/platform/mir/graphics/transformation.h
+++ b/include/platform/mir/graphics/transformation.h
@@ -39,7 +39,7 @@ inline glm::mat2 transformation(MirOrientation ori)
 
 inline glm::mat2 transformation(MirMirrorMode mode)
 {
-    glm::mat2 mat{};
+    glm::mat2 mat(1);
     if (mode == mir_mirror_mode_horizontal)
         mat[0][0] = -1;
     else if (mode == mir_mirror_mode_vertical)

--- a/include/test/mir/test/doubles/null_display_buffer.h
+++ b/include/test/mir/test/doubles/null_display_buffer.h
@@ -33,7 +33,7 @@ class NullDisplayBuffer : public graphics::DisplayBuffer, public graphics::Nativ
 public:
     geometry::Rectangle view_area() const override { return geometry::Rectangle(); }
     bool overlay(graphics::RenderableList const&) override { return false; }
-    glm::mat2 transformation() const override { return {}; }
+    glm::mat2 transformation() const override { return glm::mat2(1); }
     NativeDisplayBuffer* native_display_buffer() override { return this; }
 };
 

--- a/src/platforms/mesa/server/kms/bypass.cpp
+++ b/src/platforms/mesa/server/kms/bypass.cpp
@@ -26,7 +26,7 @@ namespace mgm = mir::graphics::mesa;
 mgm::BypassMatch::BypassMatch(geometry::Rectangle const& rect)
     : view_area(rect),
       bypass_is_feasible(true),
-      identity()
+      identity(1)
 {
 }
 

--- a/src/platforms/mesa/server/kms/display_buffer.cpp
+++ b/src/platforms/mesa/server/kms/display_buffer.cpp
@@ -581,7 +581,7 @@ void mgm::DisplayBuffer::set_transformation(glm::mat2 const& t, geometry::Rectan
 
 bool mgm::DisplayBuffer::overlay(RenderableList const& renderable_list)
 {
-    glm::mat2 static const no_transformation{};
+    glm::mat2 static const no_transformation(1);
     if (transform == no_transformation &&
        (bypass_option == mgm::BypassOption::allowed))
     {

--- a/src/platforms/mesa/server/x11/graphics/display_buffer.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display_buffer.cpp
@@ -38,6 +38,7 @@ mgx::DisplayBuffer::DisplayBuffer(::Display* const x_dpy,
                                   GLConfig const& gl_config)
                                   : report{r},
                                     area{{0,0},view_area_size},
+                                    transform(1),
                                     egl{gl_config},
                                     last_frame{f},
                                     eglGetSyncValues{nullptr}

--- a/src/renderers/gl/renderer.cpp
+++ b/src/renderers/gl/renderer.cpp
@@ -136,7 +136,8 @@ mrg::Renderer::Renderer(graphics::DisplayBuffer& display_buffer)
       clear_color{0.0f, 0.0f, 0.0f, 0.0f},
       default_program(family.add_program(vshader, default_fshader)),
       alpha_program(family.add_program(vshader, alpha_fshader)),
-      texture_cache(mgl::DefaultProgramFactory().create_texture_cache())
+      texture_cache(mgl::DefaultProgramFactory().create_texture_cache()),
+      display_transform(1)
 {
     eglBindAPI(MIR_SERVER_EGL_OPENGL_API);
     EGLDisplay disp = eglGetCurrentDisplay();

--- a/src/server/compositor/occlusion.cpp
+++ b/src/server/compositor/occlusion.cpp
@@ -34,7 +34,7 @@ bool renderable_is_occluded(
     Rectangle const& area,
     std::vector<Rectangle>& coverage)
 {
-    static glm::mat4 const identity{};
+    static glm::mat4 const identity(1);
     static Rectangle const empty{};
 
     if (renderable.transformation() != identity)

--- a/src/server/graphics/nested/display_buffer.cpp
+++ b/src/server/graphics/nested/display_buffer.cpp
@@ -75,7 +75,7 @@ mgn::detail::DisplayBuffer::DisplayBuffer(
     egl_surface{egl_display, host_stream->egl_native_window(), egl_config},
     passthrough_option(option),
     content{BackingContent::stream},
-    identity()
+    identity(1)
 {
     host_surface->set_event_handler(event_thunk, this);
 }
@@ -186,7 +186,7 @@ void mgn::detail::DisplayBuffer::release_buffer(MirBuffer* b, MirPresentationCha
 
 glm::mat2 mgn::detail::DisplayBuffer::transformation() const
 {
-    return {};
+    return glm::mat2(1);
 }
 
 mgn::detail::DisplayBuffer::~DisplayBuffer() noexcept

--- a/src/server/graphics/offscreen/display_buffer.cpp
+++ b/src/server/graphics/offscreen/display_buffer.cpp
@@ -157,7 +157,7 @@ bool mgo::DisplayBuffer::overlay(RenderableList const&)
 
 glm::mat2 mgo::DisplayBuffer::transformation() const
 {
-    return glm::mat2{};
+    return glm::mat2(1);
 }
 
 mg::NativeDisplayBuffer* mgo::DisplayBuffer::native_display_buffer()

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -234,6 +234,7 @@ ms::BasicSurface::BasicSurface(
     std::shared_ptr<SceneReport> const& report) :
     surface_name(name),
     surface_rect(rect),
+    transformation_matrix(1),
     surface_alpha(1.0f),
     hidden(false),
     input_mode(mi::InputReceptionMode::normal),

--- a/tests/include/mir/test/doubles/fake_renderable.h
+++ b/tests/include/mir/test/doubles/fake_renderable.h
@@ -72,7 +72,7 @@ public:
 
     glm::mat4 transformation() const override
     {
-        return glm::mat4();
+        return glm::mat4(1);
     }
 
     bool shaped() const override

--- a/tests/include/mir/test/doubles/stub_renderable.h
+++ b/tests/include/mir/test/doubles/stub_renderable.h
@@ -39,7 +39,8 @@ class StubRenderable : public graphics::Renderable
 {
 public:
     StubRenderable(std::shared_ptr<graphics::Buffer> const& buffer, geometry::Rectangle const& rect)
-        : rect(rect),
+        : trans(1),
+          rect(rect),
           stub_buffer(buffer)
     {}
 

--- a/tests/unit-tests/compositor/test_default_display_buffer_compositor.cpp
+++ b/tests/unit-tests/compositor/test_default_display_buffer_compositor.cpp
@@ -51,7 +51,7 @@ namespace mtd = mir::test::doubles;
 namespace
 {
 
-glm::mat2 const no_transformation{};
+glm::mat2 const no_transformation(1);
 
 struct StubSceneElement : mc::SceneElement
 {

--- a/tests/unit-tests/graphics/offscreen/test_offscreen_display.cpp
+++ b/tests/unit-tests/graphics/offscreen/test_offscreen_display.cpp
@@ -74,7 +74,7 @@ TEST_F(OffscreenDisplayTest, orientation_normal)
     display.for_each_display_sync_group([&](mg::DisplaySyncGroup& group) {
         group.for_each_display_buffer([&](mg::DisplayBuffer& db) {
             ++count;
-            EXPECT_EQ(glm::mat2{}, db.transformation());
+            EXPECT_EQ(glm::mat2(1), db.transformation());
         });
     });
 

--- a/tests/unit-tests/platforms/mesa/kms/test_display_buffer.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_display_buffer.cpp
@@ -54,7 +54,8 @@ public:
     int const mock_refresh_rate = 60;
 
     MesaDisplayBufferTest()
-        : mock_bypassable_buffer{std::make_shared<NiceMock<MockBuffer>>()}
+        : identity(1)
+        , mock_bypassable_buffer{std::make_shared<NiceMock<MockBuffer>>()}
         , mock_software_buffer{std::make_shared<NiceMock<MockBuffer>>()}
         , fake_bypassable_renderable{
              std::make_shared<FakeRenderable>(display_area)}
@@ -128,6 +129,7 @@ protected:
     int const width{56};
     int const height{78};
     mir::geometry::Rectangle const display_area{{12,34}, {width,height}};
+    glm::mat2 const identity;
     NiceMock<MockGBM> mock_gbm;
     NiceMock<MockEGL> mock_egl;
     NiceMock<MockGL>  mock_gl;
@@ -156,7 +158,7 @@ TEST_F(MesaDisplayBufferTest, unrotated_view_area_is_untouched)
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     EXPECT_EQ(display_area, db.view_area());
 }
@@ -169,7 +171,7 @@ TEST_F(MesaDisplayBufferTest, bypass_buffer_is_held_for_full_frame)
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     auto original_count = mock_bypassable_buffer.use_count();
 
@@ -193,7 +195,7 @@ TEST_F(MesaDisplayBufferTest, predictive_bypass_is_throttled)
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     for (int frame = 0; frame < 5; ++frame)
     {
@@ -219,7 +221,7 @@ TEST_F(MesaDisplayBufferTest, frames_requiring_gl_are_not_throttled)
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     for (int frame = 0; frame < 5; ++frame)
     {
@@ -239,7 +241,7 @@ TEST_F(MesaDisplayBufferTest, bypass_buffer_only_referenced_once_by_db)
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     auto original_count = mock_bypassable_buffer.use_count();
 
@@ -260,7 +262,7 @@ TEST_F(MesaDisplayBufferTest, untransformed_with_bypassable_list_can_bypass)
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     EXPECT_TRUE(db.overlay(bypassable_list));
 }
@@ -278,7 +280,7 @@ TEST_F(MesaDisplayBufferTest, failed_bypass_falls_back_gracefully)
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     EXPECT_FALSE(db.overlay(bypassable_list));
     // And then we recover. DRM finds enough resources to AddFB ...
@@ -303,7 +305,7 @@ TEST_F(MesaDisplayBufferTest, skips_bypass_because_of_lagging_resize)
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     EXPECT_FALSE(db.overlay(list));
 }
@@ -334,7 +336,7 @@ TEST_F(MesaDisplayBufferTest, fullscreen_software_buffer_cannot_bypass)
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     EXPECT_FALSE(db.overlay(list));
 }
@@ -352,7 +354,7 @@ TEST_F(MesaDisplayBufferTest, fullscreen_software_buffer_not_used_as_gbm_bo)
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     // If you find yourself using gbm_ functions on a Shm buffer then you're
     // asking for a crash (LP: #1493721) ...
@@ -390,7 +392,7 @@ TEST_F(MesaDisplayBufferTest, clone_mode_first_flip_flips_but_no_wait)
         {mock_kms_output, mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     db.swap_buffers();
     db.post();
@@ -409,7 +411,7 @@ TEST_F(MesaDisplayBufferTest, single_mode_first_post_flips_with_wait)
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     db.swap_buffers();
     db.post();
@@ -436,7 +438,7 @@ TEST_F(MesaDisplayBufferTest, clone_mode_waits_for_page_flip_on_second_flip)
         {mock_kms_output, mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     db.swap_buffers();
     db.post();
@@ -458,7 +460,7 @@ TEST_F(MesaDisplayBufferTest, skips_bypass_because_of_incompatible_list)
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     EXPECT_FALSE(db.overlay(list));
 }
@@ -483,7 +485,7 @@ TEST_F(MesaDisplayBufferTest, skips_bypass_because_of_incompatible_bypass_buffer
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     EXPECT_FALSE(db.overlay(list));
 }
@@ -499,7 +501,7 @@ TEST_F(MesaDisplayBufferTest, buffer_requiring_migration_is_ineligable_for_bypas
         {mock_kms_output},
         make_output_surface(),
         display_area,
-        {});
+        identity);
 
     EXPECT_FALSE(db.overlay(bypassable_list));
 }


### PR DESCRIPTION
GLM 0.9.9-a2 conveniently changes the behaviour of the default constructor from constructing
an identity matrix to constructing a 0-matrix. This makes much of Mir sad.

Explicitly initialise *identity* matricies everywhere.