### PR TITLE
Don't remember recent surface events after the input dispatcher is shut down.

### DIFF
--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -737,6 +737,7 @@ void mi::SurfaceInputDispatcher::stop()
 
     pointer_state_by_id.clear();
     touch_state_by_id.clear();
+    last_pointer_event.reset();
     
     started = false;
 }


### PR DESCRIPTION
The event "goes stale" and can cause a segfault. (Fixes #276)