### PR TITLE
Defer initializing DefaultServerConfiguration::reports until any subclasses have been fully constructed. (Fixes #361)

### DIFF
--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -459,7 +459,16 @@ private:
         seat_observer_multiplexer;
     CachedPtr<ObserverMultiplexer<frontend::SessionMediatorObserver>>
         session_mediator_observer_multiplexer;
-    std::shared_ptr<report::Reports> const reports;
+
+    // We should to defer initializing reports until any subclasses have been
+    // fully constructed as that allows them to configure the reporting and/or
+    // logging options.
+    // So we initializing reports in the_options() which will certainly be
+    // called before starting the server. The only tricky bit is that the_options()
+    // is called when initializing reports. Hence we need a flag to avoid endless
+    // recursion.
+    bool mutable the_options_has_been_called{false};
+    std::shared_ptr<report::Reports> mutable reports;
 
     virtual std::string the_socket_file() const;
 
@@ -470,7 +479,7 @@ private:
     std::shared_ptr<scene::BroadcastingSessionEventSink> the_broadcasting_session_event_sink();
 
     auto report_factory(char const* report_opt) -> std::unique_ptr<report::ReportFactory>;
-    auto initialise_reports() -> std::shared_ptr<report::Reports>;
+    auto initialise_reports() const -> std::shared_ptr<report::Reports>;
 
     CachedPtr<shell::detail::FrontendShell> frontend_shell;
     std::vector<mir::ExtensionDescription> the_extensions();

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -159,7 +159,6 @@ class Configuration;
 namespace report
 {
 class ReportFactory;
-class Reports;
 }
 
 namespace renderer
@@ -346,6 +345,7 @@ public:
     virtual std::shared_ptr<SharedLibraryProberReport>  the_shared_library_prober_report();
 
     virtual std::shared_ptr<ConsoleServices> the_console_services();
+    auto default_reports() -> std::shared_ptr<void>;
 
 private:
     // We need to ensure the platform library is destroyed last as the
@@ -460,16 +460,6 @@ private:
     CachedPtr<ObserverMultiplexer<frontend::SessionMediatorObserver>>
         session_mediator_observer_multiplexer;
 
-    // We should to defer initializing reports until any subclasses have been
-    // fully constructed as that allows them to configure the reporting and/or
-    // logging options.
-    // So we initializing reports in the_options() which will certainly be
-    // called before starting the server. The only tricky bit is that the_options()
-    // is called when initializing reports. Hence we need a flag to avoid endless
-    // recursion.
-    bool mutable the_options_has_been_called{false};
-    std::shared_ptr<report::Reports> mutable reports;
-
     virtual std::string the_socket_file() const;
 
     // The following caches and factory functions are internal to the
@@ -479,7 +469,6 @@ private:
     std::shared_ptr<scene::BroadcastingSessionEventSink> the_broadcasting_session_event_sink();
 
     auto report_factory(char const* report_opt) -> std::unique_ptr<report::ReportFactory>;
-    auto initialise_reports() const -> std::shared_ptr<report::Reports>;
 
     CachedPtr<shell::detail::FrontendShell> frontend_shell;
     std::vector<mir::ExtensionDescription> the_extensions();

--- a/src/server/default_server_configuration.cpp
+++ b/src/server/default_server_configuration.cpp
@@ -77,11 +77,6 @@ mir::DefaultServerConfiguration::DefaultServerConfiguration(std::shared_ptr<mo::
 auto mir::DefaultServerConfiguration::the_options() const
 ->std::shared_ptr<options::Option>
 {
-    if (!the_options_has_been_called)
-    {
-        the_options_has_been_called = true;
-        reports = initialise_reports();
-    }
     return configuration_options->the_options();
 }
 

--- a/src/server/default_server_configuration.cpp
+++ b/src/server/default_server_configuration.cpp
@@ -70,7 +70,6 @@ mir::DefaultServerConfiguration::DefaultServerConfiguration(int argc, char const
 mir::DefaultServerConfiguration::DefaultServerConfiguration(std::shared_ptr<mo::Configuration> const& configuration_options) :
     configuration_options(configuration_options),
     default_filter(std::make_shared<mi::VTFilter>())
-
 {
 }
 

--- a/src/server/default_server_configuration.cpp
+++ b/src/server/default_server_configuration.cpp
@@ -69,14 +69,19 @@ mir::DefaultServerConfiguration::DefaultServerConfiguration(int argc, char const
 
 mir::DefaultServerConfiguration::DefaultServerConfiguration(std::shared_ptr<mo::Configuration> const& configuration_options) :
     configuration_options(configuration_options),
-    default_filter(std::make_shared<mi::VTFilter>()),
-    reports{initialise_reports()}
+    default_filter(std::make_shared<mi::VTFilter>())
+
 {
 }
 
 auto mir::DefaultServerConfiguration::the_options() const
 ->std::shared_ptr<options::Option>
 {
+    if (!the_options_has_been_called)
+    {
+        the_options_has_been_called = true;
+        reports = initialise_reports();
+    }
     return configuration_options->the_options();
 }
 

--- a/src/server/report/default_server_configuration.cpp
+++ b/src/server/report/default_server_configuration.cpp
@@ -56,9 +56,9 @@ std::unique_ptr<mir::report::ReportFactory> mir::DefaultServerConfiguration::rep
     }
 }
 
-std::shared_ptr<mir::report::Reports> mir::DefaultServerConfiguration::initialise_reports() const
+std::shared_ptr<void> mir::DefaultServerConfiguration::default_reports()
 {
-    return std::make_unique<report::Reports>(const_cast<DefaultServerConfiguration&>(*this), *the_options());
+    return std::make_unique<report::Reports>(*this, *the_options());
 }
 
 auto mir::DefaultServerConfiguration::the_compositor_report() -> std::shared_ptr<mc::CompositorReport>

--- a/src/server/report/default_server_configuration.cpp
+++ b/src/server/report/default_server_configuration.cpp
@@ -56,9 +56,9 @@ std::unique_ptr<mir::report::ReportFactory> mir::DefaultServerConfiguration::rep
     }
 }
 
