### PR TITLE
Make the signature of VTFileOperations::ioctl() match that of ::ioctl()

### DIFF
--- a/src/server/console/default_configuration.cpp
+++ b/src/server/console/default_configuration.cpp
@@ -42,12 +42,12 @@ struct RealVTFileOperations : public mir::VTFileOperations
         return ::close(fd);
     }
 
-    int ioctl(int d, int request, int val)
+    int ioctl(int d, unsigned long int request, int val)
     {
         return ::ioctl(d, request, val);
     }
 
-    int ioctl(int d, int request, void* p_val)
+    int ioctl(int d, unsigned long int request, void* p_val)
     {
         return ::ioctl(d, request, p_val);
     }

--- a/src/server/console/linux_virtual_terminal.h
+++ b/src/server/console/linux_virtual_terminal.h
@@ -47,8 +47,8 @@ public:
 
     virtual int open(char const* pathname, int flags) = 0;
     virtual int close(int fd) = 0;
-    virtual int ioctl(int d, int request, int val) = 0;
-    virtual int ioctl(int d, int request, void* p_val) = 0;
+    virtual int ioctl(int d, unsigned long int request, int val) = 0;
+    virtual int ioctl(int d, unsigned long int request, void* p_val) = 0;
     virtual int tcsetattr(int d, int acts, const struct termios *tcattr) = 0;
     virtual int tcgetattr(int d, struct termios *tcattr) = 0;
 

--- a/tests/unit-tests/console/test_linux_virtual_terminal.cpp
+++ b/tests/unit-tests/console/test_linux_virtual_terminal.cpp
@@ -58,8 +58,8 @@ public:
     ~MockVTFileOperations() noexcept {}
     MOCK_METHOD2(open, int(char const*, int));
     MOCK_METHOD1(close, int(int));
-    MOCK_METHOD3(ioctl, int(int, int, int));
-    MOCK_METHOD3(ioctl, int(int, int, void*));
+    MOCK_METHOD3(ioctl, int(int, unsigned long int, int));
+    MOCK_METHOD3(ioctl, int(int, unsigned long int, void*));
     MOCK_METHOD3(tcsetattr, int(int, int, const struct termios*));
     MOCK_METHOD2(tcgetattr, int(int, struct termios*));
 };


### PR DESCRIPTION
Make the signature of VTFileOperations::ioctl() match that of ::ioctl(). (Fixes #395)