### PR TITLE
Mock touch improvements

### DIFF
--- a/benchmarks/frame-uniformity/touch_producing_server.cpp
+++ b/benchmarks/frame-uniformity/touch_producing_server.cpp
@@ -67,17 +67,7 @@ std::shared_ptr<mg::Platform> TouchProducingServer::the_graphics_platform()
 
 void TouchProducingServer::synthesize_event_at(geom::Point const& point)
 {
-    auto const minimum_touch = mtf::FakeInputDevice::minimum_touch_axis_value;
-    auto const maximum_touch = mtf::FakeInputDevice::maximum_touch_axis_value;
-    auto const display_width = screen_dimensions.size.width.as_int();
-    auto const display_height = screen_dimensions.size.height.as_int();
-
-    auto px_frac = point.x.as_int() / static_cast<double>(display_width);
-    auto py_frac = point.y.as_int() / static_cast<double>(display_height);
-    auto const abs_touch_x = minimum_touch + (maximum_touch-minimum_touch) * px_frac;
-    auto const abs_touch_y = minimum_touch + (maximum_touch-minimum_touch) * py_frac;
-
-    touch_screen->emit_event(mis::a_touch_event().at_position({abs_touch_x, abs_touch_y}));
+    touch_screen->emit_event(mis::a_touch_event().at_position(point));
 }
 
 void TouchProducingServer::thread_function()

--- a/include/test/mir/test/event_factory.h
+++ b/include/test/mir/test/event_factory.h
@@ -96,11 +96,13 @@ public:
     TouchParameters& from_device(int device_id);
     TouchParameters& at_position(geometry::Point abs_pos);
     TouchParameters& with_action(Action touch_action);
-    
+    TouchParameters& with_event_time(std::chrono::nanoseconds time);
+
     int device_id;
     int abs_x;
     int abs_y;
     Action action;
+    std::experimental::optional<std::chrono::nanoseconds> event_time;
 };
 TouchParameters a_touch_event();
 

