### PR TITLE
platform/evdev: Use ConsoleServices

### DIFF
--- a/include/platform/mir/input/platform.h
+++ b/include/platform/mir/input/platform.h
@@ -107,7 +107,8 @@ typedef void(*AddPlatformOptions)(
     boost::program_options::options_description& config);
 
 typedef PlatformPriority(*ProbePlatform)(
-    options::Option const& options);
+    options::Option const& options,
+    mir::ConsoleServices& console);
 
 typedef ModuleProperties const*(*DescribeModule)();
 
@@ -163,7 +164,9 @@ void add_input_platform_options(boost::program_options::options_description& con
  *
  * \ingroup platform_enablement
  */
-mir::input::PlatformPriority probe_input_platform(mir::options::Option const& options);
+mir::input::PlatformPriority probe_input_platform(
+    mir::options::Option const& options,
+    mir::ConsoleServices& console);
 
 /**
  * describe_input_module should return a description of the input platform.

--- a/include/platform/mir/input/platform.h
+++ b/include/platform/mir/input/platform.h
@@ -32,6 +32,7 @@
 namespace mir
 {
 class EmergencyCleanupRegistry;
+class ConsoleServices;
 
 namespace dispatch
 {
@@ -99,6 +100,7 @@ typedef mir::UniqueModulePtr<Platform>(*CreatePlatform)(
     options::Option const& options,
     std::shared_ptr<EmergencyCleanupRegistry> const& emergency_cleanup_registry,
     std::shared_ptr<InputDeviceRegistry> const& input_device_registry,
+    std::shared_ptr<ConsoleServices> const& console,
     std::shared_ptr<InputReport> const& report);
 
 typedef void(*AddPlatformOptions)(
@@ -137,6 +139,7 @@ mir::UniqueModulePtr<mir::input::Platform> create_input_platform(
     mir::options::Option const& options,
     std::shared_ptr<mir::EmergencyCleanupRegistry> const& emergency_cleanup_registry,
     std::shared_ptr<mir::input::InputDeviceRegistry> const& input_device_registry,
+    std::shared_ptr<mir::ConsoleServices> const& console,
     std::shared_ptr<mir::input::InputReport> const& report);
 
 /**

--- a/src/include/platform/mir/udev/wrapper.h
+++ b/src/include/platform/mir/udev/wrapper.h
@@ -65,6 +65,7 @@ public:
     virtual char const* sysname() const = 0;
     virtual bool initialised() const = 0;
     virtual char const* syspath() const = 0;
+    virtual std::shared_ptr<udev_device> as_raw() const = 0;
 protected:
     Device() = default;
 };

--- a/src/include/platform/mir/udev/wrapper.h
+++ b/src/include/platform/mir/udev/wrapper.h
@@ -62,6 +62,9 @@ public:
     virtual char const* devnode() const = 0;
     virtual char const* property(char const *name) const = 0;
     virtual dev_t devnum() const = 0;
+    virtual char const* sysname() const = 0;
+    virtual bool initialised() const = 0;
+    virtual char const* syspath() const = 0;
 protected:
     Device() = default;
 };

--- a/src/include/server/mir/input/input_probe.h
+++ b/src/include/server/mir/input/input_probe.h
@@ -30,6 +30,7 @@ class Option;
 }
 class EmergencyCleanupRegistry;
 class SharedLibraryProberReport;
+class ConsoleServices;
 
 namespace input
 {
@@ -38,15 +39,21 @@ class Platform;
 class InputDeviceRegistry;
 
 mir::UniqueModulePtr<Platform> probe_input_platforms(
-    options::Option const& options, std::shared_ptr<EmergencyCleanupRegistry> const& emergency_cleanup,
-    std::shared_ptr<InputDeviceRegistry> const& device_registry, std::shared_ptr<InputReport> const& input_report,
+    options::Option const& options,
+    std::shared_ptr<EmergencyCleanupRegistry> const& emergency_cleanup,
+    std::shared_ptr<InputDeviceRegistry> const& device_registry,
+    std::shared_ptr<ConsoleServices> const& console,
+    std::shared_ptr<InputReport> const& input_report,
     SharedLibraryProberReport & prober_report);
 
 /// Tries to create an input platform from the graphics module, otherwise returns a null pointer
 auto input_platform_from_graphics_module(
     graphics::Platform const& graphics_platform,
-    options::Option const& options, std::shared_ptr<EmergencyCleanupRegistry> const& emergency_cleanup,
-    std::shared_ptr<InputDeviceRegistry> const& device_registry, std::shared_ptr<InputReport> const& input_report)
+    options::Option const& options,
+    std::shared_ptr<EmergencyCleanupRegistry> const& emergency_cleanup,
+    std::shared_ptr<InputDeviceRegistry> const& device_registry,
+    std::shared_ptr<ConsoleServices> const& console,
+    std::shared_ptr<InputReport> const& input_report)
 -> mir::UniqueModulePtr<Platform>;
 }
 }

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -168,3 +168,13 @@ MIR_PLATFORM_0.31 {
     mir::options::vt_option_name*;
   };
 } MIRPLATFORM_1.0;
+
+MIR_PLATFORM_0.32 {
+ global:
+  extern "C++" {
+   mir::udev::Device::initialised*;
+   mir::udev::Device::sysname*;
+   mir::udev::Device::syspath*;
+   mir::udev::Monitor::process_event*;
+  };
+} MIR_PLATFORM_0.31;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -176,5 +176,6 @@ MIR_PLATFORM_0.32 {
    mir::udev::Device::sysname*;
    mir::udev::Device::syspath*;
    mir::udev::Monitor::process_event*;
+   mir::udev::Context::device_from_syspath*;
   };
 } MIR_PLATFORM_0.31;

--- a/src/platform/udev/udev_wrapper.cpp
+++ b/src/platform/udev/udev_wrapper.cpp
@@ -44,6 +44,7 @@ public:
     virtual char const* sysname() const override;
     virtual bool initialised() const override;
     virtual char const* syspath() const override;
+    virtual std::shared_ptr<udev_device> as_raw() const override;
 
     udev_device* const dev;
 };
@@ -106,6 +107,14 @@ bool DeviceImpl::initialised() const
 char const* DeviceImpl::syspath() const
 {
     return udev_device_get_syspath(dev);
+}
+
+std::shared_ptr<udev_device> DeviceImpl::as_raw() const
+{
+    return std::shared_ptr<udev_device>{
+        udev_device_ref(dev),
+        &udev_device_unref
+    };
 }
 }
 

--- a/src/platform/udev/udev_wrapper.cpp
+++ b/src/platform/udev/udev_wrapper.cpp
@@ -41,6 +41,9 @@ public:
     virtual char const* devnode() const override;
     virtual char const* property(char const*) const override;
     virtual dev_t devnum() const override;
+    virtual char const* sysname() const override;
+    virtual bool initialised() const override;
+    virtual char const* syspath() const override;
 
     udev_device* const dev;
 };
@@ -80,6 +83,11 @@ char const* DeviceImpl::devnode() const
     return udev_device_get_devnode(dev);
 }
 
+char const* DeviceImpl::sysname() const
+{
+    return udev_device_get_sysname(dev);
+}
+
 char const* DeviceImpl::property(char const* name) const
 {
     return udev_device_get_property_value(dev, name);
@@ -88,6 +96,16 @@ char const* DeviceImpl::property(char const* name) const
 dev_t DeviceImpl::devnum() const
 {
     return udev_device_get_devnum(dev);
+}
+
+bool DeviceImpl::initialised() const
+{
+    return static_cast<bool>(udev_device_get_is_initialized(dev));
+}
+
+char const* DeviceImpl::syspath() const
+{
+    return udev_device_get_syspath(dev);
 }
 }
 

--- a/src/platforms/evdev/CMakeLists.txt
+++ b/src/platforms/evdev/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(mirplatforminputevdevobjects OBJECT
     libinput_device_ptr.cpp
     libinput_ptr.cpp
     platform.cpp
-    )
+        fd_store.cpp fd_store.h)
 
 add_library(mirplatforminputevdev MODULE
   platform_factory.cpp

--- a/src/platforms/evdev/fd_store.cpp
+++ b/src/platforms/evdev/fd_store.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Canonical Ltd.
+ * Copyright © 2017 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 2 or 3,
@@ -13,33 +13,32 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Andreas Pokorny <andreas.pokorny@canonical.com>
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
  */
 
-#ifndef MIR_INPUT_EVDEV_LIBINPUT_PTR_H_
-#define MIR_INPUT_EVDEV_LIBINPUT_PTR_H_
+#include "fd_store.h"
 
-#include "mir_toolkit/event.h"
-#include "mir/fd.h"
+#define MIR_LOG_COMPONENT "evdev-input"
+#include "mir/log.h"
 
-#include <unordered_map>
-#include <memory>
-#include <functional>
+#include <boost/throw_exception.hpp>
 
-struct libinput;
+namespace mie = mir::input::evdev;
 
-namespace mir
+void mie::FdStore::store_fd(char const* path, mir::Fd&& fd)
 {
-namespace input
-{
-namespace evdev
-{
-using LibInputPtr = std::unique_ptr<libinput, libinput*(*)(libinput*)>;
-class FdStore;
-
-LibInputPtr make_libinput(FdStore* fd_store);
-}
-}
+    fds[path] = std::move(fd);
 }
 
-#endif
+mir::Fd mie::FdStore::take_fd(char const* path)
+{
+    try
+    {
+        return fds.at(path);
+    }
+    catch (std::out_of_range const&)
+    {
+        mir::log_warning("Failed to find requested fd for path %s", path);
+    }
+    return mir::Fd{};
+}

--- a/src/platforms/evdev/fd_store.h
+++ b/src/platforms/evdev/fd_store.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Canonical Ltd.
+ * Copyright © 2017 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 2 or 3,
@@ -13,20 +13,16 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Andreas Pokorny <andreas.pokorny@canonical.com>
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
  */
 
-#ifndef MIR_INPUT_EVDEV_LIBINPUT_PTR_H_
-#define MIR_INPUT_EVDEV_LIBINPUT_PTR_H_
-
-#include "mir_toolkit/event.h"
-#include "mir/fd.h"
+#ifndef MIR_INPUT_EVDEV_FDSTORE_H_
+#define MIR_INPUT_EVDEV_FDSTORE_H_
 
 #include <unordered_map>
-#include <memory>
-#include <functional>
+#include <sys/sysmacros.h>
 
-struct libinput;
+#include "mir/fd.h"
 
 namespace mir
 {
@@ -34,12 +30,22 @@ namespace input
 {
 namespace evdev
 {
-using LibInputPtr = std::unique_ptr<libinput, libinput*(*)(libinput*)>;
-class FdStore;
+class FdStore
+{
+public:
+    FdStore() = default;
+    void store_fd(char const* path, mir::Fd&& fd);
+    mir::Fd take_fd(char const* path);
 
-LibInputPtr make_libinput(FdStore* fd_store);
+private:
+    FdStore(FdStore const&) = delete;
+    FdStore& operator=(FdStore const&) = delete;
+
+    std::unordered_map<std::string, mir::Fd> fds;
+};
+
 }
 }
 }
 
-#endif
+#endif //MIR_INPUT_EVDEV_FDSTORE_H_

--- a/src/platforms/evdev/libinput_ptr.cpp
+++ b/src/platforms/evdev/libinput_ptr.cpp
@@ -53,14 +53,10 @@ void fd_close(int fd, void* /*userdata*/)
 }
 
 const libinput_interface fd_ops = {fd_open, fd_close};
