### PR TITLE
Options: Present all graphics platform options.

### DIFF
--- a/src/include/platform/mir/options/default_configuration.h
+++ b/src/include/platform/mir/options/default_configuration.h
@@ -22,6 +22,7 @@
 #include "mir/options/configuration.h"
 #include "mir/options/program_option.h"
 #include <boost/program_options/options_description.hpp>
+#include <vector>
 
 namespace mir
 {
@@ -49,7 +50,7 @@ public:
 private:
     // MUST be the first member to ensure it's destroyed last, lest we attempt to
     // call destructors in DSOs we've unloaded.
-    std::shared_ptr<SharedLibrary> platform_graphics_library;
+    std::vector<std::shared_ptr<SharedLibrary>> platform_libraries;
 
     std::string const config_file;
 

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -248,7 +248,7 @@ void mo::DefaultConfiguration::add_platform_options()
                 }
             }();
 
-        for (auto platform : platform_libraries)
+        for (auto& platform : platform_libraries)
         {
             /* Ideally we'd namespace these options with the platform,
              * and display them in a group as $FOO-platform-specific.
@@ -260,8 +260,20 @@ void mo::DefaultConfiguration::add_platform_options()
             }
             catch (std::runtime_error&)
             {
+                /* We've failed to add the options - probably because it's not a graphics platform,
+                 * or because it's got the wrong version - unload it; it's unnecessary.
+                 */
+                platform.reset();
             }
         }
+
+        // Remove the shared_ptrs to the libraries we've unloaded from the vector.
+        platform_libraries.erase(
+            std::remove(
+                platform_libraries.begin(),
+                platform_libraries.end(),
+                std::shared_ptr<mir::SharedLibrary>{}),
+            platform_libraries.end());
     }
     catch(...)
     {

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -220,29 +220,48 @@ void mo::DefaultConfiguration::add_platform_options()
     mo::ProgramOption options;
     options.parse_arguments(program_options, argc, argv);
 
-    // TODO: We should just load all the platform plugins we can and present their options.
-    auto env_libname = ::getenv("MIR_SERVER_PLATFORM_GRAPHICS_LIB");
-    auto env_libpath = ::getenv("MIR_SERVER_PLATFORM_PATH");
     try
     {
-        if (options.is_set(platform_graphics_lib))
-        {
-            platform_graphics_library = std::make_shared<mir::SharedLibrary>(options.get<std::string>(platform_graphics_lib));
-        }
-        else if (env_libname)
-        {
-            platform_graphics_library = std::make_shared<mir::SharedLibrary>(std::string{env_libname});
-        }
-        else
-        {
-            mir::logging::NullSharedLibraryProberReport null_report;
-            auto const plugin_path = env_libpath ? env_libpath : options.get<std::string>(platform_path);
-            auto plugins = mir::libraries_for_path(plugin_path, null_report);
-            platform_graphics_library = mir::graphics::module_for_device(plugins, options);
-        }
+        auto env_libname = ::getenv("MIR_SERVER_PLATFORM_GRAPHICS_LIB");
+        auto env_libpath = ::getenv("MIR_SERVER_PLATFORM_PATH");
 
-        auto add_platform_options = platform_graphics_library->load_function<mir::graphics::AddPlatformOptions>("add_graphics_platform_options", MIR_SERVER_GRAPHICS_PLATFORM_VERSION);
-        add_platform_options(*this->program_options);
+        platform_libraries =
+            [env_libname, env_libpath, &options]()
+            {
+                if (options.is_set(platform_graphics_lib))
+                {
+                    return std::vector<std::shared_ptr<mir::SharedLibrary>>{
+                        std::make_shared<mir::SharedLibrary>(
+                            options.get<std::string>(platform_graphics_lib))};
+                }
+                else if (env_libname)
+                {
+                    return std::vector<std::shared_ptr<mir::SharedLibrary>>{
+                        std::make_shared<mir::SharedLibrary>(std::string{env_libname})
+                    };
+                }
+                else
+                {
+                    mir::logging::NullSharedLibraryProberReport null_report;
+                    auto const plugin_path = env_libpath ? env_libpath : options.get<std::string>(platform_path);
+                    return mir::libraries_for_path(plugin_path, null_report);
+                }
+            }();
+
+        for (auto platform : platform_libraries)
+        {
+            /* Ideally we'd namespace these options with the platform,
+             * and display them in a group as $FOO-platform-specific.
+             */
+            try
+            {
+                auto add_platform_options = platform->load_function<mir::graphics::AddPlatformOptions>("add_graphics_platform_options", MIR_SERVER_GRAPHICS_PLATFORM_VERSION);
+                add_platform_options(*this->program_options);
+            }
+            catch (std::runtime_error&)
+            {
+            }
+        }
     }
     catch(...)
     {

--- a/src/platforms/mesa/server/kms/platform_symbols.cpp
+++ b/src/platforms/mesa/server/kms/platform_symbols.cpp
@@ -112,10 +112,11 @@ mir::UniqueModulePtr<mg::Platform> create_host_platform(
     // ensure mesa finds the mesa mir-platform symbols
     auto real_fops = std::make_shared<RealVTFileOperations>();
     auto real_pops = std::unique_ptr<RealPosixProcessOperations>(new RealPosixProcessOperations{});
+    auto const vtnum = options->is_set(vt_option_name) ? options->get<int>(vt_option_name) : 0;
     auto vt = std::make_shared<mgm::LinuxVirtualTerminal>(
         real_fops,
         std::move(real_pops),
-        options->get<int>(vt_option_name),
+        vtnum,
         report);
 
     auto bypass_option = mgm::BypassOption::allowed;
@@ -131,8 +132,8 @@ void add_graphics_platform_options(boost::program_options::options_description& 
     mir::assert_entry_point_signature<mg::AddPlatformOptions>(&add_graphics_platform_options);
     config.add_options()
         (vt_option_name,
-         boost::program_options::value<int>()->default_value(0),
-         "[platform-specific] VT to run on or 0 to use current.")
+         boost::program_options::value<int>(),
+         "[platform-specific] VT to run on.")
         (bypass_option_name,
          boost::program_options::value<bool>()->default_value(true),
          "[platform-specific] utilize the bypass optimization for fullscreen surfaces.");

--- a/src/platforms/mesa/server/kms/platform_symbols.cpp
+++ b/src/platforms/mesa/server/kms/platform_symbols.cpp
@@ -145,12 +145,6 @@ mg::PlatformPriority probe_graphics_platform(mo::ProgramOption const& options)
     auto const unparsed_arguments = options.unparsed_command_line();
     auto platform_option_used = false;
 
-    for (auto const& token : unparsed_arguments)
-    {
-        if (token == (std::string("--") + vt_option_name))
-            platform_option_used = true;
-    }
-
     if (options.is_set(vt_option_name))
         platform_option_used = true;
     auto nested = options.is_set(host_socket);


### PR DESCRIPTION
Previously we were calling `probe()` twice - once, before option parsing, to
guess what graphics platform we would be using and then call its
`add_platform_options()`, and then one during graphics initialisation.

Instead, unconditionally call `add_platform_options()` on every graphics
platform we can lay our hands on, and only call `probe()` when we're
working out which graphics platform to construct.