### PR TITLE
Input refactoring

### DIFF
--- a/src/server/frontend_wayland/basic_surface_event_sink.cpp
+++ b/src/server/frontend_wayland/basic_surface_event_sink.cpp
@@ -86,19 +86,19 @@ void mf::BasicSurfaceEventSink::handle_input_event(MirInputEvent const* event)
     switch (mir_input_event_get_type(event))
     {
     case mir_input_event_type_key:
-        seat->for_each_listener(client, [this, event](WlKeyboard* keyboard)
+        seat->for_each_listener(client, [this, event = mir_input_event_get_keyboard_event(event)](WlKeyboard* keyboard)
             {
                 keyboard->handle_event(event, target);
             });
         break;
     case mir_input_event_type_pointer:
-        seat->for_each_listener(client, [this, event](WlPointer* pointer)
+        seat->for_each_listener(client, [this, event = mir_input_event_get_pointer_event(event)](WlPointer* pointer)
             {
-                pointer->handle_event(mir_input_event_get_pointer_event(event), target);
+                pointer->handle_event(event, target);
             });
         break;
     case mir_input_event_type_touch:
-        seat->for_each_listener(client, [this, event](WlTouch* touch)
+        seat->for_each_listener(client, [this, event = mir_input_event_get_touch_event(event)](WlTouch* touch)
             {
                 touch->handle_event(event, target);
             });

--- a/src/server/frontend_wayland/basic_surface_event_sink.cpp
+++ b/src/server/frontend_wayland/basic_surface_event_sink.cpp
@@ -29,10 +29,10 @@
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
 
-mf::BasicSurfaceEventSink::BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, WlAbstractMirWindow* window)
+mf::BasicSurfaceEventSink::BasicSurfaceEventSink(WlSeat* seat, wl_client* client, WlSurface* surface, WlAbstractMirWindow* window)
     : seat{seat},
       client{client},
-      surface{WlSurface::from(target)},
+      surface{surface},
       window{window},
       window_size{geometry::Size{0,0}},
       destroyed{std::make_shared<bool>(false)}

--- a/src/server/frontend_wayland/basic_surface_event_sink.cpp
+++ b/src/server/frontend_wayland/basic_surface_event_sink.cpp
@@ -88,7 +88,7 @@ void mf::BasicSurfaceEventSink::handle_input_event(MirInputEvent const* event)
     case mir_input_event_type_key:
         seat->for_each_listener(client, [this, event = mir_input_event_get_keyboard_event(event)](WlKeyboard* keyboard)
             {
-                keyboard->handle_event(event, surface);
+                keyboard->handle_keyboard_event(event, surface);
             });
         break;
     case mir_input_event_type_pointer:
@@ -112,7 +112,7 @@ void mf::BasicSurfaceEventSink::handle_keymap_event(MirKeymapEvent const* event)
 {
     seat->for_each_listener(client, [this, event](WlKeyboard* keyboard)
         {
-            keyboard->handle_event(event, surface);
+            keyboard->handle_keymap_event(event, surface);
         });
 }
 
@@ -135,7 +135,7 @@ void mf::BasicSurfaceEventSink::handle_window_event(MirWindowEvent const* event)
 
     seat->for_each_listener(client, [this, event](WlKeyboard* keyboard)
         {
-            keyboard->handle_event(event, surface);
+            keyboard->handle_window_event(event, surface);
         });
 }
 

--- a/src/server/frontend_wayland/basic_surface_event_sink.cpp
+++ b/src/server/frontend_wayland/basic_surface_event_sink.cpp
@@ -29,11 +29,10 @@
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
 
-mf::BasicSurfaceEventSink::BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink, WlAbstractMirWindow* window)
+mf::BasicSurfaceEventSink::BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, WlAbstractMirWindow* window)
     : seat{seat},
       client{client},
       surface{WlSurface::from(target)},
-      event_sink{event_sink},
       window{window},
       window_size{geometry::Size{0,0}},
       destroyed{std::make_shared<bool>(false)}

--- a/src/server/frontend_wayland/basic_surface_event_sink.cpp
+++ b/src/server/frontend_wayland/basic_surface_event_sink.cpp
@@ -23,6 +23,8 @@
 #include "wl_touch.h"
 #include "wayland_utils.h"
 
+#include <linux/input-event-codes.h>
+
 namespace mf = mir::frontend;
 
 mf::BasicSurfaceEventSink::BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink)
@@ -88,10 +90,7 @@ void mf::BasicSurfaceEventSink::handle_event(MirInputEvent const* event)
             });
         break;
     case mir_input_event_type_pointer:
-        seat->for_each_listener(client, [this, event](WlPointer* pointer)
-            {
-                pointer->handle_event(event, target);
-            });
+        handle_event(mir_input_event_get_pointer_event(event));
         break;
     case mir_input_event_type_touch:
         seat->for_each_listener(client, [this, event](WlTouch* touch)
@@ -134,3 +133,126 @@ void mf::BasicSurfaceEventSink::handle_event(MirWindowEvent const* event)
             keyboard->handle_event(event, target);
         });
 }
+
+void mf::BasicSurfaceEventSink::handle_event(const MirPointerEvent* event)
+{
+    switch(mir_pointer_event_action(event))
+    {
+        case mir_pointer_action_button_down:
+        case mir_pointer_action_button_up:
+        {
+            auto const current_pointer_buttons  = mir_pointer_event_buttons(event);
+            auto const time = mir_input_event_get_event_time_ms(mir_pointer_event_input_event(event));
+
+            for (auto const& mapping :
+                {
+                    std::make_pair(mir_pointer_button_primary, BTN_LEFT),
+                    std::make_pair(mir_pointer_button_secondary, BTN_RIGHT),
+                    std::make_pair(mir_pointer_button_tertiary, BTN_MIDDLE),
+                    std::make_pair(mir_pointer_button_back, BTN_BACK),
+                    std::make_pair(mir_pointer_button_forward, BTN_FORWARD),
+                    std::make_pair(mir_pointer_button_side, BTN_SIDE),
+                    std::make_pair(mir_pointer_button_task, BTN_TASK),
+                    std::make_pair(mir_pointer_button_extra, BTN_EXTRA)
+                })
+            {
+                if (mapping.first & (current_pointer_buttons ^ last_pointer_buttons))
+                {
+                    auto const is_pressed = mapping.first & current_pointer_buttons;
+
+                    seat->for_each_listener(client, [&](WlPointer* pointer)
+                        {
+                            pointer->handle_button(time, mapping.second, is_pressed);
+                        });
+                }
+            }
+
+            last_pointer_buttons = current_pointer_buttons;
+            break;
+        }
+        /*case mir_pointer_action_enter:
+        {
+            wl_pointer_send_enter(
+                resource,
+                serial,
+                target,
+                wl_fixed_from_double(mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_x)-buffer_offset.dx.as_int()),
+                wl_fixed_from_double(mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_y)-buffer_offset.dy.as_int()));
+            if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
+                wl_pointer_send_frame(resource);
+            break;
+        }
+        case mir_pointer_action_leave:
+        {
+            wl_pointer_send_leave(
+                resource,
+                serial,
+                target);
+            if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
+                wl_pointer_send_frame(resource);
+            break;
+        }
+        case mir_pointer_action_motion:
+        {
+            // TODO: properly group vscroll and hscroll events in the same frame (as described by the frame
+            //  event description in wayland.xml) and send axis_source, axis_stop and axis_discrete events where
+            //  appropriate (may require significant reworking of the input system)
+
+            auto x = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_x)-buffer_offset.dx.as_int();
+            auto y = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_y)-buffer_offset.dy.as_int();
+
+            // libinput < 0.8 sent wheel click events with value 10. Since 0.8 the value is the angle of the click in
+            // degrees. To keep backwards-compat with existing clients, we just send multiples of the click count.
+            // Ref: https://github.com/wayland-project/weston/blob/master/libweston/libinput-device.c#L184
+            auto vscroll = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_vscroll) * 10;
+            auto hscroll = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_hscroll) * 10;
+
+            if ((x != last_x) || (y != last_y))
+            {
+                wl_pointer_send_motion(
+                    resource,
+                    mir_input_event_get_event_time_ms(event),
+                    wl_fixed_from_double(x),
+                    wl_fixed_from_double(y));
+
+                last_x = x;
+                last_y = y;
+
+                if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
+                    wl_pointer_send_frame(resource);
+            }
+            if (vscroll != 0)
+            {
+                wl_pointer_send_axis(
+                    resource,
+                    mir_input_event_get_event_time_ms(event),
+                    WL_POINTER_AXIS_VERTICAL_SCROLL,
+                    wl_fixed_from_double(vscroll));
+
+                if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
+                    wl_pointer_send_frame(resource);
+            }
+            if (hscroll != 0)
+            {
+                wl_pointer_send_axis(
+                    resource,
+                    mir_input_event_get_event_time_ms(event),
+                    WL_POINTER_AXIS_HORIZONTAL_SCROLL,
+                    wl_fixed_from_double(hscroll));
+
+                if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
+                    wl_pointer_send_frame(resource);
+            }
+            break;
+        }
+        case mir_pointer_actions:
+            break;
+            */
+        default:
+            seat->for_each_listener(client, [&](WlPointer* pointer)
+                {
+                    pointer->handle_event(mir_pointer_event_input_event(event), target);
+                });
+    }
+}
+

--- a/src/server/frontend_wayland/basic_surface_event_sink.cpp
+++ b/src/server/frontend_wayland/basic_surface_event_sink.cpp
@@ -32,7 +32,7 @@ namespace geom = mir::geometry;
 mf::BasicSurfaceEventSink::BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink)
     : seat{seat},
       client{client},
-      target{target},
+      surface{WlSurface::from(target)},
       event_sink{event_sink},
       window_size{geometry::Size{0,0}},
       destroyed{std::make_shared<bool>(false)}
@@ -88,19 +88,19 @@ void mf::BasicSurfaceEventSink::handle_input_event(MirInputEvent const* event)
     case mir_input_event_type_key:
         seat->for_each_listener(client, [this, event = mir_input_event_get_keyboard_event(event)](WlKeyboard* keyboard)
             {
-                keyboard->handle_event(event, target);
+                keyboard->handle_event(event, surface);
             });
         break;
     case mir_input_event_type_pointer:
         seat->for_each_listener(client, [this, event = mir_input_event_get_pointer_event(event)](WlPointer* pointer)
             {
-                pointer->handle_event(event, target);
+                pointer->handle_event(event, surface);
             });
         break;
     case mir_input_event_type_touch:
         seat->for_each_listener(client, [this, event = mir_input_event_get_touch_event(event)](WlTouch* touch)
             {
-                touch->handle_event(event, target);
+                touch->handle_event(event, surface);
             });
         break;
     default:
@@ -112,7 +112,7 @@ void mf::BasicSurfaceEventSink::handle_keymap_event(MirKeymapEvent const* event)
 {
     seat->for_each_listener(client, [this, event](WlKeyboard* keyboard)
         {
-            keyboard->handle_event(event, target);
+            keyboard->handle_event(event, surface);
         });
 }
 
