### PR TITLE
Send frame notifications even if there is no buffer

### DIFF
--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -141,8 +141,10 @@ private:
     WlSurfaceState pending;
     geometry::Displacement offset_;
     geometry::Size buffer_size_;
-    std::shared_ptr<std::vector<WlSurfaceState::Callback>> const pending_frames;
+    std::vector<WlSurfaceState::Callback> frame_callbacks;
     std::shared_ptr<bool> const destroyed;
+
+    void send_frame_callbacks();
 
     void destroy() override;
     void attach(std::experimental::optional<wl_resource*> const& buffer, int32_t x, int32_t y) override;


### PR DESCRIPTION
* The frame notifications are copied by value into the lamda now, and there is no need to hold them in the surface. (Does this screw stuff up? Was there a reason we were maintaining a list in the surface before, or was that legacy?)
* Frame notifications are now sent even if there is no buffer or if the buffer is null (this is consistent with Weston)

This fixes the gedit lockup when subsurfaces are dismissed.