### PR TITLE
build: Run cmake twice(‽) to pick up wlcs tests

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@ include debian/opts.mk
 export DPKG_GENSYMBOLS_CHECK_LEVEL = 4
 
 %:
-	dh $@ --parallel --fail-missing --with python3
+	dh $@ -Bbuild-$(DEB_HOST_ARCH) --parallel --fail-missing --with python3
 
 # Enable verbose debugging output from the testsuite
 export MIR_SERVER_LOGGING = on
@@ -59,6 +59,8 @@ else
 	  $(OVERRIDE_CONFIGURE_OPTIONS)
 endif
 endif
+	# Run cmake again to pick up wlcs tests, because reasons?
+	cmake build-$(DEB_HOST_ARCH)
 
 # Only build the docs when we need them
 override_dh_auto_build-indep:

--- a/spread/build/fedora/task.yaml
+++ b/spread/build/fedora/task.yaml
@@ -48,6 +48,8 @@ execute: |
 
     BUILD_DIR=$(mktemp --directory)
     cmake -H$SPREAD_PATH -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DMIR_USE_LD_GOLD=ON -G Ninja
+    # Run cmake again to pick up wlcs?!?!?!?!
+    cmake $BUILD_DIR
     cmake --build $BUILD_DIR
     cmake --build $BUILD_DIR -- ptest
 


### PR DESCRIPTION
I'm not sure why this is required, but running CMake twice reliably
causes the `wlcs` tests to run. (See #273 for example).

Do the simple, not very costly, thing rather than stare deeper into
the CMake void.