@@ -135,7 +135,7 @@ void mf::BasicSurfaceEventSink::handle_window_event(MirWindowEvent const* event)
 
     seat->for_each_listener(client, [this, event](WlKeyboard* keyboard)
         {
-            keyboard->handle_event(event, target);
+            keyboard->handle_event(event, surface);
         });
 }
 

--- a/src/server/frontend_wayland/basic_surface_event_sink.cpp
+++ b/src/server/frontend_wayland/basic_surface_event_sink.cpp
@@ -29,11 +29,12 @@
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
 
-mf::BasicSurfaceEventSink::BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink)
+mf::BasicSurfaceEventSink::BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink, WlAbstractMirWindow* window)
     : seat{seat},
       client{client},
       surface{WlSurface::from(target)},
       event_sink{event_sink},
+      window{window},
       window_size{geometry::Size{0,0}},
       destroyed{std::make_shared<bool>(false)}
 {
@@ -74,7 +75,7 @@ void mf::BasicSurfaceEventSink::handle_resize_event(MirResizeEvent const* event)
 {
     requested_size = {mir_resize_event_get_width(event), mir_resize_event_get_height(event)};
     if (requested_size != window_size)
-        send_resize(requested_size);
+        window->handle_resize(requested_size);
 }
 
 void mf::BasicSurfaceEventSink::handle_input_event(MirInputEvent const* event)
@@ -122,12 +123,12 @@ void mf::BasicSurfaceEventSink::handle_window_event(MirWindowEvent const* event)
     {
     case mir_window_attrib_focus:
         has_focus = mir_window_event_get_attribute_value(event);
-        send_resize(requested_size);
+        window->handle_resize(requested_size);
         break;
 
     case mir_window_attrib_state:
         current_state = MirWindowState(mir_window_event_get_attribute_value(event));
-        send_resize(requested_size);
+        window->handle_resize(requested_size);
         break;
 
     default:;

--- a/src/server/frontend_wayland/basic_surface_event_sink.h
+++ b/src/server/frontend_wayland/basic_surface_event_sink.h
@@ -34,7 +34,7 @@ namespace mir
 {
 namespace frontend
 {
-
+class WlSurface;
 class WlSeat;
 
 class BasicSurfaceEventSink : public NullEventSink
@@ -70,7 +70,7 @@ public:
 protected:
     WlSeat* const seat;
     wl_client* const client;
-    wl_resource* const target;
+    WlSurface* const surface;
     wl_resource* const event_sink;
     std::atomic<geometry::Size> window_size;
     std::atomic<int64_t> timestamp_ns{0};

--- a/src/server/frontend_wayland/basic_surface_event_sink.h
+++ b/src/server/frontend_wayland/basic_surface_event_sink.h
@@ -41,7 +41,7 @@ class WlAbstractMirWindow;
 class BasicSurfaceEventSink : public NullEventSink
 {
 public:
-    BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink, WlAbstractMirWindow* window);
+    BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, WlAbstractMirWindow* window);
     ~BasicSurfaceEventSink();
 
     void handle_event(EventUPtr&& event) override;
@@ -66,13 +66,10 @@ public:
         return current_state;
     }
 
-    virtual void send_resize_(geometry::Size const& /*new_size*/) const {};
-
 protected:
     WlSeat* const seat;
     wl_client* const client;
     WlSurface* const surface;
-    wl_resource* const event_sink;
     WlAbstractMirWindow* window;
     std::atomic<geometry::Size> window_size;
     std::atomic<int64_t> timestamp_ns{0};

--- a/src/server/frontend_wayland/basic_surface_event_sink.h
+++ b/src/server/frontend_wayland/basic_surface_event_sink.h
@@ -73,6 +73,7 @@ protected:
     wl_resource* const target;
     wl_resource* const event_sink;
     MirPointerButtons last_pointer_buttons{0};
+    wl_resource* last_pointer_target = nullptr;
     std::atomic<geometry::Size> window_size;
     std::atomic<int64_t> timestamp_ns{0};
     std::atomic<geometry::Size> requested_size;

--- a/src/server/frontend_wayland/basic_surface_event_sink.h
+++ b/src/server/frontend_wayland/basic_surface_event_sink.h
@@ -72,8 +72,6 @@ protected:
     wl_client* const client;
     wl_resource* const target;
     wl_resource* const event_sink;
-    MirPointerButtons last_pointer_buttons{0};
-    wl_resource* last_pointer_target = nullptr;
     std::atomic<geometry::Size> window_size;
     std::atomic<int64_t> timestamp_ns{0};
     std::atomic<geometry::Size> requested_size;
@@ -84,7 +82,6 @@ protected:
 private:
     void handle_resize_event(MirResizeEvent const* event);
     void handle_input_event(MirInputEvent const* event);
-    void handle_pointer_event(MirPointerEvent const* event);
     void handle_keymap_event(MirKeymapEvent const* event);
     void handle_window_event(MirWindowEvent const* event);
 

--- a/src/server/frontend_wayland/basic_surface_event_sink.h
+++ b/src/server/frontend_wayland/basic_surface_event_sink.h
@@ -72,6 +72,7 @@ protected:
     wl_client* const client;
     wl_resource* const target;
     wl_resource* const event_sink;
+    MirPointerButtons last_pointer_buttons{0};
     std::atomic<geometry::Size> window_size;
     std::atomic<int64_t> timestamp_ns{0};
     std::atomic<geometry::Size> requested_size;
@@ -84,6 +85,8 @@ private:
     void handle_event(MirInputEvent const* event);
     void handle_event(MirKeymapEvent const* event);
     void handle_event(MirWindowEvent const* event);
+
+    void handle_event(MirPointerEvent const* event);
 };
 }
 }

--- a/src/server/frontend_wayland/basic_surface_event_sink.h
+++ b/src/server/frontend_wayland/basic_surface_event_sink.h
@@ -21,12 +21,14 @@
 
 #include "null_event_sink.h"
 
-#include <mir_toolkit/event.h>
+#include "mir/executor.h"
+#include "mir_toolkit/event.h"
 
 #include <wayland-server-core.h>
 
 #include <atomic>
 #include <functional>
+#include <memory>
 
 namespace mir
 {
@@ -38,14 +40,8 @@ class WlSeat;
 class BasicSurfaceEventSink : public NullEventSink
 {
 public:
-    BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink)
-        : seat{seat},
-        client{client},
-        target{target},
-        event_sink{event_sink},
-        window_size{geometry::Size{0,0}}
-    {
-    }
+    BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink);
+    ~BasicSurfaceEventSink();
 
     void handle_event(EventUPtr&& event) override;
 
@@ -81,6 +77,10 @@ protected:
     std::atomic<geometry::Size> requested_size;
     std::atomic<bool> has_focus{false};
     std::atomic<MirWindowState> current_state{mir_window_state_unknown};
+    std::shared_ptr<bool> const destroyed;
+
+private:
+    void handle_event_on_wayland_thread(EventUPtr&& event);
 };
 }
 }

--- a/src/server/frontend_wayland/basic_surface_event_sink.h
+++ b/src/server/frontend_wayland/basic_surface_event_sink.h
@@ -80,7 +80,10 @@ protected:
     std::shared_ptr<bool> const destroyed;
 
 private:
-    void handle_event_on_wayland_thread(EventUPtr&& event);
+    void handle_event(MirResizeEvent const* event);
+    void handle_event(MirInputEvent const* event);
+    void handle_event(MirKeymapEvent const* event);
+    void handle_event(MirWindowEvent const* event);
 };
 }
 }

--- a/src/server/frontend_wayland/basic_surface_event_sink.h
+++ b/src/server/frontend_wayland/basic_surface_event_sink.h
@@ -82,12 +82,12 @@ protected:
     std::shared_ptr<bool> const destroyed;
 
 private:
-    void handle_event(MirResizeEvent const* event);
-    void handle_event(MirInputEvent const* event);
-    void handle_event(MirKeymapEvent const* event);
-    void handle_event(MirWindowEvent const* event);
+    void handle_resize_event(MirResizeEvent const* event);
+    void handle_input_event(MirInputEvent const* event);
+    void handle_pointer_event(MirPointerEvent const* event);
+    void handle_keymap_event(MirKeymapEvent const* event);
+    void handle_window_event(MirWindowEvent const* event);
 
-    void handle_event(MirPointerEvent const* event);
 };
 }
 }

--- a/src/server/frontend_wayland/basic_surface_event_sink.h
+++ b/src/server/frontend_wayland/basic_surface_event_sink.h
@@ -36,11 +36,12 @@ namespace frontend
 {
 class WlSurface;
 class WlSeat;
+class WlAbstractMirWindow;
 
 class BasicSurfaceEventSink : public NullEventSink
 {
 public:
-    BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink);
+    BasicSurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink, WlAbstractMirWindow* window);
     ~BasicSurfaceEventSink();
 
     void handle_event(EventUPtr&& event) override;
@@ -65,13 +66,14 @@ public:
         return current_state;
     }
 
-    virtual void send_resize(geometry::Size const& new_size) const = 0;
+    virtual void send_resize_(geometry::Size const& new_size) const = 0;
 
 protected:
     WlSeat* const seat;
     wl_client* const client;
     WlSurface* const surface;
     wl_resource* const event_sink;
+    WlAbstractMirWindow* window;
     std::atomic<geometry::Size> window_size;
     std::atomic<int64_t> timestamp_ns{0};
     std::atomic<geometry::Size> requested_size;

--- a/src/server/frontend_wayland/basic_surface_event_sink.h
+++ b/src/server/frontend_wayland/basic_surface_event_sink.h
@@ -66,7 +66,7 @@ public:
         return current_state;
     }
 
-    virtual void send_resize_(geometry::Size const& new_size) const = 0;
+    virtual void send_resize_(geometry::Size const& /*new_size*/) const {};
 
 protected:
     WlSeat* const seat;

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -292,32 +292,6 @@ void WlCompositor::create_region(wl_client* client, wl_resource* resource, uint3
     new Region{client, resource, id};
 }
 
-class SurfaceEventSink : public BasicSurfaceEventSink
-{
-public:
-    SurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink, WlAbstractMirWindow* window,
-        std::shared_ptr<bool> const& destroyed) :
-        BasicSurfaceEventSink{seat, client, target, event_sink, window},
-        destroyed{destroyed}
-    {
-    }
-
-    void send_resize_(geometry::Size const& new_size) const override;
-
-private:
-    std::shared_ptr<bool> const destroyed;
-};
-
-void SurfaceEventSink::send_resize_(geometry::Size const& new_size) const
-{
-    seat->spawn(run_unless(
-        destroyed,
-        [event_sink= event_sink, width = new_size.width.as_int(), height = new_size.height.as_int()]()
-        {
-            wl_shell_surface_send_configure(event_sink, WL_SHELL_SURFACE_RESIZE_NONE, width, height);
-        }));
-}
-
 class WlShellSurface  : public wayland::ShellSurface, public WlAbstractMirWindow
 {
 public:
@@ -329,10 +303,8 @@ public:
         std::shared_ptr<mf::Shell> const& shell,
         WlSeat& seat)
         : ShellSurface(client, parent, id),
