### PR TITLE
[Wayland] Make use of the specified output in fullscreen requests. (Fixes #423)

### DIFF
--- a/src/server/frontend_wayland/output_manager.h
+++ b/src/server/frontend_wayland/output_manager.h
@@ -24,6 +24,8 @@
 #include <wayland-server-core.h>
 #include <wayland-server-protocol.h>
 
+#include <experimental/optional>
+
 #include <memory>
 #include <vector>
 #include <unordered_map>
@@ -62,6 +64,18 @@ class OutputManager
 {
 public:
     OutputManager(wl_display* display, DisplayChanger& display_config);
+
+    auto output_id_for(std::experimental::optional<struct wl_resource*> const& /*output*/) ->
+    mir::optional_value<mir::graphics::DisplayConfigurationOutputId>
+    {
+        return {};
+    }
+
+    auto output_id_for(struct wl_resource* /*output*/) -> mir::graphics::DisplayConfigurationOutputId
+    {
+        return {};
+    }
+
 
 private:
     void create_output(graphics::DisplayConfigurationOutput const& initial_config);

--- a/src/server/frontend_wayland/output_manager.h
+++ b/src/server/frontend_wayland/output_manager.h
@@ -45,6 +45,8 @@ public:
 
     void handle_configuration_changed(graphics::DisplayConfigurationOutput const& /*config*/);
 
+    bool matches_client_resource(wl_client* client, struct wl_resource* resource) const;
+
 private:
     static void send_initial_config(wl_resource* client_resource, graphics::DisplayConfigurationOutput const& config);
 
@@ -65,17 +67,11 @@ class OutputManager
 public:
     OutputManager(wl_display* display, DisplayChanger& display_config);
 
-    auto output_id_for(std::experimental::optional<struct wl_resource*> const& /*output*/) ->
-    mir::optional_value<mir::graphics::DisplayConfigurationOutputId>
-    {
-        return {};
-    }
+    auto output_id_for(wl_client* client, std::experimental::optional<struct wl_resource*> const& /*output*/) const
+        -> optional_value<graphics::DisplayConfigurationOutputId>;
 
-    auto output_id_for(struct wl_resource* /*output*/) -> mir::graphics::DisplayConfigurationOutputId
-    {
-        return {};
-    }
-
+    auto output_id_for(wl_client* client, struct wl_resource* /*output*/) const
+        -> graphics::DisplayConfigurationOutputId;
 
 private:
     void create_output(graphics::DisplayConfigurationOutput const& initial_config);

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -283,9 +283,10 @@ public:
         uint32_t id,
         WlSurface* surface,
         std::shared_ptr<mf::Shell> const& shell,
-        WlSeat& seat)
+        WlSeat& seat,
+        OutputManager* output_manager)
         : ShellSurface(client, parent, id),
-          WlAbstractMirWindow{&seat, client, surface, shell}
+          WlAbstractMirWindow{&seat, client, surface, shell, output_manager}
     {
     }
 
@@ -495,10 +496,12 @@ public:
     WlShell(
         wl_display* display,
         std::shared_ptr<mf::Shell> const& shell,
-        WlSeat& seat)
+        WlSeat& seat,
+        OutputManager* const output_manager)
         : Shell(display, 1),
           shell{shell},
-          seat{seat}
+          seat{seat},
+          output_manager{output_manager}
     {
     }
 
@@ -508,11 +511,12 @@ public:
         uint32_t id,
         wl_resource* surface) override
     {
-        new WlShellSurface(client, resource, id, WlSurface::from(surface), shell, seat);
+        new WlShellSurface(client, resource, id, WlSurface::from(surface), shell, seat, output_manager);
     }
 private:
     std::shared_ptr<mf::Shell> const shell;
     WlSeat& seat;
+    OutputManager* const output_manager;
 };
 }
 }
