### PR TITLE
Remove obsolete checks on Mir version in MirAL code.

### DIFF
--- a/src/miral/application_authorizer.cpp
+++ b/src/miral/application_authorizer.cpp
@@ -21,7 +21,6 @@
 #include <mir/frontend/session_credentials.h>
 #include <mir/frontend/session_authorizer.h>
 #include <mir/server.h>
-#include <mir/version.h>
 
 namespace mf = mir::frontend;
 

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -27,7 +27,6 @@
 #include <mir/shell/display_layout.h>
 #include <mir/shell/persistent_surface_store.h>
 #include <mir/shell/surface_ready_observer.h>
-#include <mir/version.h>
 
 #include <boost/throw_exception.hpp>
 
@@ -756,20 +755,13 @@ void miral::BasicWindowManager::raise_tree(Window const& root)
 
 void miral::BasicWindowManager::start_drag_and_drop(WindowInfo& window_info, std::vector<uint8_t> const& handle)
 {
-#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(0, 27, 0)
     std::shared_ptr<scene::Surface>(window_info.window())->start_drag_and_drop(handle);
     focus_controller->set_drag_and_drop_handle(handle);
-#else
-    (void)window_info;
-    (void)handle;
-#endif
 }
 
 void miral::BasicWindowManager::end_drag_and_drop()
 {
-#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(0, 27, 0)
     focus_controller->clear_drag_and_drop_handle();
-#endif
 }
 
 void miral::BasicWindowManager::move_tree(miral::WindowInfo& root, mir::geometry::Displacement movement)
@@ -1235,11 +1227,10 @@ void miral::BasicWindowManager::update_event_timestamp(MirTouchEvent const* tev)
 void miral::BasicWindowManager::update_event_timestamp(MirInputEvent const* iev)
 {
     last_input_event_timestamp = mir_input_event_get_event_time(iev);
-#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(0, 27, 0)
+
     if (last_input_event)
         mir_event_unref(last_input_event);
     last_input_event = mir_event_ref(mir_input_event_get_event(iev));
-#endif
 }
 
 void miral::BasicWindowManager::invoke_under_lock(std::function<void()> const& callback)

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -32,7 +32,6 @@
 #include <mir/observer_registrar.h>
 #include <mir/shell/abstract_shell.h>
 #include <mir/shell/window_manager.h>
-#include <mir/version.h>
 
 #include <boost/bimap.hpp>
 #include <boost/bimap/multiset_of.hpp>

--- a/src/miral/keymap.cpp
+++ b/src/miral/keymap.cpp
@@ -23,7 +23,6 @@
 #include <mir/input/device.h>
 #include <mir/options/option.h>
 #include <mir/server.h>
-#include <mir/version.h>
 
 #include <mir/input/keymap.h>
 #include <mir/input/mir_keyboard_config.h>

--- a/src/miral/runner.cpp
+++ b/src/miral/runner.cpp
@@ -23,7 +23,6 @@
 #include <mir/main_loop.h>
 #include <mir/report_exception.h>
 #include <mir/options/option.h>
-#include <mir/version.h>
 
 #include <chrono>
 #include <cstdlib>

--- a/src/miral/set_window_management_policy.cpp
+++ b/src/miral/set_window_management_policy.cpp
@@ -22,7 +22,6 @@
 
 #include <mir/server.h>
 #include <mir/options/option.h>
-#include <mir/version.h>
 
 namespace msh = mir::shell;
 

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -20,7 +20,6 @@
 #include "window_info_defaults.h"
 
 #include <mir/scene/surface.h>
-#include <mir/version.h>
 
 #include <limits>
 

--- a/src/miral/window_management_options.cpp
+++ b/src/miral/window_management_options.cpp
@@ -25,7 +25,6 @@
 #include <mir/server.h>
 #include <mir/options/option.h>
 #include <mir/shell/system_compositor_window_manager.h>
-#include <mir/version.h>
 
 namespace msh = mir::shell;
 

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -20,7 +20,6 @@
 
 #include <mir/shell/surface_specification.h>
 #include <mir/scene/surface_creation_parameters.h>
-#include <mir/version.h>
 
 struct miral::WindowSpecification::Self
 {

--- a/tests/miral/test_server.cpp
+++ b/tests/miral/test_server.cpp
@@ -30,7 +30,6 @@
 #include <mir/fd.h>
 #include <mir/main_loop.h>
 #include <mir/server.h>
-#include <mir/version.h>
 
 #include <boost/throw_exception.hpp>
 

--- a/tests/miral/test_window_manager_tools.h
+++ b/tests/miral/test_window_manager_tools.h
@@ -27,7 +27,6 @@
 #include <mir/shell/display_layout.h>
 #include <mir/shell/focus_controller.h>
 #include <mir/shell/persistent_surface_store.h>
-#include <mir/version.h>
 
 #include <mir/test/doubles/stub_session.h>
 #include <mir/test/doubles/stub_surface.h>
@@ -55,11 +54,9 @@ struct StubFocusController : mir::shell::FocusController
     virtual auto surface_at(mir::geometry::Point /*cursor*/) const -> std::shared_ptr<mir::scene::Surface> override
         { return {}; }
 
-#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(0, 27, 0)
     void set_drag_and_drop_handle(std::vector<uint8_t> const& /*handle*/) override {}
 
     void clear_drag_and_drop_handle() override {}
-#endif
 };
 
 struct StubDisplayLayout : mir::shell::DisplayLayout

--- a/tests/miral/window_id.cpp
+++ b/tests/miral/window_id.cpp
@@ -22,8 +22,6 @@
 
 #include <miral/application_info.h>
 
-#include <mir/version.h>
-
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 


### PR DESCRIPTION
We don't need any of this now that MirAL is shipped with Mir.