### PR TITLE
[miral-shell] Fix default font on Ubuntu 18.04 and Arch

### DIFF
--- a/examples/example-server-lib/titlebar_config.cpp
+++ b/examples/example-server-lib/titlebar_config.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Canonical Ltd.
+ * Copyright © 2016-2018 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -26,9 +26,11 @@ auto default_font() -> std::string
 {
     for (std::string const file : { "Ubuntu-B.ttf", "FreeSansBold.ttf" })
     {
-        for (auto const path : { "/usr/share/fonts/truetype/ubuntu-font-family/",   // Ubuntu Ubuntu-B.ttf
+        for (auto const path : { "/usr/share/fonts/truetype/ubuntu-font-family/",   // Ubuntu < 18.04 Ubuntu-B.ttf
+                                 "/usr/share/fonts/truetype/ubuntu/",               // Ubuntu >= 18.04 Ubuntu-B.ttf
                                  "/usr/share/fonts/truetype/freefont/",             // Debian FreeSansBold.ttf
-                                 "/usr/share/fonts/gnu-free/"})                     // Fedora FreeSansBold.ttf
+                                 "/usr/share/fonts/gnu-free/",                      // Fedora FreeSansBold.ttf
+                                 "/usr/share/fonts/TTF/"})                          // Arch Ubuntu-B.ttf
         {
             auto const full_path = path + file;
             if (access(full_path.c_str(), R_OK) == 0)
@@ -36,7 +38,7 @@ auto default_font() -> std::string
         }
     }
 
-    return "/usr/share/fonts/truetype/ubuntu-font-family/Ubuntu-B.ttf";
+    return "/usr/share/fonts/truetype/freefont/FreeSansBold.ttf";
 }
 
 std::mutex mutex;


### PR DESCRIPTION
Add a couple more places to look for font files.

Maybe we should stop with the special cases and emulate something like this?

```
find /usr/share/fonts/ -name Ubuntu-B.ttf -or -name FreeSansBold.ttf
```