--- a/include/test/mir_test_framework/fake_input_device.h
+++ b/include/test/mir_test_framework/fake_input_device.h
@@ -39,15 +39,6 @@ namespace mir_test_framework
 class FakeInputDevice
 {
 public:
-    /**
-     * Valid value range of simulated touch coordinates. The simulated coordinates will be remapped to
-     * the coordinates of the given input sink.
-     * \{
-     */
-    static const int maximum_touch_axis_value = 0xFFFF;
-    static const int minimum_touch_axis_value = 0;
-    /// \}
-
     FakeInputDevice() = default;
     virtual ~FakeInputDevice() = default;
 

--- a/tests/integration-tests/test_touchspot_visualization.cpp
+++ b/tests/integration-tests/test_touchspot_visualization.cpp
@@ -44,9 +44,6 @@ namespace mtf = mir_test_framework;
 
 namespace
 {
-//TODO not yet configured at the input simulating device
-const auto minimum_touch = mtf::FakeInputDevice::minimum_touch_axis_value;
-const auto maximum_touch = mtf::FakeInputDevice::maximum_touch_axis_value;
 
 ACTION_P(UnblockBarrier, barrier)
 {
@@ -143,25 +140,14 @@ struct TestTouchspotVisualizations : mtf::DeferredInProcessServer
     }
 };
 
-geom::Point transform_to_screen_space(geom::Point in_touchpad_space)
-{
-    auto display_width = ServerConfiguration::display_bounds.size.width.as_uint32_t();
-    auto display_height = ServerConfiguration::display_bounds.size.height.as_uint32_t();
-    
-    float scale_x = float(display_width) / (maximum_touch - minimum_touch + 1);
-    float scale_y = float(display_height) / (maximum_touch - minimum_touch + 1);
-    
-    return {scale_x * in_touchpad_space.x.as_uint32_t(), scale_y * in_touchpad_space.y.as_uint32_t()};
-}
-
 }
 
 using namespace ::testing;
 
 TEST_F(TestTouchspotVisualizations, touch_is_given_to_touchspot_visualizer)
 {
-    static geom::Point abs_touch = { minimum_touch, minimum_touch };
-    static std::vector<geom::Point> expected_spots = { transform_to_screen_space(abs_touch) };
+    geom::Point const abs_touch{0, 0};
+    std::vector<geom::Point> const expected_spots{abs_touch};
 
     InSequence seq;
     // First we will see the spots cleared, as this is the start of a new gesture.
@@ -179,12 +165,12 @@ TEST_F(TestTouchspotVisualizations, touch_is_given_to_touchspot_visualizer)
 
 TEST_F(TestTouchspotVisualizations, touchspots_follow_gesture)
 {
-    static geom::Point abs_touch = { minimum_touch, minimum_touch };
-    static geom::Point abs_touch_2 = { maximum_touch, maximum_touch };
-    static std::vector<geom::Point> expected_spots_1 =
-       { transform_to_screen_space(abs_touch) };
-    static std::vector<geom::Point> expected_spots_2 = 
-       { transform_to_screen_space(abs_touch_2) };
+    auto const display_size{ServerConfiguration::display_bounds.size};
+    geom::Point const abs_touch{0, 0};
+    geom::Point const abs_touch_2{display_size.width.as_uint32_t() - 1,
+                                   display_size.height.as_uint32_t() - 1};
+    std::vector<geom::Point> expected_spots_1{abs_touch};
+    std::vector<geom::Point> expected_spots_2{abs_touch_2};
 
     InSequence seq;
 

--- a/tests/mir_test/event_factory.cpp
+++ b/tests/mir_test/event_factory.cpp
@@ -148,6 +148,12 @@ mis::TouchParameters& mis::TouchParameters::with_action(Action touch_action)
     return *this;
 }
 
+mis::TouchParameters& mis::TouchParameters::with_event_time(std::chrono::nanoseconds event_time)
+{
+    this->event_time = event_time;
+    return *this;
+}
+
 mis::TouchParameters mis::a_touch_event()
 {
     return mis::TouchParameters();

--- a/tests/mir_test_framework/fake_input_device_impl.cpp
+++ b/tests/mir_test_framework/fake_input_device_impl.cpp
@@ -222,8 +222,9 @@ void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::TouchPa
     if (!sink)
         BOOST_THROW_EXCEPTION(std::runtime_error("Device is not started."));
 
-    auto const event_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        std::chrono::steady_clock::now().time_since_epoch());
+    auto const event_time = touch.event_time.value_or(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch()));
 
     auto touch_action = mir_touch_action_up;
     if (touch.action == synthesis::TouchParameters::Action::Tap)

--- a/tests/mir_test_framework/fake_input_device_impl.cpp
+++ b/tests/mir_test_framework/fake_input_device_impl.cpp
@@ -317,14 +317,6 @@ void mtf::FakeInputDeviceImpl::InputDevice::apply_settings(mi::TouchscreenSettin
 void mtf::FakeInputDeviceImpl::InputDevice::map_touch_coordinates(float& x, float& y)
 {
     auto info = get_output_info();
-    auto touch_range = FakeInputDevice::maximum_touch_axis_value - FakeInputDevice::minimum_touch_axis_value + 1;
-    auto const width = info.output_size.width.as_int();
-    auto const height = info.output_size.height.as_int();
-    auto x_scale = width / float(touch_range);
-    auto y_scale = height / float(touch_range);
-    x = (x - float(FakeInputDevice::minimum_touch_axis_value))*x_scale;
-    y = (y - float(FakeInputDevice::minimum_touch_axis_value))*y_scale;
-
     info.transform_to_scene(x, y);
 }
 


### PR DESCRIPTION
Improvements to the mock touch class, including changing its input coordinates to be the same as screen coordinates.

Note: these changes are needed for upcoming WLCS tests.