### PR TITLE
Disable flaky tests for nested servers (workaround for #138, #143, #147 & #148)

### DIFF
--- a/tests/acceptance-tests/test_nested_input.cpp
+++ b/tests/acceptance-tests/test_nested_input.cpp
@@ -367,7 +367,7 @@ private:
 
 }
 
-TEST_F(NestedInput, nested_event_filter_receives_keyboard_from_host)
+TEST_F(NestedInput, DISABLED_nested_event_filter_receives_keyboard_from_host)
 {
     NiceMock<MockEventFilter> nested_event_filter;
     EXPECT_CALL(nested_event_filter, handle(mt::InputDeviceStateEvent())).Times(AnyNumber());
@@ -391,7 +391,7 @@ TEST_F(NestedInput, nested_event_filter_receives_keyboard_from_host)
     EXPECT_TRUE(all_events_received.wait_for(10s));
 }
 
-TEST_F(NestedInput, nested_input_device_hub_lists_keyboard)
+TEST_F(NestedInput, DISABLED_nested_input_device_hub_lists_keyboard)
 {
     NestedServerWithMockEventFilter nested_mir{new_connection()};
     wait_for_input_devices_added_to(nested_mir.server);
@@ -407,7 +407,7 @@ TEST_F(NestedInput, nested_input_device_hub_lists_keyboard)
         });
 }
 
