### PR TITLE
Sequence xdg-top-level and xdg-surface configure events correctly.

### DIFF
--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -139,27 +139,7 @@ void WlAbstractMirWindow::commit(WlSurfaceState const& state)
 
 geometry::Size WlAbstractMirWindow::window_size()
 {
-    if (window_size_.is_set())
-    {
-        return window_size_.value();
-    }
-    else
-    {
-        auto buffer_size = surface->buffer_size();
-
-        // Sometimes, when using xdg-shell, qterminal creates an insanely tall buffer
-        const auto max_allowed_buffer_height = geometry::Height{10000};
-        const auto corrected_buffer_height   = geometry::Height{1000};
-
-        if (buffer_size.height > max_allowed_buffer_height)
-        {
-            log_warning("Insane buffer height sanitized: buffer_size.height = %d (was %d)",
-                        corrected_buffer_height.as_int(), buffer_size.height.as_int());
-            buffer_size.height = corrected_buffer_height;
-        }
-
-        return buffer_size;
-    }
+     return window_size_.is_set()? window_size_.value() : surface->buffer_size();
 }
 
 void WlAbstractMirWindow::visiblity(bool visible)

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -81,12 +81,12 @@ protected:
 
     geometry::Size window_size();
     shell::SurfaceSpecification& spec();
+    void commit(WlSurfaceState const& state) override;
 
 private:
     std::unique_ptr<shell::SurfaceSpecification> pending_changes;
     bool buffer_list_needs_refresh = true;
 
-    void commit(WlSurfaceState const& state) override;
     void visiblity(bool visible) override;
 };
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -101,7 +101,7 @@ private:
 class XdgPopupV6 : wayland::XdgPopupV6
 {
 public:
-    XdgPopupV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    XdgPopupV6(struct wl_client* client, struct wl_resource* parent, uint32_t id, XdgSurfaceV6* self);
 
     void grab(struct wl_resource* seat, uint32_t serial) override;
     void destroy() override;
@@ -244,7 +244,7 @@ void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct
     params->aux_rect_placement_offset_y = pos->aux_rect_placement_offset_y;
     params->placement_hints = mir_placement_hints_slide_any;
 
-    new XdgPopupV6{client, parent, id};
+    new XdgPopupV6{client, parent, id, this};
     surface->set_role(this);
 }
 
@@ -478,9 +478,13 @@ void mf::XdgSurfaceV6EventSink::send_resize(geometry::Size const& new_size) cons
 
 // XdgPopupV6
 
-mf::XdgPopupV6::XdgPopupV6(struct wl_client* client, struct wl_resource* parent, uint32_t id)
+mf::XdgPopupV6::XdgPopupV6(struct wl_client* client, struct wl_resource* parent, uint32_t id, XdgSurfaceV6* self)
     : wayland::XdgPopupV6(client, parent, id)
-{}
+{
+    // TODO Make this readable!!! This "works" by exploiting the non-obvious side-effect
+    // of causing a zxdg_surface_v6_send_configure() event to become pending.
+    self->set_next_commit_action([]{});
+}
 
 void mf::XdgPopupV6::grab(struct wl_resource* seat, uint32_t serial)
 {


### PR DESCRIPTION
qtwayland gets confused by receiving these event out of order. (Fixes #280)