### PR TITLE
When a surface is rendered acknowledge all frames that have been committed.

### DIFF
--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -143,7 +143,7 @@ void mf::WlSurface::attach(std::experimental::optional<wl_resource*> const& buff
 
     role->visiblity(!!buffer);
 
-    pending.buffer = buffer;
+    pending.buffer = buffer.value_or(nullptr);
 }
 
 void mf::WlSurface::damage(int32_t x, int32_t y, int32_t width, int32_t height)

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -127,6 +127,7 @@ private:
     WlSurfaceState pending;
     geometry::Displacement buffer_offset_;
     geometry::Size buffer_size_;
+    std::shared_ptr<std::vector<WlSurfaceState::Callback>> const pending_frames;
     std::shared_ptr<bool> const destroyed;
 
     void destroy() override;


### PR DESCRIPTION
We messed up the handling of frames in a recent refactor: this restores the correct behaviour. (Fixes #284)