### PR TITLE
The role needs to be notified when a surface is destroyed

### DIFF
--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -130,6 +130,7 @@ mf::WlSurface* mf::WlSurface::from(wl_resource* resource)
 void mf::WlSurface::destroy()
 {
     *destroyed = true;
+    role->destroy();
     wl_resource_destroy(resource);
 }
 

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -71,6 +71,7 @@ mf::WlSurface::WlSurface(
 mf::WlSurface::~WlSurface()
 {
     *destroyed = true;
+    role->destroy();
     session->destroy_buffer_stream(stream_id);
 }
 
@@ -130,7 +131,6 @@ mf::WlSurface* mf::WlSurface::from(wl_resource* resource)
 void mf::WlSurface::destroy()
 {
     *destroyed = true;
-    role->destroy();
     wl_resource_destroy(resource);
 }
 


### PR DESCRIPTION
Restores the previous behaviour. (Fixes #289)