### PR TITLE
We can't safely destroy objects whose implementation may lie in a .so that's been unloaded.

### DIFF
--- a/src/server/glib_main_loop_sources.cpp
+++ b/src/server/glib_main_loop_sources.cpp
@@ -190,6 +190,13 @@ void md::add_server_action_gsource(
         void const* const owner;
         std::function<void(void)> const action;
         std::function<bool(void const*)> const should_dispatch;
+
+        // If we come to finalize() before dispatch() we have already
+        // torn down most of Mir and even unloaded some shared libraries.
+        // That means the action could refer to  stuff that is no longer
+        // in the address space.
+        // We will just leak any resources instead of crashing.
+        bool mutable dispatched{false};
     };
 
     struct ServerActionGSource
@@ -215,13 +222,14 @@ void md::add_server_action_gsource(
         {
             auto const& ctx = reinterpret_cast<ServerActionGSource*>(source)->ctx;
             ctx.action();
+            ctx.dispatched = true;
             return FALSE;
         }
 
         static void finalize(GSource* source)
         {
             auto const sa_gsource = reinterpret_cast<ServerActionGSource*>(source);
-            if (sa_gsource->ctx_constructed)
+            if (sa_gsource->ctx_constructed && sa_gsource->ctx.dispatched)
                 sa_gsource->ctx.~ServerActionContext();
         }
     };


### PR DESCRIPTION
Fixes #327, #112