-char const default_seat[] = "seat0";
 }
 
-mie::LibInputPtr mie::make_libinput(udev* context)
+mie::LibInputPtr mie::make_libinput()
 {
-    auto ret = mie::LibInputPtr{libinput_udev_create_context(&fd_ops, nullptr, context), libinput_unref};
-    // Temporary technical debt - pick the first seat as default.
-    if (libinput_udev_assign_seat(ret.get(), default_seat) != 0)
-        BOOST_THROW_EXCEPTION(std::runtime_error("Failure assigning udev seat"));
+    auto ret = mie::LibInputPtr{libinput_path_create_context(&fd_ops, nullptr), libinput_unref};
     return ret;
 }

--- a/src/platforms/evdev/libinput_ptr.cpp
+++ b/src/platforms/evdev/libinput_ptr.cpp
@@ -18,6 +18,7 @@
 
 #include "libinput.h"
 #include "libinput_ptr.h"
+#include "fd_store.h"
 
 #include <boost/throw_exception.hpp>
 
@@ -26,25 +27,25 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <linux/input.h>
+#include <iostream>
+#include <cstring>
 
 namespace mie = mir::input::evdev;
 
 namespace
 {
-int use_monotonic_clock(int evdev)
+int fd_open(const char* path, int flags, void* userdata)
 {
-    if (evdev != -1)
-    {
-        int const clockId = CLOCK_MONOTONIC;
-        // Switch each evdev 'client' to MONOTONIC
-        ioctl(evdev, EVIOCSCLOCKID, &clockId);
-    }
-    return evdev;
-}
+    auto fd_store = static_cast<mie::FdStore*>(userdata);
 
-int fd_open(const char* path, int flags, void* /*userdata*/)
-{
-    return use_monotonic_clock(::open(path, flags));
+    auto fd = fd_store->take_fd(path);
+
+    if (fcntl(fd, F_SETFL, flags) == -1)
+    {
+        std::cerr << "Failed to set flags: " << strerror(errno) << " (" << errno << ")" << std::endl;
+    }
+
+    return fd_store->take_fd(path);
 }
 
 void fd_close(int fd, void* /*userdata*/)
@@ -55,8 +56,12 @@ void fd_close(int fd, void* /*userdata*/)
 const libinput_interface fd_ops = {fd_open, fd_close};
 }
 
-mie::LibInputPtr mie::make_libinput()
+mie::LibInputPtr mie::make_libinput(FdStore* fd_store)
 {
-    auto ret = mie::LibInputPtr{libinput_path_create_context(&fd_ops, nullptr), libinput_unref};
+    auto ret = mie::LibInputPtr{
+        libinput_path_create_context(
+            &fd_ops,
+            fd_store),
+        libinput_unref};
     return ret;
 }

