### PR TITLE
Revert "Merge #448"

### DIFF
--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -448,7 +448,7 @@ protected:
     CachedPtr<scene::ApplicationNotRespondingDetector> application_not_responding_detector;
     CachedPtr<cookie::Authority> cookie_authority;
     CachedPtr<input::KeyMapper> key_mapper;
-    std::shared_ptr<ConsoleServices> console_services{nullptr};
+    CachedPtr<ConsoleServices> console_services;
 
 private:
     std::shared_ptr<options::Configuration> const configuration_options;

--- a/src/server/console/default_configuration.cpp
+++ b/src/server/console/default_configuration.cpp
@@ -96,30 +96,13 @@ struct RealPosixProcessOperations : public mir::PosixProcessOperations
 
 std::shared_ptr<mir::ConsoleServices> mir::DefaultServerConfiguration::the_console_services()
 {
-    if (!console_services)
-    {
-        console_services =
-            [this]() -> std::shared_ptr<ConsoleServices>
+    return console_services(
+        [this]() -> std::shared_ptr<ConsoleServices>
+        {
+            auto const vt = the_options()->get<int>(options::vt_option_name);
+
+            if (!vt)
             {
-                auto const vt = the_options()->get<int>(options::vt_option_name);
-
-                if (!vt)
-                {
-                    try
-                    {
-                        auto const vt_services = std::make_shared<mir::LogindConsoleServices>(
-                            std::dynamic_pointer_cast<mir::GLibMainLoop>(the_main_loop()));
-                        mir::log_debug("Using logind for session management");
-                        return vt_services;
-                    }
-                    catch (std::exception const& e)
-                    {
-                        mir::log_debug(
-                            "Not using logind for session management: %s",
-                            e.what());
-                    }
-                }
-
                 try
                 {
                     auto const vt_services = std::make_shared<mir::LogindConsoleServices>(
@@ -131,30 +114,43 @@ std::shared_ptr<mir::ConsoleServices> mir::DefaultServerConfiguration::the_conso
                 {
                     mir::log_debug(
                         "Not using logind for session management: %s",
-                        e.what());
+                        boost::diagnostic_information(e).c_str());
                 }
+            }
 
-                try
-                {
-                    auto const vt_services = std::make_shared<mir::LinuxVirtualTerminal>(
-                        std::make_unique<RealVTFileOperations>(),
-                        std::make_unique<RealPosixProcessOperations>(),
-                        vt,
-                        *the_emergency_cleanup(),
-                        the_display_report());
-                    mir::log_debug("Using Linux VT subsystem for session management");
-                    return vt_services;
-                }
-                catch (std::exception const& e)
-                {
-                    mir::log_debug(
-                        "Not using Linux VT subsystem for session management: %s",
-                        e.what());
-                }
+            try
+            {
+                auto const vt_services = std::make_shared<mir::LogindConsoleServices>(
+                    std::dynamic_pointer_cast<mir::GLibMainLoop>(the_main_loop()));
+                mir::log_debug("Using logind for session management");
+                return vt_services;
+            }
+            catch (std::exception const& e)
+            {
+                mir::log_debug(
+                    "Not using logind for session management: %s",
+                    boost::diagnostic_information(e).c_str());
+            }
 
-                mir::log_debug("No session management supported");
-                return std::make_shared<mir::NullConsoleServices>();
-            }();
-    }
-    return console_services;
+            try
+            {
+                auto const vt_services = std::make_shared<mir::LinuxVirtualTerminal>(
+                    std::make_unique<RealVTFileOperations>(),
+                    std::make_unique<RealPosixProcessOperations>(),
+                    vt,
+                    *the_emergency_cleanup(),
+                    the_display_report());
+                mir::log_debug("Using Linux VT subsystem for session management");
+                return vt_services;
+            }
+            catch (std::exception const& e)
+            {
+                mir::log_debug(
+                    "Not using Linux VT subsystem for session management: %s",
+                    boost::diagnostic_information(e).c_str());
+            }
+
+            mir::log_debug("No session management supported");
+            return std::make_shared<mir::NullConsoleServices>();
+        });
 }

--- a/src/server/console/default_configuration.cpp
+++ b/src/server/console/default_configuration.cpp
@@ -120,20 +120,6 @@ std::shared_ptr<mir::ConsoleServices> mir::DefaultServerConfiguration::the_conso
 
             try
             {
-                auto const vt_services = std::make_shared<mir::LogindConsoleServices>(
-                    std::dynamic_pointer_cast<mir::GLibMainLoop>(the_main_loop()));
-                mir::log_debug("Using logind for session management");
-                return vt_services;
-            }
-            catch (std::exception const& e)
-            {
-                mir::log_debug(
-                    "Not using logind for session management: %s",
-                    boost::diagnostic_information(e).c_str());
-            }
-
-            try
-            {
                 auto const vt_services = std::make_shared<mir::LinuxVirtualTerminal>(
                     std::make_unique<RealVTFileOperations>(),
                     std::make_unique<RealPosixProcessOperations>(),


### PR DESCRIPTION
The first call to the_console_services() happens before the configuration is parsed (as part of loading platforms to add their options). That means --vt is seen with its default value and LogindConsoleServices always selected.

This revert restores the less efficient, but working behaviour.