### PR TITLE
Consolidate the fullscreen (and other Window state) handling

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -392,23 +392,7 @@ protected:
         uint32_t /*framerate*/,
         std::experimental::optional<struct wl_resource*> const& output) override
     {
-        if (surface_id.as_value())
-        {
-            auto& mods = spec();
-            mods.state = mir_window_state_fullscreen;
-            if (output)
-            {
-                // TODO{alan_g} mods.output_id = DisplayConfigurationOutputId_from(output)
-            }
-        }
-        else
-        {
-            params->state = mir_window_state_fullscreen;
-            if (output)
-            {
-                // TODO{alan_g} params->output_id = DisplayConfigurationOutputId_from(output)
-            }
-        }
+        WlAbstractMirWindow::set_fullscreen(output);
     }
 
     void set_popup(
@@ -452,23 +436,8 @@ protected:
 
     void set_maximized(std::experimental::optional<struct wl_resource*> const& output) override
     {
-        if (surface_id.as_value())
-        {
-            auto& mods = spec();
-            mods.state = mir_window_state_maximized;
-            if (output)
-            {
-                // TODO{alan_g} mods.output_id = DisplayConfigurationOutputId_from(output)
-            }
-        }
-        else
-        {
-            params->state = mir_window_state_maximized;
-            if (output)
-            {
-                // TODO{alan_g} params->output_id = DisplayConfigurationOutputId_from(output)
-            }
-        }
+        (void)output;
+        WlAbstractMirWindow::set_maximized();
     }
 
     void set_title(std::string const& title) override

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -31,6 +31,52 @@
 #include "mir/scene/surface.h"
 #include "mir/scene/surface_creation_parameters.h"
 
+void mir::frontend::WlAbstractMirWindow::set_maximized()
+{
+    // We must process this request immediately (i.e. don't defer until commit())
+    set_state_now(mir_window_state_maximized);
+}
+
+void mir::frontend::WlAbstractMirWindow::unset_maximized()
+{
+    // We must process this request immediately (i.e. don't defer until commit())
+    set_state_now(mir_window_state_restored);
+}
+
+void mir::frontend::WlAbstractMirWindow::set_fullscreen(std::experimental::optional<struct wl_resource*> const& output)
+{
+    (void)output; // TODO specify the output when setting fullscreen
+    // We must process this request immediately (i.e. don't defer until commit())
+    set_state_now(mir_window_state_fullscreen);
+}
+
+void mir::frontend::WlAbstractMirWindow::unset_fullscreen()
+{
+    // We must process this request immediately (i.e. don't defer until commit())
+    set_state_now(mir_window_state_restored);
+}
+
+void mir::frontend::WlAbstractMirWindow::set_minimized()
+{
+    // We must process this request immediately (i.e. don't defer until commit())
+    set_state_now(mir_window_state_minimized);
+}
+
+void mir::frontend::WlAbstractMirWindow::set_state_now(MirWindowState state)
+{
+    if (surface_id.as_value())
+    {
+        shell::SurfaceSpecification mods;
+        mods.state = state;
+        auto const session = get_session(client);
+        shell->modify_surface(session, surface_id, mods);
+    }
+    else
+    {
+        params->state = state;
+    }
+}
+
 namespace mir
 {
 namespace frontend

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -74,6 +74,7 @@ void mir::frontend::WlAbstractMirWindow::set_state_now(MirWindowState state)
     else
     {
         params->state = state;
+        create_mir_window();
     }
 }
 
@@ -162,6 +163,13 @@ void WlAbstractMirWindow::commit(WlSurfaceState const& state)
         pending_changes.reset();
         return;
     }
+
+    create_mir_window();
+}
+
+void WlAbstractMirWindow::create_mir_window()
+{
+    auto const session = get_session(client);
 
     if (params->size == geometry::Size{})
         params->size = window_size();

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -24,6 +24,9 @@
 #include "mir/geometry/size.h"
 #include "mir/optional_value.h"
 
+#include <mir_toolkit/common.h>
+
+#include <experimental/optional>
 #include <memory>
 
 struct wl_client;
@@ -66,6 +69,18 @@ public:
     ~WlAbstractMirWindow() override;
 
     void invalidate_buffer_list() override;
+
+    void set_maximized();
+
+    void unset_maximized();
+
+    void set_fullscreen(std::experimental::optional<wl_resource*> const& output);
+
+    void unset_fullscreen();
+
+    void set_minimized();
+
+    void set_state_now(MirWindowState state);
 
 protected:
     std::shared_ptr<bool> const destroyed;

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -103,6 +103,8 @@ private:
     bool buffer_list_needs_refresh = true;
 
     void visiblity(bool visible) override;
+
+    void create_mir_window();
 };
 
 }

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -68,16 +68,16 @@ public:
     void clear_next_commit_action();
     void set_max_size(int32_t width, int32_t height);
     void set_min_size(int32_t width, int32_t height);
-    void set_maximized();
-    void unset_maximized();
-    void set_fullscreen(std::experimental::optional<struct wl_resource*> const& output);
-    void unset_fullscreen();
-    void set_minimized();
-    void set_state_now(MirWindowState state);
 
     using WlAbstractMirWindow::client;
     using WlAbstractMirWindow::params;
     using WlAbstractMirWindow::surface_id;
+    using WlAbstractMirWindow::set_maximized;
+    using WlAbstractMirWindow::unset_maximized;
+    using WlAbstractMirWindow::set_fullscreen;
+    using WlAbstractMirWindow::unset_fullscreen;
+    using WlAbstractMirWindow::set_minimized;
+    using WlAbstractMirWindow::set_state_now;
 
     struct wl_resource* const parent;
     std::shared_ptr<Shell> const shell;
@@ -412,52 +412,6 @@ void mf::XdgSurfaceV6::set_min_size(int32_t width, int32_t height)
     {
         params->min_width = geom::Width{width};
         params->min_height = geom::Height{height};
-    }
-}
-
-void mf::XdgSurfaceV6::set_maximized()
-{
-    // We must process this request immediately (i.e. don't defer until commit())
-    set_state_now(mir_window_state_maximized);
-}
-
-void mf::XdgSurfaceV6::unset_maximized()
-{
-    // We must process this request immediately (i.e. don't defer until commit())
-    set_state_now(mir_window_state_restored);
-}
-
-void mf::XdgSurfaceV6::set_fullscreen(std::experimental::optional<struct wl_resource*> const& output)
-{
-    (void)output; // TODO specify the output when setting fullscreen
-    // We must process this request immediately (i.e. don't defer until commit())
-    set_state_now(mir_window_state_fullscreen);
-}
-
-void mf::XdgSurfaceV6::unset_fullscreen()
-{
-    // We must process this request immediately (i.e. don't defer until commit())
-    set_state_now(mir_window_state_restored);
-}
-
-void mf::XdgSurfaceV6::set_minimized()
-{
-    // We must process this request immediately (i.e. don't defer until commit())
-    set_state_now(mir_window_state_minimized);
-}
-
-void mf::XdgSurfaceV6::set_state_now(MirWindowState state)
-{
-    if (surface_id.as_value())
-    {
-        shell::SurfaceSpecification mods;
-        mods.state = state;
-        auto const session = get_session(client);
-        shell->modify_surface(session, surface_id, mods);
-    }
-    else
-    {
-        params->state = state;
     }
 }
 


### PR DESCRIPTION
Implement the common state changing logic in WlAbstractMirWindow. (Fixes: #311)