### PR TITLE
Restructure WlSurface::commit()

### DIFF
--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -103,8 +103,9 @@ void mf::WlSubsurface::invalidate_buffer_list()
     parent->invalidate_buffer_list();
 }
 
-void mf::WlSubsurface::commit()
+void mf::WlSubsurface::commit(WlSurfaceState const& state)
 {
+    surface->commit(state);
     invalidate_buffer_list();
     // TODO: if in desync mode, immediately make the buffer get rendered
 }

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -68,7 +68,7 @@ private:
 
     virtual void new_buffer_size(geometry::Size const& buffer_size) override;
     void invalidate_buffer_list() override;
-    virtual void commit() override;
+    virtual void commit(WlSurfaceState const& state) override;
     virtual void visiblity(bool visible) override;
 
     WlSurface* surface;

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -64,7 +64,6 @@ public:
 class WlSurface : public wayland::Surface
 {
 public:
-
     WlSurface(wl_client* client,
               wl_resource* parent,
               uint32_t id,
@@ -81,6 +80,7 @@ public:
     std::unique_ptr<WlSurface, std::function<void(WlSurface*)>> add_child(WlSubsurface* child);
     void invalidate_buffer_list();
     void populate_buffer_list(std::vector<shell::StreamSpecification>& buffers) const;
+    void commit(WlSurfaceState const& state);
 
     mir::frontend::BufferStreamId stream_id;
     std::shared_ptr<mir::frontend::BufferStream> stream;

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -21,8 +21,6 @@
 
 #include "generated/wayland_wrapper.h"
 
-#include "double_buffered.h"
-
 #include "mir/frontend/buffer_stream_id.h"
 #include "mir/frontend/surface_id.h"
 
@@ -49,9 +47,24 @@ class BufferStream;
 class WlSurfaceRole;
 class WlSubsurface;
 
+class WlSurfaceState
+{
+public:
+    WlSurfaceState(): frame_callbacks{std::make_unique<std::vector<wl_resource*>>()} {}
+
+    // NOTE: buffer can be both nullopt and nullptr (I know, sounds dumb, but bare with me)
+    // if it's nullopt, there is not a new buffer and no value should be copied to current state
+    // if it's nullptr, there is a new buffer and it is a null buffer, which should replace the current buffer
+    std::experimental::optional<wl_resource*> buffer;
+
+    std::experimental::optional<geometry::Displacement> buffer_offset;
+    std::unique_ptr<std::vector<wl_resource*>> frame_callbacks;
+};
+
 class WlSurface : public wayland::Surface
 {
 public:
+
     WlSurface(wl_client* client,
               wl_resource* parent,
               uint32_t id,
@@ -61,10 +74,10 @@ public:
     ~WlSurface();
 
     std::shared_ptr<bool> destroyed_flag() const { return destroyed; }
-    geometry::Displacement const& buffer_offset() const { return buffer_offset_; }
+    geometry::Displacement buffer_offset() const { return buffer_offset_; }
 
     void set_role(WlSurfaceRole* role_);
-    void set_buffer_offset(geometry::Displacement const& offset) { return buffer_offset_ = offset; }
+    void set_buffer_offset(geometry::Displacement const& offset) { pending.buffer_offset = offset; }
     std::unique_ptr<WlSurface, std::function<void(WlSurface*)>> add_child(WlSubsurface* child);
     void invalidate_buffer_list();
     void populate_buffer_list(std::vector<shell::StreamSpecification>& buffers) const;
@@ -76,17 +89,14 @@ public:
     static WlSurface* from(wl_resource* resource);
 
 private:
-    void remove_child(WlSubsurface* child);
-
     std::shared_ptr<mir::graphics::WaylandAllocator> const allocator;
     std::shared_ptr<mir::Executor> const executor;
 
     WlSurfaceRole* role;
     std::vector<WlSubsurface*> children;
 
-    wl_resource* pending_buffer;
-    DoubleBuffered<geometry::Displacement> buffer_offset_;
-    std::shared_ptr<std::vector<wl_resource*>> const pending_frames;
+    WlSurfaceState pending;
+    geometry::Displacement buffer_offset_;
     std::shared_ptr<bool> const destroyed;
 
     void destroy() override;

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -43,7 +43,7 @@ class NullWlSurfaceRole : public WlSurfaceRole
 public:
     void new_buffer_size(geometry::Size const& /*buffer_size*/) override {}
     void invalidate_buffer_list() override {}
-    void commit() override {}
+    void commit(WlSurfaceState const& /*state*/) override {}
     void visiblity(bool /*visible*/) override {}
     void destroy() override {}
 } null_wl_surface_role_instance;
@@ -98,8 +98,10 @@ shell::SurfaceSpecification& WlAbstractMirWindow::spec()
     return *pending_changes;
 }
 
-void WlAbstractMirWindow::commit()
+void WlAbstractMirWindow::commit(WlSurfaceState const& state)
 {
+    WlSurface::from(surface)->commit(state);
+
     auto const session = get_session(client);
 
     if (surface_id.as_value())

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -43,13 +43,15 @@ namespace frontend
 {
 class Shell;
 class BasicSurfaceEventSink;
+class WlSurface;
+class WlSurfaceState;
 
 class WlSurfaceRole
 {
 public:
     virtual void new_buffer_size(geometry::Size const& buffer_size) = 0;
     virtual void invalidate_buffer_list() = 0;
-    virtual void commit() = 0;
+    virtual void commit(WlSurfaceState const& state) = 0;
     virtual void visiblity(bool visible) = 0;
     virtual void destroy() = 0;
     virtual ~WlSurfaceRole() = default;
@@ -84,7 +86,7 @@ private:
     std::unique_ptr<shell::SurfaceSpecification> pending_changes;
     bool buffer_list_needs_refresh = true;
 
-    void commit() override;
+    void commit(WlSurfaceState const& state) override;
     void new_buffer_size(geometry::Size const& buffer_size) override;
     void visiblity(bool visible) override;
 };


### PR DESCRIPTION
The main idea of this PR is encapsulate all double buffered surface state in a single class, and restructure the surface committing system to work like so:
* requests are made to the surface that modify the pending state
* WlSurface::commit() is called
  * it calls WlSurfaceRole::commit(state) with its pending state
    * that can either call WlSurface::commit(state), or it can cache the state to be committed later (this will be done for synchronized subsurfaces)
      * in WlSurface::commit(state) the buffer is actually created and submitted
    * the role then does whatever committing it needs to do