### PR TITLE
Correct the glm matrix used for software cursor transformation (Fixes #322)

### DIFF
--- a/src/server/graphics/software_cursor.cpp
+++ b/src/server/graphics/software_cursor.cpp
@@ -93,7 +93,7 @@ public:
 
     glm::mat4 transformation() const override
     {
-        return glm::mat4();
+        return glm::mat4(1);
     }
 
     bool shaped() const override


### PR DESCRIPTION
Correct the glm matrix used for software cursor transformation (Fixes #322)