### PR TITLE
Provide options to use toolkit libmirclient support in miral-desktop, miral-app and miral-run

### DIFF
--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -5,6 +5,8 @@ launcher=qterminal
 hostsocket=
 bindir=$(dirname $0)
 qt_qpa=wayland
+gdk_backend=wayland,mir
+sdl_videodriver=wayland
 
 if [ -n "${MIR_SOCKET}" ]
 then
@@ -31,6 +33,8 @@ do
     echo "    -wayland-socket-name <socket> set the wayland socket [${wayland_display}]"
     echo "    -bindir <bindir>              path to the miral executable [${bindir}]"
     echo "    -qt-mirclient                 use ubuntumirclient instead of qtwayland"
+    echo "    -gtk-mirclient                GTK uses mir instead of wayland,mir"
+    echo "    -sdl-mirclient                SDL uses mir instead of wayland"
     exit 0
   elif [ "$1" == "-kiosk" ];              then miral_server=miral-kiosk
   elif [ "$1" == "-launcher" ];           then shift; launcher=$1
@@ -38,6 +42,8 @@ do
   elif [ "$1" == "-wayland-socket-name" ];then shift; wayland_display=$1
   elif [ "$1" == "-bindir" ];             then shift; bindir=$1
   elif [ "$1" == "-qt-mirclient" ];       then qt_qpa=ubuntumirclient
+  elif [ "$1" == "-gtk-mirclient" ];      then gdk_backend=mir
+  elif [ "$1" == "-sdl-mirclient" ];      then sdl_videodriver=mir
   elif [ "${1:0:2}" == "--" ];            then break
   fi
   shift
@@ -54,5 +60,5 @@ sh -c "${bindir}${miral_server} $* ${hostsocket} --file ${socket} --wayland-sock
 while [ ! -e "${socket}" ]; do echo "waiting for ${socket}"; sleep 1 ;done
 
 unset QT_QPA_PLATFORMTHEME
-MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=wayland,mir QT_QPA_PLATFORM=${qt_qpa} SDL_VIDEODRIVER=wayland WAYLAND_DISPLAY=${wayland_display} NO_AT_BRIDGE=1 dbus-run-session -- ${launcher}
+MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=${gdk_backend} QT_QPA_PLATFORM=${qt_qpa} SDL_VIDEODRIVER=${sdl_videodriver} WAYLAND_DISPLAY=${wayland_display} NO_AT_BRIDGE=1 dbus-run-session -- ${launcher}
 killall ${bindir}${miral_server} || killall ${bindir}${miral_server}.bin

--- a/examples/miral-shell/miral-desktop.sh
+++ b/examples/miral-shell/miral-desktop.sh
@@ -7,6 +7,8 @@ launcher=qterminal
 bindir=$(dirname $0)
 vt=4
 qt_qpa=wayland
