### PR TITLE
Rework buffers update

### DIFF
--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -122,32 +122,22 @@ void mf::WlSubsurface::invalidate_buffer_list()
 
 void mf::WlSubsurface::commit(WlSurfaceState const& state)
 {
+    if (!cached_state)
+        cached_state = WlSurfaceState();
+
+    cached_state.value().update_from(state);
+
     if (synchronized())
     {
-        if (!cached_state)
-            cached_state = WlSurfaceState();
-
-        cached_state.value().update_from(state);
-
         if (cached_state.value().buffer_list_needs_refresh() && !*parent_destroyed)
             parent->invalidate_child_buffers();
     }
     else
     {
-        if (cached_state) // unusual
-        {
-            cached_state.value().update_from(state);
-            surface->commit(cached_state.value());
-            if (cached_state.value().buffer_list_needs_refresh())
-                invalidate_buffer_list();
-            cached_state = std::experimental::nullopt;
-        }
-        else
-        {
-            surface->commit(state);
-            if (state.buffer_list_needs_refresh())
-                invalidate_buffer_list();
-        }
+        surface->commit(cached_state.value());
+        if (cached_state.value().buffer_list_needs_refresh())
+            invalidate_buffer_list();
+        cached_state = std::experimental::nullopt;
     }
 }
 

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -47,6 +47,7 @@ mf::WlSubsurface::WlSubsurface(struct wl_client* client, struct wl_resource* obj
       synchronized_{true}
 {
     surface->set_role(this);
+    surface->invalidate_child_buffers();
 }
 
 mf::WlSubsurface::~WlSubsurface()

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -60,7 +60,6 @@ public:
                               geometry::Displacement const& parent_offset) const;
 
     bool synchronized() const override;
-
     SurfaceId surface_id() const override;
 
     void parent_has_committed();

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -54,8 +54,7 @@ void mf::WlSurfaceState::update_from(WlSurfaceState const& source)
 
 bool mf::WlSurfaceState::buffer_list_needs_refresh() const
 {
-    return buffer ||
-           buffer_offset ||
+    return buffer_offset ||
            child_buffers_changed;
 }
 

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -47,6 +47,16 @@ void mf::WlSurfaceState::update_from(WlSurfaceState const& source)
     frame_callbacks.insert(end(frame_callbacks),
                            begin(source.frame_callbacks),
                            end(source.frame_callbacks));
+
+    if (source.child_buffers_changed)
+        child_buffers_changed = true;
+}
+
+bool mf::WlSurfaceState::buffer_list_needs_refresh() const
+{
+    return buffer ||
+           buffer_offset ||
+           child_buffers_changed;
 }
 
 mf::WlSurface::WlSurface(

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -62,6 +62,10 @@ struct WlSurfaceState
     // if you add variables, don't forget to update this
     void update_from(WlSurfaceState const& source);
 
+    void invalidate_child_buffers() { child_buffers_changed = true; }
+
+    bool buffer_list_needs_refresh() const;
+
     // NOTE: buffer can be both nullopt and nullptr (I know, sounds dumb, but bare with me)
     // if it's nullopt, there is not a new buffer and no value should be copied to current state
     // if it's nullptr, there is a new buffer and it is a null buffer, which should replace the current buffer
@@ -69,6 +73,9 @@ struct WlSurfaceState
 
     std::experimental::optional<geometry::Displacement> buffer_offset;
     std::vector<Callback> frame_callbacks;
+
+private:
+    bool child_buffers_changed{false};
 };
 
 class NullWlSurfaceRole : public WlSurfaceRole
@@ -110,6 +117,7 @@ public:
     void set_buffer_offset(geometry::Displacement const& offset) { pending.buffer_offset = offset; }
     std::unique_ptr<WlSurface, std::function<void(WlSurface*)>> add_child(WlSubsurface* child);
     void invalidate_buffer_list();
+    void invalidate_child_buffers() { pending.invalidate_child_buffers(); }
     void populate_buffer_list(std::vector<shell::StreamSpecification>& buffers,
                               geometry::Displacement const& parent_offset) const;
     void commit(WlSurfaceState const& state);

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -119,7 +119,10 @@ WlAbstractMirWindow::~WlAbstractMirWindow()
 
 void WlAbstractMirWindow::invalidate_buffer_list()
 {
-    buffer_list_needs_refresh = true;
+    shell::SurfaceSpecification buffer_list_spec;
+    buffer_list_spec.streams = std::vector<shell::StreamSpecification>();
+    surface->populate_buffer_list(buffer_list_spec.streams.value(), {});
+    shell->modify_surface(get_session(client), surface_id_, buffer_list_spec);
 }
 
 shell::SurfaceSpecification& WlAbstractMirWindow::spec()
@@ -149,12 +152,11 @@ void WlAbstractMirWindow::commit(WlSurfaceState const& state)
             new_size_spec.height = window_size().height;
         }
 
-        if (buffer_list_needs_refresh)
+        if (state.buffer_list_needs_refresh())
         {
             auto& buffer_list_spec = spec();
             buffer_list_spec.streams = std::vector<shell::StreamSpecification>();
             surface->populate_buffer_list(buffer_list_spec.streams.value(), {});
-            buffer_list_needs_refresh = false;
         }
 
         if (pending_changes)
@@ -178,7 +180,6 @@ void WlAbstractMirWindow::create_mir_window()
 
     params->streams = std::vector<shell::StreamSpecification>{};
     surface->populate_buffer_list(params->streams.value(), {});
-    buffer_list_needs_refresh = false;
 
     surface_id_ = shell->create_surface(session, *params, sink);
 

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -75,13 +75,9 @@ public:
     void invalidate_buffer_list() override;
 
     void set_maximized();
-
     void unset_maximized();
-
     void set_fullscreen(std::experimental::optional<wl_resource*> const& output);
-
     void unset_fullscreen();
-
     void set_minimized();
 
     void set_state_now(MirWindowState state);
@@ -105,7 +101,6 @@ protected:
 private:
     SurfaceId surface_id_;
     std::unique_ptr<shell::SurfaceSpecification> pending_changes;
-    bool buffer_list_needs_refresh = true;
 
     void visiblity(bool visible) override;
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -246,7 +246,6 @@ void mf::XdgSurfaceV6::set_window_geometry(int32_t x, int32_t y, int32_t width, 
     {
         spec().width = geom::Width{width};
         spec().height = geom::Height{height};
-        invalidate_buffer_list();
     }
 }
 


### PR DESCRIPTION
Now there are two ways to signal that the buffer list needs a refresh. the buffer list is refreshed when buffers are added, removed, offsets are changed or (in the future) input regions are changed.

Both surfaces and surface roles have `invalidate_buffer_list()`, which recursively goes up the subsurface tree and triggers an immediate buffer list refresh with `populate_buffer_list()`. This is called when a asynchronous subsurface is committed.

For synchronous subsurfaces and non-subsurfaces, `SurfaceState::buffer_list_needs_refresh()` returns if a buffer list refresh is needed on that commit.