-        WlAbstractMirWindow{client, surface, resource, shell}
+          WlAbstractMirWindow{&seat, client, surface, resource, shell}
     {
-        // We can't pass this to the WlAbstractMirWindow constructor as it needs creating *after* destroyed
-        sink = std::make_shared<SurfaceEventSink>(&seat, client, surface, event_sink, this, destroyed);
     }
 
     ~WlShellSurface() override
@@ -385,6 +357,12 @@ protected:
 
             surface->set_role(this);
         }
+    }
+
+    void handle_resize(const geometry::Size & new_size) override
+    {
+        wl_shell_surface_send_configure(event_sink, WL_SHELL_SURFACE_RESIZE_NONE, new_size.width.as_int(),
+                                        new_size.height.as_int());
     }
 
     void set_fullscreen(

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -299,11 +299,11 @@ public:
         wl_client* client,
         wl_resource* parent,
         uint32_t id,
-        wl_resource* surface,
+        WlSurface* surface,
         std::shared_ptr<mf::Shell> const& shell,
         WlSeat& seat)
         : ShellSurface(client, parent, id),
-          WlAbstractMirWindow{&seat, client, surface, resource, shell}
+          WlAbstractMirWindow{&seat, client, surface, shell}
     {
     }
 
@@ -361,7 +361,7 @@ protected:
 
     void handle_resize(const geometry::Size & new_size) override
     {
-        wl_shell_surface_send_configure(event_sink, WL_SHELL_SURFACE_RESIZE_NONE, new_size.width.as_int(),
+        wl_shell_surface_send_configure(resource, WL_SHELL_SURFACE_RESIZE_NONE, new_size.width.as_int(),
                                         new_size.height.as_int());
     }
 
@@ -526,7 +526,7 @@ public:
         uint32_t id,
         wl_resource* surface) override
     {
-        new WlShellSurface(client, resource, id, surface, shell, seat);
+        new WlShellSurface(client, resource, id, WlSurface::from(surface), shell, seat);
     }
 private:
     std::shared_ptr<mf::Shell> const shell;

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -295,20 +295,20 @@ void WlCompositor::create_region(wl_client* client, wl_resource* resource, uint3
 class SurfaceEventSink : public BasicSurfaceEventSink
 {
 public:
-    SurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink,
+    SurfaceEventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink, WlAbstractMirWindow* window,
         std::shared_ptr<bool> const& destroyed) :
-        BasicSurfaceEventSink{seat, client, target, event_sink},
+        BasicSurfaceEventSink{seat, client, target, event_sink, window},
         destroyed{destroyed}
     {
     }
 
-    void send_resize(geometry::Size const& new_size) const override;
+    void send_resize_(geometry::Size const& new_size) const override;
 
 private:
     std::shared_ptr<bool> const destroyed;
 };
 
-void SurfaceEventSink::send_resize(geometry::Size const& new_size) const
+void SurfaceEventSink::send_resize_(geometry::Size const& new_size) const
 {
     seat->spawn(run_unless(
         destroyed,
@@ -318,7 +318,7 @@ void SurfaceEventSink::send_resize(geometry::Size const& new_size) const
         }));
 }
 
-class WlShellSurface  : public wayland::ShellSurface, WlAbstractMirWindow
+class WlShellSurface  : public wayland::ShellSurface, public WlAbstractMirWindow
 {
 public:
     WlShellSurface(
@@ -332,7 +332,7 @@ public:
         WlAbstractMirWindow{client, surface, resource, shell}
     {
         // We can't pass this to the WlAbstractMirWindow constructor as it needs creating *after* destroyed
-        sink = std::make_shared<SurfaceEventSink>(&seat, client, surface, event_sink, destroyed);
+        sink = std::make_shared<SurfaceEventSink>(&seat, client, surface, event_sink, this, destroyed);
     }
 
     ~WlShellSurface() override

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -68,7 +68,7 @@ mf::WlKeyboard::~WlKeyboard()
     on_destroy(this);
 }
 
-void mf::WlKeyboard::handle_event(MirKeyboardEvent const* key_event, wl_resource* /*target*/)
+void mf::WlKeyboard::handle_event(MirKeyboardEvent const* key_event, WlSurface* /*surface*/)
 {
     auto const input_ev = mir_keyboard_event_input_event(key_event);
     auto const ev = mir::client::Event{mir_event_ref(mir_input_event_get_event(input_ev))};
@@ -103,7 +103,7 @@ void mf::WlKeyboard::handle_event(MirKeyboardEvent const* key_event, wl_resource
     update_modifier_state();
 }
 
-void mf::WlKeyboard::handle_event(MirWindowEvent const* event, wl_resource* target)
+void mf::WlKeyboard::handle_event(MirWindowEvent const* event, WlSurface* surface)
 {
     if (mir_window_event_get_attribute(event) == mir_window_attrib_focus)
     {
@@ -141,17 +141,17 @@ void mf::WlKeyboard::handle_event(MirWindowEvent const* event, wl_resource* targ
             }
             update_modifier_state();
 
-            wl_keyboard_send_enter(resource, serial, target, &key_state);
+            wl_keyboard_send_enter(resource, serial, surface->raw_resource(), &key_state);
             wl_array_release(&key_state);
         }
         else
         {
-            wl_keyboard_send_leave(resource, serial, target);
+            wl_keyboard_send_leave(resource, serial, surface->raw_resource());
         }
     }
 }
 
-void mf::WlKeyboard::handle_event(MirKeymapEvent const* event, wl_resource* /*target*/)
+void mf::WlKeyboard::handle_event(MirKeymapEvent const* event, WlSurface* /*surface*/)
 {
     char const* buffer;
     size_t length;

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -68,7 +68,7 @@ mf::WlKeyboard::~WlKeyboard()
     on_destroy(this);
 }
 
-void mf::WlKeyboard::handle_event(MirKeyboardEvent const* key_event, WlSurface* /*surface*/)
+void mf::WlKeyboard::handle_keyboard_event(MirKeyboardEvent const* key_event, WlSurface* /*surface*/)
 {
     auto const input_ev = mir_keyboard_event_input_event(key_event);
     auto const ev = mir::client::Event{mir_event_ref(mir_input_event_get_event(input_ev))};
@@ -103,7 +103,7 @@ void mf::WlKeyboard::handle_event(MirKeyboardEvent const* key_event, WlSurface* 
     update_modifier_state();
 }
 
-void mf::WlKeyboard::handle_event(MirWindowEvent const* event, WlSurface* surface)
+void mf::WlKeyboard::handle_window_event(MirWindowEvent const* event, WlSurface* surface)
 {
     if (mir_window_event_get_attribute(event) == mir_window_attrib_focus)
     {
@@ -151,7 +151,7 @@ void mf::WlKeyboard::handle_event(MirWindowEvent const* event, WlSurface* surfac
     }
 }
 
-void mf::WlKeyboard::handle_event(MirKeymapEvent const* event, WlSurface* /*surface*/)
+void mf::WlKeyboard::handle_keymap_event(MirKeymapEvent const* event, WlSurface* /*surface*/)
 {
     char const* buffer;
     size_t length;

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -38,16 +38,13 @@ mf::WlKeyboard::WlKeyboard(
     uint32_t id,
     mir::input::Keymap const& initial_keymap,
     std::function<void(WlKeyboard*)> const& on_destroy,
-    std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state,
-    std::shared_ptr<mir::Executor> const& executor)
+    std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state)
     : Keyboard(client, parent, id),
-        keymap{nullptr, &xkb_keymap_unref},
-        state{nullptr, &xkb_state_unref},
-        context{xkb_context_new(XKB_CONTEXT_NO_FLAGS), &xkb_context_unref},
-        executor{executor},
-        on_destroy{on_destroy},
-        acquire_current_keyboard_state{acquire_current_keyboard_state},
-        destroyed{std::make_shared<bool>(false)}
+      keymap{nullptr, &xkb_keymap_unref},
+      state{nullptr, &xkb_state_unref},
+      context{xkb_context_new(XKB_CONTEXT_NO_FLAGS), &xkb_context_unref},
+      on_destroy{on_destroy},
+      acquire_current_keyboard_state{acquire_current_keyboard_state}
 {
     // TODO: We should really grab the keymap for the focused surface when
     // we receive focus.
@@ -69,109 +66,88 @@ mf::WlKeyboard::WlKeyboard(
 mf::WlKeyboard::~WlKeyboard()
 {
     on_destroy(this);
-    *destroyed = true;
 }
 
 void mf::WlKeyboard::handle_event(MirInputEvent const* event, wl_resource* /*target*/)
 {
-    executor->spawn(run_unless(
-        destroyed,
-        [
-            ev = mir::client::Event{mir_event_ref(mir_input_event_get_event(event))},
-            this
-        ] ()
-        {
-            auto const serial = wl_display_next_serial(wl_client_get_display(client));
-            auto const event = mir_event_get_input_event(ev);
-            auto const key_event = mir_input_event_get_keyboard_event(event);
-            auto const scancode = mir_keyboard_event_scan_code(key_event);
-            /*
-                * HACK! Maintain our own XKB state, so we can serialise it for
-                * wl_keyboard_send_modifiers
-                */
+    auto const ev = mir::client::Event{mir_event_ref(mir_input_event_get_event(event))};
+    auto const serial = wl_display_next_serial(wl_client_get_display(client));
+    auto const key_event = mir_input_event_get_keyboard_event(event);
+    auto const scancode = mir_keyboard_event_scan_code(key_event);
+    /*
+        * HACK! Maintain our own XKB state, so we can serialise it for
+        * wl_keyboard_send_modifiers
+        */
 
-            switch (mir_keyboard_event_action(key_event))
-            {
-                case mir_keyboard_action_up:
-                    xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_UP);
-                    wl_keyboard_send_key(resource,
-                        serial,
-                        mir_input_event_get_event_time_ms(event),
-                        mir_keyboard_event_scan_code(key_event),
-                        WL_KEYBOARD_KEY_STATE_RELEASED);
-                    break;
-                case mir_keyboard_action_down:
-                    xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_DOWN);
-                    wl_keyboard_send_key(resource,
-                        serial,
-                        mir_input_event_get_event_time_ms(event),
-                        mir_keyboard_event_scan_code(key_event),
-                        WL_KEYBOARD_KEY_STATE_PRESSED);
-                    break;
-                default:
-                    break;
-            }
-            update_modifier_state();
-        }));
+    switch (mir_keyboard_event_action(key_event))
+    {
+        case mir_keyboard_action_up:
+            xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_UP);
+            wl_keyboard_send_key(resource,
+                serial,
+                mir_input_event_get_event_time_ms(event),
+                mir_keyboard_event_scan_code(key_event),
+                WL_KEYBOARD_KEY_STATE_RELEASED);
+            break;
+        case mir_keyboard_action_down:
+            xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_DOWN);
+            wl_keyboard_send_key(resource,
+                serial,
+                mir_input_event_get_event_time_ms(event),
+                mir_keyboard_event_scan_code(key_event),
+                WL_KEYBOARD_KEY_STATE_PRESSED);
+            break;
+        default:
+            break;
+    }
+    update_modifier_state();
 }
 
 void mf::WlKeyboard::handle_event(MirWindowEvent const* event, wl_resource* target)
 {
     if (mir_window_event_get_attribute(event) == mir_window_attrib_focus)
     {
-        executor->spawn(run_unless(
-            destroyed,
-            [
-                target = target,
-                target_window_destroyed = WlSurface::from(target)->destroyed_flag(),
-                focussed = mir_window_event_get_attribute_value(event),
-                this
-            ]()
+        auto const focussed = mir_window_event_get_attribute_value(event);
+        auto const serial = wl_display_next_serial(wl_client_get_display(client));
+        if (focussed)
+        {
+            /*
+                * TODO:
+                *  *) Send the surface's keymap here.
+                */
+            auto const keyboard_state = acquire_current_keyboard_state();
+
+            wl_array key_state;
+            wl_array_init(&key_state);
+
+            auto* const array_storage = wl_array_add(
+                &key_state,
+                keyboard_state.size() * sizeof(decltype(keyboard_state)::value_type));
+            if (!array_storage)
             {
-                if (*target_window_destroyed)
-                    return;
+                wl_resource_post_no_memory(resource);
+                BOOST_THROW_EXCEPTION(std::bad_alloc());
+            }
+            std::memcpy(
+                array_storage,
+                keyboard_state.data(),
+                keyboard_state.size() * sizeof(decltype(keyboard_state)::value_type));
 
-                auto const serial = wl_display_next_serial(wl_client_get_display(client));
-                if (focussed)
-                {
-                    /*
-                        * TODO:
-                        *  *) Send the surface's keymap here.
-                        */
-                    auto const keyboard_state = acquire_current_keyboard_state();
+            // Rebuild xkb state
+            state = decltype(state)(xkb_state_new(keymap.get()), &xkb_state_unref);
+            for (auto scancode : keyboard_state)
+            {
+                xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_DOWN);
+            }
+            update_modifier_state();
 
-                    wl_array key_state;
-                    wl_array_init(&key_state);
-
-                    auto* const array_storage = wl_array_add(
-                        &key_state,
-                        keyboard_state.size() * sizeof(decltype(keyboard_state)::value_type));
-                    if (!array_storage)
-                    {
-                        wl_resource_post_no_memory(resource);
-                        BOOST_THROW_EXCEPTION(std::bad_alloc());
-                    }
-                    std::memcpy(
-                        array_storage,
-                        keyboard_state.data(),
-                        keyboard_state.size() * sizeof(decltype(keyboard_state)::value_type));
-
-                    // Rebuild xkb state
-                    state = decltype(state)(xkb_state_new(keymap.get()), &xkb_state_unref);
-                    for (auto scancode : keyboard_state)
-                    {
-                        xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_DOWN);
-                    }
-                    update_modifier_state();
-
-                    wl_keyboard_send_enter(resource, serial, target, &key_state);
-                    wl_array_release(&key_state);
-                }
-                else
-                {
-                    wl_keyboard_send_leave(resource, serial, target);
-                }
-            }));
+            wl_keyboard_send_enter(resource, serial, target, &key_state);
+            wl_array_release(&key_state);
+        }
+        else
+        {
+            wl_keyboard_send_leave(resource, serial, target);
+        }
     }
 }
 

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -68,11 +68,11 @@ mf::WlKeyboard::~WlKeyboard()
     on_destroy(this);
 }
 
