### PR TITLE
Disconnect a sink when its target window is destroyed

### DIFF
--- a/src/server/frontend_wayland/basic_surface_event_sink.h
+++ b/src/server/frontend_wayland/basic_surface_event_sink.h
@@ -69,6 +69,8 @@ public:
         return current_state;
     }
 
+    void disconnect() { *destroyed = true; }
+
 protected:
     WlSeat* const seat;
     wl_client* const client;

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -107,6 +107,7 @@ WlAbstractMirWindow::WlAbstractMirWindow(WlSeat* seat, wl_client* client, WlSurf
 
 WlAbstractMirWindow::~WlAbstractMirWindow()
 {
+    sink->disconnect();
     *destroyed = true;
     if (surface_id_.as_value())
     {


### PR DESCRIPTION
Disconnect a sink when its target window is destroyed (Fixes #357)