### PR TITLE
[travis] allow ubuntu-devel to fail, too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,14 +40,15 @@ env:
   matrix:
   - SYSTEM=google:ubuntu-16.04 VARIANT=amd64
   - SYSTEM=google:ubuntu-16.04 VARIANT=arm64
-  - SYSTEM=google:ubuntu-17.10 VARIANT=amd64
-  - SYSTEM=google:ubuntu-devel VARIANT=clang
+  - SYSTEM=google:ubuntu-17.10 VARIANT=clang
+  - SYSTEM=google:ubuntu-devel VARIANT=amd64
   - SYSTEM=linode:fedora-27 VARIANT=amd64
   - SYSTEM=linode:fedora-rawhide VARIANT=amd64
 
 matrix:
   allow_failures:
   - env: SYSTEM=linode:fedora-rawhide VARIANT=amd64
+  - env: SYSTEM=google:ubuntu-devel VARIANT=amd64
   fast_finish: true
 
 before_install:


### PR DESCRIPTION
Same as Fedora Rawhide, Ubuntu devel may be in an inconsistent state,
allow it to fail.