### PR TITLE
Don't install the mir_performance_tests "wrapper" before installing the real executable

### DIFF
--- a/tests/performance-tests/CMakeLists.txt
+++ b/tests/performance-tests/CMakeLists.txt
@@ -1,7 +1,3 @@
-install(PROGRAMS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir_performance_tests
-  DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-
 mir_add_wrapped_executable(mir_performance_tests
     test_glmark2-es2-mir.cpp
     test_compositor.cpp


### PR DESCRIPTION
The mir_add_wrapped_executable() function provides the correct install() invocation, luckily it overwrites the incorrect binary. But we shouldn't need luck.