-void mf::WlKeyboard::handle_event(MirInputEvent const* event, wl_resource* /*target*/)
+void mf::WlKeyboard::handle_event(MirKeyboardEvent const* key_event, wl_resource* /*target*/)
 {
-    auto const ev = mir::client::Event{mir_event_ref(mir_input_event_get_event(event))};
+    auto const input_ev = mir_keyboard_event_input_event(key_event);
+    auto const ev = mir::client::Event{mir_event_ref(mir_input_event_get_event(input_ev))};
     auto const serial = wl_display_next_serial(wl_client_get_display(client));
-    auto const key_event = mir_input_event_get_keyboard_event(event);
     auto const scancode = mir_keyboard_event_scan_code(key_event);
     /*
         * HACK! Maintain our own XKB state, so we can serialise it for
@@ -85,7 +85,7 @@ void mf::WlKeyboard::handle_event(MirInputEvent const* event, wl_resource* /*tar
             xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_UP);
             wl_keyboard_send_key(resource,
                 serial,
-                mir_input_event_get_event_time_ms(event),
+                mir_input_event_get_event_time_ms(input_ev),
                 mir_keyboard_event_scan_code(key_event),
                 WL_KEYBOARD_KEY_STATE_RELEASED);
             break;
@@ -93,7 +93,7 @@ void mf::WlKeyboard::handle_event(MirInputEvent const* event, wl_resource* /*tar
             xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_DOWN);
             wl_keyboard_send_key(resource,
                 serial,
-                mir_input_event_get_event_time_ms(event),
+                mir_input_event_get_event_time_ms(input_ev),
                 mir_keyboard_event_scan_code(key_event),
                 WL_KEYBOARD_KEY_STATE_PRESSED);
             break;

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -46,6 +46,7 @@ class Keymap;
 
 namespace frontend
 {
+class WlSurface;
 
 class WlKeyboard : public wayland::Keyboard
 {
@@ -60,9 +61,9 @@ public:
 
     ~WlKeyboard();
 
-    void handle_event(MirKeyboardEvent const* event, wl_resource* /*target*/);
-    void handle_event(MirWindowEvent const* event, wl_resource* target);
-    void handle_event(MirKeymapEvent const* event, wl_resource* /*target*/);
+    void handle_event(MirKeyboardEvent const* event, WlSurface* surface);
+    void handle_event(MirWindowEvent const* event, WlSurface* surface);
+    void handle_event(MirKeymapEvent const* event, WlSurface* surface);
     void set_keymap(mir::input::Keymap const& new_keymap);
 
 private:

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -56,8 +56,7 @@ public:
         uint32_t id,
         mir::input::Keymap const& initial_keymap,
         std::function<void(WlKeyboard*)> const& on_destroy,
-        std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state,
-        std::shared_ptr<mir::Executor> const& executor);
+        std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state);
 
     ~WlKeyboard();
 
@@ -73,10 +72,8 @@ private:
     std::unique_ptr<xkb_state, void (*)(xkb_state *)> state;
     std::unique_ptr<xkb_context, void (*)(xkb_context *)> const context;
 
-    std::shared_ptr<mir::Executor> const executor;
     std::function<void(WlKeyboard*)> on_destroy;
     std::function<std::vector<uint32_t>()> const acquire_current_keyboard_state;
-    std::shared_ptr<bool> const destroyed;
 
     uint32_t mods_depressed{0};
     uint32_t mods_latched{0};

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -61,9 +61,9 @@ public:
 
     ~WlKeyboard();
 
-    void handle_event(MirKeyboardEvent const* event, WlSurface* surface);
-    void handle_event(MirWindowEvent const* event, WlSurface* surface);
-    void handle_event(MirKeymapEvent const* event, WlSurface* surface);
+    void handle_keyboard_event(MirKeyboardEvent const* event, WlSurface* surface);
+    void handle_window_event(MirWindowEvent const* event, WlSurface* surface);
+    void handle_keymap_event(MirKeymapEvent const* event, WlSurface* surface);
     void set_keymap(mir::input::Keymap const& new_keymap);
 
 private:

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -29,7 +29,7 @@ struct xkb_state;
 struct xkb_context;
 
 // from "mir_toolkit/events/event.h"
-struct MirInputEvent;
+struct MirKeyboardEvent;
 struct MirSurfaceEvent;
 typedef struct MirSurfaceEvent MirWindowEvent;
 struct MirKeymapEvent;
@@ -60,7 +60,7 @@ public:
 
     ~WlKeyboard();
 
-    void handle_event(MirInputEvent const* event, wl_resource* /*target*/);
+    void handle_event(MirKeyboardEvent const* event, wl_resource* /*target*/);
     void handle_event(MirWindowEvent const* event, wl_resource* target);
     void handle_event(MirKeymapEvent const* event, wl_resource* /*target*/);
     void set_keymap(mir::input::Keymap const& new_keymap);

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -68,7 +68,7 @@ mf::WlPointer::~WlPointer()
     on_destroy(this);
 }
 
