### PR TITLE
refactored WlAbstractMirWindow

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -332,8 +332,7 @@ public:
 
     ~WlShellSurface() override
     {
-        auto* const mir_surface = WlSurface::from(surface);
-        mir_surface->set_role(null_wl_surface_role_ptr);
+        surface->set_role(null_wl_surface_role_ptr);
     }
 
 protected:
@@ -344,9 +343,7 @@ protected:
 
     void set_toplevel() override
     {
-        auto* const mir_surface = WlSurface::from(surface);
-
-        mir_surface->set_role(this);
+        surface->set_role(this);
     }
 
     void set_transient(
@@ -381,8 +378,7 @@ protected:
             params->aux_rect_placement_offset_x = 0;
             params->aux_rect_placement_offset_y = 0;
 
-            auto* const mir_surface = WlSurface::from(surface);
-            mir_surface->set_role(this);
+            surface->set_role(this);
         }
     }
 
@@ -445,8 +441,7 @@ protected:
             params->aux_rect_placement_offset_x = 0;
             params->aux_rect_placement_offset_y = 0;
 
-            auto* const mir_surface = WlSurface::from(surface);
-            mir_surface->set_role(this);
+            surface->set_role(this);
         }
     }
 

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -92,12 +92,6 @@ void mf::WlSubsurface::destroy()
     wl_resource_destroy(resource);
 }
 
-void mf::WlSubsurface::new_buffer_size(geometry::Size const& buffer_size)
-{
-    (void)buffer_size;
-    // TODO
-}
-
 void mf::WlSubsurface::invalidate_buffer_list()
 {
     parent->invalidate_buffer_list();

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -66,7 +66,6 @@ private:
 
     void destroy() override; // overrides function in both WlSurfaceRole and wayland::Subsurface
 
-    virtual void new_buffer_size(geometry::Size const& buffer_size) override;
     void invalidate_buffer_list() override;
     virtual void commit(WlSurfaceState const& state) override;
     virtual void visiblity(bool visible) override;

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -228,9 +228,9 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
          *
          * TODO: Provide a mg::Buffer::logical_size() to do this properly.
          */
-        stream->resize(mir_buffer->size());
+        buffer_size_ = mir_buffer->size();
+        stream->resize(buffer_size_);
         stream->submit_buffer(mir_buffer);
-        role->new_buffer_size(mir_buffer->size());
     }
 }
 

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -25,6 +25,7 @@
 #include "mir/frontend/surface_id.h"
 
 #include "mir/geometry/displacement.h"
+#include "mir/geometry/size.h"
 
 #include <vector>
 
@@ -74,6 +75,7 @@ public:
 
     std::shared_ptr<bool> destroyed_flag() const { return destroyed; }
     geometry::Displacement buffer_offset() const { return buffer_offset_; }
+    geometry::Size buffer_size() const { return buffer_size_; }
 
     void set_role(WlSurfaceRole* role_);
     void set_buffer_offset(geometry::Displacement const& offset) { pending.buffer_offset = offset; }
@@ -97,6 +99,7 @@ private:
 
     WlSurfaceState pending;
     geometry::Displacement buffer_offset_;
+    geometry::Size buffer_size_;
     std::shared_ptr<bool> const destroyed;
 
     void destroy() override;

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -49,7 +49,6 @@ class WlSurfaceState;
 class WlSurfaceRole
 {
 public:
-    virtual void new_buffer_size(geometry::Size const& buffer_size) = 0;
     virtual void invalidate_buffer_list() = 0;
     virtual void commit(WlSurfaceState const& state) = 0;
     virtual void visiblity(bool visible) = 0;
@@ -70,24 +69,23 @@ public:
 protected:
     std::shared_ptr<bool> const destroyed;
     wl_client* const client;
-    wl_resource* const surface;
+    WlSurface* const surface;
     wl_resource* const event_sink;
     std::shared_ptr<frontend::Shell> const shell;
     std::shared_ptr<BasicSurfaceEventSink> sink;
 
     std::unique_ptr<scene::SurfaceCreationParameters> const params;
     SurfaceId surface_id;
-    optional_value<geometry::Size> window_size;
+    optional_value<geometry::Size> window_size_;
 
+    geometry::Size window_size();
     shell::SurfaceSpecification& spec();
 
 private:
-    geometry::Size latest_buffer_size;
     std::unique_ptr<shell::SurfaceSpecification> pending_changes;
     bool buffer_list_needs_refresh = true;
 
     void commit(WlSurfaceState const& state) override;
-    void new_buffer_size(geometry::Size const& buffer_size) override;
     void visiblity(bool visible) override;
 };
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -210,8 +210,7 @@ mf::XdgSurfaceV6::XdgSurfaceV6(wl_client* client, wl_resource* parent, uint32_t 
 
 mf::XdgSurfaceV6::~XdgSurfaceV6()
 {
-    auto* const mir_surface = WlSurface::from(surface);
-    mir_surface->set_role(null_wl_surface_role_ptr);
+    surface->set_role(null_wl_surface_role_ptr);
 }
 
 void mf::XdgSurfaceV6::destroy()
@@ -222,8 +221,7 @@ void mf::XdgSurfaceV6::destroy()
 void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
 {
     new XdgToplevelV6{client, parent, id, shell, this};
-    auto* const mir_surface = WlSurface::from(surface);
-    mir_surface->set_role(this);
+    surface->set_role(this);
 }
 
 void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct wl_resource* positioner)
@@ -245,17 +243,15 @@ void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct
     params->placement_hints = mir_placement_hints_slide_any;
 
     new XdgPopupV6{client, parent, id};
-    auto* const mir_surface = WlSurface::from(surface);
-    mir_surface->set_role(this);
+    surface->set_role(this);
 }
 
 void mf::XdgSurfaceV6::set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
 {
-    auto* const mir_surface = WlSurface::from(surface);
     geom::Displacement const buffer_offset{-x, -y};
 
-    mir_surface->set_buffer_offset(buffer_offset);
-    window_size = geom::Size{width, height};
+    surface->set_buffer_offset(buffer_offset);
+    window_size_ = geom::Size{width, height};
 
     if (surface_id.as_value())
     {


### PR DESCRIPTION
* removed `WlSurfaceRole::new_buffer_size()`
* changed the `surface` member of `WlAbstractMirWindow` from a `wl_resource*` to a `WlSurface*`