### PR TITLE
Give more threads useful names

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -45,6 +45,7 @@
 #include "mir/frontend/session.h"
 #include "mir/scene/surface_creation_parameters.h"
 #include "mir/scene/surface.h"
+#include <mir/thread_name.h>
 
 #include "mir/graphics/buffer_properties.h"
 #include "mir/graphics/buffer.h"
@@ -687,7 +688,13 @@ mf::WaylandConnector::~WaylandConnector()
 
 void mf::WaylandConnector::start()
 {
-    dispatch_thread = std::thread{wl_display_run, display.get()};
+    dispatch_thread = std::thread{
+        [](wl_display* d)
+        {
+            mir::set_thread_name("Mir/Wayland");
+            wl_display_run(d);
+        },
+        display.get()};
 }
 
 void mf::WaylandConnector::stop()

--- a/tests/mir_test_framework/async_server_runner.cpp
+++ b/tests/mir_test_framework/async_server_runner.cpp
@@ -24,6 +24,7 @@
 #include "mir/main_loop.h"
 #include "mir/geometry/rectangle.h"
 #include "mir/options/option.h"
+#include <mir/thread_name.h>
 #include "mir/test/doubles/null_logger.h"
 #include <miral/set_window_management_policy.h>
 #include <mir/shell/canonical_window_manager.h>
@@ -112,6 +113,7 @@ void mtf::AsyncServerRunner::start_server()
         {
             try
             {
+                mir::set_thread_name("mtf/AsyncServer");
                 server.run();
             }
             catch (std::exception const& e)


### PR DESCRIPTION
I had many threads called "mir_wlcs_tests." this makes it easier to follow