-std::shared_ptr<mir::report::Reports> mir::DefaultServerConfiguration::initialise_reports()
+std::shared_ptr<mir::report::Reports> mir::DefaultServerConfiguration::initialise_reports() const
 {
-    return std::make_unique<report::Reports>(*this, *the_options());
+    return std::make_unique<report::Reports>(const_cast<DefaultServerConfiguration&>(*this), *the_options());
 }
 
 auto mir::DefaultServerConfiguration::the_compositor_report() -> std::shared_ptr<mc::CompositorReport>

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -147,7 +147,6 @@ struct TemporaryCompositeEventFilter : public mi::CompositeEventFilter
 struct mir::Server::Self
 {
     bool exit_status{false};
-    std::weak_ptr<options::Option> options;
     std::string config_file;
     std::shared_ptr<ServerConfiguration> server_config;
 
@@ -346,7 +345,7 @@ void mir::Server::set_config_filename(std::string const& config_file)
 auto mir::Server::get_options() const -> std::shared_ptr<options::Option>
 {
     verify_accessing_allowed(self->server_config);
-    return self->options.lock();
+    return self->server_config->the_options();
 }
 
 void mir::Server::set_exception_handler(std::function<void()> const& exception_handler)
@@ -384,7 +383,6 @@ void mir::Server::apply_settings()
 
     auto const config = std::make_shared<ServerConfiguration>(options, self);
     self->server_config = config;
-    self->options = config->the_options();
 
     mir::logging::set_logger(config->the_logger());
 }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -397,6 +397,9 @@ void mir::Server::run()
         auto const emergency_cleanup = self->server_config->the_emergency_cleanup();
         auto const composite_event_filter = self->server_config->the_composite_event_filter();
 
+        // keep the default_reports alive while the server is running
+        auto const default_reports = self->server_config->default_reports();
+
         self->temporary_event_filter->move_filters(composite_event_filter);
 
         if (self->emergency_cleanup_handler)

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -942,5 +942,6 @@ MIR_SERVER_0.32 {
   extern "C++" {
     mir::Server::mir_socket_name*;
     mir::Server::wayland_display*;
+    mir::DefaultServerConfiguration::default_reports*;
   };
 } MIR_SERVER_0.31;

--- a/tests/mir_test_framework/server_runner.cpp
+++ b/tests/mir_test_framework/server_runner.cpp
@@ -103,6 +103,7 @@ std::shared_ptr<mir::MainLoop> mtf::ServerRunner::start_mir_server()
     bool started{false};
     auto const ml = server_config().the_main_loop();
     mir::logging::set_logger(server_config().the_logger());
+    auto const default_reports = server_config().default_reports();
 
     server_thread = std::thread([&]
     {

--- a/tests/mir_test_framework/server_runner.cpp
+++ b/tests/mir_test_framework/server_runner.cpp
@@ -103,12 +103,12 @@ std::shared_ptr<mir::MainLoop> mtf::ServerRunner::start_mir_server()
     bool started{false};
     auto const ml = server_config().the_main_loop();
     mir::logging::set_logger(server_config().the_logger());
-    auto const default_reports = server_config().default_reports();
 
     server_thread = std::thread([&]
     {
         try
         {
+            auto const default_reports = server_config().default_reports();
             mir::run_mir(server_config(), [&](mir::DisplayServer&)
             {
                 // By enqueuing the notification code in the main loop, we are


### PR DESCRIPTION
Defer initializing DefaultServerConfiguration::reports until any subclasses have been fully constructed. (Fixes #361)