### PR TITLE
Windows can have content when created

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -304,15 +304,12 @@ private:
 
 void SurfaceEventSink::send_resize(geometry::Size const& new_size) const
 {
-    if (window_size != new_size)
-    {
-        seat->spawn(run_unless(
-            destroyed,
-            [event_sink= event_sink, width = new_size.width.as_int(), height = new_size.height.as_int()]()
-            {
-                wl_shell_surface_send_configure(event_sink, WL_SHELL_SURFACE_RESIZE_NONE, width, height);
-            }));
-    }
+    seat->spawn(run_unless(
+        destroyed,
+        [event_sink= event_sink, width = new_size.width.as_int(), height = new_size.height.as_int()]()
+        {
+            wl_shell_surface_send_configure(event_sink, WL_SHELL_SURFACE_RESIZE_NONE, width, height);
+        }));
 }
 
 class WlShellSurface  : public wayland::ShellSurface, WlAbstractMirWindow

--- a/src/server/frontend_wayland/wl_mir_window.cpp
+++ b/src/server/frontend_wayland/wl_mir_window.cpp
@@ -94,20 +94,9 @@ shell::SurfaceSpecification& WlAbstractMirWindow::spec()
 void WlAbstractMirWindow::commit()
 {
     auto const session = get_session(client);
-    auto const latest_window_size = window_size.is_set() ? window_size.value() : latest_buffer_size;
 
     if (surface_id.as_value())
     {
-        auto const surface = get_surface_for_id(session, surface_id);
-
-        if (!window_size.is_set() && surface->size() != latest_buffer_size)
-        {
-            sink->latest_resize(latest_buffer_size);
-            auto& new_size_spec = spec();
-            new_size_spec.width = latest_buffer_size.width;
-            new_size_spec.height = latest_buffer_size.height;
-        }
-
         if (pending_changes)
             shell->modify_surface(session, surface_id, *pending_changes);
 
@@ -117,7 +106,7 @@ void WlAbstractMirWindow::commit()
 
     auto* const mir_surface = WlSurface::from(surface);
     if (params->size == geometry::Size{})
-        params->size = latest_window_size;
+        params->size = window_size.is_set() ? window_size.value() : latest_buffer_size;
     if (params->size == geometry::Size{})
         params->size = geometry::Size{640, 480};
 

--- a/src/server/frontend_wayland/wl_mir_window.cpp
+++ b/src/server/frontend_wayland/wl_mir_window.cpp
@@ -126,6 +126,14 @@ void WlAbstractMirWindow::commit()
 void WlAbstractMirWindow::new_buffer_size(geometry::Size const& buffer_size)
 {
     latest_buffer_size = buffer_size;
+
+    // Sometimes, when using xdg-shell, qterminal creates an insanely tall buffer
+    if (latest_buffer_size.height > geometry::Height{10000})
+    {
+        log_warning("Insane buffer height sanitized: latest_buffer_size.height = %d (was %d)",
+                    1000, latest_buffer_size.height.as_int());
+        latest_buffer_size.height = geometry::Height{1000};
+    }
 }
 
 void WlAbstractMirWindow::visiblity(bool visible)

--- a/src/server/frontend_wayland/wl_mir_window.cpp
+++ b/src/server/frontend_wayland/wl_mir_window.cpp
@@ -97,6 +97,17 @@ void WlAbstractMirWindow::commit()
 
     if (surface_id.as_value())
     {
+        auto const surface = get_surface_for_id(session, surface_id);
+
+        // If the window side isn't set explicitly assume it matches the latest buffer
+        if (!window_size.is_set() && surface->size() != latest_buffer_size)
+        {
+            sink->latest_resize(latest_buffer_size);
+            auto& new_size_spec = spec();
+            new_size_spec.width = latest_buffer_size.width;
+            new_size_spec.height = latest_buffer_size.height;
+        }
+
         if (pending_changes)
             shell->modify_surface(session, surface_id, *pending_changes);
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -247,8 +247,18 @@ void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct
 
 void mf::XdgSurfaceV6::set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
 {
-    WlSurface::from(surface)->buffer_offset = geom::Displacement{-x, -y};
+    auto* const mir_surface = WlSurface::from(surface);
+    geom::Displacement const buffer_offset{-x, -y};
+
+    mir_surface->buffer_offset = buffer_offset;
     window_size = geom::Size{width, height};
+
+    if (surface_id.as_value())
+    {
+        spec().width = geom::Width{width};
+        spec().height = geom::Height{height};
+        spec().streams = std::move(std::vector<shell::StreamSpecification>{{mir_surface->stream_id, buffer_offset, {}}});
+    }
 }
 
 void mf::XdgSurfaceV6::ack_configure(uint32_t serial)

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -446,15 +446,12 @@ mf::XdgSurfaceV6EventSink::XdgSurfaceV6EventSink(WlSeat* seat, wl_client* client
 
 void mf::XdgSurfaceV6EventSink::send_resize(geometry::Size const& new_size) const
 {
-    if (window_size != new_size)
-    {
-        seat->spawn(run_unless(destroyed, [this, new_size]()
-            {
-                auto const serial = wl_display_next_serial(wl_client_get_display(client));
-                notify_resize(new_size);
-                zxdg_surface_v6_send_configure(event_sink, serial);
-            }));
-    }
+    seat->spawn(run_unless(destroyed, [this, new_size]()
+        {
+            auto const serial = wl_display_next_serial(wl_client_get_display(client));
+            notify_resize(new_size);
+            zxdg_surface_v6_send_configure(event_sink, serial);
+        }));
 }
 
 void mf::XdgSurfaceV6EventSink::post_configure(int serial) const

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -247,13 +247,13 @@ ms::BasicSurface::BasicSurface(
     confine_pointer_state_(state),
     cursor_stream_adapter{std::make_unique<ms::CursorStreamImageAdapter>(*this)}
 {
+    auto callback = [this](auto const& size) { observers.frame_posted(this, 1, size); };
+
     for (auto& layer : layers)
     {
-        layer.stream->set_frame_posted_callback(
-            [this](auto const& size)
-            {
-                observers.frame_posted(this, 1, size);
-            });
+        if (layer.stream->has_submitted_buffer())
+            callback(layer.stream->stream_size());
+        layer.stream->set_frame_posted_callback(callback);
     }
     report->surface_created(this, surface_name);
 }

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -320,10 +320,6 @@ TEST_F(BasicSurfaceTest, default_region_is_surface_rectangle)
 
 TEST_F(BasicSurfaceTest, default_invisible_surface_doesnt_get_input)
 {
-    EXPECT_CALL(*mock_buffer_stream, has_submitted_buffer())
-        .WillOnce(testing::Return(false))
-        .WillOnce(testing::Return(true));
-
     ms::BasicSurface surface{
         name,
         geom::Rectangle{{0,0}, {100,100}},
@@ -331,6 +327,10 @@ TEST_F(BasicSurfaceTest, default_invisible_surface_doesnt_get_input)
         streams,
         std::shared_ptr<mg::CursorImage>(),
         report};
+
+    EXPECT_CALL(*mock_buffer_stream, has_submitted_buffer())
+        .WillOnce(testing::Return(false))
+        .WillOnce(testing::Return(true));
 
     EXPECT_FALSE(surface.input_area_contains({50,50}));
     EXPECT_TRUE(surface.input_area_contains({50,50}));


### PR DESCRIPTION
Handling this correctly in Mir means Qt apps can create surfaces and XDG shell windows as they expect