### PR TITLE
Input regions

### DIFF
--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -20,7 +20,8 @@ set(
   wl_pointer.cpp                wl_pointer.h
   wl_touch.cpp                  wl_touch.h
   xdg_shell_v6.cpp              xdg_shell_v6.h
-  deleted_for_resource.cpp       deleted_for_resource.h)
+  deleted_for_resource.cpp      deleted_for_resource.h
+  wl_region.cpp                 wl_region.h)
 
 add_library(
   mirfrontend-wayland OBJECT

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -25,6 +25,7 @@
 #include "wl_surface.h"
 #include "wl_seat.h"
 #include "xdg_shell_v6.h"
+#include "wl_region.h"
 
 #include "basic_surface_event_sink.h"
 #include "null_event_sink.h"
@@ -267,30 +268,9 @@ void WlCompositor::create_surface(wl_client* client, wl_resource* resource, uint
     new WlSurface{client, resource, id, executor, allocator};
 }
 
-class Region : public wayland::Region
-{
-public:
-    Region(wl_client* client, wl_resource* parent, uint32_t id)
-        : wayland::Region(client, parent, id)
-    {
-    }
-protected:
-
-    void destroy() override
-    {
-    }
-    void add(int32_t /*x*/, int32_t /*y*/, int32_t /*width*/, int32_t /*height*/) override
-    {
-    }
-    void subtract(int32_t /*x*/, int32_t /*y*/, int32_t /*width*/, int32_t /*height*/) override
-    {
-    }
-
-};
-
 void WlCompositor::create_region(wl_client* client, wl_resource* resource, uint32_t id)
 {
-    new Region{client, resource, id};
+    new WlRegion{client, resource, id};
 }
 
 class WlShellSurface  : public wayland::ShellSurface, public WlAbstractMirWindow

--- a/src/server/frontend_wayland/wl_region.cpp
+++ b/src/server/frontend_wayland/wl_region.cpp
@@ -20,6 +20,7 @@
 #include "wl_region.h"
 
 namespace mf = mir::frontend;
+namespace geom = mir::geometry;
 
 mf::WlRegion::WlRegion(struct wl_client* client, struct wl_resource* parent, uint32_t id)
     : wayland::Region(client, parent, id)
@@ -28,6 +29,17 @@ mf::WlRegion::WlRegion(struct wl_client* client, struct wl_resource* parent, uin
 mf::WlRegion::~WlRegion()
 {}
 
+std::vector<geom::Rectangle> mf::WlRegion::rectangle_vector()
+{
+    return rects;
+}
+
+mf::WlRegion* mf::WlRegion::from(wl_resource* resource)
+{
+    void* raw = wl_resource_get_user_data(resource);
+    return static_cast<WlRegion*>(static_cast<wayland::Region*>(raw));
+}
+
 void mf::WlRegion::destroy()
 {
     wl_resource_destroy(resource);
@@ -35,10 +47,7 @@ void mf::WlRegion::destroy()
 
 void mf::WlRegion::add(int32_t x, int32_t y, int32_t width, int32_t height)
 {
-    (void)x;
-    (void)y;
-    (void)width;
-    (void)height;
+    rects.push_back(geom::Rectangle{{x, y}, {width, height}});
 }
 
 void mf::WlRegion::subtract(int32_t x, int32_t y, int32_t width, int32_t height)
@@ -47,4 +56,5 @@ void mf::WlRegion::subtract(int32_t x, int32_t y, int32_t width, int32_t height)
     (void)y;
     (void)width;
     (void)height;
+    log_warning("WlRegion::subtract not implemented. ignoring.");
 }

--- a/src/server/frontend_wayland/wl_region.cpp
+++ b/src/server/frontend_wayland/wl_region.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by:
+ *   William Wold <william.wold@canonical.com>
+ */
+
+#include "wl_region.h"
+
+namespace mf = mir::frontend;
+
+mf::WlRegion::WlRegion(struct wl_client* client, struct wl_resource* parent, uint32_t id)
+    : wayland::Region(client, parent, id)
+{}
+
+mf::WlRegion::~WlRegion()
+{}
+
+void mf::WlRegion::destroy()
+{
+    wl_resource_destroy(resource);
+}
+
+void mf::WlRegion::add(int32_t x, int32_t y, int32_t width, int32_t height)
+{
+    (void)x;
+    (void)y;
+    (void)width;
+    (void)height;
+}
+
+void mf::WlRegion::subtract(int32_t x, int32_t y, int32_t width, int32_t height)
+{
+    (void)x;
+    (void)y;
+    (void)width;
+    (void)height;
+}

--- a/src/server/frontend_wayland/wl_region.h
+++ b/src/server/frontend_wayland/wl_region.h
@@ -22,6 +22,10 @@
 
 #include "generated/wayland_wrapper.h"
 
+#include "mir/geometry/rectangle.h"
+
+#include <vector>
+
 namespace mir
 {
 namespace frontend
@@ -33,10 +37,16 @@ public:
     WlRegion(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     ~WlRegion();
 
+    std::vector<geometry::Rectangle> rectangle_vector();
+
+    static WlRegion* from(wl_resource* resource);
+
 private:
     void destroy() override;
     void add(int32_t x, int32_t y, int32_t width, int32_t height) override;
     void subtract(int32_t x, int32_t y, int32_t width, int32_t height) override;
+
+    std::vector<geometry::Rectangle> rects;
 };
 
 }

--- a/src/server/frontend_wayland/wl_region.h
+++ b/src/server/frontend_wayland/wl_region.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by:
+ *   William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_FRONTEND_WL_REGION_H_
+#define MIR_FRONTEND_WL_REGION_H_
+
+#include "generated/wayland_wrapper.h"
+
+namespace mir
+{
+namespace frontend
+{
+
+class WlRegion: wayland::Region
+{
+public:
+    WlRegion(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    ~WlRegion();
+
+private:
+    void destroy() override;
+    void add(int32_t x, int32_t y, int32_t width, int32_t height) override;
+    void subtract(int32_t x, int32_t y, int32_t width, int32_t height) override;
+};
+
+}
+}
+
+#endif // MIR_FRONTEND_WL_REGION_H_

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -60,9 +60,10 @@ mf::WlSubsurface::~WlSubsurface()
 }
 
 void mf::WlSubsurface::populate_surface_data(std::vector<shell::StreamSpecification>& buffer_streams,
+                                             std::vector<mir::geometry::Rectangle>& input_shape_accumulator,
                                              geometry::Displacement const& parent_offset) const
 {
-    surface->populate_surface_data(buffer_streams, parent_offset);
+    surface->populate_surface_data(buffer_streams, input_shape_accumulator, parent_offset);
 }
 
 bool mf::WlSubsurface::synchronized() const

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -17,8 +17,9 @@
  */
 
 #include "wl_subcompositor.h"
-
 #include "wl_surface.h"
+
+#include "mir/geometry/rectangle.h"
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -57,6 +57,7 @@ public:
     ~WlSubsurface();
 
     void populate_surface_data(std::vector<shell::StreamSpecification>& buffer_streams,
+                               std::vector<mir::geometry::Rectangle>& input_shape_accumulator,
                                geometry::Displacement const& parent_offset) const;
 
     bool synchronized() const override;

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -144,18 +144,19 @@ void mf::WlSurface::populate_surface_data(std::vector<shell::StreamSpecification
 {
     geometry::Displacement offset = parent_offset + offset_;
     buffer_streams.push_back({stream_id, offset, {}});
+    geom::Rectangle surface_rect = {geom::Point{} + offset, buffer_size_};
     if (input_shape)
     {
         for (auto rect : input_shape.value())
         {
             rect.top_left = rect.top_left + offset;
+            rect = rect.intersection_with(surface_rect); // clip to surface
             input_shape_accumulator.push_back(rect);
         }
     }
     else
     {
-        // TODO: make fill the whole surface
-        log_warning("WlSurface has empty input shape");
+        input_shape_accumulator.push_back(surface_rect);
     }
     for (WlSubsurface* subsurface : children)
     {

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -239,29 +239,14 @@ void mf::WlSurface::set_input_region(std::experimental::optional<wl_resource*> c
 {
     if (region)
     {
-        // On Ubuntu 17.10 and later, the following two statements do the same thing.
-        // The former fails to compile on Ubuntu 16.04.
-
-        // pending.input_shape = WlRegion::from(region.value())->rectangle_vector();
-
-        pending.input_shape =
-            std::experimental::optional<std::experimental::optional<std::vector<geom::Rectangle>>>{
-                std::experimental::optional<std::vector<geom::Rectangle>>{
-                    WlRegion::from(region.value())->rectangle_vector()}};
+        // since pending.input_shape is an optional optional, this is needed
+        auto shape = WlRegion::from(region.value())->rectangle_vector();
+        pending.input_shape = decltype(pending.input_shape)::value_type{move(shape)};
     }
     else
     {
-        // set the inner optional to nullopt to indicate the input region should be updated to null
-
-        // On Ubuntu 17.10 and later, the following two statements do the same thing.
-        // The former fails to compile on Ubuntu 16.04.
-
-        // pending.input_shape = {std::experimental::nullopt};
-
-        pending.input_shape =
-            std::experimental::optional<std::experimental::optional<std::vector<geom::Rectangle>>>{
-                std::experimental::optional<std::vector<geom::Rectangle>>{
-                    std::experimental::nullopt}};
+        // set the inner optional to nullopt to indicate the input region should be updated, but with a null region
+        pending.input_shape = decltype(pending.input_shape)::value_type{};
     }
 }
 

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -239,11 +239,29 @@ void mf::WlSurface::set_input_region(std::experimental::optional<wl_resource*> c
 {
     if (region)
     {
-        pending.input_shape = WlRegion::from(region.value())->rectangle_vector();
+        // On Ubuntu 17.10 and later, the following two statements do the same thing.
+        // The former fails to compile on Ubuntu 16.04.
+
+        // pending.input_shape = WlRegion::from(region.value())->rectangle_vector();
+
+        pending.input_shape =
+            std::experimental::optional<std::experimental::optional<std::vector<geom::Rectangle>>>{
+                std::experimental::optional<std::vector<geom::Rectangle>>{
+                    WlRegion::from(region.value())->rectangle_vector()}};
     }
     else
     {
-        pending.input_shape = {std::experimental::nullopt};
+        // set the inner optional to nullopt to indicate the input region should be updated to null
+
+        // On Ubuntu 17.10 and later, the following two statements do the same thing.
+        // The former fails to compile on Ubuntu 16.04.
+
+        // pending.input_shape = {std::experimental::nullopt};
+
+        pending.input_shape =
+            std::experimental::optional<std::experimental::optional<std::vector<geom::Rectangle>>>{
+                std::experimental::optional<std::vector<geom::Rectangle>>{
+                    std::experimental::nullopt}};
     }
 }
 

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -44,6 +44,9 @@ void mf::WlSurfaceState::update_from(WlSurfaceState const& source)
     if (source.offset)
         offset = source.offset;
 
+    if (source.input_shape)
+        input_shape = source.input_shape;
+
     frame_callbacks.insert(end(frame_callbacks),
                            begin(source.frame_callbacks),
                            end(source.frame_callbacks));
@@ -55,6 +58,7 @@ void mf::WlSurfaceState::update_from(WlSurfaceState const& source)
 bool mf::WlSurfaceState::surface_data_needs_refresh() const
 {
     return offset ||
+           input_shape ||
            surface_data_invalidated;
 }
 

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -66,7 +66,7 @@ struct WlSurfaceState
     // if you add variables, don't forget to update this
     void update_from(WlSurfaceState const& source);
 
-    void invalidate_surface_data() { surface_data_invalidated = true; }
+    void invalidate_surface_data() const { surface_data_invalidated = true; }
 
     bool surface_data_needs_refresh() const;
 
@@ -82,7 +82,9 @@ struct WlSurfaceState
 private:
     // only set to true if invalidate_surface_data() is called
     // surface_data_needs_refresh() returns true if this is true, or if other things are changed which mandate a refresh
-    bool surface_data_invalidated{false};
+    // is marked mutable so invalidate_surface_data() can be const and be called from a const reference
+    // (this is the only thing we need to modify from the const reference)
+    bool mutable surface_data_invalidated{false};
 };
 
 class NullWlSurfaceRole : public WlSurfaceRole

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -76,7 +76,7 @@ struct WlSurfaceState
     std::experimental::optional<wl_resource*> buffer;
 
     std::experimental::optional<geometry::Displacement> offset;
-    std::experimental::optional<std::vector<geometry::Rectangle>> input_shape;
+    std::experimental::optional<std::experimental::optional<std::vector<geometry::Rectangle>>> input_shape;
     std::vector<Callback> frame_callbacks;
 
 private:
@@ -126,6 +126,7 @@ public:
     void refresh_surface_data_now();
     void pending_invalidate_surface_data() { pending.invalidate_surface_data(); }
     void populate_surface_data(std::vector<shell::StreamSpecification>& buffer_streams,
+                               std::vector<mir::geometry::Rectangle>& input_shape_accumulator,
                                geometry::Displacement const& parent_offset) const;
     void commit(WlSurfaceState const& state);
 
@@ -147,6 +148,7 @@ private:
     geometry::Displacement offset_;
     geometry::Size buffer_size_;
     std::vector<WlSurfaceState::Callback> frame_callbacks;
+    std::experimental::optional<std::vector<mir::geometry::Rectangle>> input_shape;
     std::shared_ptr<bool> const destroyed;
 
     void send_frame_callbacks();

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -44,6 +44,10 @@ namespace shell
 {
 struct StreamSpecification;
 }
+namespace geometry
+{
+class Rectangle;
+}
 
 namespace frontend
 {
@@ -72,6 +76,7 @@ struct WlSurfaceState
     std::experimental::optional<wl_resource*> buffer;
 
     std::experimental::optional<geometry::Displacement> offset;
+    std::experimental::optional<std::vector<geometry::Rectangle>> input_shape;
     std::vector<Callback> frame_callbacks;
 
 private:

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -113,7 +113,7 @@ public:
 
     std::shared_ptr<bool> destroyed_flag() const { return destroyed; }
     geometry::Displacement offset() const { return offset_; }
-    geometry::Size buffer_size() const { return buffer_size_; }
+    geometry::Size buffer_size() const { return buffer_size_.value_or(geometry::Size{}); }
     bool synchronized() const;
     std::pair<geometry::Point, wl_resource*> transform_point(geometry::Point point) const;
     wl_resource* raw_resource() { return resource; }
@@ -146,7 +146,7 @@ private:
 
     WlSurfaceState pending;
     geometry::Displacement offset_;
-    geometry::Size buffer_size_;
+    std::experimental::optional<geometry::Size> buffer_size_;
     std::vector<WlSurfaceState::Callback> frame_callbacks;
     std::experimental::optional<std::vector<mir::geometry::Rectangle>> input_shape;
     std::shared_ptr<bool> const destroyed;

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -31,6 +31,8 @@
 #include "mir/scene/surface.h"
 #include "mir/scene/surface_creation_parameters.h"
 
+namespace geom = mir::geometry;
+
 void mir::frontend::WlAbstractMirWindow::set_maximized()
 {
     // We must process this request immediately (i.e. don't defer until commit())
@@ -117,12 +119,18 @@ WlAbstractMirWindow::~WlAbstractMirWindow()
     }
 }
 
+void WlAbstractMirWindow::populate_spec_with_surface_data(shell::SurfaceSpecification& spec)
+{
+    spec.streams = std::vector<shell::StreamSpecification>();
+    spec.input_shape = std::vector<geom::Rectangle>();
+    surface->populate_surface_data(spec.streams.value(), spec.input_shape.value(), {});
+}
+
 void WlAbstractMirWindow::refresh_surface_data_now()
 {
-    shell::SurfaceSpecification buffer_list_spec;
-    buffer_list_spec.streams = std::vector<shell::StreamSpecification>();
-    surface->populate_surface_data(buffer_list_spec.streams.value(), {});
-    shell->modify_surface(get_session(client), surface_id_, buffer_list_spec);
+    shell::SurfaceSpecification surface_data_spec;
+    populate_spec_with_surface_data(surface_data_spec);
+    shell->modify_surface(get_session(client), surface_id_, surface_data_spec);
 }
 
 shell::SurfaceSpecification& WlAbstractMirWindow::spec()
@@ -154,15 +162,7 @@ void WlAbstractMirWindow::commit(WlSurfaceState const& state)
 
         if (state.surface_data_needs_refresh())
         {
-            auto& buffer_list_spec = spec();
-            buffer_list_spec.streams = std::vector<shell::StreamSpecification>();
-            surface->populate_surface_data(buffer_list_spec.streams.value(), {});
-        }
-
-        if (state.input_shape)
-        {
-            auto& input_shape_spec = spec();
-            input_shape_spec.input_shape = move(state.input_shape.value());
+            populate_spec_with_surface_data(spec());
         }
 
         if (pending_changes)
@@ -185,7 +185,8 @@ void WlAbstractMirWindow::create_mir_window()
         params->size = geometry::Size{640, 480};
 
     params->streams = std::vector<shell::StreamSpecification>{};
-    surface->populate_surface_data(params->streams.value(), {});
+    params->input_shape = std::vector<geom::Rectangle>{};
+    surface->populate_surface_data(params->streams.value(), params->input_shape.value(), {});
 
     surface_id_ = shell->create_surface(session, *params, sink);
 

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -159,6 +159,12 @@ void WlAbstractMirWindow::commit(WlSurfaceState const& state)
             surface->populate_surface_data(buffer_list_spec.streams.value(), {});
         }
 
+        if (state.input_shape)
+        {
+            auto& input_shape_spec = spec();
+            input_shape_spec.input_shape = move(state.input_shape.value());
+        }
+
         if (pending_changes)
             shell->modify_surface(session, surface_id_, *pending_changes);
 

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -72,6 +72,7 @@ public:
 
     SurfaceId surface_id() const override { return surface_id_; };
 
+    void populate_spec_with_surface_data(shell::SurfaceSpecification& spec);
     void refresh_surface_data_now() override;
 
     void set_maximized();

--- a/tests/mir_test_framework/canonical_window_manager.cpp
+++ b/tests/mir_test_framework/canonical_window_manager.cpp
@@ -388,7 +388,7 @@ void msh::CanonicalWindowManagerPolicy::handle_modify_surface(
             false,
             display_area);
 
-        apply_resize(surface, top_left, new_size);
+        surface->resize(new_size);
     }
 
     if (modifications.input_shape.is_set())
@@ -402,6 +402,11 @@ void msh::CanonicalWindowManagerPolicy::handle_modify_surface(
             rect.top_left = rect.top_left - displacement;
         }
         surface->set_input_region(rectangles);
+    }
+
+    if (modifications.width.is_set() || modifications.height.is_set())
+    {
+        move_tree(surface, {});
     }
 
     if (modifications.state.is_set())


### PR DESCRIPTION
Added support for Wayland supplied input regions. They are stored as a vector of rectangles both in `WlSurface` and (since input region is double buffered) in WlSurfaceState`. They are stored relative to the wayland surface (`offset` must be added to them to make them relative to the logical Mir window). They are accessed by the `WlAbstractMirWindow` by `populate_surface_data()`.

The most noticeable effect of this PR is that GTK windows are now resizable. Also, it's needed for subsurface input.