-TEST_F(NestedInput, on_add_device_observer_gets_device_added_calls_on_existing_devices)
+TEST_F(NestedInput, DISABLED_on_add_device_observer_gets_device_added_calls_on_existing_devices)
 {
     std::shared_ptr<NiceMock<mtd::MockInputDeviceObserver>> mock_observer{
         std::make_shared<NiceMock<mtd::MockInputDeviceObserver>>()};
@@ -424,7 +424,7 @@ TEST_F(NestedInput, on_add_device_observer_gets_device_added_calls_on_existing_d
     nested_hub->remove_observer(mock_observer);
 }
 
-TEST_F(NestedInput, device_added_on_host_triggeres_nested_device_observer)
+TEST_F(NestedInput, DISABLED_device_added_on_host_triggeres_nested_device_observer)
 {
     std::shared_ptr<NiceMock<mtd::MockInputDeviceObserver>> mock_observer{
         std::make_shared<NiceMock<mtd::MockInputDeviceObserver>>()};
@@ -451,7 +451,7 @@ TEST_F(NestedInput, device_added_on_host_triggeres_nested_device_observer)
     input_device_changes_complete.wait_for(10s);
 }
 
-TEST_F(NestedInput, on_input_device_state_nested_server_emits_input_device_state)
+TEST_F(NestedInput, DISABLED_on_input_device_state_nested_server_emits_input_device_state)
 {
     mir::test::Signal client_to_host_event_received;
     mir::test::Signal client_to_nested_event_received;
@@ -478,7 +478,7 @@ TEST_F(NestedInput, on_input_device_state_nested_server_emits_input_device_state
     client_to_host_event_received.wait_for(2s);
 }
 
-TEST_F(NestedInputWithMouse, mouse_pointer_coordinates_in_nested_server_are_accumulated)
+TEST_F(NestedInputWithMouse, DISABLED_mouse_pointer_coordinates_in_nested_server_are_accumulated)
 {
     auto const initial_movement_x = 30;
     auto const initial_movement_y = 30;
@@ -516,7 +516,7 @@ TEST_F(NestedInputWithMouse, mouse_pointer_coordinates_in_nested_server_are_accu
     ASSERT_TRUE(event_received.wait_for(60s));
 }
 
-TEST_F(NestedInputWithMouse, mouse_pointer_position_is_in_sync_with_host_server)
+TEST_F(NestedInputWithMouse, DISABLED_mouse_pointer_position_is_in_sync_with_host_server)
 {
     int const x[] = {30, -10, 10};
     int const y[] = {30, 100, 50};
@@ -549,7 +549,7 @@ TEST_F(NestedInputWithMouse, mouse_pointer_position_is_in_sync_with_host_server)
     ASSERT_TRUE(event_received.wait_for(60s));
 }
 
-TEST_F(NestedInput, nested_clients_can_change_host_device_configurations)
+TEST_F(NestedInput, DISABLED_nested_clients_can_change_host_device_configurations)
 {
     auto const acceleration_bias = 0.9f;
     std::string const uid{"mouse-uid"};
@@ -590,7 +590,7 @@ TEST_F(NestedInput, nested_clients_can_change_host_device_configurations)
     EXPECT_THAT(mir_pointer_config_get_acceleration_bias(ptr_conf), acceleration_bias);
 }
 
-TEST_F(NestedInput, pressed_keys_on_vt_switch_are_forgotten)
+TEST_F(NestedInput, DISABLED_pressed_keys_on_vt_switch_are_forgotten)
 {
     NiceMock<MockEventFilter> nested_event_filter;
 

--- a/tests/acceptance-tests/test_nested_mir.cpp
+++ b/tests/acceptance-tests/test_nested_mir.cpp
@@ -652,7 +652,7 @@ TEST_F(NestedServer, nested_platform_connects_and_disconnects)
     EXPECT_TRUE(signal.wait_for(30s));
 }
 
-TEST_F(NestedServerWithTwoDisplays, sees_expected_outputs)
+TEST_F(NestedServerWithTwoDisplays, DISABLED_sees_expected_outputs)
 {
     NestedMirRunner nested_mir{new_connection()};
 
@@ -779,7 +779,7 @@ TEST_F(NestedServer, client_may_connect_to_nested_server_and_create_surface)
     EXPECT_TRUE(became_exposed_and_focused);
 }
 
-TEST_F(NestedServerWithTwoDisplays, posts_when_scene_has_visible_changes)
+TEST_F(NestedServerWithTwoDisplays, DISABLED_posts_when_scene_has_visible_changes)
 {
     auto const number_of_nested_surfaces = 2;
     auto const number_of_cursor_streams = number_of_nested_surfaces;
@@ -1164,7 +1164,7 @@ TEST_F(NestedServer, base_configuration_change_in_host_is_seen_in_nested)
 }
 
 // lp:1511798
-TEST_F(NestedServerWithTwoDisplays, display_configuration_reset_when_application_exits)
+TEST_F(NestedServerWithTwoDisplays, DISABLED_display_configuration_reset_when_application_exits)
 {
     NestedMirRunner nested_mir{new_connection()};
     ignore_rebuild_of_egl_context();
@@ -1371,7 +1371,7 @@ TEST_F(NestedServer, when_monitor_plugged_in_client_is_notified_of_new_display_c
     mir_display_config_release(configuration);
 }
 
-TEST_F(NestedServer, given_nested_server_set_base_display_configuration_when_monitor_plugged_in_configuration_is_reset)
+TEST_F(NestedServer, DISABLED_given_nested_server_set_base_display_configuration_when_monitor_plugged_in_configuration_is_reset)
 {
     NestedMirRunner nested_mir{new_connection()};
     ignore_rebuild_of_egl_context();
@@ -1554,7 +1554,7 @@ TEST_F(NestedServer,
     Mock::VerifyAndClearExpectations(&display);
 }
 
-TEST_F(NestedServerWithTwoDisplays, uses_passthrough_when_surface_size_is_appropriate)
+TEST_F(NestedServerWithTwoDisplays, DISABLED_uses_passthrough_when_surface_size_is_appropriate)
 {
     using namespace std::chrono_literals;
     NestedMirRunner nested_mir{new_connection()};


### PR DESCRIPTION
Opinions may legitimately differ on whether this is a good idea (vote accordingly). However, these intermittent failures are a PITA. Also:

1. We're not working on the code these test; and,
2. "Nested" only works with the legacy libmirclient AND the Mir EGL patch to mesa

I've not deleted them as they should compile and we may want to reinstate in the future (e.g. if we address 2).