@@ -638,10 +642,10 @@ mf::WaylandConnector::WaylandConnector(
     output_manager = std::make_unique<mf::OutputManager>(
         display.get(),
         display_config);
-    shell_global = std::make_unique<mf::WlShell>(display.get(), shell, *seat_global);
+    shell_global = std::make_unique<mf::WlShell>(display.get(), shell, *seat_global, output_manager.get());
     data_device_manager_global = mf::create_data_device_manager(display.get());
     if (!getenv("MIR_DISABLE_XDG_SHELL_V6_UNSTABLE"))
-        xdg_shell_global = std::make_unique<XdgShellV6>(display.get(), shell, *seat_global);
+        xdg_shell_global = std::make_unique<XdgShellV6>(display.get(), shell, *seat_global, output_manager.get());
 
     wl_display_init_shm(display.get());
 

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -18,6 +18,7 @@
 
 #include "wl_surface_role.h"
 
+#include "output_manager.h"
 #include "wayland_utils.h"
 #include "wl_surface.h"
 #include "basic_surface_event_sink.h"
@@ -47,9 +48,22 @@ void mir::frontend::WlAbstractMirWindow::unset_maximized()
 
 void mir::frontend::WlAbstractMirWindow::set_fullscreen(std::experimental::optional<struct wl_resource*> const& output)
 {
-    (void)output; // TODO specify the output when setting fullscreen
     // We must process this request immediately (i.e. don't defer until commit())
-    set_state_now(mir_window_state_fullscreen);
+    if (surface_id_.as_value())
+    {
+        shell::SurfaceSpecification mods;
+        mods.state = mir_window_state_fullscreen;
+        mods.output_id = output_manager->output_id_for(output);
+        auto const session = get_session(client);
+        shell->modify_surface(session, surface_id_, mods);
+    }
+    else
+    {
+        params->state = mir_window_state_fullscreen;
+        if (output)
+            params->output_id = output_manager->output_id_for(output.value());
+        create_mir_window();
+    }
 }
 
 void mir::frontend::WlAbstractMirWindow::unset_fullscreen()
@@ -94,11 +108,12 @@ std::shared_ptr<scene::Surface> get_surface_for_id(std::shared_ptr<Session> cons
 }
 
 WlAbstractMirWindow::WlAbstractMirWindow(WlSeat* seat, wl_client* client, WlSurface* surface,
-                                         std::shared_ptr<Shell> const& shell)
+                                         std::shared_ptr<Shell> const& shell, OutputManager* output_manager)
         : destroyed{std::make_shared<bool>(false)},
           client{client},
           surface{surface},
           shell{shell},