-void mf::WlPointer::handle_event(MirPointerEvent const* event, wl_resource* target)
+void mf::WlPointer::handle_event(MirPointerEvent const* event, WlSurface* surface)
 {
     switch(mir_pointer_event_action(event))
     {
@@ -107,13 +107,13 @@ void mf::WlPointer::handle_event(MirPointerEvent const* event, wl_resource* targ
         {
             auto point = Point{mir_pointer_event_axis_value(event, mir_pointer_axis_x),
                                         mir_pointer_event_axis_value(event, mir_pointer_axis_y)};
-            //auto transformed = WlSurface::from(target)->transform_point(point);
-            handle_enter(point - WlSurface::from(target)->buffer_offset(), target);
+            auto transformed = surface->transform_point(point);
+            handle_enter(transformed.first, transformed.second);
             break;
         }
         case mir_pointer_action_leave:
         {
-            handle_leave(target);
+            handle_leave(surface->raw_resource());
             break;
         }
         case mir_pointer_action_motion:
@@ -126,8 +126,8 @@ void mf::WlPointer::handle_event(MirPointerEvent const* event, wl_resource* targ
 
             auto point = Point{mir_pointer_event_axis_value(event, mir_pointer_axis_x),
                                         mir_pointer_event_axis_value(event, mir_pointer_axis_y)};
-            //auto transformed = WlSurface::from(target)->transform_point(point);
-            handle_motion(timestamp, point - WlSurface::from(target)->buffer_offset());
+            auto transformed = surface->transform_point(point);
+            handle_motion(timestamp, transformed.first);
 
             auto hscroll = mir_pointer_event_axis_value(event, mir_pointer_axis_hscroll) * 10;
             handle_axis(timestamp, WL_POINTER_AXIS_HORIZONTAL_SCROLL, hscroll);

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -83,6 +83,30 @@ void mf::WlPointer::handle_button(uint32_t time, uint32_t button, bool is_presse
         wl_pointer_send_frame(resource);
 }
 
+void mf::WlPointer::handle_enter(Point position, wl_resource* target)
+{
+    auto const serial = wl_display_next_serial(display);
+    wl_pointer_send_enter(
+        resource,
+        serial,
+        target,
+        wl_fixed_from_double(position.x.as_int()),
+        wl_fixed_from_double(position.y.as_int()));
+    if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
+        wl_pointer_send_frame(resource);
+}
+
+void mf::WlPointer::handle_leave(wl_resource* target)
+{
+    auto const serial = wl_display_next_serial(display);
+    wl_pointer_send_leave(
+        resource,
+        serial,
+        target);
+    if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
+        wl_pointer_send_frame(resource);
+}
+
 void mf::WlPointer::handle_event(MirInputEvent const* event, wl_resource* target)
 {
     executor->spawn(run_unless(

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -72,6 +72,17 @@ mf::WlPointer::~WlPointer()
     on_destroy(this);
 }
 
+void mf::WlPointer::handle_button(uint32_t time, uint32_t button, bool is_pressed)
+{
+    auto const serial = wl_display_next_serial(display);
+    auto const action = is_pressed ?
+                        WL_POINTER_BUTTON_STATE_PRESSED :
+                        WL_POINTER_BUTTON_STATE_RELEASED;
+    wl_pointer_send_button(resource, serial, time, button, action);
+    if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
+        wl_pointer_send_frame(resource);
+}
+
 void mf::WlPointer::handle_event(MirInputEvent const* event, wl_resource* target)
 {
     executor->spawn(run_unless(

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -55,20 +55,16 @@ mf::WlPointer::WlPointer(
     wl_client* client,
     wl_resource* parent,
     uint32_t id,
-    std::function<void(WlPointer*)> const& on_destroy,
-    std::shared_ptr<mir::Executor> const& executor)
+    std::function<void(WlPointer*)> const& on_destroy)
     : Pointer(client, parent, id),
         display{wl_client_get_display(client)},
-        executor{executor},
         on_destroy{on_destroy},
-        destroyed{std::make_shared<bool>(false)},
         cursor{std::make_unique<NullCursor>()}
 {
 }
 
 mf::WlPointer::~WlPointer()
 {
-    *destroyed = true;
     on_destroy(this);
 }
 
@@ -95,7 +91,7 @@ void mf::WlPointer::handle_enter(Point position, wl_resource* target)
 
 void mf::WlPointer::handle_motion(uint32_t time, mir::geometry::Point position)
 {
-    if ((position.x.as_int() != last_x) || (position.y.as_int() != last_y))
+    if (!last_position || position != last_position.value())
     {
         wl_pointer_send_motion(
             resource,
@@ -104,8 +100,7 @@ void mf::WlPointer::handle_motion(uint32_t time, mir::geometry::Point position)
             wl_fixed_from_double(position.y.as_int()));
         if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
             wl_pointer_send_frame(resource);
-        last_x = position.x.as_int();
-        last_y = position.y.as_int();
+        last_position = position;
     }
 }
 
@@ -132,143 +127,7 @@ void mf::WlPointer::handle_leave(wl_resource* target)
         target);
     if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
         wl_pointer_send_frame(resource);
-}
-
-void mf::WlPointer::handle_event(MirInputEvent const* event, wl_resource* target)
-{
-    executor->spawn(run_unless(
-        destroyed,
-        [
-            ev = mir::client::Event{mir_input_event_get_event(event)},
-            target,
-            target_window_destroyed = WlSurface::from(target)->destroyed_flag(),
-            this
-        ]()
-        {
-            if (*target_window_destroyed)
-                return;
-
-            cursor->apply_to(target);
-
-            auto const serial = wl_display_next_serial(display);
-            auto const event = mir_event_get_input_event(ev);
-            auto const pointer_event = mir_input_event_get_pointer_event(event);
-            auto const buffer_offset = WlSurface::from(target)->buffer_offset();
-
-            switch(mir_pointer_event_action(pointer_event))
-            {
-                case mir_pointer_action_button_down:
-                case mir_pointer_action_button_up:
-                {
-                    auto const current_set  = mir_pointer_event_buttons(pointer_event);
-                    auto const current_time = mir_input_event_get_event_time_ms(event);
-
-                    for (auto const& mapping :
-                        {
-                            std::make_pair(mir_pointer_button_primary, BTN_LEFT),
-                            std::make_pair(mir_pointer_button_secondary, BTN_RIGHT),
-                            std::make_pair(mir_pointer_button_tertiary, BTN_MIDDLE),
-                            std::make_pair(mir_pointer_button_back, BTN_BACK),
-                            std::make_pair(mir_pointer_button_forward, BTN_FORWARD),
-                            std::make_pair(mir_pointer_button_side, BTN_SIDE),
-                            std::make_pair(mir_pointer_button_task, BTN_TASK),
-                            std::make_pair(mir_pointer_button_extra, BTN_EXTRA)
-                        })
-                    {
-                        if (mapping.first & (current_set ^ last_set))
-                        {
-                            auto const action = (mapping.first & current_set) ?
-                                                WL_POINTER_BUTTON_STATE_PRESSED :
-                                                WL_POINTER_BUTTON_STATE_RELEASED;
-
-                            wl_pointer_send_button(resource, serial, current_time, mapping.second, action);
-                            if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
-                                wl_pointer_send_frame(resource);
-                        }
-                    }
-
-                    last_set = current_set;
-                    break;
-                }
-                case mir_pointer_action_enter:
-                {
-                    wl_pointer_send_enter(
-                        resource,
-                        serial,
-                        target,
-                        wl_fixed_from_double(mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_x)-buffer_offset.dx.as_int()),
-                        wl_fixed_from_double(mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_y)-buffer_offset.dy.as_int()));
-                    if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
-                        wl_pointer_send_frame(resource);
-                    break;
-                }
-                case mir_pointer_action_leave:
-                {
-                    wl_pointer_send_leave(
-                        resource,
-                        serial,
-                        target);
-                    if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
-                        wl_pointer_send_frame(resource);
-                    break;
-                }
-                case mir_pointer_action_motion:
-                {
-                    // TODO: properly group vscroll and hscroll events in the same frame (as described by the frame
-                    //  event description in wayland.xml) and send axis_source, axis_stop and axis_discrete events where
-                    //  appropriate (may require significant reworking of the input system)
-
-                    auto x = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_x)-buffer_offset.dx.as_int();
-                    auto y = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_y)-buffer_offset.dy.as_int();
-
-                    // libinput < 0.8 sent wheel click events with value 10. Since 0.8 the value is the angle of the click in
-                    // degrees. To keep backwards-compat with existing clients, we just send multiples of the click count.
-                    // Ref: https://github.com/wayland-project/weston/blob/master/libweston/libinput-device.c#L184
-                    auto vscroll = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_vscroll) * 10;
-                    auto hscroll = mir_pointer_event_axis_value(pointer_event, mir_pointer_axis_hscroll) * 10;
-
-                    if ((x != last_x) || (y != last_y))
-                    {
-                        wl_pointer_send_motion(
-                            resource,
-                            mir_input_event_get_event_time_ms(event),
-                            wl_fixed_from_double(x),
-                            wl_fixed_from_double(y));
-
-                        last_x = x;
-                        last_y = y;
-
-                        if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
-                            wl_pointer_send_frame(resource);
-                    }
-                    if (vscroll != 0)
-                    {
-                        wl_pointer_send_axis(
-                            resource,
-                            mir_input_event_get_event_time_ms(event),
-                            WL_POINTER_AXIS_VERTICAL_SCROLL,
-                            wl_fixed_from_double(vscroll));
-
-                        if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
-                            wl_pointer_send_frame(resource);
-                    }
-                    if (hscroll != 0)
-                    {
-                        wl_pointer_send_axis(
-                            resource,
-                            mir_input_event_get_event_time_ms(event),
-                            WL_POINTER_AXIS_HORIZONTAL_SCROLL,
-                            wl_fixed_from_double(hscroll));
-
-                        if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
-                            wl_pointer_send_frame(resource);
-                    }
-                    break;
-                }
-                case mir_pointer_actions:
-                    break;
-            }
-        }));
+    last_position = std::experimental::nullopt;
 }
 
 namespace

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -42,12 +42,9 @@ public:
         wl_client* client,
         wl_resource* parent,
         uint32_t id,
-        std::function<void(WlPointer*)> const& on_destroy,
-        std::shared_ptr<mir::Executor> const& executor);
+        std::function<void(WlPointer*)> const& on_destroy);
 
     ~WlPointer();
-
-    void handle_event(MirInputEvent const* event, wl_resource* target);
 
     void handle_button(uint32_t time, uint32_t button, wl_pointer_button_state state);
     void handle_enter(mir::geometry::Point position, wl_resource* target);
@@ -59,13 +56,9 @@ public:
 
 private:
     wl_display* const display;
-    std::shared_ptr<mir::Executor> const executor;
-
     std::function<void(WlPointer*)> on_destroy;
-    std::shared_ptr<bool> const destroyed;
 
-    MirPointerButtons last_set{0};
-    float last_x{0}, last_y{0};
+    std::experimental::optional<mir::geometry::Point> last_position;
 
     void set_cursor(uint32_t serial, std::experimental::optional<wl_resource*> const& surface, int32_t hotspot_x, int32_t hotspot_y) override;
     void release() override;

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -47,6 +47,9 @@ public:
 
     void handle_event(MirInputEvent const* event, wl_resource* target);
 
+    void handle_button(uint32_t time, uint32_t button, bool is_pressed);
+    void handle_enter(mir::Geometry::Point position, wl_resource* resource);
+
     struct Cursor;
 
 private:

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -19,6 +19,8 @@
 #ifndef MIR_FRONTEND_WL_POINTER_H
 #define MIR_FRONTEND_WL_POINTER_H
 
+#include "mir/geometry/point.h"
+
 #include "generated/wayland_wrapper.h"
 
 struct MirInputEvent;
@@ -48,7 +50,8 @@ public:
     void handle_event(MirInputEvent const* event, wl_resource* target);
 
     void handle_button(uint32_t time, uint32_t button, bool is_pressed);
