### PR TITLE
[spread] add make to build dependencies

### DIFF
--- a/spread/build/fedora/task.yaml
+++ b/spread/build/fedora/task.yaml
@@ -13,6 +13,7 @@ execute: |
 
     dnf install --assumeyes \
         cmake \
+        make \
         gcc-c++ \
         boost-devel \
         mesa-libEGL-devel \


### PR DESCRIPTION
Make is no longer preinstalled on the GCE images.