### PR TITLE
Ignore the return value of write when outputting diagnostics. (Fixes #376)

### DIFF
--- a/tests/unit-tests/test_logind_console_services.cpp
+++ b/tests/unit-tests/test_logind_console_services.cpp
@@ -207,7 +207,7 @@ public:
             std::cout << "Messages from DBusMock: " << std::endl;
             while ((bytes_read = ::read(mock_stdout, buffer, sizeof(buffer))) > 0)
             {
-                ::write(STDOUT_FILENO, buffer, bytes_read);
+                (void)::write(STDOUT_FILENO, buffer, bytes_read);
             }
             if (bytes_read < 0)
             {


### PR DESCRIPTION
Ignore the return value of write when outputting diagnostics. (Fixes #376)