### PR TITLE
Don't force -flto for libmiral

### DIFF
--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -1,12 +1,3 @@
-if(${CMAKE_COMPILER_IS_GNUCXX})
-    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -flto")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -flto")
-    set(CMAKE_AR "gcc-ar")
-    set(CMAKE_NM "gcc-nm")
-    set(CMAKE_RANLIB "gcc-ranlib")
-endif()
-
 include_directories(
   ${PROJECT_SOURCE_DIR}/include/platform
   ${PROJECT_SOURCE_DIR}/include/client

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -96,16 +96,19 @@ set_target_properties(miral
 
 # clang generates slightly different symbols (but we don't care)
 if (CMAKE_COMPILER_IS_GNUCXX)
-    # Using dpkg-gensymbols only makes sense on Debian based distros
-    if (EXISTS /etc/debian_version)
-        find_program(MIR_DPKG_GENSYMBOLS dpkg-gensymbols)
-        if (MIR_DPKG_GENSYMBOLS)
-            add_custom_target(check-miral-symbols ALL
-                DEPENDS miral ${PROJECT_SOURCE_DIR}/debian/libmiral${MIRAL_ABI}.symbols
-                COMMAND rm -f ${CMAKE_CURRENT_BINARY_DIR}/libmiral${MIRAL_ABI}.symbols
-                COMMAND dpkg-gensymbols -e${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libmiral.so.${MIRAL_ABI} -plibmiral${MIRAL_ABI} -v${MIRAL_VERSION} -O${CMAKE_CURRENT_BINARY_DIR}/libmiral${MIRAL_ABI}.symbols
-                WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-                VERBATIM)
+    # g++ generates slightly different symbols without LTO (but we don't care)
+    if (MIR_LINK_TIME_OPTIMIZATION)
+        # Using dpkg-gensymbols only makes sense on Debian based distros
+        if (EXISTS /etc/debian_version)
+            find_program(MIR_DPKG_GENSYMBOLS dpkg-gensymbols)
+            if (MIR_DPKG_GENSYMBOLS)
+                add_custom_target(check-miral-symbols ALL
+                    DEPENDS miral ${PROJECT_SOURCE_DIR}/debian/libmiral${MIRAL_ABI}.symbols
+                    COMMAND rm -f ${CMAKE_CURRENT_BINARY_DIR}/libmiral${MIRAL_ABI}.symbols
+                    COMMAND dpkg-gensymbols -e${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libmiral.so.${MIRAL_ABI} -plibmiral${MIRAL_ABI} -v${MIRAL_VERSION} -O${CMAKE_CURRENT_BINARY_DIR}/libmiral${MIRAL_ABI}.symbols
+                    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+                    VERBATIM)
+            endif()
         endif()
     endif()
 endif()

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -94,22 +94,20 @@ set_target_properties(miral
         LINK_DEPENDS ${symbol_map}
 )
 
-# clang generates slightly different symbols (but we don't care)
-if (CMAKE_COMPILER_IS_GNUCXX)
-    # g++ generates slightly different symbols without LTO (but we don't care)
-    if (MIR_LINK_TIME_OPTIMIZATION)
-        # Using dpkg-gensymbols only makes sense on Debian based distros
-        if (EXISTS /etc/debian_version)
-            find_program(MIR_DPKG_GENSYMBOLS dpkg-gensymbols)
-            if (MIR_DPKG_GENSYMBOLS)
-                add_custom_target(check-miral-symbols ALL
-                    DEPENDS miral ${PROJECT_SOURCE_DIR}/debian/libmiral${MIRAL_ABI}.symbols
-                    COMMAND rm -f ${CMAKE_CURRENT_BINARY_DIR}/libmiral${MIRAL_ABI}.symbols
-                    COMMAND dpkg-gensymbols -e${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libmiral.so.${MIRAL_ABI} -plibmiral${MIRAL_ABI} -v${MIRAL_VERSION} -O${CMAKE_CURRENT_BINARY_DIR}/libmiral${MIRAL_ABI}.symbols
-                    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-                    VERBATIM)
-            endif()
-        endif()
+
+
+if (CMAKE_COMPILER_IS_GNUCXX   AND  # clang generates slightly different symbols (but we don't care)
+    MIR_LINK_TIME_OPTIMIZATION AND  # g++ generates slightly different symbols without LTO (but we don't care)
+    EXISTS /etc/debian_version)     # Using dpkg-gensymbols only makes sense on Debian based distros
+
+    find_program(MIR_DPKG_GENSYMBOLS dpkg-gensymbols)
+    if (MIR_DPKG_GENSYMBOLS)
+        add_custom_target(check-miral-symbols ALL
+            DEPENDS miral ${PROJECT_SOURCE_DIR}/debian/libmiral${MIRAL_ABI}.symbols
+            COMMAND rm -f ${CMAKE_CURRENT_BINARY_DIR}/libmiral${MIRAL_ABI}.symbols
+            COMMAND dpkg-gensymbols -e${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libmiral.so.${MIRAL_ABI} -plibmiral${MIRAL_ABI} -v${MIRAL_VERSION} -O${CMAKE_CURRENT_BINARY_DIR}/libmiral${MIRAL_ABI}.symbols
+            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+            VERBATIM)
     endif()
 endif()
 


### PR DESCRIPTION
src/miral/CMakeLists.txt has some hardcoded compile flags inherited from its days as a standalone project.
These should be inherited from the parent project instead. (Fixes #266)