+gdk_backend=wayland,mir
+sdl_videodriver=wayland
 
 while [ $# -gt 0 ]
 do
@@ -22,6 +24,8 @@ do
     echo "    -wayland-socket-name <socket> set the wayland socket [${wayland_display}]"
     echo "    -bindir <bindir>              path to the miral executable [${bindir}]"
     echo "    -qt-mirclient                 use ubuntumirclient instead of qtwayland"
+    echo "    -gtk-mirclient                GTK uses mir instead of wayland,mir"
+    echo "    -sdl-mirclient                SDL uses mir instead of wayland"
     exit 0
   elif [ "$1" == "-kiosk" ];              then miral_server=miral-kiosk
   elif [ "$1" == "-launcher" ];           then shift; launcher=$1
@@ -30,6 +34,8 @@ do
   elif [ "$1" == "-wayland-socket-name" ];then shift; wayland_display=$1
   elif [ "$1" == "-bindir" ];             then shift; bindir=$1
   elif [ "$1" == "-qt-mirclient" ];       then qt_qpa=ubuntumirclient
+  elif [ "$1" == "-gtk-mirclient" ];      then gdk_backend=mir
+  elif [ "$1" == "-sdl-mirclient" ];      then sdl_videodriver=mir
   elif [ "${1:0:2}" == "--" ];            then break
   fi
   shift
@@ -49,5 +55,5 @@ sudo --background --preserve-env sh -c "${bindir}${miral_server} --wayland-socke
 while [ ! -e "${socket}" ]; do echo "waiting for ${socket}"; sleep 1 ;done
 
 unset QT_QPA_PLATFORMTHEME
-MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=wayland,mir QT_QPA_PLATFORM=${qt_qpa} SDL_VIDEODRIVER=wayland WAYLAND_DISPLAY=${wayland_display} NO_AT_BRIDGE=1 dbus-run-session -- ${launcher}
+MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=${gdk_backend} QT_QPA_PLATFORM=${qt_qpa} SDL_VIDEODRIVER=${sdl_videodriver} WAYLAND_DISPLAY=${wayland_display} NO_AT_BRIDGE=1 dbus-run-session -- ${launcher}
 sudo killall ${bindir}${miral_server} || sudo killall ${bindir}${miral_server}.bin

--- a/examples/miral-shell/miral-run.sh
+++ b/examples/miral-shell/miral-run.sh
@@ -1,4 +1,27 @@
-#!/bin/sh
+#! /bin/bash
+
+qt_qpa=wayland
+gdk_backend=wayland,mir
+sdl_videodriver=wayland
+
+while [ $# -gt 0 ]
+do
+  if [ "$1" == "--help" -o "$1" == "-h" ]
+  then
+    echo "$(basename $0) - Handy launch script for clients of a Mir server"
+    echo "Usage: $(basename $0) [options] <client> [client args]"
+    echo "Options are:"
+    echo "    -qt-mirclient                 use ubuntumirclient instead of qtwayland"
+    echo "    -gtk-mirclient                GTK uses mir instead of wayland,mir"
+    echo "    -sdl-mirclient                SDL uses mir instead of wayland"
+    exit 0
+  elif [ "$1" == "-qt-mirclient" ];       then qt_qpa=ubuntumirclient
+  elif [ "$1" == "-gtk-mirclient" ];      then gdk_backend=mir
+  elif [ "$1" == "-sdl-mirclient" ];      then sdl_videodriver=mir
+  else break
+  fi
+  shift
+done
 
 if   [ -e "${XDG_RUNTIME_DIR}/miral_socket" ];
 then
@@ -30,8 +53,8 @@ unset QT_QPA_PLATFORMTHEME
 
 if [ "$1" = "gdb" ]
 then
-  MIR_SOCKET=${mir_socket} WAYLAND_DISPLAY=${wayland_socket} XDG_SESSION_TYPE=mir GDK_BACKEND=wayland,mir QT_QPA_PLATFORM=wayland SDL_VIDEODRIVER=wayland NO_AT_BRIDGE=1 "$@" ${extras}
+  MIR_SOCKET=${mir_socket} WAYLAND_DISPLAY=${wayland_socket} XDG_SESSION_TYPE=mir GDK_BACKEND=${gdk_backend} QT_QPA_PLATFORM=${qt_qpa} SDL_VIDEODRIVER=${sdl_videodriver} NO_AT_BRIDGE=1 "$@" ${extras}
 else
-  MIR_SOCKET=${mir_socket} WAYLAND_DISPLAY=${wayland_socket} XDG_SESSION_TYPE=mir GDK_BACKEND=wayland,mir QT_QPA_PLATFORM=wayland SDL_VIDEODRIVER=wayland NO_AT_BRIDGE=1 "$@" ${extras}&
+  MIR_SOCKET=${mir_socket} WAYLAND_DISPLAY=${wayland_socket} XDG_SESSION_TYPE=mir GDK_BACKEND=${gdk_backend} QT_QPA_PLATFORM=${qt_qpa} SDL_VIDEODRIVER=${sdl_videodriver} NO_AT_BRIDGE=1 "$@" ${extras}&
 fi
 


### PR DESCRIPTION
This is most useful on 16.04LTS where the toolkit Wayland support tends to be flaky. E.g. 

 o Qt clients hang.
 o GDK clients crash when xdg-shell v5 is unavailable (instead falling back to wl_shell or gtk-mir)