-    void handle_enter(mir::Geometry::Point position, wl_resource* resource);
+    void handle_enter(mir::geometry::Point position, wl_resource* target);
+    void handle_leave(wl_resource* target);
 
     struct Cursor;
 

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -35,6 +35,7 @@ class Executor;
 
 namespace frontend
 {
+class WlSurface;
 
 class WlPointer : public wayland::Pointer
 {
@@ -48,7 +49,7 @@ public:
 
     ~WlPointer();
 
-    void handle_event(MirPointerEvent const* event, wl_resource* target);
+    void handle_event(MirPointerEvent const* event, WlSurface* surface);
 
     struct Cursor;
 

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -49,8 +49,10 @@ public:
 
     void handle_event(MirInputEvent const* event, wl_resource* target);
 
-    void handle_button(uint32_t time, uint32_t button, bool is_pressed);
+    void handle_button(uint32_t time, uint32_t button, wl_pointer_button_state state);
     void handle_enter(mir::geometry::Point position, wl_resource* target);
+    void handle_motion(uint32_t time, mir::geometry::Point position);
+    void handle_axis(uint32_t time, wl_pointer_axis axis, double distance);
     void handle_leave(wl_resource* target);
 
     struct Cursor;

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -26,6 +26,8 @@
 struct MirInputEvent;
 typedef unsigned int MirPointerButtons;
 
+struct MirPointerEvent;
+
 namespace mir
 {
 
@@ -46,11 +48,7 @@ public:
 
     ~WlPointer();
 
-    void handle_button(uint32_t time, uint32_t button, wl_pointer_button_state state);
-    void handle_enter(mir::geometry::Point position, wl_resource* target);
-    void handle_motion(uint32_t time, mir::geometry::Point position);
-    void handle_axis(uint32_t time, wl_pointer_axis axis, double distance);
-    void handle_leave(wl_resource* target);
+    void handle_event(MirPointerEvent const* event, wl_resource* target);
 
     struct Cursor;
 
@@ -58,7 +56,14 @@ private:
     wl_display* const display;
     std::function<void(WlPointer*)> on_destroy;
 
+    MirPointerButtons last_buttons{0};
     std::experimental::optional<mir::geometry::Point> last_position;
+
+    void handle_button(uint32_t time, uint32_t button, wl_pointer_button_state state);
+    void handle_enter(mir::geometry::Point position, wl_resource* target);
+    void handle_motion(uint32_t time, mir::geometry::Point position);
+    void handle_axis(uint32_t time, wl_pointer_axis axis, double distance);
+    void handle_leave(wl_resource* target);
 
     void set_cursor(uint32_t serial, std::experimental::optional<wl_resource*> const& surface, int32_t hotspot_x, int32_t hotspot_y) override;
     void release() override;

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -236,11 +236,9 @@ void mf::WlSeat::get_pointer(wl_client* client, wl_resource* resource, uint32_t 
             client,
             resource,
             id,
-            [pointer_listeners = std::weak_ptr<ListenerList<WlPointer>>(pointer_listeners), client = client]
-            (WlPointer* listener)
+            [listeners = pointer_listeners, client](WlPointer* listener)
             {
-                if (auto listeners = pointer_listeners.lock())
-                    listeners->unregister_listener(client, listener);
+                listeners->unregister_listener(client, listener);
             },
             executor});
 }
@@ -254,11 +252,9 @@ void mf::WlSeat::get_keyboard(wl_client* client, wl_resource* resource, uint32_t
             resource,
             id,
             *keymap,
-            [keyboard_listeners = std::weak_ptr<ListenerList<WlKeyboard>>(keyboard_listeners), client = client]
-            (WlKeyboard* listener)
+            [listeners = keyboard_listeners, client](WlKeyboard* listener)
             {
-                if (auto listeners = keyboard_listeners.lock())
-                    listeners->unregister_listener(client, listener);
+                listeners->unregister_listener(client, listener);
             },
             [seat = seat]()
             {
@@ -297,11 +293,9 @@ void mf::WlSeat::get_touch(wl_client* client, wl_resource* resource, uint32_t id
             client,
             resource,
             id,
-            [touch_listeners = std::weak_ptr<ListenerList<WlTouch>>(touch_listeners), client = client]
-            (WlTouch* listener)
+            [listeners = touch_listeners, client](WlTouch* listener)
             {
-                if (auto listeners = touch_listeners.lock())
-                    listeners->unregister_listener(client, listener);
+                listeners->unregister_listener(client, listener);
             },
             executor});
 }

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -255,8 +255,7 @@ void mf::WlSeat::get_keyboard(wl_client* client, wl_resource* resource, uint32_t
                 }
 
                 return std::vector<uint32_t>{pressed_keys.begin(), pressed_keys.end()};
-            },
-            executor});
+            }});
 }
 
 void mf::WlSeat::get_touch(wl_client* client, wl_resource* resource, uint32_t id)
@@ -270,8 +269,7 @@ void mf::WlSeat::get_touch(wl_client* client, wl_resource* resource, uint32_t id
             [listeners = touch_listeners, client](WlTouch* listener)
             {
                 listeners->unregister_listener(client, listener);
-            },
-            executor});
+            }});
 }
 
 void mf::WlSeat::release(struct wl_client* /*client*/, struct wl_resource* us)

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -214,8 +214,7 @@ void mf::WlSeat::get_pointer(wl_client* client, wl_resource* resource, uint32_t 
             [listeners = pointer_listeners, client](WlPointer* listener)
             {
                 listeners->unregister_listener(client, listener);
-            },
-            executor});
+            }});
 }
 
 void mf::WlSeat::get_keyboard(wl_client* client, wl_resource* resource, uint32_t id)

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -64,13 +64,15 @@ public:
 
     void unregister_listener(wl_client* client, T const* listener)
     {
-        std::vector<T*> client_listeners = listeners[client];
+        std::vector<T*>& client_listeners = listeners[client];
         client_listeners.erase(
             std::remove(
                 client_listeners.begin(),
                 client_listeners.end(),
                 listener),
             client_listeners.end());
+        if (client_listeners.size() == 0)
+            listeners.erase(client);
     }
 
     void for_each(wl_client* client, std::function<void(T*)> func)

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -73,10 +73,10 @@ public:
             client_listeners.end());
     }
 
-    void for_each(wl_client* client, std::function<void(T*)> lambda)
+    void for_each(wl_client* client, std::function<void(T*)> func)
     {
         for (auto listener: listeners[client])
-            lambda(listener);
+            func(listener);
     }
 
 private:
@@ -165,44 +165,19 @@ mf::WlSeat::~WlSeat()
     input_hub->remove_observer(config_observer);
 }
 
-void mf::WlSeat::handle_pointer_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const
+void mf::WlSeat::for_each_listener(wl_client* client, std::function<void(WlPointer*)> func)
 {
-    pointer_listeners->for_each(client, [&](WlPointer* pointer)
-        {
-            pointer->handle_event(input_event, target);
-        });
+    pointer_listeners->for_each(client, func);
 }
 
-void mf::WlSeat::handle_keyboard_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const
+void mf::WlSeat::for_each_listener(wl_client* client, std::function<void(WlKeyboard*)> func)
 {
-    keyboard_listeners->for_each(client, [&](WlKeyboard* keyboard)
-        {
-            keyboard->handle_event(input_event, target);
-        });
+    keyboard_listeners->for_each(client, func);
 }
 
-void mf::WlSeat::handle_touch_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const
+void mf::WlSeat::for_each_listener(wl_client* client, std::function<void(WlTouch*)> func)
 {
-    touch_listeners->for_each(client, [&](WlTouch* touch)
-        {
-            touch->handle_event(input_event, target);
-        });
-}
-
-void mf::WlSeat::handle_event(wl_client* client, MirKeymapEvent const* keymap_event, wl_resource* target) const
-{
-    keyboard_listeners->for_each(client, [&](WlKeyboard* keyboard)
-        {
-            keyboard->handle_event(keymap_event, target);
-        });
-}
-
-void mf::WlSeat::handle_event(wl_client* client, MirWindowEvent const* window_event, wl_resource* target) const
-{
-    keyboard_listeners->for_each(client, [&](WlKeyboard* keyboard)
-        {
-            keyboard->handle_event(window_event, target);
-        });
+    touch_listeners->for_each(client, func);
 }
 
 void mf::WlSeat::spawn(std::function<void()>&& work)

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -73,9 +73,9 @@ private:
     std::unique_ptr<mir::input::Keymap> const keymap;
     std::shared_ptr<ConfigObserver> const config_observer;
 
-    std::unique_ptr<std::unordered_map<wl_client*, ListenerList<WlPointer>>> const pointer_listeners;
-    std::unique_ptr<std::unordered_map<wl_client*, ListenerList<WlKeyboard>>> const keyboard_listeners;
-    std::unique_ptr<std::unordered_map<wl_client*, ListenerList<WlTouch>>> const touch_listeners;
+    std::unique_ptr<ListenerList<WlPointer>> const pointer_listeners;
+    std::unique_ptr<ListenerList<WlKeyboard>> const keyboard_listeners;
+    std::unique_ptr<ListenerList<WlTouch>> const touch_listeners;
 
     std::shared_ptr<input::InputDeviceHub> const input_hub;
     std::shared_ptr<input::Seat> const seat;

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -73,7 +73,7 @@ private:
     std::unique_ptr<mir::input::Keymap> const keymap;
     std::shared_ptr<ConfigObserver> const config_observer;
 
-    // these are shared pointers so devices can hold week pointers
+    // listener list are shared pointers so devices can keep them around long enough to remove themselves
     std::shared_ptr<ListenerList<WlPointer>> const pointer_listeners;
     std::shared_ptr<ListenerList<WlKeyboard>> const keyboard_listeners;
     std::shared_ptr<ListenerList<WlTouch>> const touch_listeners;

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -56,11 +56,9 @@ public:
 
     ~WlSeat();
 
-    void handle_pointer_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const;
-    void handle_keyboard_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const;
-    void handle_touch_event(wl_client* client, MirInputEvent const* input_event, wl_resource* target) const;
-    void handle_event(wl_client* client, MirKeymapEvent const* keymap_event, wl_resource* target) const;
-    void handle_event(wl_client* client, MirWindowEvent const* window_event, wl_resource* target) const;
+    void for_each_listener(wl_client* client, std::function<void(WlPointer*)> func);
+    void for_each_listener(wl_client* client, std::function<void(WlKeyboard*)> func);
+    void for_each_listener(wl_client* client, std::function<void(WlTouch*)> func);
 
     void spawn(std::function<void()>&& work);
 

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -73,9 +73,10 @@ private:
     std::unique_ptr<mir::input::Keymap> const keymap;
     std::shared_ptr<ConfigObserver> const config_observer;
 
