### PR TITLE
send frame events better

### DIFF
--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -65,6 +65,7 @@ private:
     void handle_motion(uint32_t time, mir::geometry::Point position);
     void handle_axis(uint32_t time, wl_pointer_axis axis, double distance);
     void handle_leave(wl_resource* target);
+    void handle_frame();
 
     void set_cursor(uint32_t serial, std::experimental::optional<wl_resource*> const& surface, int32_t hotspot_x, int32_t hotspot_y) override;
     void release() override;

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -60,10 +60,7 @@ private:
     MirPointerButtons last_buttons{0};
     std::experimental::optional<mir::geometry::Point> last_position;
 
-    void handle_button(uint32_t time, uint32_t button, wl_pointer_button_state state);
     void handle_enter(mir::geometry::Point position, wl_resource* target);
-    void handle_motion(uint32_t time, mir::geometry::Point position);
-    void handle_axis(uint32_t time, wl_pointer_axis axis, double distance);
     void handle_leave(wl_resource* target);
     void handle_frame();
 


### PR DESCRIPTION
Move some logic out of the handle_* functions. Allows for grouping *some* events into the same pointer frame, and helps with other stuff I've been working on.