### PR TITLE
GLibMainLoop extensions

### DIFF
--- a/include/server/mir/main_loop.h
+++ b/include/server/mir/main_loop.h
@@ -36,6 +36,7 @@ class MainLoop :
 public:
     virtual void run() = 0;
     virtual void stop() = 0;
+    virtual bool running() const = 0;
 };
 
 }

--- a/src/include/server/mir/glib_main_loop.h
+++ b/src/include/server/mir/glib_main_loop.h
@@ -93,6 +93,10 @@ public:
 
     void reprocess_all_sources();
 
+    /**
+     * Make the GLibMainLoop's GMainContext the thread-default context
+     */
+    void run_with_context_as_thread_default(std::function<void()> const& code);
 private:
     bool should_process_actions_for(void const* owner);
     void handle_exception(std::exception_ptr const& e);

--- a/src/include/server/mir/glib_main_loop.h
+++ b/src/include/server/mir/glib_main_loop.h
@@ -55,6 +55,7 @@ public:
 
     void run() override;
     void stop() override;
+    bool running() const override;
 
     void register_signal_handler(
         std::initializer_list<int> signals,
@@ -98,7 +99,7 @@ private:
 
     std::shared_ptr<time::Clock> const clock;
     detail::GMainContextHandle const main_context;
-    std::atomic<bool> running;
+    std::atomic<bool> running_;
     detail::FdSources fd_sources;
     detail::SignalSources signal_sources;
     std::mutex do_not_process_mutex;

--- a/src/server/glib_main_loop.cpp
+++ b/src/server/glib_main_loop.cpp
@@ -26,6 +26,7 @@
 #include <condition_variable>
 
 #include <boost/throw_exception.hpp>
+#include <future>
 
 namespace
 {
@@ -286,10 +287,11 @@ void mir::GLibMainLoop::enqueue_with_guaranteed_execution(mir::ServerAction cons
         };
 
     {
-        std::lock_guard<std::mutex> lock{run_on_halt_mutex};
+        std::unique_lock<std::mutex> lock{run_on_halt_mutex};
 
         if (!running_)
         {
+            lock.unlock();
             action();
             return;
         }
@@ -392,6 +394,55 @@ void mir::GLibMainLoop::reprocess_all_sources()
 
     std::unique_lock<std::mutex> reprocessed_lock{reprocessed_mutex};
     reprocessed_cv.wait(reprocessed_lock, [&] { return reprocessed == true; });
+}
+
+void mir::GLibMainLoop::run_with_context_as_thread_default(std::function<void()> const& code)
+{
+    auto promise = std::make_shared<std::promise<void>>();
+    auto done = promise->get_future();
+
+    enqueue_with_guaranteed_execution(
+        [this, promise, &code]()
+        {
+            /*
+             * There are three possible states here:
+             * 1)   We've been dispatched from the main loop; the thread already owns main_context,
+             *      so we can acquire it.
+             * 2)   The main loop is not running, so we've been immediately dispatched from the calling
+             *      thread. The main loop is not running, so we can successfully acquire main_context
+             *      immediately.
+             * 3)   The main loop *is* running, but is currently processing a stop() request.
+             *      In this case, we've been immediately dispatched from the calling thread, but
+             *      cannot acquire main_context until stop() has completed.
+             *
+             *      There *is* a GLib API that would be helpful here; g_main_context_wait().
+             *      however, that is (silently) deprecated, and spews a GLib-CRITICAL warning
+             *      if you use it.
+             *
+             *      This case is unlikely, and is should be rapidly transient, so just busy-wait :(
+             */
+            {
+                std::lock_guard<std::mutex> lock{run_on_halt_mutex};
+                while (!g_main_context_acquire(main_context))
+                    std::this_thread::yield();
+            }
+
+            // We now own the main_context, so this will work.
+            g_main_context_push_thread_default(main_context);
+            try
+            {
+                code();
+                promise->set_value();
+            }
+            catch(...)
+            {
+                promise->set_exception(std::current_exception());
+            }
+            g_main_context_pop_thread_default(main_context);
+            g_main_context_release(main_context);
+        });
+
+    done.get();
 }
 
 void mir::GLibMainLoop::handle_exception(std::exception_ptr const& e)

--- a/tests/include/mir/test/doubles/mock_main_loop.h
+++ b/tests/include/mir/test/doubles/mock_main_loop.h
@@ -37,6 +37,7 @@ public:
 
     void run() override {}
     void stop() override {}
+    bool running() const override { return true; }
 
     MOCK_METHOD2(register_signal_handler,
                  void(std::initializer_list<int>,

--- a/tests/unit-tests/test_glib_main_loop.cpp
+++ b/tests/unit-tests/test_glib_main_loop.cpp
@@ -1476,6 +1476,128 @@ TEST_F(GLibMainLoopTest, running_returns_false_after_stopping)
     EXPECT_FALSE(ml.running());
 }
 
+TEST_F(GLibMainLoopTest, run_with_context_as_thread_default_works_before_ml_is_started)
+{
+    using namespace testing;
+    using namespace std::literals::chrono_literals;
+
+    auto thread_context = std::unique_ptr<GMainContext, decltype(&g_main_context_unref)>{
+        g_main_context_new(),
+        &g_main_context_unref};
+
+    // Ensure that *this* thread's default context is known.
+    g_main_context_push_thread_default(thread_context.get());
+
+    auto callback_run = std::make_shared<mt::Signal>();
+    ml.run_with_context_as_thread_default(
+        [callback_run]()
+        {
+            auto idle_callback = g_idle_source_new();
+            g_source_set_callback(
+                idle_callback,
+                [](gpointer ctx) -> gboolean
+                {
+                    static_cast<mt::Signal*>(ctx)->raise();
+                    return false;
+                },
+                callback_run.get(),
+                nullptr);
+            g_source_attach(
+                idle_callback,
+                g_main_context_get_thread_default());
+        });
+
+    // Dispatch anything that has been mistakenly attached to the GMainContext we constructed.
+    while (g_main_context_iteration(thread_context.get(), false))
+        ;
+
+    // Our callback should *not* have been run, as we're not running the mainloop.
+    EXPECT_FALSE(callback_run->raised());
+
+    UnblockMainLoop looper{ml};
+    // The main loop should now process the source we added
+    EXPECT_TRUE(callback_run->wait_for(30s));
+
+    g_main_context_pop_thread_default(thread_context.get());
+}
+
+TEST_F(GLibMainLoopTest, run_with_context_as_thread_default_works_when_ml_is_running)
+{
+    using namespace testing;
+    using namespace std::literals::chrono_literals;
+
+    UnblockMainLoop unblock{ml};
+
+    auto started = std::make_shared<mt::Signal>();
+    ml.spawn(
+        [started]()
+        {
+            started->raise();
+        });
+
+    ASSERT_TRUE(started->wait_for(30s));
+
+    auto thread_context = std::unique_ptr<GMainContext, decltype(&g_main_context_unref)>{
+        g_main_context_new(),
+        &g_main_context_unref};
+
+    // Ensure that *this* thread's default context is known.
+    g_main_context_push_thread_default(thread_context.get());
+
+    auto callback_run = std::make_shared<mt::Signal>();
+    ml.run_with_context_as_thread_default(
+        [callback_run]()
+        {
+            auto idle_callback = g_idle_source_new();
+            g_source_set_callback(
+                idle_callback,
+                [](gpointer ctx) -> gboolean
+                {
+                    static_cast<mt::Signal*>(ctx)->raise();
+                    return false;
+                },
+                callback_run.get(),
+                nullptr);
+            g_source_attach(
+                idle_callback,
+                g_main_context_get_thread_default());
+        });
+
+    // We shouldn't have anything on the thread_context...
+    EXPECT_FALSE(g_main_context_pending(thread_context.get()));
+
+    // ...and the main loop should get around to running our callback soon.
+    EXPECT_TRUE(callback_run->wait_for(30s));
+
+    g_main_context_pop_thread_default(thread_context.get());
+}
+
+TEST_F(GLibMainLoopTest, run_with_context_as_thread_default_handles_exceptions)
+{
+    using namespace testing;
+    using namespace std::literals::chrono_literals;
+
+    // Without a running loop
+    EXPECT_THROW(
+        ml.run_with_context_as_thread_default([]() { throw std::logic_error{"Hello!"}; }),
+        std::logic_error);
+
+    UnblockMainLoop unblock{ml};
+
+    auto started = std::make_shared<mt::Signal>();
+    ml.spawn(
+        [started]()
+        {
+            started->raise();
+        });
+
+    ASSERT_TRUE(started->wait_for(30s));
+
+    EXPECT_THROW(
+        ml.run_with_context_as_thread_default([]() { throw std::out_of_range{"Hello!"}; }),
+        std::out_of_range);
+}
+
 // This test recreates a scenario we get in our integration and acceptance test
 // runs, and which creates problems for the default glib signal source. The
 // scenario involves creating, running (with signal handling) and destroying


### PR DESCRIPTION
This adds a couple of new APIs to GLibMainLoop:
 * `bool GLibMainLoop::running()`, which returns whether or not the main loop is active, and
 * `run_with_context_as_thread_default()`, which runs the supplied functor with GLibMainLoop's `GMainContext*` as the thread-default main context.

These are useful for integrating with various GIO components, such as GDBus, which use the thread-default main loop for dispatch.