### PR TITLE
stopped clipping input shape to input shape to surface bounds

### DIFF
--- a/tests/mir_test_framework/canonical_window_manager.cpp
+++ b/tests/mir_test_framework/canonical_window_manager.cpp
@@ -393,15 +393,7 @@ void msh::CanonicalWindowManagerPolicy::handle_modify_surface(
 
     if (modifications.input_shape.is_set())
     {
-        auto rectangles = modifications.input_shape.value();
-        auto displacement = surface->top_left() - Point{0, 0}; 
-        for(auto& rect : rectangles)
-        {
-            rect.top_left = rect.top_left + displacement;
-            rect = rect.intersection_with({surface->top_left(), surface->size()});
-            rect.top_left = rect.top_left - displacement;
-        }
-        surface->set_input_region(rectangles);
+        surface->set_input_region(modifications.input_shape.value());
     }
 
     if (modifications.width.is_set() || modifications.height.is_set())


### PR DESCRIPTION
stopped CanonicalWindowManagerPolicy from clipping input shape to surface bounds (fixes subsurface input tests)