+          output_manager{output_manager},
           sink{std::make_shared<BasicSurfaceEventSink>(seat, client, surface, this)},
           params{std::make_unique<scene::SurfaceCreationParameters>(
                  scene::SurfaceCreationParameters().of_type(mir_window_type_freestyle))}

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -53,7 +53,7 @@ void mir::frontend::WlAbstractMirWindow::set_fullscreen(std::experimental::optio
     {
         shell::SurfaceSpecification mods;
         mods.state = mir_window_state_fullscreen;
-        mods.output_id = output_manager->output_id_for(output);
+        mods.output_id = output_manager->output_id_for(client, output);
         auto const session = get_session(client);
         shell->modify_surface(session, surface_id_, mods);
     }
@@ -61,7 +61,7 @@ void mir::frontend::WlAbstractMirWindow::set_fullscreen(std::experimental::optio
     {
         params->state = mir_window_state_fullscreen;
         if (output)
-            params->output_id = output_manager->output_id_for(output.value());
+            params->output_id = output_manager->output_id_for(client, output.value());
         create_mir_window();
     }
 }

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -46,6 +46,7 @@ namespace frontend
 {
 class Shell;
 class BasicSurfaceEventSink;
+class OutputManager;
 class WlSurface;
 class WlSeat;
 struct WlSurfaceState;
@@ -66,7 +67,7 @@ class WlAbstractMirWindow : public WlSurfaceRole
 {
 public:
     WlAbstractMirWindow(WlSeat* seat, wl_client* client, WlSurface* surface,
-                        std::shared_ptr<frontend::Shell> const& shell);
+                        std::shared_ptr<frontend::Shell> const& shell, OutputManager* output_manager);
 
     ~WlAbstractMirWindow() override;
 
@@ -90,6 +91,7 @@ protected:
     wl_client* const client;
     WlSurface* const surface;
     std::shared_ptr<frontend::Shell> const shell;
+    OutputManager* output_manager;
     std::shared_ptr<BasicSurfaceEventSink> const sink;
 
     std::unique_ptr<scene::SurfaceCreationParameters> const params;

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -48,7 +48,7 @@ public:
     static XdgSurfaceV6* from(wl_resource* surface);
 
     XdgSurfaceV6(wl_client* client, wl_resource* parent, uint32_t id, WlSurface* surface,
-                 std::shared_ptr<Shell> const& shell, WlSeat& seat);
+                 std::shared_ptr<Shell> const& shell, WlSeat& seat, OutputManager* output_manager);
     ~XdgSurfaceV6() override;
 
     void destroy() override;
@@ -151,10 +151,15 @@ namespace mf = mir::frontend;  // Keep CLion's parsing happy
 
 // XdgShellV6
 
-mf::XdgShellV6::XdgShellV6(struct wl_display* display, std::shared_ptr<mf::Shell> const shell, WlSeat& seat)
-    : wayland::XdgShellV6(display, 1),
-      shell{shell},
-      seat{seat}
+mf::XdgShellV6::XdgShellV6(
+    struct wl_display* display,
+    std::shared_ptr<mf::Shell> const shell,
+    WlSeat& seat,
+    OutputManager* output_manager) :
+    wayland::XdgShellV6(display, 1),
+    shell{shell},
+    seat{seat},
+    output_manager{output_manager}
 {}
 
 void mf::XdgShellV6::destroy(struct wl_client* client, struct wl_resource* resource)
@@ -171,7 +176,7 @@ void mf::XdgShellV6::create_positioner(struct wl_client* client, struct wl_resou
 void mf::XdgShellV6::get_xdg_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id,
                                      struct wl_resource* surface)
 {
-    new XdgSurfaceV6{client, resource, id, WlSurface::from(surface), shell, seat};
+    new XdgSurfaceV6{client, resource, id, WlSurface::from(surface), shell, seat, output_manager};
 }
 
 void mf::XdgShellV6::pong(struct wl_client* client, struct wl_resource* resource, uint32_t serial)
@@ -189,9 +194,9 @@ mf::XdgSurfaceV6* mf::XdgSurfaceV6::from(wl_resource* surface)
 }
 
 mf::XdgSurfaceV6::XdgSurfaceV6(wl_client* client, wl_resource* parent, uint32_t id, WlSurface* surface,
-                               std::shared_ptr<mf::Shell> const& shell, WlSeat& seat)
+                               std::shared_ptr<mf::Shell> const& shell, WlSeat& seat, OutputManager* output_manager)
     : wayland::XdgSurfaceV6(client, parent, id),
-      WlAbstractMirWindow{&seat, client, surface, shell},
+      WlAbstractMirWindow{&seat, client, surface, shell, output_manager},
       parent{parent},
       shell{shell}
 {

--- a/src/server/frontend_wayland/xdg_shell_v6.h
+++ b/src/server/frontend_wayland/xdg_shell_v6.h
@@ -29,11 +29,12 @@ namespace frontend
 
 class Shell;
 class WlSeat;
+class OutputManager;
 
 class XdgShellV6 : public wayland::XdgShellV6
 {
 public:
-    XdgShellV6(struct wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat);
+    XdgShellV6(struct wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
 
     void destroy(struct wl_client* client, struct wl_resource* resource) override;
     void create_positioner(struct wl_client* client, struct wl_resource* resource, uint32_t id) override;
@@ -44,6 +45,7 @@ public:
 private:
     std::shared_ptr<Shell> const shell;
     WlSeat& seat;
+    OutputManager* output_manager;
 };
 
 }


### PR DESCRIPTION
[Wayland] Make use of the specified output in fullscreen requests. (Fixes #423)