### PR TITLE
mesa-kms: Select EGLConfig matching our GBM format.

### DIFF
--- a/src/platforms/mesa/server/kms/egl_helper.cpp
+++ b/src/platforms/mesa/server/kms/egl_helper.cpp
@@ -191,9 +191,9 @@ void mgmh::EGLHelper::setup_internal(GBMHelper const& gbm, bool initialize, EGLi
     // TODO: Get the required EGL_{RED,GREEN,BLUE}_SIZE values out of gbm_format
     EGLint const config_attr[] = {
         EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
-        EGL_RED_SIZE, 5,
-        EGL_GREEN_SIZE, 5,
-        EGL_BLUE_SIZE, 5,
+        EGL_RED_SIZE, 8,
+        EGL_GREEN_SIZE, 8,
+        EGL_BLUE_SIZE, 8,
         EGL_ALPHA_SIZE, 0,
         EGL_DEPTH_SIZE, depth_buffer_bits,
         EGL_STENCIL_SIZE, stencil_buffer_bits,

--- a/src/platforms/mesa/server/kms/egl_helper.cpp
+++ b/src/platforms/mesa/server/kms/egl_helper.cpp
@@ -171,14 +171,14 @@ std::vector<EGLConfig> get_matching_configs(EGLDisplay dpy, EGLint const attr[])
     if ((eglChooseConfig(dpy, attr, nullptr, 0, &num_egl_configs) == EGL_FALSE) ||
         (num_egl_configs == 0))
     {
-        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to choose EGL config"));
+        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to enumerate any matching EGL configs"));
     }
 
     std::vector<EGLConfig> matching_configs(static_cast<size_t>(num_egl_configs));
     if ((eglChooseConfig(dpy, attr, matching_configs.data(), static_cast<EGLint>(matching_configs.size()), &num_egl_configs) == EGL_FALSE) ||
         (num_egl_configs == 0))
     {
-        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to choose EGL config"));
+        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to acquire matching EGL configs"));
     }
 
     matching_configs.resize(static_cast<size_t>(num_egl_configs));

--- a/src/platforms/mesa/server/kms/egl_helper.h
+++ b/src/platforms/mesa/server/kms/egl_helper.h
@@ -59,7 +59,7 @@ public:
 
     void report_egl_configuration(std::function<void(EGLDisplay, EGLConfig)>);
 private:
-    void setup_internal(GBMHelper const& gbm, bool initialize);
+    void setup_internal(GBMHelper const& gbm, bool initialize, EGLint gbm_format);
 
     EGLint const depth_buffer_bits;
     EGLint const stencil_buffer_bits;

--- a/tests/mir_test_doubles/mock_egl.cpp
+++ b/tests/mir_test_doubles/mock_egl.cpp
@@ -103,9 +103,16 @@ mtd::MockEGL::MockEGL()
         [&] (EGLDisplay, const EGLint *, EGLConfig *configs,
              EGLint config_size, EGLint *num_config) -> EGLBoolean
         {
-            EGLint const min_size = std::min(config_size, fake_configs_num);
-            std::copy(fake_configs, fake_configs + min_size, configs);
-            *num_config = min_size;
+            if (configs != nullptr)
+            {
+                EGLint const min_size = std::min(config_size, fake_configs_num);
+                std::copy(fake_configs, fake_configs + min_size, configs);
+                *num_config = min_size;
+            }
+            else
+            {
+                *num_config = fake_configs_num;
+            }
             return EGL_TRUE;
         }));
 

--- a/tests/unit-tests/platforms/mesa/kms/test_display.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_display.cpp
@@ -777,7 +777,14 @@ TEST_F(MesaDisplayTest, respects_gl_config)
         null_report};
 }
 
-TEST_F(MesaDisplayTest, supports_as_low_as_15bit_colour)
+/*
+ * It *would* be nice to support 15bit colour, but the mesa-kms platform
+ * has, from the first commit, unconditonally allocated 24-bit framebuffers.
+ *
+ * It's not clear to me that Mir has ever been successfully tested on a platform
+ * that doesn't support 24-bit rendering.
+ */
+TEST_F(MesaDisplayTest, DISABLED_supports_as_low_as_15bit_colour)
 {  // Regression test for LP: #1212753
     using namespace testing;
 

--- a/tests/unit-tests/platforms/mesa/kms/test_display_configuration.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_display_configuration.cpp
@@ -102,6 +102,11 @@ public:
             .WillByDefault(DoAll(SetArgPointee<2>(mock_egl.fake_configs[0]),
                                  SetArgPointee<4>(1),
                                  Return(EGL_TRUE)));
+        ON_CALL(mock_egl, eglGetConfigAttrib(_, mock_egl.fake_configs[0], EGL_NATIVE_VISUAL_ID, _))
+            .WillByDefault(
+                DoAll(
+                    SetArgPointee<3>(GBM_FORMAT_XRGB8888),
+                        Return(EGL_TRUE)));
 
         mock_egl.provide_egl_extensions();
         mock_gl.provide_gles_extensions();

--- a/tests/unit-tests/platforms/mesa/kms/test_display_generic.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_display_generic.cpp
@@ -54,6 +54,11 @@ public:
             .WillByDefault(DoAll(SetArgPointee<2>(mock_egl.fake_configs[0]),
                                  SetArgPointee<4>(1),
                                  Return(EGL_TRUE)));
+        ON_CALL(mock_egl, eglGetConfigAttrib(_, mock_egl.fake_configs[0], EGL_NATIVE_VISUAL_ID, _))
+            .WillByDefault(
+                DoAll(
+                    SetArgPointee<3>(GBM_FORMAT_XRGB8888),
+                    Return(EGL_TRUE)));
 
         mock_egl.provide_egl_extensions();
         mock_gl.provide_gles_extensions();

--- a/tests/unit-tests/platforms/mesa/kms/test_display_multi_monitor.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_display_multi_monitor.cpp
@@ -119,6 +119,11 @@ public:
             .WillByDefault(DoAll(SetArgPointee<2>(mock_egl.fake_configs[0]),
                                  SetArgPointee<4>(1),
                                  Return(EGL_TRUE)));
+        ON_CALL(mock_egl, eglGetConfigAttrib(_, mock_egl.fake_configs[0], EGL_NATIVE_VISUAL_ID, _))
+            .WillByDefault(
+                DoAll(
+                    SetArgPointee<3>(GBM_FORMAT_XRGB8888),
+                    Return(EGL_TRUE)));
 
         mock_egl.provide_egl_extensions();
         mock_gl.provide_gles_extensions();


### PR DESCRIPTION
Fixes #435 