### PR TITLE
Ensure resize configuration events are not superseded. (Fixes #449)

### DIFF
--- a/src/server/frontend_wayland/basic_surface_event_sink.cpp
+++ b/src/server/frontend_wayland/basic_surface_event_sink.cpp
@@ -72,7 +72,13 @@ void mf::BasicSurfaceEventSink::handle_event(EventUPtr&& event)
 
 void mf::BasicSurfaceEventSink::handle_resize_event(MirResizeEvent const* event)
 {
-    requested_size = {mir_resize_event_get_width(event), mir_resize_event_get_height(event)};
+    geometry::Size const new_size{mir_resize_event_get_width(event), mir_resize_event_get_height(event)};
+    handle_resize(new_size);
+}
+
+void mf::BasicSurfaceEventSink::handle_resize(mir::geometry::Size const& new_size)
+{
+    requested_size = new_size;
     if (requested_size != window_size)
         window->handle_resize(requested_size);
 }

--- a/src/server/frontend_wayland/basic_surface_event_sink.h
+++ b/src/server/frontend_wayland/basic_surface_event_sink.h
@@ -38,6 +38,7 @@ public:
     ~BasicSurfaceEventSink();
 
     void handle_event(EventUPtr&& event) override;
+    void handle_resize(mir::geometry::Size const& new_size);
 
     void handle_lifecycle_event(MirLifecycleState) override {}
     void handle_display_config_change(graphics::DisplayConfiguration const&) override {}

--- a/src/server/frontend_wayland/wl_surface_role.cpp
+++ b/src/server/frontend_wayland/wl_surface_role.cpp
@@ -211,7 +211,7 @@ void WlAbstractMirWindow::create_mir_window()
     auto const client_size = window->client_size();
 
     if (client_size != params->size)
-        handle_resize(client_size);
+        sink->handle_resize(client_size);
 }
 
 geometry::Size WlAbstractMirWindow::window_size()


### PR DESCRIPTION
Note there are couple of racy wlcs tests this breaks:

XdgToplevelV6Configuration.maximized_and_unmaximized
XdgToplevelV6Configuration.fullscreened_and_restored

These are fixed in: https://github.com/MirServer/wlcs/pull/58