### PR TITLE
[LogindConsoleServices test] Stop the mainloop thread in test cases, instead of leaving it running while destroying objects it may reference

### DIFF
--- a/tests/unit-tests/console/test_logind_console_services.cpp
+++ b/tests/unit-tests/console/test_logind_console_services.cpp
@@ -195,7 +195,7 @@ public:
     void TearDown() override
     {
         // Tests cases *must* stop the mainloop thread before destroying
-        // block scope objects that are referenced by enqued logic.
+        // block scope objects that are referenced by enqueued logic.
         ASSERT_TRUE(ml_thread_stopped);
 
         // Print the dbusmock output if we've failed.
@@ -223,7 +223,7 @@ public:
     }
 
     // Tests cases *must* stop the mainloop thread before destroying
-    // block scope objects that are referenced by enqued logic.
+    // block scope objects that are referenced by enqueued logic.
     void stop_mainloop()
     {
         ml_thread.stop();

--- a/tests/unit-tests/console/test_logind_console_services.cpp
+++ b/tests/unit-tests/console/test_logind_console_services.cpp
@@ -194,6 +194,10 @@ public:
 
     void TearDown() override
     {
+        // I'm not sure why explicitly stopping the main loop here works better than
+        // implicitly in the destructor. (Issue #398) OTOH this is a logical place.
+        ml_thread.stop();
+
         // Print the dbusmock output if we've failed.
         auto const test_info = ::testing::UnitTest::GetInstance()->current_test_info();
         if (test_info->result()->Failed() && dbusmock)
@@ -667,7 +671,7 @@ private:
     mir::Fd mock_stdout;
 
     std::shared_ptr<mir::GLibMainLoop> const ml;
-    mt::AutoUnblockThread const ml_thread;
+    mt::AutoUnblockThread ml_thread;
 };
 
 using namespace testing;


### PR DESCRIPTION
[LogindConsoleServices test] Stop the mainloop thread in test cases, instead of leaving it running while destroying objects it may reference. (Fixes #398)