### PR TITLE
made null role commit

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -332,7 +332,7 @@ public:
 
     ~WlShellSurface() override
     {
-        surface->set_role(null_wl_surface_role_ptr);
+        surface->clear_role();
     }
 
 protected:

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -53,7 +53,7 @@ mf::WlSubsurface::~WlSubsurface()
     // unique pointer automatically removes `this` from parent child list
 
     invalidate_buffer_list();
-    surface->set_role(null_wl_surface_role_ptr);
+    surface->clear_role();
 }
 
 void mf::WlSubsurface::populate_buffer_list(std::vector<shell::StreamSpecification>& buffers,

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -47,6 +47,7 @@ namespace frontend
 class BufferStream;
 class Session;
 class WlSurfaceRole;
+class NullWlSurfaceRole;
 class WlSubsurface;
 
 struct WlSurfaceState
@@ -86,6 +87,7 @@ public:
     bool synchronized() const;
 
     void set_role(WlSurfaceRole* role_);
+    void clear_role();
     void set_buffer_offset(geometry::Displacement const& offset) { pending.buffer_offset = offset; }
     std::unique_ptr<WlSurface, std::function<void(WlSurface*)>> add_child(WlSubsurface* child);
     void invalidate_buffer_list();
@@ -104,6 +106,7 @@ private:
     std::shared_ptr<mir::graphics::WaylandAllocator> const allocator;
     std::shared_ptr<mir::Executor> const executor;
 
+    std::unique_ptr<NullWlSurfaceRole> const null_role;
     WlSurfaceRole* role;
     std::vector<WlSubsurface*> children;
 

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -38,20 +38,6 @@ namespace frontend
 
 namespace
 {
-class NullWlSurfaceRole : public WlSurfaceRole
-{
-public:
-    void invalidate_buffer_list() override {}
-    void commit(WlSurfaceState const& /*state*/) override {}
-    void visiblity(bool /*visible*/) override {}
-    void destroy() override {}
-} null_wl_surface_role_instance;
-}
-
-WlSurfaceRole* const null_wl_surface_role_ptr = &null_wl_surface_role_instance;
-
-namespace
-{
 std::shared_ptr<scene::Surface> get_surface_for_id(std::shared_ptr<Session> const& session, SurfaceId surface_id)
 {
     return std::dynamic_pointer_cast<scene::Surface>(session->get_surface(surface_id));

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -55,7 +55,7 @@ public:
     virtual void visiblity(bool visible) = 0;
     virtual void destroy() = 0;
     virtual ~WlSurfaceRole() = default;
-} extern * const null_wl_surface_role_ptr;
+};
 
 class WlAbstractMirWindow : public WlSurfaceRole
 {

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -210,7 +210,7 @@ mf::XdgSurfaceV6::XdgSurfaceV6(wl_client* client, wl_resource* parent, uint32_t 
 
 mf::XdgSurfaceV6::~XdgSurfaceV6()
 {
-    surface->set_role(null_wl_surface_role_ptr);
+    surface->clear_role();
 }
 
 void mf::XdgSurfaceV6::destroy()


### PR DESCRIPTION
Tuned null role from a global into a member of each surface, so it can store a pointer to its surface and use that to commit when requested.