--- a/src/platforms/evdev/libinput_ptr.h
+++ b/src/platforms/evdev/libinput_ptr.h
@@ -35,7 +35,7 @@ namespace evdev
 {
 using LibInputPtr = std::unique_ptr<libinput, libinput*(*)(libinput*)>;
 
-LibInputPtr make_libinput(::udev* context);
+LibInputPtr make_libinput();
 }
 }
 }

--- a/src/platforms/evdev/platform.cpp
+++ b/src/platforms/evdev/platform.cpp
@@ -65,6 +65,61 @@ std::string describe(libinput_device* dev)
     return desc;
 }
 
+class DispatchableUDevMonitor : public md::Dispatchable
+{
+public:
+    DispatchableUDevMonitor(
+        mu::Context& context,
+        std::function<void(mu::Monitor::EventType, mu::Device const&)> on_event)
+        : monitor(context),
+          fd{monitor.fd()},
+          on_event{std::move(on_event)}
+    {
+        monitor.filter_by_subsystem("input");
+        monitor.enable();
+
+        auto fake_shared_context = std::shared_ptr<mu::Context>{&context, [](auto){}};
+        mu::Enumerator device_enumerator{fake_shared_context};
+
+        device_enumerator.match_subsystem("input");
+        device_enumerator.scan_devices();
+
+        for (auto const& device : device_enumerator)
+        {
+            if (device.initialised())
+            {
+                this->on_event(mu::Monitor::EventType::ADDED, device);
+            }
+        }
+    }
+
+    mir::Fd watch_fd() const override
+    {
+        return fd;
+    }
+
+    bool dispatch(md::FdEvents events) override
+    {
+        if (events & md::FdEvent::error)
+        {
+            return false;
+        }
+
+        monitor.process_events(on_event);
+        return true;
+    }
+
+    md::FdEvents relevant_events() const override
+    {
+        return md::FdEvent::readable;
+    }
+
+private:
+    mu::Monitor monitor;
+    mir::Fd fd;
+    std::function<void(mu::Monitor::EventType, mu::Device const&)> const on_event;
+};
+
 } // namespace
 
 mie::Platform::Platform(std::shared_ptr<InputDeviceRegistry> const& registry,
@@ -84,11 +139,56 @@ std::shared_ptr<mir::dispatch::Dispatchable> mie::Platform::dispatchable()
 
 void mie::Platform::start()
 {
-    lib = make_libinput(udev_context->ctx());
+    lib = make_libinput();
     libinput_dispatchable =
         std::make_shared<md::ReadableFd>(
             Fd{IntOwnedFd{libinput_get_fd(lib.get())}}, [this]{process_input_events();}
         );
+    udev_dispatchable =
+        std::make_shared<DispatchableUDevMonitor>(
+            *udev_context,
+            [this](auto type, auto const& device)
+            {
+                switch(type)
+                {
+                case mu::Monitor::ADDED:
+                {
+                    if (auto devnode = device.devnode())
+                    {
+                        // Libinput filters out anything without “event” as its name
+                        if (strncmp(device.sysname(), "event", strlen("event")) != 0)
+                        {
+                            return;
+                        }
+                        auto input_device = libinput_path_add_device(lib.get(), devnode);
+                        if (input_device)
+                        {
+                            this->device_added(input_device);
+                        }
+                    }
+                    break;
+                }
+                case mu::Monitor::REMOVED:
+                {
+                    for (auto const& input_device : this->devices)
+                    {
+                        auto device_udev = libinput_device_get_udev_device(input_device->device());
+
+                        if (device_udev)
+                        {
+                            if (strcmp(device.syspath(), udev_device_get_syspath(device_udev)) == 0)
+                            {
+                                libinput_path_remove_device(input_device->device());
+                            }
+                        }
+                    }
+                    break;
+                }
+                default:
+                    break;
+                }
+            });
+    platform_dispatchable->add_watch(udev_dispatchable);
     platform_dispatchable->add_watch(libinput_dispatchable);
     process_input_events();
 }
@@ -194,6 +294,7 @@ auto mie::Platform::find_device(libinput_device_group const* devgroup) -> declty
 
 void mie::Platform::stop()
 {
+    platform_dispatchable->remove_watch(udev_dispatchable);
     platform_dispatchable->remove_watch(libinput_dispatchable);
     while (!devices.empty())
     {
@@ -201,5 +302,6 @@ void mie::Platform::stop()
         devices.pop_back();
     }
     libinput_dispatchable.reset();
+    udev_dispatchable.reset();
     lib.reset();
 }

--- a/src/platforms/evdev/platform.h
+++ b/src/platforms/evdev/platform.h
@@ -41,6 +41,7 @@ namespace dispatch
 {
 class MultiplexingDispatchable;
 class ReadableFd;
+class Dispatchable;
 }
 namespace input
 {
@@ -48,7 +49,6 @@ class InputDeviceRegistry;
 namespace evdev
 {
 
-struct MonitorDispatchable;
 class LibInputDevice;
 
 class Platform : public input::Platform
@@ -74,6 +74,7 @@ private:
     std::shared_ptr<dispatch::MultiplexingDispatchable> const platform_dispatchable;
     std::shared_ptr<::libinput> lib;
     std::shared_ptr<dispatch::ReadableFd> libinput_dispatchable;
+    std::shared_ptr<dispatch::Dispatchable> udev_dispatchable;
 
     std::vector<std::shared_ptr<LibInputDevice>> devices;
     auto find_device(libinput_device_group const* group) -> decltype(devices)::iterator;

--- a/src/platforms/evdev/platform.h
+++ b/src/platforms/evdev/platform.h
@@ -21,10 +21,14 @@
 
 #include "libinput_ptr.h"
 #include "libinput_device_ptr.h"
+#include "fd_store.h"
 
 #include "mir/input/platform.h"
+#include "mir/console_services.h"
 
 #include <vector>
+#include <unordered_map>
+#include <future>
 
 struct libinput_device_group;
 struct libinput_device;
@@ -33,8 +37,6 @@ namespace mir
 {
 namespace udev
 {
-class Device;
-class Monitor;
 class Context;
 }
 namespace dispatch
@@ -42,6 +44,7 @@ namespace dispatch
 class MultiplexingDispatchable;
 class ReadableFd;
 class Dispatchable;
+class ActionQueue;
 }
 namespace input
 {
@@ -54,9 +57,11 @@ class LibInputDevice;
 class Platform : public input::Platform
 {
 public:
-    Platform(std::shared_ptr<InputDeviceRegistry> const& registry,
-             std::shared_ptr<InputReport> const& report,
-             std::unique_ptr<udev::Context>&& udev_context);
+    Platform(
+        std::shared_ptr<InputDeviceRegistry> const& registry,
+        std::shared_ptr<InputReport> const& report,
+        std::unique_ptr<udev::Context>&& udev_context,
+        std::shared_ptr<ConsoleServices> const& console);
     std::shared_ptr<mir::dispatch::Dispatchable> dispatchable() override;
     void start() override;
     void stop() override;
@@ -68,13 +73,19 @@ private:
     void device_removed(libinput_device* dev);
     void process_input_events();
 
+    FdStore device_fds;
+
     std::shared_ptr<InputReport> const report;
     std::shared_ptr<udev::Context> const udev_context;
     std::shared_ptr<InputDeviceRegistry> const input_device_registry;
+    std::shared_ptr<ConsoleServices> const console;
     std::shared_ptr<dispatch::MultiplexingDispatchable> const platform_dispatchable;
     std::shared_ptr<::libinput> lib;
     std::shared_ptr<dispatch::ReadableFd> libinput_dispatchable;
     std::shared_ptr<dispatch::Dispatchable> udev_dispatchable;
+    std::shared_ptr<dispatch::ActionQueue> action_queue;
+    std::unordered_map<dev_t, std::future<std::unique_ptr<mir::Device>>> pending_devices;
+    std::unordered_map<dev_t, std::unique_ptr<mir::Device>> device_watchers;
 
     std::vector<std::shared_ptr<LibInputDevice>> devices;
     auto find_device(libinput_device_group const* group) -> decltype(devices)::iterator;

--- a/src/platforms/evdev/platform_factory.cpp
+++ b/src/platforms/evdev/platform_factory.cpp
@@ -75,11 +75,15 @@ mir::UniqueModulePtr<mi::Platform> create_input_platform(
     mo::Option const& /*options*/,
     std::shared_ptr<mir::EmergencyCleanupRegistry> const& /*emergency_cleanup_registry*/,
     std::shared_ptr<mi::InputDeviceRegistry> const& input_device_registry,
-    std::shared_ptr<mir::ConsoleServices> const& /*console*/,
+    std::shared_ptr<mir::ConsoleServices> const& console,
     std::shared_ptr<mi::InputReport> const& report)
 {
     mir::assert_entry_point_signature<mi::CreatePlatform>(&create_input_platform);
-    return mir::make_module_ptr<mie::Platform>(input_device_registry, report, std::make_unique<mu::Context>());
+    return mir::make_module_ptr<mie::Platform>(
+        input_device_registry,
+        report,
+        std::make_unique<mu::Context>(),
+        console);
 }
 
 void add_input_platform_options(
@@ -90,7 +94,8 @@ void add_input_platform_options(
 }
 
 mi::PlatformPriority probe_input_platform(
-    mo::Option const& options)
+    mo::Option const& options,
+    mir::ConsoleServices&)
 {
     mir::assert_entry_point_signature<mi::ProbePlatform>(&probe_input_platform);
     if (options.is_set(host_socket_opt))

--- a/src/platforms/evdev/platform_factory.cpp
+++ b/src/platforms/evdev/platform_factory.cpp
@@ -75,6 +75,7 @@ mir::UniqueModulePtr<mi::Platform> create_input_platform(
     mo::Option const& /*options*/,
     std::shared_ptr<mir::EmergencyCleanupRegistry> const& /*emergency_cleanup_registry*/,
     std::shared_ptr<mi::InputDeviceRegistry> const& input_device_registry,
+    std::shared_ptr<mir::ConsoleServices> const& /*console*/,
     std::shared_ptr<mi::InputReport> const& report)
 {
     mir::assert_entry_point_signature<mi::CreatePlatform>(&create_input_platform);

--- a/src/platforms/mesa/server/x11/input/input.cpp
+++ b/src/platforms/mesa/server/x11/input/input.cpp
@@ -33,6 +33,7 @@ mir::UniqueModulePtr<mi::Platform> create_input_platform(
     mo::Option const& /*options*/,
     std::shared_ptr<mir::EmergencyCleanupRegistry> const& /*emergency_cleanup_registry*/,
     std::shared_ptr<mi::InputDeviceRegistry> const& input_device_registry,
+    std::shared_ptr<mir::ConsoleServices> const& /*console*/,
     std::shared_ptr<mi::InputReport> const& /*report*/)
 {
     mir::assert_entry_point_signature<mi::CreatePlatform>(&create_input_platform);

--- a/src/platforms/mesa/server/x11/input/input.cpp
+++ b/src/platforms/mesa/server/x11/input/input.cpp
@@ -47,7 +47,8 @@ void add_input_platform_options(
 }
 
 mi::PlatformPriority probe_input_platform(
-    mo::Option const& options)
+    mo::Option const& options,
+    mir::ConsoleServices&)
 {
     mir::assert_entry_point_signature<mi::ProbePlatform>(&probe_input_platform);
     if (options.is_set("host-socket") || options.is_set("vt"))

--- a/src/server/input/CMakeLists.txt
+++ b/src/server/input/CMakeLists.txt
@@ -27,6 +27,7 @@ set(
   ${PROJECT_SOURCE_DIR}/include/server/mir/input/seat_observer.h
   ${PROJECT_SOURCE_DIR}/include/server/mir/input/input_dispatcher.h
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/input/seat.h
+  ${PROJECT_SOURCE_DIR}/src/include/server/mir/input/input_probe.h
 )
 
 add_library(

--- a/src/server/input/default_configuration.cpp
+++ b/src/server/input/default_configuration.cpp
@@ -219,13 +219,23 @@ mir::DefaultServerConfiguration::the_input_manager()
                 // Maybe the graphics platform also supplies input (e.g. mesa-x11 or nested)
                 // NB this makes the (valid) assumption that graphics initializes before input
                 auto platform = mi::input_platform_from_graphics_module(
-                    *the_graphics_platform(), *options, emergency_cleanup, device_registry, input_report);
+                    *the_graphics_platform(),
+                    *options,
+                    emergency_cleanup,
+                    device_registry,
+                    the_console_services(),
+                    input_report);
 
                 // otherwise (usually) we probe for it
                 if (!platform)
                 {
-                    platform = probe_input_platforms(*options, emergency_cleanup, device_registry,
-                                                     input_report, *the_shared_library_prober_report());
+                    platform = probe_input_platforms(
+                        *options,
+                        emergency_cleanup,
+                        device_registry,
+                        the_console_services(),
+                        input_report,
+                        *the_shared_library_prober_report());
                 }
 
                 return std::make_shared<mi::DefaultInputManager>(the_input_reading_multiplexer(), std::move(platform));

--- a/src/server/input/input_probe.cpp
+++ b/src/server/input/input_probe.cpp
@@ -74,7 +74,7 @@ mir::UniqueModulePtr<mi::Platform> mi::probe_input_platforms(
                 auto const probe = module->load_function<mi::ProbePlatform>(
                     "probe_input_platform", MIR_SERVER_INPUT_PLATFORM_VERSION);
 
-                if (probe(options) > reject_platform_priority)
+                if (probe(options, *console) > reject_platform_priority)
                 {
                     platform_module = module;
 

--- a/src/server/input/input_probe.cpp
+++ b/src/server/input/input_probe.cpp
@@ -37,12 +37,14 @@ namespace
 mir::UniqueModulePtr<mi::Platform> create_input_platform(
     mir::SharedLibrary const& lib, mir::options::Option const& options,
     std::shared_ptr<mir::EmergencyCleanupRegistry> const& cleanup_registry,
-    std::shared_ptr<mi::InputDeviceRegistry> const& registry, std::shared_ptr<mi::InputReport> const& report)
+    std::shared_ptr<mi::InputDeviceRegistry> const& registry,
+    std::shared_ptr<mir::ConsoleServices> const& console,
+    std::shared_ptr<mi::InputReport> const& report)
 {
     auto desc = lib.load_function<mi::DescribeModule>("describe_input_module", MIR_SERVER_INPUT_PLATFORM_VERSION)();
     auto create = lib.load_function<mi::CreatePlatform>("create_input_platform", MIR_SERVER_INPUT_PLATFORM_VERSION);
 
-    auto result = create(options, cleanup_registry, registry, report);
+    auto result = create(options, cleanup_registry, registry, console, report);
 
     mir::log_info(
         "Selected input driver: %s (version: %d.%d.%d)",
@@ -53,8 +55,11 @@ mir::UniqueModulePtr<mi::Platform> create_input_platform(
 }
 
 mir::UniqueModulePtr<mi::Platform> mi::probe_input_platforms(
-    mo::Option const& options, std::shared_ptr<EmergencyCleanupRegistry> const& emergency_cleanup,
-    std::shared_ptr<mi::InputDeviceRegistry> const& device_registry, std::shared_ptr<mi::InputReport> const& input_report,
+    mo::Option const& options,
+    std::shared_ptr<EmergencyCleanupRegistry> const& emergency_cleanup,
+    std::shared_ptr<mi::InputDeviceRegistry> const& device_registry,
+    std::shared_ptr<mir::ConsoleServices> const& console,
+    std::shared_ptr<mi::InputReport> const& input_report,
     mir::SharedLibraryProberReport& prober_report)
 {
     auto reject_platform_priority = mi::PlatformPriority::dummy;
@@ -97,7 +102,7 @@ mir::UniqueModulePtr<mi::Platform> mi::probe_input_platforms(
     if (!platform_module)
         BOOST_THROW_EXCEPTION(std::runtime_error{"No appropriate input platform module found"});
 
-    return create_input_platform(*platform_module, options, emergency_cleanup, device_registry, input_report);
+    return create_input_platform(*platform_module, options, emergency_cleanup, device_registry, console, input_report);
 }
 
 auto mi::input_platform_from_graphics_module(
@@ -105,6 +110,7 @@ auto mi::input_platform_from_graphics_module(
     options::Option const& options,
     std::shared_ptr<EmergencyCleanupRegistry> const& emergency_cleanup,
     std::shared_ptr<InputDeviceRegistry> const& device_registry,
+    std::shared_ptr<ConsoleServices> const& console,
     std::shared_ptr<InputReport> const& input_report)
 -> mir::UniqueModulePtr<Platform>
 {
@@ -114,7 +120,7 @@ auto mi::input_platform_from_graphics_module(
         auto* const vtab = (void*&)(graphics_platform);
         SharedLibrary const platform_module{detail::libname_impl(vtab)};
 
-        return create_input_platform(platform_module, options, emergency_cleanup, device_registry, input_report);
+        return create_input_platform(platform_module, options, emergency_cleanup, device_registry, console, input_report);
     }
     catch (std::runtime_error const&)
     {

--- a/tests/include/mir/test/doubles/mock_libinput.h
+++ b/tests/include/mir/test/doubles/mock_libinput.h
@@ -38,7 +38,7 @@ public:
     MockLibInput();
     ~MockLibInput() noexcept;
     void wake();
-    void setup_device(libinput_device* device, libinput_device_group* group, udev_device* u_dev, char const* name,
+    void setup_device(libinput_device* device, libinput_device_group* group, std::shared_ptr<udev_device> u_dev, char const* name,
                       char const* sysname, unsigned int vendor, unsigned int product);
 
     libinput_event* setup_touch_event(libinput_device* dev, libinput_event_type type, uint64_t event_time, int slot,
@@ -176,10 +176,19 @@ public:
         return reinterpret_cast<PtrT>(++last_fake_ptr);
     }
 
+    dev_t get_next_devnum()
+    {
+        auto const next_devnum =
+            makedev(major(last_devnum) + 1, minor(last_devnum) + 1);
+        last_devnum = next_devnum;
+        return next_devnum;
+    }
+
     std::vector<libinput_event*> events;
 private:
     dispatch::ActionQueue libinput_simulation_queue;
     unsigned int last_fake_ptr{0};
+    dev_t last_devnum{makedev(1,0)};
     void push_back(libinput_event* event);
 };
 

--- a/tests/include/mir/test/doubles/mock_udev.h
+++ b/tests/include/mir/test/doubles/mock_udev.h
@@ -35,9 +35,11 @@ struct MockUdev
 public:
     MockUdev();
     ~MockUdev() noexcept;
+    MOCK_METHOD1(udev_device_get_devnum, dev_t(udev_device*));
     MOCK_METHOD1(udev_device_get_devnode, char const*(udev_device*));
     MOCK_METHOD2(udev_device_get_property_value, char const*(udev_device* device, char const* property));
     MOCK_METHOD1(udev_device_unref, udev_device*(udev_device* device));
+    MOCK_METHOD1(udev_device_ref,udev_device*(udev_device* device));
 };
 
 }

--- a/tests/mir_test_doubles/mock_libinput.cpp
+++ b/tests/mir_test_doubles/mock_libinput.cpp
@@ -38,6 +38,7 @@ mtd::MockLibInput::MockLibInput()
                               {
                                   if (events.empty())
                                       return nullptr;
+                                  libinput_simulation_queue.dispatch(mir::dispatch::FdEvent::readable);
                                   auto ret = events.front();
                                   events.erase(events.begin());
                                   return ret;
@@ -78,7 +79,7 @@ void mtd::MockLibInput::push_back(libinput_event* event)
     wake();
 }
 
-void mtd::MockLibInput::setup_device(libinput_device* dev, libinput_device_group* group, udev_device* u_dev, char const* name, char const* sysname, unsigned int vendor, unsigned int product)
+void mtd::MockLibInput::setup_device(libinput_device* dev, libinput_device_group* group, std::shared_ptr<udev_device> u_dev, char const* name, char const* sysname, unsigned int vendor, unsigned int product)
 {
     ON_CALL(*this, libinput_device_get_name(dev))
         .WillByDefault(Return(name));
@@ -95,7 +96,7 @@ void mtd::MockLibInput::setup_device(libinput_device* dev, libinput_device_group
     ON_CALL(*this, libinput_device_unref(dev))
         .WillByDefault(Return(nullptr));
     ON_CALL(*this, libinput_device_get_udev_device(dev))
-        .WillByDefault(Return(u_dev));
+        .WillByDefault(InvokeWithoutArgs([u_dev]() { return udev_device_ref(u_dev.get());}));
 }
 
 mtd::MockLibInput::~MockLibInput() noexcept

--- a/tests/mir_test_doubles/mock_udev.cpp
+++ b/tests/mir_test_doubles/mock_udev.cpp
@@ -30,11 +30,19 @@ mtd::MockUdev::MockUdev()
     using namespace testing;
     assert(global_udev == nullptr && "Only one udev mock object per process is allowed");
     global_udev = this;
+
+    ON_CALL(*this, udev_device_ref(_))
+        .WillByDefault(ReturnArg<0>());
 }
 
 mtd::MockUdev::~MockUdev() noexcept
 {
     global_udev = nullptr;
+}
+
+dev_t udev_device_get_devnum(udev_device* dev)
+{
+    return global_udev->udev_device_get_devnum(dev);
 }
 
 char const* udev_device_get_devnode(udev_device* dev)
@@ -50,4 +58,9 @@ char const* udev_device_get_property_value(udev_device* dev, char const* propert
 udev_device* udev_device_unref(udev_device* device)
 {
     return global_udev->udev_device_unref(device);
+}
+
+udev_device* udev_device_ref(udev_device* device)
+{
+    return global_udev->udev_device_ref(device);
 }

--- a/tests/mir_test_framework/libinput_environment.cpp
+++ b/tests/mir_test_framework/libinput_environment.cpp
@@ -78,7 +78,7 @@ mtf::LibInputEnvironment::LibInputEnvironment()
         device.second.properties[model] = device.first;
     }
 
-    ON_CALL(mock_libinput, libinput_udev_create_context(_,_,_))
+    ON_CALL(mock_libinput, libinput_path_create_context(_,_))
         .WillByDefault(Return(li_context));
     ON_CALL(mock_libinput, libinput_device_get_device_group(_))
             .WillByDefault(Return(nullptr));

--- a/tests/mir_test_framework/stub_input.cpp
+++ b/tests/mir_test_framework/stub_input.cpp
@@ -46,7 +46,8 @@ void add_input_platform_options(
 }
 
 mi::PlatformPriority probe_input_platform(
-    mo::Option const& /*options*/)
+    mo::Option const& /*options*/,
+    mir::ConsoleServices& /*console*/)
 {
     mir::assert_entry_point_signature<mi::ProbePlatform>(&probe_input_platform);
     return mi::PlatformPriority::dummy;

--- a/tests/mir_test_framework/stub_input.cpp
+++ b/tests/mir_test_framework/stub_input.cpp
@@ -31,6 +31,7 @@ mir::UniqueModulePtr<mi::Platform> create_input_platform(
     mo::Option const& /*options*/,
     std::shared_ptr<mir::EmergencyCleanupRegistry> const& /*emergency_cleanup_registry*/,
     std::shared_ptr<mi::InputDeviceRegistry> const& input_device_registry,
+    std::shared_ptr<mir::ConsoleServices> const& /*console*/,
     std::shared_ptr<mi::InputReport> const& /*report*/)
 {
     mir::assert_entry_point_signature<mi::CreatePlatform>(&create_input_platform);

--- a/tests/mir_test_framework/udev_environment.cpp
+++ b/tests/mir_test_framework/udev_environment.cpp
@@ -40,6 +40,19 @@
 
 namespace mtf = mir_test_framework;
 
+/*
+ * Conveniently, umockdev doesn't do the setup required to make
+ * udev_device_get_is_initialized return true; this breaks the invariant
+ * "either udev_device_get_is_initialized returns true, or you will receive
+ * an ADD event for it once it is initialized".
+ *
+ * Just always return initialised for now, until we want to verify.
+ */
+int udev_device_get_is_initialized(udev_device*)
+{
+    return 1;
+}
+
 mtf::UdevEnvironment::UdevEnvironment()
     : recordings_path(mtf::test_data_path() + "/udev-recordings")
 {

--- a/tests/umock-acceptance-tests/CMakeLists.txt
+++ b/tests/umock-acceptance-tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_dependencies(mir_umock_acceptance_tests GMock)
 target_link_libraries(mir_umock_acceptance_tests
   mir-test-assist
   mir-test-framework-static
+  mir-test-doubles-static
 
   ${UMOCKDEV_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT} # Link in pthread.

--- a/tests/umock-acceptance-tests/test_libinput.cpp
+++ b/tests/umock-acceptance-tests/test_libinput.cpp
@@ -18,13 +18,17 @@
 
 #include "mir/input/platform.h"
 #include "mir/test/doubles/mock_option.h"
-#include "mir/shared_library.h"
+#include "mir/console_services.h"
 
+#include "mir/shared_library.h"
 #include "mir_test_framework/udev_environment.h"
 #include "mir_test_framework/executable_path.h"
+#include "mir/test/doubles/stub_console_services.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <fcntl.h>
+#include <mir/fd.h>
 
 namespace mtf = mir_test_framework;
 namespace mtd = mir::test::doubles;
@@ -48,12 +52,13 @@ char const host_socket_opt[] = "host-socket";
 TEST(LibInput, DISABLED_probes_as_unsupported_without_device_access)
 {
     NiceMock<mtd::MockOption> options;
+    mtd::StubConsoleServices console;
 
     // dumb assumption - nobody runs this test cases as root..
     // or allows accessing evdev input devices from non privileged users.
     auto library = get_libinput_platform();
     auto probe_fun = library->load_function<mir::input::ProbePlatform>(probe_input_platform_symbol);
-    EXPECT_THAT(probe_fun(options), Eq(mir::input::PlatformPriority::unsupported));
+    EXPECT_THAT(probe_fun(options, console), Eq(mir::input::PlatformPriority::unsupported));
 }
 
 TEST(LibInput, probes_as_supported_with_at_least_one_device_to_deal_with)
@@ -61,10 +66,11 @@ TEST(LibInput, probes_as_supported_with_at_least_one_device_to_deal_with)
     mtf::UdevEnvironment env;
     env.add_standard_device("laptop-keyboard");
     NiceMock<mtd::MockOption> options;
+    mtd::StubConsoleServices console;
 
     auto library = get_libinput_platform();
     auto probe_fun = library->load_function<mir::input::ProbePlatform>(probe_input_platform_symbol);
-    EXPECT_THAT(probe_fun(options), Ge(mir::input::PlatformPriority::supported));
+    EXPECT_THAT(probe_fun(options, console), Ge(mir::input::PlatformPriority::supported));
 }
 
 TEST(LibInput, probes_as_unsupported_on_nested_configs)
@@ -72,6 +78,7 @@ TEST(LibInput, probes_as_unsupported_on_nested_configs)
     mtf::UdevEnvironment env;
     env.add_standard_device("laptop-keyboard");
     NiceMock<mtd::MockOption> options;
+    mtd::StubConsoleServices console;
 
     ON_CALL(options,is_set(StrEq(host_socket_opt)))
         .WillByDefault(Return(true));
@@ -80,15 +87,16 @@ TEST(LibInput, probes_as_unsupported_on_nested_configs)
 
     auto library = get_libinput_platform();
     auto probe_fun = library->load_function<mir::input::ProbePlatform>(probe_input_platform_symbol);
-    EXPECT_THAT(probe_fun(options), Eq(mir::input::PlatformPriority::unsupported));
+    EXPECT_THAT(probe_fun(options, console), Eq(mir::input::PlatformPriority::unsupported));
 }
 
 TEST(LibInput, probes_as_supported_when_umock_dev_available_or_before_input_devices_are_available)
 {
     mtf::UdevEnvironment env;
     NiceMock<mtd::MockOption> options;
+    mtd::StubConsoleServices console;
 
     auto library = get_libinput_platform();
     auto probe_fun = library->load_function<mir::input::ProbePlatform>(probe_input_platform_symbol);
-    EXPECT_THAT(probe_fun(options), Eq(mir::input::PlatformPriority::supported));
+    EXPECT_THAT(probe_fun(options, console), Eq(mir::input::PlatformPriority::supported));
 }

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -180,6 +180,7 @@ target_link_libraries(
   ${GMOCK_LIBRARIES}
   ${Boost_LIBRARIES}
   ${UMOCKDEV_LIBRARIES}
+  ${LIBINPUT_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT} # Link in pthread.
 )
 

--- a/tests/unit-tests/input/evdev/CMakeLists.txt
+++ b/tests/unit-tests/input/evdev/CMakeLists.txt
@@ -1,12 +1,21 @@
 list(APPEND UNIT_TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/test_evdev_device_detection.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/test_evdev_input_platform.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_libinput_device.cpp
   $<TARGET_OBJECTS:mirevdevutilsobjects>
   $<TARGET_OBJECTS:mirplatforminputevdevobjects>
+)
+
+list(APPEND UMOCK_UNIT_TEST_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_evdev_input_platform.cpp
 )
 
 set(
   UNIT_TEST_SOURCES
   ${UNIT_TEST_SOURCES}
   PARENT_SCOPE)
+
+set(
+  UMOCK_UNIT_TEST_SOURCES
+  ${UMOCK_UNIT_TEST_SOURCES}
+  PARENT_SCOPE
+)

--- a/tests/unit-tests/input/evdev/test_evdev_device_detection.cpp
+++ b/tests/unit-tests/input/evdev/test_evdev_device_detection.cpp
@@ -42,7 +42,7 @@ TEST_P(EvdevDeviceDetection, evaluates_expected_input_class)
     using namespace testing;
     auto const& param = GetParam();
     auto dev = env.setup_device(std::get<0>(param));
-    std::shared_ptr<libinput> lib = mie::make_libinput();
+    std::shared_ptr<libinput> lib = mie::make_libinput(nullptr);
     mie::LibInputDevice device(mir::report::null_input_report(), mie::make_libinput_device(lib, dev));
     auto info = device.get_device_info();
     EXPECT_THAT(info.capabilities, Eq(std::get<1>(param)));

--- a/tests/unit-tests/input/evdev/test_evdev_device_detection.cpp
+++ b/tests/unit-tests/input/evdev/test_evdev_device_detection.cpp
@@ -41,9 +41,8 @@ TEST_P(EvdevDeviceDetection, evaluates_expected_input_class)
 {
     using namespace testing;
     auto const& param = GetParam();
-    udev* ctx = reinterpret_cast<udev*>(1);
     auto dev = env.setup_device(std::get<0>(param));
-    std::shared_ptr<libinput> lib = mie::make_libinput(ctx);
+    std::shared_ptr<libinput> lib = mie::make_libinput();
     mie::LibInputDevice device(mir::report::null_input_report(), mie::make_libinput_device(lib, dev));
     auto info = device.get_device_info();
     EXPECT_THAT(info.capabilities, Eq(std::get<1>(param)));

--- a/tests/unit-tests/input/evdev/test_evdev_input_platform.cpp
+++ b/tests/unit-tests/input/evdev/test_evdev_input_platform.cpp
@@ -195,6 +195,6 @@ TEST_F(EvdevInputPlatform, creates_new_context_on_resume)
     platform->start();
     platform->stop();
 
-    EXPECT_CALL(env.mock_libinput, libinput_udev_create_context(_,_,_));
+    EXPECT_CALL(env.mock_libinput, libinput_path_create_context(_,_));
     platform->start();
 }

--- a/tests/unit-tests/input/evdev/test_evdev_input_platform.cpp
+++ b/tests/unit-tests/input/evdev/test_evdev_input_platform.cpp
@@ -64,6 +64,14 @@ struct EvdevInputPlatform : public ::testing::TestWithParam<std::string>
     mtf::UdevEnvironment udev;
     testing::NiceMock<mtd::MockLibInput> li_mock;
 
+    libinput* const fake_context{reinterpret_cast<libinput*>(0xaabbcc)};
+
+    EvdevInputPlatform()
+    {
+        ON_CALL(li_mock, libinput_path_create_context(_,_))
+            .WillByDefault(Return(fake_context));
+    }
+
     auto create_input_platform()
     {
         auto ctx = std::make_unique<mu::Context>();
@@ -135,10 +143,6 @@ TEST_P(EvdevInputPlatform, scans_on_start)
 
     EXPECT_CALL(mock_registry, add_device(_));
 
-    auto fake_context = reinterpret_cast<libinput*>(0xaabb);
-
-    ON_CALL(li_mock, libinput_path_create_context(_,_))
-        .WillByDefault(Return(fake_context));
     ON_CALL(li_mock, libinput_path_add_device(fake_context, _))
         .WillByDefault(
             WithArgs<1>(
@@ -168,10 +172,6 @@ TEST_P(EvdevInputPlatform, detects_on_hotplug)
     using namespace ::testing;
     auto platform = create_input_platform();
 
-    auto fake_context = reinterpret_cast<libinput*>(0xaabb);
-
-    ON_CALL(li_mock, libinput_path_create_context(_,_))
-        .WillByDefault(Return(fake_context));
     ON_CALL(li_mock, libinput_path_add_device(fake_context, _))
         .WillByDefault(
             WithArgs<1>(
@@ -204,10 +204,6 @@ TEST_P(EvdevInputPlatform, detects_hot_removal)
     using namespace ::testing;
     auto platform = create_input_platform();
 
-    auto fake_context = reinterpret_cast<libinput*>(0xaabb);
-
-    ON_CALL(li_mock, libinput_path_create_context(_,_))
-        .WillByDefault(Return(fake_context));
     ON_CALL(li_mock, libinput_path_add_device(fake_context, _))
         .WillByDefault(
             WithArgs<1>(
@@ -251,10 +247,6 @@ TEST_P(EvdevInputPlatform, removes_devices_on_stop)
     using namespace ::testing;
     auto platform = create_input_platform();
 
-    auto fake_context = reinterpret_cast<libinput*>(0xaabb);
-
-    ON_CALL(li_mock, libinput_path_create_context(_,_))
-        .WillByDefault(Return(fake_context));
     ON_CALL(li_mock, libinput_path_add_device(fake_context, _))
         .WillByDefault(
             WithArgs<1>(
@@ -296,10 +288,6 @@ TEST_F(EvdevInputPlatform, register_ungrouped_devices)
     auto platform = create_input_platform();
     EXPECT_CALL(mock_registry, add_device(_)).Times(2);
 
-    auto fake_context = reinterpret_cast<libinput*>(0xaabb);
-
-    ON_CALL(li_mock, libinput_path_create_context(_,_))
-        .WillByDefault(Return(fake_context));
     ON_CALL(li_mock, libinput_path_add_device(fake_context, _))
         .WillByDefault(
             WithArgs<1>(
@@ -332,10 +320,6 @@ TEST_F(EvdevInputPlatform, ignore_devices_from_same_group)
 
     EXPECT_CALL(mock_registry, add_device(_)).Times(1);
 
-    auto fake_context = reinterpret_cast<libinput*>(0xaabb);
-
-    ON_CALL(li_mock, libinput_path_create_context(_,_))
-        .WillByDefault(Return(fake_context));
     ON_CALL(li_mock, libinput_path_add_device(fake_context, _))
         .WillByDefault(
             WithArgs<1>(

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -135,7 +135,7 @@ struct LibInputDevice : public ::testing::Test
     {
         ON_CALL(mock_sink, bounding_rectangle())
             .WillByDefault(Return(geom::Rectangle({0,0}, {100,100})));
-        lib = mie::make_libinput(fake_udev);
+        lib = mie::make_libinput();
     }
 
     libinput_device* setup_laptop_keyboard()

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -135,7 +135,7 @@ struct LibInputDevice : public ::testing::Test
     {
         ON_CALL(mock_sink, bounding_rectangle())
             .WillByDefault(Return(geom::Rectangle({0,0}, {100,100})));
-        lib = mie::make_libinput();
+        lib = mie::make_libinput(nullptr);
     }
 
     libinput_device* setup_laptop_keyboard()
@@ -328,7 +328,9 @@ TEST_F(LibInputDevice, unique_id_contains_device_name)
 {
     auto fake_device = env.mock_libinput.get_next_fake_ptr<libinput_device*>();
     auto fake_dev_group = env.mock_libinput.get_next_fake_ptr<libinput_device_group*>();
-    auto udev_dev = env.mock_libinput.get_next_fake_ptr<udev_device*>();
+    auto udev_dev = std::shared_ptr<udev_device>{
+        env.mock_libinput.get_next_fake_ptr<udev_device*>(),
+        [](auto){}};
     env.mock_libinput.setup_device(fake_device, fake_dev_group, udev_dev, "Keyboard", "event4", 1, 2);
 
     mie::LibInputDevice dev(mir::report::null_input_report(),

--- a/tests/unit-tests/input/test_input_platform_probing.cpp
+++ b/tests/unit-tests/input/test_input_platform_probing.cpp
@@ -132,8 +132,13 @@ TEST_F(InputPlatformProbe, stub_platform_not_picked_up_by_default)
 {
     disable_x11();
     auto platform =
-        mi::probe_input_platforms(mock_options, mt::fake_shared(stub_emergency), mt::fake_shared(mock_registry),
-                                  mr::null_input_report(), *stub_prober_report);
+        mi::probe_input_platforms(
+            mock_options,
+            mt::fake_shared(stub_emergency),
+            mt::fake_shared(mock_registry),
+            nullptr,
+            mr::null_input_report(),
+            *stub_prober_report);
 
     EXPECT_THAT(platform, OfPtrType<mi::evdev::Platform>());
 }
@@ -143,8 +148,13 @@ char const vt[] = "vt";
 TEST_F(InputPlatformProbe, x11_platform_found_and_used_when_display_connection_works)
 {
     auto platform =
-        mi::probe_input_platforms(mock_options, mt::fake_shared(stub_emergency), mt::fake_shared(mock_registry),
-                                  mr::null_input_report(), *stub_prober_report);
+        mi::probe_input_platforms(
+            mock_options,
+            mt::fake_shared(stub_emergency),
+            mt::fake_shared(mock_registry),
+            nullptr,
+            mr::null_input_report(),
+            *stub_prober_report);
 
     EXPECT_THAT(platform, OfPtrType<mi::X::XInputPlatform>());
 }
@@ -159,8 +169,13 @@ TEST_F(InputPlatformProbe, when_multiple_x11_platforms_are_eligible_only_one_is_
     ASSERT_THAT(link(real_lib.c_str(), fake_lib.c_str()), Eq(0));
 
     auto platform =
-        mi::probe_input_platforms(mock_options, mt::fake_shared(stub_emergency), mt::fake_shared(mock_registry),
-                                  mr::null_input_report(), *stub_prober_report);
+        mi::probe_input_platforms(
+            mock_options,
+            mt::fake_shared(stub_emergency),
+            mt::fake_shared(mock_registry),
+            nullptr,
+            mr::null_input_report(),
+            *stub_prober_report);
 
     EXPECT_THAT(platform, OfPtrType<mi::X::XInputPlatform>());
 
@@ -171,8 +186,13 @@ TEST_F(InputPlatformProbe, x11_input_platform_not_used_when_vt_specified)
 {
     ON_CALL(mock_options, is_set(StrEq(vt))).WillByDefault(Return(true));
     auto platform =
-        mi::probe_input_platforms(mock_options, mt::fake_shared(stub_emergency), mt::fake_shared(mock_registry),
-                                  mr::null_input_report(), *stub_prober_report);
+        mi::probe_input_platforms(
+            mock_options,
+            mt::fake_shared(stub_emergency),
+            mt::fake_shared(mock_registry),
+            nullptr,
+            mr::null_input_report(),
+            *stub_prober_report);
 
     EXPECT_THAT(platform, OfPtrType<mi::evdev::Platform>());
 }
@@ -185,7 +205,12 @@ TEST_F(InputPlatformProbe, allows_forcing_stub_input_platform)
     platform_input_lib_value = mtf::server_input_platform("input-stub.so");
     platform_input_lib_value_as_any = platform_input_lib_value;
     auto platform =
-        mi::probe_input_platforms(mock_options, mt::fake_shared(stub_emergency), mt::fake_shared(mock_registry),
-                                  mr::null_input_report(), *stub_prober_report);
+        mi::probe_input_platforms(
+            mock_options,
+            mt::fake_shared(stub_emergency),
+            mt::fake_shared(mock_registry),
+            nullptr,
+            mr::null_input_report(),
+            *stub_prober_report);
     EXPECT_THAT(platform, OfPtrType<mtf::StubInputPlatform>());
 }

--- a/tests/unit-tests/input/test_x11_module.cpp
+++ b/tests/unit-tests/input/test_x11_module.cpp
@@ -22,6 +22,7 @@
 #include "mir/test/doubles/mock_x11.h"
 #include "mir/test/doubles/mock_option.h"
 #include "mir_test_framework/executable_path.h"
+#include "mir/test/doubles/stub_console_services.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -47,6 +48,7 @@ struct X11Platform : Test
     NiceMock<mtd::MockOption> options;
     NiceMock<mtd::MockX11> mock_x11;
     std::shared_ptr<mir::SharedLibrary> library{get_x11_platform()};
+    mtd::StubConsoleServices console;
 };
 
 }
@@ -57,7 +59,7 @@ TEST_F(X11Platform, probes_as_unsupported_without_display)
         .WillByDefault(Return(nullptr));
 
     auto probe_fun = library->load_function<mir::input::ProbePlatform>(probe_input_platform_symbol);
-    EXPECT_THAT(probe_fun(options), Eq(mir::input::PlatformPriority::unsupported));
+    EXPECT_THAT(probe_fun(options, console), Eq(mir::input::PlatformPriority::unsupported));
 }
 
 TEST_F(X11Platform, probes_as_supported_with_display)
@@ -65,7 +67,7 @@ TEST_F(X11Platform, probes_as_supported_with_display)
     // default setup of MockX11 already provides fake objects
 
     auto probe_fun = library->load_function<mir::input::ProbePlatform>(probe_input_platform_symbol);
-    EXPECT_THAT(probe_fun(options), Ge(mir::input::PlatformPriority::supported));
+    EXPECT_THAT(probe_fun(options, console), Ge(mir::input::PlatformPriority::supported));
 }
 
 TEST_F(X11Platform, probes_as_unsupported_on_nested_configs)
@@ -76,6 +78,6 @@ TEST_F(X11Platform, probes_as_unsupported_on_nested_configs)
         .WillByDefault(Return("something"));
 
     auto probe_fun = library->load_function<mir::input::ProbePlatform>(probe_input_platform_symbol);
-    EXPECT_THAT(probe_fun(options), Eq(mir::input::PlatformPriority::unsupported));
+    EXPECT_THAT(probe_fun(options, console), Eq(mir::input::PlatformPriority::unsupported));
 }
 


### PR DESCRIPTION
This migrates the libinput platform to the use of `ConsoleServices` for device access.