### PR TITLE
CachedPtr: Hold a strong reference.

### DIFF
--- a/include/common/mir/cached_ptr.h
+++ b/include/common/mir/cached_ptr.h
@@ -27,7 +27,7 @@ namespace mir
 template<typename Type>
 class CachedPtr
 {
-    std::weak_ptr<Type> cache;
+    std::shared_ptr<Type> cache;
     CachedPtr(CachedPtr const&) = delete;
     CachedPtr& operator=(CachedPtr const&) = delete;
 public:
@@ -35,12 +35,11 @@ public:
 
     std::shared_ptr<Type> operator()(std::function<std::shared_ptr<Type>()> make)
     {
-        auto result = cache.lock();
-        if (!result)
+        if (!cache)
         {
-                cache = result = make();
+                cache = make();
         }
-        return result;
+        return cache;
     }
 };
 } // namespace mir

--- a/tests/integration-tests/test_server_shutdown.cpp
+++ b/tests/integration-tests/test_server_shutdown.cpp
@@ -148,6 +148,9 @@ TEST_F(ServerShutdown, server_can_shut_down_when_clients_are_blocked)
 
     // Shutting down the server should not block
     stop_server();
+
+    // Kill the ServerConfiguration to ensure the Clients are unblocked.
+    server_configuration.reset();
 }
 
 TEST_F(ServerShutdown, server_releases_resources_on_shutdown_with_connected_clients)


### PR DESCRIPTION
This means that the ServerConfiguration is the ultimate owner of all
configuration objects, and components can safely use configuration
objects in their constructors without necessarily holding a reference
to the object to keep it alive.