-    std::unique_ptr<ListenerList<WlPointer>> const pointer_listeners;
-    std::unique_ptr<ListenerList<WlKeyboard>> const keyboard_listeners;
-    std::unique_ptr<ListenerList<WlTouch>> const touch_listeners;
+    // these are shared pointers so devices can hold week pointers
+    std::shared_ptr<ListenerList<WlPointer>> const pointer_listeners;
+    std::shared_ptr<ListenerList<WlKeyboard>> const keyboard_listeners;
+    std::shared_ptr<ListenerList<WlTouch>> const touch_listeners;
 
     std::shared_ptr<input::InputDeviceHub> const input_hub;
     std::shared_ptr<input::Seat> const seat;

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -41,9 +41,6 @@ class Keymap;
 }
 namespace frontend
 {
-template<class InputInterface>
-class InputCtx; // defined in wl_seat.cpp
-
 class WlPointer;
 class WlKeyboard;
 class WlTouch;
@@ -68,14 +65,17 @@ public:
     void spawn(std::function<void()>&& work);
 
 private:
+    template<class T>
+    class ListenerList;
+
     class ConfigObserver;
 
     std::unique_ptr<mir::input::Keymap> const keymap;
     std::shared_ptr<ConfigObserver> const config_observer;
 
-    std::unique_ptr<std::unordered_map<wl_client*, InputCtx<WlPointer>>> const pointer;
-    std::unique_ptr<std::unordered_map<wl_client*, InputCtx<WlKeyboard>>> const keyboard;
-    std::unique_ptr<std::unordered_map<wl_client*, InputCtx<WlTouch>>> const touch;
+    std::unique_ptr<std::unordered_map<wl_client*, ListenerList<WlPointer>>> const pointer_listeners;
+    std::unique_ptr<std::unordered_map<wl_client*, ListenerList<WlKeyboard>>> const keyboard_listeners;
+    std::unique_ptr<std::unordered_map<wl_client*, ListenerList<WlTouch>>> const touch_listeners;
 
     std::shared_ptr<input::InputDeviceHub> const input_hub;
     std::shared_ptr<input::Seat> const seat;

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -34,6 +34,7 @@
 #include "mir/shell/surface_specification.h"
 
 namespace mf = mir::frontend;
+namespace geom = mir::geometry;
 
 void mf::WlSurfaceState::update_from(WlSurfaceState const& source)
 {
@@ -79,6 +80,11 @@ mf::WlSurface::~WlSurface()
 bool mf::WlSurface::synchronized() const
 {
     return role->synchronized();
+}
+
+std::pair<geom::Point, wl_resource*> mf::WlSurface::transform_point(geom::Point point) const
+{
+    return std::make_pair(point + buffer_offset_, resource);
 }
 
 void mf::WlSurface::set_role(WlSurfaceRole* role_)

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -84,7 +84,7 @@ bool mf::WlSurface::synchronized() const
 
 std::pair<geom::Point, wl_resource*> mf::WlSurface::transform_point(geom::Point point) const
 {
-    return std::make_pair(point + buffer_offset_, resource);
+    return std::make_pair(point - buffer_offset_, resource);
 }
 
 void mf::WlSurface::set_role(WlSurfaceRole* role_)

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -101,6 +101,7 @@ public:
     geometry::Size buffer_size() const { return buffer_size_; }
     bool synchronized() const;
     std::pair<geometry::Point, wl_resource*> transform_point(geometry::Point point) const;
+    wl_resource* raw_resource() { return resource; }
 
     void set_role(WlSurfaceRole* role_);
     void clear_role();

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -28,6 +28,7 @@
 
 #include "mir/geometry/displacement.h"
 #include "mir/geometry/size.h"
+#include "mir/geometry/point.h"
 
 #include <vector>
 
@@ -99,6 +100,7 @@ public:
     geometry::Displacement buffer_offset() const { return buffer_offset_; }
     geometry::Size buffer_size() const { return buffer_size_; }
     bool synchronized() const;
+    std::pair<geometry::Point, wl_resource*> transform_point(geometry::Point point) const;
 
     void set_role(WlSurfaceRole* role_);
     void clear_role();

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -91,16 +91,15 @@ std::shared_ptr<scene::Surface> get_surface_for_id(std::shared_ptr<Session> cons
 }
 }
 
-WlAbstractMirWindow::WlAbstractMirWindow(WlSeat* seat, wl_client* client, wl_resource* surface, wl_resource* event_sink,
+WlAbstractMirWindow::WlAbstractMirWindow(WlSeat* seat, wl_client* client, WlSurface* surface,
                                          std::shared_ptr<Shell> const& shell)
         : destroyed{std::make_shared<bool>(false)},
           client{client},
-          surface{WlSurface::from(surface)},
-          event_sink{event_sink},
+          surface{surface},
           shell{shell},
           sink{std::make_shared<BasicSurfaceEventSink>(seat, client, surface, this)},
           params{std::make_unique<scene::SurfaceCreationParameters>(
-              scene::SurfaceCreationParameters().of_type(mir_window_type_freestyle))}
+                 scene::SurfaceCreationParameters().of_type(mir_window_type_freestyle))}
 {
 }
 

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -122,6 +122,11 @@ void WlAbstractMirWindow::invalidate_buffer_list()
     buffer_list_needs_refresh = true;
 }
 
+void WlAbstractMirWindow::handle_resize(geometry::Size const& new_size)
+{
+    sink->send_resize_(new_size);
+}
+
 shell::SurfaceSpecification& WlAbstractMirWindow::spec()
 {
     if (!pending_changes)
@@ -188,7 +193,7 @@ void WlAbstractMirWindow::create_mir_window()
     auto const client_size = window->client_size();
 
     if (client_size != params->size)
-        sink->send_resize(client_size);
+        sink->send_resize_(client_size);
 }
 
 geometry::Size WlAbstractMirWindow::window_size()

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -47,6 +47,7 @@ namespace frontend
 class Shell;
 class BasicSurfaceEventSink;
 class WlSurface;
+class WlSeat;
 struct WlSurfaceState;
 
 class WlSurfaceRole
