### PR TITLE
Switched WlSurface::surface_id from variable to getter

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -333,10 +333,10 @@ protected:
         auto const session = get_session(client);
         auto& parent_surface = *WlSurface::from(parent);
 
-        if (surface_id.as_value())
+        if (surface_id().as_value())
         {
             auto& mods = spec();
-            mods.parent_id = parent_surface.surface_id;
+            mods.parent_id = parent_surface.surface_id();
             mods.aux_rect = geom::Rectangle{{x, y}, {}};
             mods.surface_placement_gravity = mir_placement_gravity_northwest;
             mods.aux_rect_placement_gravity = mir_placement_gravity_southeast;
@@ -348,7 +348,7 @@ protected:
         {
             if (flags & WL_SHELL_SURFACE_TRANSIENT_INACTIVE)
                 params->type = mir_window_type_gloss;
-            params->parent_id = parent_surface.surface_id;
+            params->parent_id = parent_surface.surface_id();
             params->aux_rect = geom::Rectangle{{x, y}, {}};
             params->surface_placement_gravity = mir_placement_gravity_northwest;
             params->aux_rect_placement_gravity = mir_placement_gravity_southeast;
@@ -385,10 +385,10 @@ protected:
         auto const session = get_session(client);
         auto& parent_surface = *WlSurface::from(parent);
 
-        if (surface_id.as_value())
+        if (surface_id().as_value())
         {
             auto& mods = spec();
-            mods.parent_id = parent_surface.surface_id;
+            mods.parent_id = parent_surface.surface_id();
             mods.aux_rect = geom::Rectangle{{x, y}, {}};
             mods.surface_placement_gravity = mir_placement_gravity_northwest;
             mods.aux_rect_placement_gravity = mir_placement_gravity_southeast;
@@ -401,7 +401,7 @@ protected:
             if (flags & WL_SHELL_SURFACE_TRANSIENT_INACTIVE)
                 params->type = mir_window_type_gloss;
 
-            params->parent_id = parent_surface.surface_id;
+            params->parent_id = parent_surface.surface_id();
             params->aux_rect = geom::Rectangle{{x, y}, {}};
             params->surface_placement_gravity = mir_placement_gravity_northwest;
             params->aux_rect_placement_gravity = mir_placement_gravity_southeast;
@@ -421,7 +421,7 @@ protected:
 
     void set_title(std::string const& title) override
     {
-        if (surface_id.as_value())
+        if (surface_id().as_value())
         {
             spec().name = title;
         }
@@ -437,18 +437,18 @@ protected:
 
     void move(struct wl_resource* /*seat*/, uint32_t /*serial*/) override
     {
-        if (surface_id.as_value())
+        if (surface_id().as_value())
         {
             if (auto session = get_session(client))
             {
-                shell->request_operation(session, surface_id, sink->latest_timestamp_ns(), Shell::UserRequest::move);
+                shell->request_operation(session, surface_id(), sink->latest_timestamp_ns(), Shell::UserRequest::move);
             }
         }
     }
 
     void resize(struct wl_resource* /*seat*/, uint32_t /*serial*/, uint32_t edges) override
     {
-        if (surface_id.as_value())
+        if (surface_id().as_value())
         {
             if (auto session = get_session(client))
             {
@@ -493,7 +493,7 @@ protected:
 
                 shell->request_operation(
                     session,
-                    surface_id,
+                    surface_id(),
                     sink->latest_timestamp_ns(),
                     Shell::UserRequest::resize,
                     edge);

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -260,8 +260,12 @@ WlStreamCursor::WlStreamCursor(
 
 void WlStreamCursor::apply_to(wl_resource* target)
 {
-    auto const mir_window = session->get_surface(mf::WlSurface::from(target)->surface_id);
-    mir_window->set_cursor_stream(stream, hotspot);
+    auto id = mf::WlSurface::from(target)->surface_id();
+    if (id.as_value())
+    {
+        auto const mir_window = session->get_surface(id);
+        mir_window->set_cursor_stream(stream, hotspot);
+    }
 }
 
 WlHiddenCursor::WlHiddenCursor(
@@ -272,6 +276,10 @@ WlHiddenCursor::WlHiddenCursor(
 
 void WlHiddenCursor::apply_to(wl_resource* target)
 {
-    auto const mir_window = session->get_surface(mf::WlSurface::from(target)->surface_id);
-    mir_window->set_cursor_image({});
+    auto id = mf::WlSurface::from(target)->surface_id();
+    if (id.as_value())
+    {
+        auto const mir_window = session->get_surface(id);
+        mir_window->set_cursor_image({});
+    }
 }

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -68,6 +68,11 @@ bool mf::WlSubsurface::synchronized() const
     return synchronized_ || parent->synchronized();
 }
 
+mf::SurfaceId mf::WlSubsurface::surface_id() const
+{
+    return parent->surface_id();
+}
+
 void mf::WlSubsurface::parent_has_committed()
 {
     if (cached_state && synchronized())

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -61,6 +61,8 @@ public:
 
     bool synchronized() const override;
 
+    SurfaceId surface_id() const override;
+
     void parent_has_committed();
 
 private:

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -87,6 +87,11 @@ std::pair<geom::Point, wl_resource*> mf::WlSurface::transform_point(geom::Point 
     return std::make_pair(point - buffer_offset_, resource);
 }
 
+mf::SurfaceId mf::WlSurface::surface_id() const
+{
+    return role->surface_id();
+}
+
 void mf::WlSurface::set_role(WlSurfaceRole* role_)
 {
     role = role_;
@@ -295,6 +300,7 @@ mf::NullWlSurfaceRole::NullWlSurfaceRole(WlSurface* surface) :
 {
 }
 
+mf::SurfaceId mf::NullWlSurfaceRole::surface_id() const { return {}; }
 void mf::NullWlSurfaceRole::invalidate_buffer_list() {}
 void mf::NullWlSurfaceRole::commit(WlSurfaceState const& state) { surface->commit(state); }
 void mf::NullWlSurfaceRole::visiblity(bool /*visible*/) {}

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -75,6 +75,7 @@ class NullWlSurfaceRole : public WlSurfaceRole
 {
 public:
     NullWlSurfaceRole(WlSurface* surface);
+    SurfaceId surface_id() const override;
     void invalidate_buffer_list() override;
     void commit(WlSurfaceState const& state) override;
     void visiblity(bool /*visible*/) override;
@@ -102,6 +103,7 @@ public:
     bool synchronized() const;
     std::pair<geometry::Point, wl_resource*> transform_point(geometry::Point point) const;
     wl_resource* raw_resource() { return resource; }
+    mir::frontend::SurfaceId surface_id() const;
 
     void set_role(WlSurfaceRole* role_);
     void clear_role();
@@ -115,7 +117,6 @@ public:
     std::shared_ptr<mir::frontend::Session> const session;
     mir::frontend::BufferStreamId const stream_id;
     std::shared_ptr<mir::frontend::BufferStream> const stream;
-    mir::frontend::SurfaceId surface_id;       // ID of any associated surface
 
     static WlSurface* from(wl_resource* resource);
 

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -54,6 +54,7 @@ class WlSurfaceRole
 {
 public:
     virtual bool synchronized() const { return false; }
+    virtual SurfaceId surface_id() const = 0;
     virtual void invalidate_buffer_list() = 0;
     virtual void commit(WlSurfaceState const& state) = 0;
     virtual void visiblity(bool visible) = 0;
@@ -68,6 +69,8 @@ public:
                         std::shared_ptr<frontend::Shell> const& shell);
 
     ~WlAbstractMirWindow() override;
+
+    SurfaceId surface_id() const override { return surface_id_; };
 
     void invalidate_buffer_list() override;
 
@@ -93,7 +96,6 @@ protected:
     std::shared_ptr<BasicSurfaceEventSink> const sink;
 
     std::unique_ptr<scene::SurfaceCreationParameters> const params;
-    SurfaceId surface_id;
     optional_value<geometry::Size> window_size_;
 
     geometry::Size window_size();
@@ -101,6 +103,7 @@ protected:
     void commit(WlSurfaceState const& state) override;
 
 private:
+    SurfaceId surface_id_;
     std::unique_ptr<shell::SurfaceSpecification> pending_changes;
     bool buffer_list_needs_refresh = true;
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -222,7 +222,7 @@ void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct
     auto& parent_surface = *XdgSurfaceV6::from(parent);
 
     params->type = mir_window_type_freestyle;
-    params->parent_id = parent_surface.surface_id;
+    params->parent_id = parent_surface.surface_id();
     if (pos->size.is_set()) params->size = pos->size.value();
     params->aux_rect = pos->aux_rect;
     params->surface_placement_gravity = pos->surface_placement_gravity;
@@ -242,7 +242,7 @@ void mf::XdgSurfaceV6::set_window_geometry(int32_t x, int32_t y, int32_t width, 
     surface->set_buffer_offset(buffer_offset);
     window_size_ = geom::Size{width, height};
 
-    if (surface_id.as_value())
+    if (surface_id().as_value())
     {
         spec().width = geom::Width{width};
         spec().height = geom::Height{height};
@@ -259,7 +259,7 @@ void mf::XdgSurfaceV6::ack_configure(uint32_t serial)
 
 void mf::XdgSurfaceV6::set_title(std::string const& title)
 {
-    if (surface_id.as_value())
+    if (surface_id().as_value())
     {
         spec().name = title;
     }
@@ -271,18 +271,18 @@ void mf::XdgSurfaceV6::set_title(std::string const& title)
 
 void mf::XdgSurfaceV6::move(struct wl_resource* /*seat*/, uint32_t /*serial*/)
 {
-    if (surface_id.as_value())
+    if (surface_id().as_value())
     {
         if (auto session = get_session(client))
         {
-            shell->request_operation(session, surface_id, sink->latest_timestamp_ns(), Shell::UserRequest::move);
+            shell->request_operation(session, surface_id(), sink->latest_timestamp_ns(), Shell::UserRequest::move);
         }
     }
 }
 
 void mf::XdgSurfaceV6::resize(struct wl_resource* /*seat*/, uint32_t /*serial*/, uint32_t edges)
 {
-    if (surface_id.as_value())
+    if (surface_id().as_value())
     {
         if (auto session = get_session(client))
         {
@@ -327,7 +327,7 @@ void mf::XdgSurfaceV6::resize(struct wl_resource* /*seat*/, uint32_t /*serial*/,
 
             shell->request_operation(
                 session,
-                surface_id,
+                surface_id(),
                 sink->latest_timestamp_ns(),
                 Shell::UserRequest::resize,
                 edge);
@@ -342,7 +342,7 @@ void mf::XdgSurfaceV6::set_notify_resize(std::function<void(geometry::Size const
 
 void mf::XdgSurfaceV6::set_parent(optional_value<SurfaceId> parent_id)
 {
-    if (surface_id.as_value())
+    if (surface_id().as_value())
     {
         spec().parent_id = parent_id;
     }
@@ -354,7 +354,7 @@ void mf::XdgSurfaceV6::set_parent(optional_value<SurfaceId> parent_id)
 
 void mf::XdgSurfaceV6::set_max_size(int32_t width, int32_t height)
 {
-    if (surface_id.as_value())
+    if (surface_id().as_value())
     {
         if (width == 0) width = std::numeric_limits<int>::max();
         if (height == 0) height = std::numeric_limits<int>::max();
@@ -385,7 +385,7 @@ void mf::XdgSurfaceV6::set_max_size(int32_t width, int32_t height)
 
 void mf::XdgSurfaceV6::set_min_size(int32_t width, int32_t height)
 {
-    if (surface_id.as_value())
+    if (surface_id().as_value())
     {
         auto& mods = spec();
         mods.min_width = geom::Width{width};
@@ -512,7 +512,7 @@ void mf::XdgToplevelV6::set_parent(std::experimental::optional<struct wl_resourc
 {
     if (parent && parent.value())
     {
-        self->set_parent(XdgToplevelV6::from(parent.value())->self->surface_id);
+        self->set_parent(XdgToplevelV6::from(parent.value())->self->surface_id());
     }
     else
     {


### PR DESCRIPTION
Changed WlSurface::surface_id from a variable to a getter and added a surface id getter to WlSurfaceRole. This is needed to get the surface id for subsurfaces, and is better design imo.