### PR TITLE
Notify the compositor of surfaces that have content before they are added to the scene.

### DIFF
--- a/src/server/scene/legacy_scene_change_notification.cpp
+++ b/src/server/scene/legacy_scene_change_notification.cpp
@@ -110,10 +110,6 @@ void ms::LegacySceneChangeNotification::add_surface_observer(ms::Surface* surfac
         auto observer = std::make_shared<NonLegacySurfaceChangeNotification>(notifier, damage_notify_change, surface);
         surface->add_observer(observer);
 
-        // If the surface already has content we need to (re)composite
-        if (surface->visible())
-            scene_notify_change();
-
         std::unique_lock<decltype(surface_observers_guard)> lg(surface_observers_guard);
         surface_observers[surface] = observer;
     }
@@ -122,6 +118,10 @@ void ms::LegacySceneChangeNotification::add_surface_observer(ms::Surface* surfac
 void ms::LegacySceneChangeNotification::surface_added(ms::Surface* surface)
 {
     add_surface_observer(surface);
+
+    // If the surface already has content we need to (re)composite
+    if (!buffer_notify_change && surface->visible())
+        scene_notify_change();
 }
 
 void ms::LegacySceneChangeNotification::surface_exists(ms::Surface* surface)

--- a/src/server/scene/legacy_scene_change_notification.cpp
+++ b/src/server/scene/legacy_scene_change_notification.cpp
@@ -110,6 +110,10 @@ void ms::LegacySceneChangeNotification::add_surface_observer(ms::Surface* surfac
         auto observer = std::make_shared<NonLegacySurfaceChangeNotification>(notifier, damage_notify_change, surface);
         surface->add_observer(observer);
 
+        // If the surface already has content we need to (re)composite
+        if (surface->visible())
+            scene_notify_change();
+
         std::unique_lock<decltype(surface_observers_guard)> lg(surface_observers_guard);
         surface_observers[surface] = observer;
     }


### PR DESCRIPTION
Both Wayland and Mir clients can provide content when creating a window, we need draw them before another buffer is submitted.  (Fixes #328)