### PR TITLE
Ensure ExternalInputDeviceHub::remove_observer() synchronizes memory across threads

### DIFF
--- a/src/server/glib_main_loop_sources.cpp
+++ b/src/server/glib_main_loop_sources.cpp
@@ -161,10 +161,11 @@ void md::add_idle_gsource(
         static gboolean static_call(IdleContext* ctx)
         {
             ctx->callback();
+            ctx->callback = []{};
             return G_SOURCE_REMOVE;
         }
-        static void static_destroy(IdleContext* ctx) { delete ctx; }
-        std::function<void()> const callback;
+        static void static_destroy(IdleContext* ctx) { ctx->callback(); delete ctx; }
+        std::function<void()> callback;
     };
 
     GSourceRef gsource{g_idle_source_new()};

--- a/src/server/glib_main_loop_sources.cpp
+++ b/src/server/glib_main_loop_sources.cpp
@@ -161,11 +161,10 @@ void md::add_idle_gsource(
         static gboolean static_call(IdleContext* ctx)
         {
             ctx->callback();
-            ctx->callback = []{};
             return G_SOURCE_REMOVE;
         }
-        static void static_destroy(IdleContext* ctx) { ctx->callback(); delete ctx; }
-        std::function<void()> callback;
+        static void static_destroy(IdleContext* ctx) { delete ctx; }
+        std::function<void()> const callback;
     };
 
     GSourceRef gsource{g_idle_source_new()};

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -88,8 +88,9 @@ void mi::ExternalInputDeviceHub::remove_observer(std::weak_ptr<InputDeviceObserv
     auto observer = obs.lock();
     if (observer)
     {
+        std::mutex mutex;
         std::condition_variable cv;
-        std::atomic<bool> removed{false};
+        bool removed{false};
 
         data->observer_queue->enqueue_with_guaranteed_execution(
             [&,this]
@@ -97,17 +98,15 @@ void mi::ExternalInputDeviceHub::remove_observer(std::weak_ptr<InputDeviceObserv
                 // Unless remove() is on the same thread as add() external synchronization would be needed
                 data->observers.remove(observer);
 
-                // We do *not* take a lock and instead rely on removed being atomic,
-                // as enqueue_with_guaranteed_execution may run on our stack.
+                std::lock_guard<decltype(mutex)> lock{mutex};
                 removed = true;
                 cv.notify_one();
             });
 
-        std::mutex mutex;
         std::unique_lock<decltype(mutex)> lock{mutex};
 
         // Before returning wait for the remove - otherwise notifications can still happen
-        cv.wait(lock, [&] { return removed.load(); });
+        cv.wait(lock, [&] { return removed; });
     }
 }
 


### PR DESCRIPTION
Ensure ExternalInputDeviceHub::remove_observer() synchronizes memory across threads. (Fixes #359)