@@ -63,8 +64,8 @@ public:
 class WlAbstractMirWindow : public WlSurfaceRole
 {
 public:
-    WlAbstractMirWindow(wl_client* client, wl_resource* surface, wl_resource* event_sink,
-        std::shared_ptr<frontend::Shell> const& shell);
+    WlAbstractMirWindow(WlSeat* seat, wl_client* client, wl_resource* surface, wl_resource* event_sink,
+                        std::shared_ptr<frontend::Shell> const& shell);
 
     ~WlAbstractMirWindow() override;
 
@@ -82,7 +83,7 @@ public:
 
     void set_state_now(MirWindowState state);
 
-    virtual void handle_resize(geometry::Size const& new_size);
+    virtual void handle_resize(geometry::Size const& new_size) = 0;
 
 protected:
     std::shared_ptr<bool> const destroyed;
@@ -90,7 +91,7 @@ protected:
     WlSurface* const surface;
     wl_resource* const event_sink;
     std::shared_ptr<frontend::Shell> const shell;
-    std::shared_ptr<BasicSurfaceEventSink> sink;
+    std::shared_ptr<BasicSurfaceEventSink> const sink;
 
     std::unique_ptr<scene::SurfaceCreationParameters> const params;
     SurfaceId surface_id;

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -64,7 +64,7 @@ public:
 class WlAbstractMirWindow : public WlSurfaceRole
 {
 public:
-    WlAbstractMirWindow(WlSeat* seat, wl_client* client, wl_resource* surface, wl_resource* event_sink,
+    WlAbstractMirWindow(WlSeat* seat, wl_client* client, WlSurface* surface,
                         std::shared_ptr<frontend::Shell> const& shell);
 
     ~WlAbstractMirWindow() override;
@@ -89,7 +89,6 @@ protected:
     std::shared_ptr<bool> const destroyed;
     wl_client* const client;
     WlSurface* const surface;
-    wl_resource* const event_sink;
     std::shared_ptr<frontend::Shell> const shell;
     std::shared_ptr<BasicSurfaceEventSink> const sink;
 

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -82,6 +82,8 @@ public:
 
     void set_state_now(MirWindowState state);
 
+    virtual void handle_resize(geometry::Size const& new_size);
+
 protected:
     std::shared_ptr<bool> const destroyed;
     wl_client* const client;

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -30,105 +30,88 @@ mf::WlTouch::WlTouch(
     wl_client* client,
     wl_resource* parent,
     uint32_t id,
-    std::function<void(WlTouch*)> const& on_destroy,
-    std::shared_ptr<mir::Executor> const& executor)
+    std::function<void(WlTouch*)> const& on_destroy)
     : Touch(client, parent, id),
-        executor{executor},
-        on_destroy{on_destroy},
-        destroyed{std::make_shared<bool>(false)}
+      on_destroy{on_destroy}
 {
 }
 
 mf::WlTouch::~WlTouch()
 {
     on_destroy(this);
-    *destroyed = true;
 }
 
 void mf::WlTouch::handle_event(MirInputEvent const* event, wl_resource* target)
 {
-    executor->spawn(run_unless(
-        destroyed,
-        [
-            ev = mir::client::Event{mir_input_event_get_event(event)},
-            target = target,
-            target_window_destroyed = WlSurface::from(target)->destroyed_flag(),
-            this
-        ]()
+    auto const ev = mir::client::Event{mir_input_event_get_event(event)};
+    auto const input_ev = mir_event_get_input_event(ev);
+    auto const touch_ev = mir_input_event_get_touch_event(input_ev);
+    auto const buffer_offset = WlSurface::from(target)->buffer_offset();
+
+    for (auto i = 0u; i < mir_touch_event_point_count(touch_ev); ++i)
+    {
+        auto const touch_id = mir_touch_event_id(touch_ev, i);
+        auto const action = mir_touch_event_action(touch_ev, i);
+        auto const x = mir_touch_event_axis_value(
+            touch_ev,
+            i,
+            mir_touch_axis_x) - buffer_offset.dx.as_int();
+        auto const y = mir_touch_event_axis_value(
+            touch_ev,
+            i,
+            mir_touch_axis_y) - buffer_offset.dy.as_int();
+
+        switch (action)
         {
-            if (*target_window_destroyed)
-                return;
-
-            auto const input_ev = mir_event_get_input_event(ev);
-            auto const touch_ev = mir_input_event_get_touch_event(input_ev);
-            auto const buffer_offset = WlSurface::from(target)->buffer_offset();
-
-            for (auto i = 0u; i < mir_touch_event_point_count(touch_ev); ++i)
-            {
-                auto const touch_id = mir_touch_event_id(touch_ev, i);
-                auto const action = mir_touch_event_action(touch_ev, i);
-                auto const x = mir_touch_event_axis_value(
-                    touch_ev,
-                    i,
-                    mir_touch_axis_x) - buffer_offset.dx.as_int();
-                auto const y = mir_touch_event_axis_value(
-                    touch_ev,
-                    i,
-                    mir_touch_axis_y) - buffer_offset.dy.as_int();
-
-                switch (action)
-                {
-                case mir_touch_action_down:
-                    wl_touch_send_down(
-                        resource,
-                        wl_display_get_serial(wl_client_get_display(client)),
-                        mir_input_event_get_event_time_ms(input_ev),
-                        target,
-                        touch_id,
-                        wl_fixed_from_double(x),
-                        wl_fixed_from_double(y));
-                    break;
-                case mir_touch_action_up:
-                    wl_touch_send_up(
-                        resource,
-                        wl_display_get_serial(wl_client_get_display(client)),
-                        mir_input_event_get_event_time_ms(input_ev),
-                        touch_id);
-                    break;
-                case mir_touch_action_change:
-                    wl_touch_send_motion(
-                        resource,
-                        mir_input_event_get_event_time_ms(input_ev),
-                        touch_id,
-                        wl_fixed_from_double(x),
-                        wl_fixed_from_double(y));
-                    break;
-                case mir_touch_actions:
-                    /*
-                        * We should never receive an event with this action set;
-                        * the only way would be if a *new* action has been added
-                        * to the enum, and this hasn't been updated.
-                        *
-                        * There's nothing to do here, but don't use default: so
-                        * that the compiler will warn if a new enum value is added.
-                        */
-                    break;
-                }
-            }
-
-            if (mir_touch_event_point_count(touch_ev) > 0)
-            {
-                /*
-                    * This is mostly paranoia; I assume we won't actually be called
-                    * with an empty touch event.
-                    *
-                    * Regardless, the Wayland protocol requires that there be at least
-                    * one event sent before we send the ending frame, so make that explicit.
-                    */
-                wl_touch_send_frame(resource);
-            }
+        case mir_touch_action_down:
+            wl_touch_send_down(
+                resource,
+                wl_display_get_serial(wl_client_get_display(client)),
+                mir_input_event_get_event_time_ms(input_ev),
+                target,
+                touch_id,
+                wl_fixed_from_double(x),
+                wl_fixed_from_double(y));
+            break;
+        case mir_touch_action_up:
+            wl_touch_send_up(
+                resource,
+                wl_display_get_serial(wl_client_get_display(client)),
+                mir_input_event_get_event_time_ms(input_ev),
+                touch_id);
+            break;
+        case mir_touch_action_change:
+            wl_touch_send_motion(
+                resource,
+                mir_input_event_get_event_time_ms(input_ev),
+                touch_id,
+                wl_fixed_from_double(x),
+                wl_fixed_from_double(y));
+            break;
+        case mir_touch_actions:
+            /*
+                * We should never receive an event with this action set;
+                * the only way would be if a *new* action has been added
+                * to the enum, and this hasn't been updated.
+                *
+                * There's nothing to do here, but don't use default: so
+                * that the compiler will warn if a new enum value is added.
+                */
+            break;
         }
-        ));
+    }
+
+    if (mir_touch_event_point_count(touch_ev) > 0)
+    {
+        /*
+            * This is mostly paranoia; I assume we won't actually be called
+            * with an empty touch event.
+            *
+            * Regardless, the Wayland protocol requires that there be at least
+            * one event sent before we send the ending frame, so make that explicit.
+            */
+        wl_touch_send_frame(resource);
+    }
 }
 
 void mf::WlTouch::release()

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -41,11 +41,10 @@ mf::WlTouch::~WlTouch()
     on_destroy(this);
 }
 
-void mf::WlTouch::handle_event(MirInputEvent const* event, wl_resource* target)
+void mf::WlTouch::handle_event(MirTouchEvent const* touch_ev, wl_resource* target)
 {
-    auto const ev = mir::client::Event{mir_input_event_get_event(event)};
-    auto const input_ev = mir_event_get_input_event(ev);
-    auto const touch_ev = mir_input_event_get_touch_event(input_ev);
+    auto const input_ev = mir_touch_event_input_event(touch_ev);
+    auto const ev = mir::client::Event{mir_input_event_get_event(input_ev)};
     auto const buffer_offset = WlSurface::from(target)->buffer_offset();
 
     for (auto i = 0u; i < mir_touch_event_point_count(touch_ev); ++i)

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -41,11 +41,12 @@ mf::WlTouch::~WlTouch()
     on_destroy(this);
 }
 
-void mf::WlTouch::handle_event(MirTouchEvent const* touch_ev, wl_resource* target)
+void mf::WlTouch::handle_event(MirTouchEvent const* touch_ev, WlSurface* surface)
 {
+    // TODO: support for touches on subsurfaces
     auto const input_ev = mir_touch_event_input_event(touch_ev);
     auto const ev = mir::client::Event{mir_input_event_get_event(input_ev)};
-    auto const buffer_offset = WlSurface::from(target)->buffer_offset();
+    auto const buffer_offset = surface->buffer_offset();
 
     for (auto i = 0u; i < mir_touch_event_point_count(touch_ev); ++i)
     {
@@ -67,7 +68,7 @@ void mf::WlTouch::handle_event(MirTouchEvent const* touch_ev, wl_resource* targe
                 resource,
                 wl_display_get_serial(wl_client_get_display(client)),
                 mir_input_event_get_event_time_ms(input_ev),
-                target,
+                surface->raw_resource(),
                 touch_id,
                 wl_fixed_from_double(x),
                 wl_fixed_from_double(y));

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -22,7 +22,7 @@
 #include "generated/wayland_wrapper.h"
 
 // from "mir_toolkit/events/event.h"
-struct MirInputEvent;
+struct MirTouchEvent;
 
 namespace mir
 {
@@ -43,7 +43,7 @@ public:
 
     ~WlTouch();
 
-    void handle_event(MirInputEvent const* event, wl_resource* target);
+    void handle_event(MirTouchEvent const* event, wl_resource* target);
 
 private:
     std::function<void(WlTouch*)> on_destroy;

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -39,17 +39,14 @@ public:
         wl_client* client,
         wl_resource* parent,
         uint32_t id,
-        std::function<void(WlTouch*)> const& on_destroy,
-        std::shared_ptr<mir::Executor> const& executor);
+        std::function<void(WlTouch*)> const& on_destroy);
 
     ~WlTouch();
 
     void handle_event(MirInputEvent const* event, wl_resource* target);
 
 private:
-    std::shared_ptr<mir::Executor> const executor;
     std::function<void(WlTouch*)> on_destroy;
-    std::shared_ptr<bool> const destroyed;
 
     void release() override;
 };

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -26,11 +26,11 @@ struct MirTouchEvent;
 
 namespace mir
 {
-
 class Executor;
 
 namespace frontend
 {
+class WlSurface;
 
 class WlTouch : public wayland::Touch
 {
@@ -43,7 +43,7 @@ public:
 
     ~WlTouch();
 
-    void handle_event(MirTouchEvent const* event, wl_resource* target);
+    void handle_event(MirTouchEvent const* touch_ev, WlSurface* surface);
 
 private:
     std::function<void(WlTouch*)> on_destroy;

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -82,7 +82,6 @@ public:
 
     struct wl_resource* const parent;
     std::shared_ptr<Shell> const shell;
-    std::shared_ptr<BasicSurfaceEventSink> const sink;
     std::function<void()> next_commit_action{[]{}};
     std::function<void(geometry::Size const& new_size, MirWindowState state, bool active)> notify_resize =
         [](auto, auto, auto){};
@@ -192,12 +191,10 @@ mf::XdgSurfaceV6* mf::XdgSurfaceV6::get_xdgsurface(wl_resource* surface) const
 mf::XdgSurfaceV6::XdgSurfaceV6(wl_client* client, wl_resource* parent, uint32_t id, wl_resource* surface,
                                std::shared_ptr<mf::Shell> const& shell, WlSeat& seat)
     : wayland::XdgSurfaceV6(client, parent, id),
-      WlAbstractMirWindow{client, surface, resource, shell},
+      WlAbstractMirWindow{&seat, client, surface, resource, shell},
       parent{parent},
-      shell{shell},
-      sink{std::make_shared<BasicSurfaceEventSink>(&seat, client, surface, resource, this)}
+      shell{shell}
 {
-    WlAbstractMirWindow::sink = sink;
 }
 
 mf::XdgSurfaceV6::~XdgSurfaceV6()

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -41,7 +41,6 @@ namespace frontend
 class Shell;
 class XdgSurfaceV6;
 class WlSeat;
-class XdgSurfaceV6EventSink;
 
 class XdgSurfaceV6 : wayland::XdgSurfaceV6, public WlAbstractMirWindow
 {
@@ -58,6 +57,8 @@ public:
     void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) override;
     void ack_configure(uint32_t serial) override;
     void commit(WlSurfaceState const& state) override;
+
+    void handle_resize(const geometry::Size & new_size) override;
 
     void set_parent(optional_value<SurfaceId> parent_id);
     void set_title(std::string const& title);
@@ -81,25 +82,10 @@ public:
 
     struct wl_resource* const parent;
     std::shared_ptr<Shell> const shell;
-    std::shared_ptr<XdgSurfaceV6EventSink> const sink;
+    std::shared_ptr<BasicSurfaceEventSink> const sink;
     std::function<void()> next_commit_action{[]{}};
-};
-
-class XdgSurfaceV6EventSink : public BasicSurfaceEventSink
-{
-public:
-    using BasicSurfaceEventSink::BasicSurfaceEventSink;
-
-    XdgSurfaceV6EventSink(WlSeat* seat, wl_client* client, wl_resource* target, wl_resource* event_sink, WlAbstractMirWindow* window,
-                          std::shared_ptr<bool> const& destroyed);
-
-    void send_resize_(geometry::Size const& new_size) const override;
-
     std::function<void(geometry::Size const& new_size, MirWindowState state, bool active)> notify_resize =
         [](auto, auto, auto){};
-
-private:
-    std::shared_ptr<bool> const destroyed;
 };
 
 class XdgPopupV6 : wayland::XdgPopupV6
@@ -209,7 +195,7 @@ mf::XdgSurfaceV6::XdgSurfaceV6(wl_client* client, wl_resource* parent, uint32_t 
       WlAbstractMirWindow{client, surface, resource, shell},
       parent{parent},
       shell{shell},
-      sink{std::make_shared<XdgSurfaceV6EventSink>(&seat, client, surface, resource, this, destroyed)}
+      sink{std::make_shared<BasicSurfaceEventSink>(&seat, client, surface, resource, this)}
 {
     WlAbstractMirWindow::sink = sink;
 }
@@ -352,9 +338,9 @@ void mf::XdgSurfaceV6::resize(struct wl_resource* /*seat*/, uint32_t /*serial*/,
     }
 }
 
-void mf::XdgSurfaceV6::set_notify_resize(std::function<void(geometry::Size const&, MirWindowState, bool)> notify_resize)
+void mf::XdgSurfaceV6::set_notify_resize(std::function<void(geometry::Size const&, MirWindowState, bool)> notify_resize_)
 {
-    sink->notify_resize = notify_resize;
+    notify_resize = notify_resize_;
 }
 
 void mf::XdgSurfaceV6::set_parent(optional_value<SurfaceId> parent_id)
@@ -415,12 +401,12 @@ void mf::XdgSurfaceV6::set_min_size(int32_t width, int32_t height)
     }
 }
 
-void mir::frontend::XdgSurfaceV6::clear_next_commit_action()
+void mf::XdgSurfaceV6::clear_next_commit_action()
 {
     next_commit_action = []{};
 }
 
-void mir::frontend::XdgSurfaceV6::set_next_commit_action(std::function<void()> action)
+void mf::XdgSurfaceV6::set_next_commit_action(std::function<void()> action)
 {
     next_commit_action = [this, action]
     {
@@ -430,30 +416,18 @@ void mir::frontend::XdgSurfaceV6::set_next_commit_action(std::function<void()> a
     };
 }
 
-void mir::frontend::XdgSurfaceV6::commit(mir::frontend::WlSurfaceState const& state)
+void mf::XdgSurfaceV6::commit(mf::WlSurfaceState const& state)
 {
     WlAbstractMirWindow::commit(state);
     next_commit_action();
     clear_next_commit_action();
 }
 
-// XdgSurfaceV6EventSink
-
-mf::XdgSurfaceV6EventSink::XdgSurfaceV6EventSink(WlSeat* seat, wl_client* client, wl_resource* target,
-                                                 wl_resource* event_sink, WlAbstractMirWindow* window, std::shared_ptr<bool> const& destroyed)
-    : BasicSurfaceEventSink(seat, client, target, event_sink, window),
-      destroyed{destroyed}
+void mf::XdgSurfaceV6::handle_resize(geometry::Size const& new_size)
 {
-}
-
-void mf::XdgSurfaceV6EventSink::send_resize_(geometry::Size const& new_size) const
-{
-    seat->spawn(run_unless(destroyed, [this, new_size]()
-        {
-            auto const serial = wl_display_next_serial(wl_client_get_display(client));
-            notify_resize(new_size, state(), is_active());
-            zxdg_surface_v6_send_configure(event_sink, serial);
-        }));
+    auto const serial = wl_display_next_serial(wl_client_get_display(client));
+    notify_resize(new_size, sink->state(), sink->is_active());
+    zxdg_surface_v6_send_configure(event_sink, serial);
 }
 
 // XdgPopupV6


### PR DESCRIPTION
Big refactor of how input is handled in Wayland code. Changes of note:
* Added generic 'for_each_interface' functions to WlSeat, so seats need not be concerned with handling events
* Split up big hanel_event functions in WlPointer, WlKeyboard and WlTouch
* Removed event sinks for specific protocols, now only BasicSurfaceEventSink is used.