### PR TITLE
subsurfaces accept input in the correct order

### DIFF
--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -107,9 +107,10 @@ bool mf::WlSurface::synchronized() const
 std::experimental::optional<std::pair<geom::Point, mf::WlSurface*>> mf::WlSurface::transform_point(geom::Point point)
 {
     point = point - offset_;
-    for (auto child : children)
+    // loop backwards so the first subsurface we find that accepts the input is the topmost one
+    for (auto child_it = children.rbegin(); child_it != children.rend(); ++child_it)
     {
-        auto result = child->transform_point(point);
+        auto result = (*child_it)->transform_point(point);
         if (result)
             return result;
     }

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -146,7 +146,7 @@ private:
 
     NullWlSurfaceRole null_role;
     WlSurfaceRole* role;
-    std::vector<WlSubsurface*> children;
+    std::vector<WlSubsurface*> children; // ordering is from bottom to top
 
     WlSurfaceState pending;
     geometry::Displacement offset_;


### PR DESCRIPTION
Rendering was in the correct order, but input was bottom-to-top. This fixes that.