### PR TITLE
Window Role cleanup

### DIFF
--- a/include/server/mir/scene/surface_creation_parameters.h
+++ b/include/server/mir/scene/surface_creation_parameters.h
@@ -34,6 +34,7 @@
 
 namespace mir
 {
+namespace shell { class SurfaceSpecification; }
 namespace scene
 {
 class Surface;
@@ -71,6 +72,8 @@ struct SurfaceCreationParameters
     SurfaceCreationParameters& with_edge_attachment(MirEdgeAttachment edge);
 
     SurfaceCreationParameters& with_buffer_stream(frontend::BufferStreamId const& id);
+
+    void update_from(shell::SurfaceSpecification const& that);
 
     std::string name;
     geometry::Size size;

--- a/include/server/mir/shell/surface_specification.h
+++ b/include/server/mir/shell/surface_specification.h
@@ -57,6 +57,7 @@ struct StreamCursor
 struct SurfaceSpecification
 {
     bool is_empty() const;
+    void update_from(SurfaceSpecification const& that);
 
     optional_value<geometry::Width> width;
     optional_value<geometry::Height> height;

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -325,34 +325,22 @@ protected:
         int32_t y,
         uint32_t flags) override
     {
-        auto const session = get_session(client);
         auto& parent_surface = *WlSurface::from(parent);
 
-        if (surface_id().as_value())
-        {
-            auto& mods = spec();
-            mods.parent_id = parent_surface.surface_id();
-            mods.aux_rect = geom::Rectangle{{x, y}, {}};
-            mods.surface_placement_gravity = mir_placement_gravity_northwest;
-            mods.aux_rect_placement_gravity = mir_placement_gravity_southeast;
-            mods.placement_hints = mir_placement_hints_slide_x;
-            mods.aux_rect_placement_offset_x = 0;
-            mods.aux_rect_placement_offset_y = 0;
-        }
-        else
-        {
-            if (flags & WL_SHELL_SURFACE_TRANSIENT_INACTIVE)
-                params->type = mir_window_type_gloss;
-            params->parent_id = parent_surface.surface_id();
-            params->aux_rect = geom::Rectangle{{x, y}, {}};
-            params->surface_placement_gravity = mir_placement_gravity_northwest;
-            params->aux_rect_placement_gravity = mir_placement_gravity_southeast;
-            params->placement_hints = mir_placement_hints_slide_x;
-            params->aux_rect_placement_offset_x = 0;
-            params->aux_rect_placement_offset_y = 0;
+        mir::shell::SurfaceSpecification mods;
 
-            surface->set_role(this);
-        }
+        if (flags & WL_SHELL_SURFACE_TRANSIENT_INACTIVE)
+            mods.type = mir_window_type_gloss;
+        mods.parent_id = parent_surface.surface_id();
+        mods.aux_rect = geom::Rectangle{{x, y}, {}};
+        mods.surface_placement_gravity = mir_placement_gravity_northwest;
+        mods.aux_rect_placement_gravity = mir_placement_gravity_southeast;
+        mods.placement_hints = mir_placement_hints_slide_x;
+        mods.aux_rect_placement_offset_x = 0;
+        mods.aux_rect_placement_offset_y = 0;
+
+        apply_spec(mods);
+        surface->set_role(this);
     }
 
     void handle_resize(const geometry::Size & new_size) override
@@ -380,32 +368,20 @@ protected:
         auto const session = get_session(client);
         auto& parent_surface = *WlSurface::from(parent);
 
-        if (surface_id().as_value())
-        {
-            auto& mods = spec();
-            mods.parent_id = parent_surface.surface_id();
-            mods.aux_rect = geom::Rectangle{{x, y}, {}};
-            mods.surface_placement_gravity = mir_placement_gravity_northwest;
-            mods.aux_rect_placement_gravity = mir_placement_gravity_southeast;
-            mods.placement_hints = mir_placement_hints_slide_x;
-            mods.aux_rect_placement_offset_x = 0;
-            mods.aux_rect_placement_offset_y = 0;
-        }
-        else
-        {
-            if (flags & WL_SHELL_SURFACE_TRANSIENT_INACTIVE)
-                params->type = mir_window_type_gloss;
+        mir::shell::SurfaceSpecification mods;
 
-            params->parent_id = parent_surface.surface_id();
-            params->aux_rect = geom::Rectangle{{x, y}, {}};
-            params->surface_placement_gravity = mir_placement_gravity_northwest;
-            params->aux_rect_placement_gravity = mir_placement_gravity_southeast;
-            params->placement_hints = mir_placement_hints_slide_x;
-            params->aux_rect_placement_offset_x = 0;
-            params->aux_rect_placement_offset_y = 0;
+        if (flags & WL_SHELL_SURFACE_TRANSIENT_INACTIVE)
+            mods.type = mir_window_type_gloss;
+        mods.parent_id = parent_surface.surface_id();
+        mods.aux_rect = geom::Rectangle{{x, y}, {}};
+        mods.surface_placement_gravity = mir_placement_gravity_northwest;
+        mods.aux_rect_placement_gravity = mir_placement_gravity_southeast;
+        mods.placement_hints = mir_placement_hints_slide_x;
+        mods.aux_rect_placement_offset_x = 0;
+        mods.aux_rect_placement_offset_y = 0;
 
-            surface->set_role(this);
-        }
+        apply_spec(mods);
+        surface->set_role(this);
     }
 
     void set_maximized(std::experimental::optional<struct wl_resource*> const& output) override
@@ -416,14 +392,7 @@ protected:
 
     void set_title(std::string const& title) override
     {
-        if (surface_id().as_value())
-        {
-            spec().name = title;
-        }
-        else
-        {
-            params->name = title;
-        }
+        WindowWlSurfaceRole::set_title(title);
     }
 
     void pong(uint32_t /*serial*/) override

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -306,10 +306,7 @@ public:
     {
     }
 
-    ~WlShellSurface() override
-    {
-        surface->clear_role();
-    }
+    ~WlShellSurface() = default;
 
 protected:
     void destroy() override

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -386,7 +386,7 @@ protected:
     void set_maximized(std::experimental::optional<struct wl_resource*> const& output) override
     {
         (void)output;
-        WindowWlSurfaceRole::set_maximized();
+        WindowWlSurfaceRole::set_state_now(mir_window_state_maximized);
     }
 
     void set_title(std::string const& title) override

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -242,3 +242,15 @@ void mf::WindowWlSurfaceRole::visiblity(bool visible)
     }
 }
 
+void mf::WindowPositionerData::apply_to(ms::SurfaceCreationParameters& params) const
+{
+    if (size.is_set())
+        params.size = size.value();
+    params.aux_rect = aux_rect;
+    params.surface_placement_gravity = surface_placement_gravity;
+    params.aux_rect_placement_gravity = aux_rect_placement_gravity;
+    params.aux_rect_placement_offset_x = aux_rect_placement_offset_x;
+    params.aux_rect_placement_offset_y = aux_rect_placement_offset_y;
+    params.placement_hints = mir_placement_hints_slide_any;
+}
+

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -88,6 +88,18 @@ void mf::WindowWlSurfaceRole::refresh_surface_data_now()
     shell->modify_surface(get_session(client), surface_id_, surface_data_spec);
 }
 
+void mf::WindowWlSurfaceRole::apply_positioner(Positioner const& positioner)
+{
+    if (positioner.size.is_set())
+        params->size = positioner.size.value();
+    params->aux_rect = positioner.aux_rect;
+    params->surface_placement_gravity = positioner.surface_placement_gravity;
+    params->aux_rect_placement_gravity = positioner.aux_rect_placement_gravity;
+    params->aux_rect_placement_offset_x = positioner.aux_rect_placement_offset_x;
+    params->aux_rect_placement_offset_y = positioner.aux_rect_placement_offset_y;
+    params->placement_hints = mir_placement_hints_slide_any;
+}
+
 void mf::WindowWlSurfaceRole::set_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
 {
     geom::Displacement const offset{-x, -y};
@@ -351,17 +363,5 @@ void mf::WindowWlSurfaceRole::visiblity(bool visible)
         if (mir_surface->state() != mir_window_state_hidden)
             spec().state = mir_window_state_hidden;
     }
-}
-
-void mf::WindowPositionerData::apply_to(ms::SurfaceCreationParameters& params) const
-{
-    if (size.is_set())
-        params.size = size.value();
-    params.aux_rect = aux_rect;
-    params.surface_placement_gravity = surface_placement_gravity;
-    params.aux_rect_placement_gravity = aux_rect_placement_gravity;
-    params.aux_rect_placement_offset_x = aux_rect_placement_offset_x;
-    params.aux_rect_placement_offset_y = aux_rect_placement_offset_y;
-    params.placement_hints = mir_placement_hints_slide_any;
 }
 

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -60,6 +60,7 @@ mf::WindowWlSurfaceRole::WindowWlSurfaceRole(WlSeat* seat, wl_client* client, Wl
 
 mf::WindowWlSurfaceRole::~WindowWlSurfaceRole()
 {
+    surface->clear_role();
     sink->disconnect();
     *destroyed = true;
     if (surface_id_.as_value())

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -88,44 +88,15 @@ void mf::WindowWlSurfaceRole::refresh_surface_data_now()
     shell->modify_surface(get_session(client), surface_id_, surface_data_spec);
 }
 
-void mf::WindowWlSurfaceRole::apply_positioner(Positioner const& positioner)
+void mf::WindowWlSurfaceRole::apply_spec(mir::shell::SurfaceSpecification const& new_spec)
 {
     if (surface_id().as_value())
     {
-        if (positioner.size)
-        {
-            spec().width = positioner.size.value().width;
-            spec().height = positioner.size.value().height;
-        }
-        if (positioner.aux_rect)
-            spec().aux_rect = positioner.aux_rect.value();
-        if (positioner.surface_placement_gravity)
-            spec().surface_placement_gravity = positioner.surface_placement_gravity.value();
-        if (positioner.aux_rect_placement_gravity)
-            spec().aux_rect_placement_gravity = positioner.aux_rect_placement_gravity.value();
-        if (positioner.aux_rect_placement_offset)
-        {
-            spec().aux_rect_placement_offset_x = positioner.aux_rect_placement_offset.value().dx.as_int();
-            spec().aux_rect_placement_offset_y = positioner.aux_rect_placement_offset.value().dy.as_int();
-        }
-        spec().placement_hints = mir_placement_hints_slide_any;
+        spec().update_from(new_spec);
     }
     else
     {
-        if (positioner.size)
-            params->size = positioner.size.value();
-        if (positioner.aux_rect)
-            params->aux_rect = positioner.aux_rect.value();
-        if (positioner.surface_placement_gravity)
-            params->surface_placement_gravity = positioner.surface_placement_gravity.value();
-        if (positioner.aux_rect_placement_gravity)
-            params->aux_rect_placement_gravity = positioner.aux_rect_placement_gravity.value();
-        if (positioner.aux_rect_placement_offset)
-        {
-            params->aux_rect_placement_offset_x = positioner.aux_rect_placement_offset.value().dx.as_int();
-            params->aux_rect_placement_offset_y = positioner.aux_rect_placement_offset.value().dy.as_int();
-        }
-        params->placement_hints = mir_placement_hints_slide_any;
+        params->update_from(new_spec);
     }
 }
 

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -216,18 +216,6 @@ void mf::WindowWlSurfaceRole::set_min_size(int32_t width, int32_t height)
     }
 }
 
-void mf::WindowWlSurfaceRole::set_maximized()
-{
-    // We must process this request immediately (i.e. don't defer until commit())
-    set_state_now(mir_window_state_maximized);
-}
-
-void mf::WindowWlSurfaceRole::unset_maximized()
-{
-    // We must process this request immediately (i.e. don't defer until commit())
-    set_state_now(mir_window_state_restored);
-}
-
 void mf::WindowWlSurfaceRole::set_fullscreen(std::experimental::optional<struct wl_resource*> const& output)
 {
     // We must process this request immediately (i.e. don't defer until commit())
@@ -246,18 +234,6 @@ void mf::WindowWlSurfaceRole::set_fullscreen(std::experimental::optional<struct 
             params->output_id = output_manager->output_id_for(client, output.value());
         create_mir_window();
     }
-}
-
-void mf::WindowWlSurfaceRole::unset_fullscreen()
-{
-    // We must process this request immediately (i.e. don't defer until commit())
-    set_state_now(mir_window_state_restored);
-}
-
-void mf::WindowWlSurfaceRole::set_minimized()
-{
-    // We must process this request immediately (i.e. don't defer until commit())
-    set_state_now(mir_window_state_minimized);
 }
 
 void mf::WindowWlSurfaceRole::set_state_now(MirWindowState state)

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -90,14 +90,43 @@ void mf::WindowWlSurfaceRole::refresh_surface_data_now()
 
 void mf::WindowWlSurfaceRole::apply_positioner(Positioner const& positioner)
 {
-    if (positioner.size.is_set())
-        params->size = positioner.size.value();
-    params->aux_rect = positioner.aux_rect;
-    params->surface_placement_gravity = positioner.surface_placement_gravity;
-    params->aux_rect_placement_gravity = positioner.aux_rect_placement_gravity;
-    params->aux_rect_placement_offset_x = positioner.aux_rect_placement_offset_x;
-    params->aux_rect_placement_offset_y = positioner.aux_rect_placement_offset_y;
-    params->placement_hints = mir_placement_hints_slide_any;
+    if (surface_id().as_value())
+    {
+        if (positioner.size)
+        {
+            spec().width = positioner.size.value().width;
+            spec().height = positioner.size.value().height;
+        }
+        if (positioner.aux_rect)
+            spec().aux_rect = positioner.aux_rect.value();
+        if (positioner.surface_placement_gravity)
+            spec().surface_placement_gravity = positioner.surface_placement_gravity.value();
+        if (positioner.aux_rect_placement_gravity)
+            spec().aux_rect_placement_gravity = positioner.aux_rect_placement_gravity.value();
+        if (positioner.aux_rect_placement_offset)
+        {
+            spec().aux_rect_placement_offset_x = positioner.aux_rect_placement_offset.value().dx.as_int();
+            spec().aux_rect_placement_offset_y = positioner.aux_rect_placement_offset.value().dy.as_int();
+        }
+        spec().placement_hints = mir_placement_hints_slide_any;
+    }
+    else
+    {
+        if (positioner.size)
+            params->size = positioner.size.value();
+        if (positioner.aux_rect)
+            params->aux_rect = positioner.aux_rect.value();
+        if (positioner.surface_placement_gravity)
+            params->surface_placement_gravity = positioner.surface_placement_gravity.value();
+        if (positioner.aux_rect_placement_gravity)
+            params->aux_rect_placement_gravity = positioner.aux_rect_placement_gravity.value();
+        if (positioner.aux_rect_placement_offset)
+        {
+            params->aux_rect_placement_offset_x = positioner.aux_rect_placement_offset.value().dx.as_int();
+            params->aux_rect_placement_offset_y = positioner.aux_rect_placement_offset.value().dy.as_int();
+        }
+        params->placement_hints = mir_placement_hints_slide_any;
+    }
 }
 
 void mf::WindowWlSurfaceRole::set_geometry(int32_t x, int32_t y, int32_t width, int32_t height)

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -55,6 +55,17 @@ class WlSeat;
 class WindowWlSurfaceRole : public WlSurfaceRole
 {
 public:
+    class Positioner
+    {
+    public:
+        optional_value<geometry::Size> size;
+        optional_value<geometry::Rectangle> aux_rect;
+        optional_value<MirPlacementGravity> surface_placement_gravity;
+        optional_value<MirPlacementGravity> aux_rect_placement_gravity;
+        optional_value<int> aux_rect_placement_offset_x;
+        optional_value<int> aux_rect_placement_offset_y;
+    };
+
     WindowWlSurfaceRole(WlSeat* seat, wl_client* client, WlSurface* surface,
                         std::shared_ptr<frontend::Shell> const& shell, OutputManager* output_manager);
 
@@ -65,6 +76,7 @@ public:
     void populate_spec_with_surface_data(shell::SurfaceSpecification& spec);
     void refresh_surface_data_now() override;
 
+    void apply_positioner(Positioner const& positioner);
     void set_geometry(int32_t x, int32_t y, int32_t width, int32_t height);
     void set_title(std::string const& title);
     void initiate_interactive_move();
@@ -104,19 +116,6 @@ private:
     void create_mir_window();
 
     void visiblity(bool visible) override;
-};
-
-class WindowPositionerData
-{
-public:
-    optional_value<geometry::Size> size;
-    optional_value<geometry::Rectangle> aux_rect;
-    optional_value<MirPlacementGravity> surface_placement_gravity;
-    optional_value<MirPlacementGravity> aux_rect_placement_gravity;
-    optional_value<int> aux_rect_placement_offset_x;
-    optional_value<int> aux_rect_placement_offset_y;
-
-    void apply_to(scene::SurfaceCreationParameters& params) const;
 };
 
 }

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -108,6 +108,8 @@ public:
     optional_value<MirPlacementGravity> aux_rect_placement_gravity;
     optional_value<int> aux_rect_placement_offset_x;
     optional_value<int> aux_rect_placement_offset_y;
+
+    void apply_to(scene::SurfaceCreationParameters& params) const;
 };
 
 }

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -24,6 +24,7 @@
 #include "mir/frontend/surface_id.h"
 #include "mir/geometry/displacement.h"
 #include "mir/geometry/size.h"
+#include "mir/geometry/rectangle.h"
 #include "mir/optional_value.h"
 
 #include <mir_toolkit/common.h>
@@ -96,6 +97,17 @@ private:
     void create_mir_window();
 
     void visiblity(bool visible) override;
+};
+
+class WindowPositionerData
+{
+public:
+    optional_value<geometry::Size> size;
+    optional_value<geometry::Rectangle> aux_rect;
+    optional_value<MirPlacementGravity> surface_placement_gravity;
+    optional_value<MirPlacementGravity> aux_rect_placement_gravity;
+    optional_value<int> aux_rect_placement_offset_x;
+    optional_value<int> aux_rect_placement_offset_y;
 };
 
 }

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -55,15 +55,6 @@ class WlSeat;
 class WindowWlSurfaceRole : public WlSurfaceRole
 {
 public:
-    class Positioner
-    {
-    public:
-        std::experimental::optional<geometry::Size> size;
-        std::experimental::optional<geometry::Rectangle> aux_rect;
-        std::experimental::optional<MirPlacementGravity> surface_placement_gravity;
-        std::experimental::optional<MirPlacementGravity> aux_rect_placement_gravity;
-        std::experimental::optional<geometry::Displacement> aux_rect_placement_offset;
-    };
 
     WindowWlSurfaceRole(WlSeat* seat, wl_client* client, WlSurface* surface,
                         std::shared_ptr<frontend::Shell> const& shell, OutputManager* output_manager);
@@ -75,7 +66,7 @@ public:
     void populate_spec_with_surface_data(shell::SurfaceSpecification& spec);
     void refresh_surface_data_now() override;
 
-    void apply_positioner(Positioner const& positioner);
+    void apply_spec(shell::SurfaceSpecification const& new_spec);
     void set_geometry(int32_t x, int32_t y, int32_t width, int32_t height);
     void set_title(std::string const& title);
     void initiate_interactive_move();

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -65,6 +65,13 @@ public:
     void populate_spec_with_surface_data(shell::SurfaceSpecification& spec);
     void refresh_surface_data_now() override;
 
+    void set_geometry(int32_t x, int32_t y, int32_t width, int32_t height);
+    void set_title(std::string const& title);
+    void initiate_interactive_move();
+    void initiate_interactive_resize(MirResizeEdge edge);
+    void set_parent(optional_value<SurfaceId> parent_id);
+    void set_max_size(int32_t width, int32_t height);
+    void set_min_size(int32_t width, int32_t height);
     void set_maximized();
     void unset_maximized();
     void set_fullscreen(std::experimental::optional<wl_resource*> const& output);

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -58,12 +58,11 @@ public:
     class Positioner
     {
     public:
-        optional_value<geometry::Size> size;
-        optional_value<geometry::Rectangle> aux_rect;
-        optional_value<MirPlacementGravity> surface_placement_gravity;
-        optional_value<MirPlacementGravity> aux_rect_placement_gravity;
-        optional_value<int> aux_rect_placement_offset_x;
-        optional_value<int> aux_rect_placement_offset_y;
+        std::experimental::optional<geometry::Size> size;
+        std::experimental::optional<geometry::Rectangle> aux_rect;
+        std::experimental::optional<MirPlacementGravity> surface_placement_gravity;
+        std::experimental::optional<MirPlacementGravity> aux_rect_placement_gravity;
+        std::experimental::optional<geometry::Displacement> aux_rect_placement_offset;
     };
 
     WindowWlSurfaceRole(WlSeat* seat, wl_client* client, WlSurface* surface,

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -65,8 +65,8 @@ public:
 
     void populate_spec_with_surface_data(shell::SurfaceSpecification& spec);
     void refresh_surface_data_now() override;
-
     void become_surface_role();
+
     void apply_spec(shell::SurfaceSpecification const& new_spec);
     void set_geometry(int32_t x, int32_t y, int32_t width, int32_t height);
     void set_title(std::string const& title);
@@ -75,11 +75,7 @@ public:
     void set_parent(optional_value<SurfaceId> parent_id);
     void set_max_size(int32_t width, int32_t height);
     void set_min_size(int32_t width, int32_t height);
-    void set_maximized();
-    void unset_maximized();
     void set_fullscreen(std::experimental::optional<wl_resource*> const& output);
-    void unset_fullscreen();
-    void set_minimized();
 
     void set_state_now(MirWindowState state);
 

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -66,6 +66,7 @@ public:
     void populate_spec_with_surface_data(shell::SurfaceSpecification& spec);
     void refresh_surface_data_now() override;
 
+    void become_surface_role();
     void apply_spec(shell::SurfaceSpecification const& new_spec);
     void set_geometry(int32_t x, int32_t y, int32_t width, int32_t height);
     void set_title(std::string const& title);
@@ -87,25 +88,28 @@ public:
 protected:
     std::shared_ptr<bool> const destroyed;
     wl_client* const client;
+
+    geometry::Size window_size();
+    MirWindowState window_state();
+    bool is_active();
+    uint64_t latest_timestamp_ns();
+
+    void commit(WlSurfaceState const& state) override;
+
+private:
     WlSurface* const surface;
     std::shared_ptr<frontend::Shell> const shell;
     OutputManager* output_manager;
     std::shared_ptr<WlSurfaceEventSink> const sink;
-
     std::unique_ptr<scene::SurfaceCreationParameters> const params;
     optional_value<geometry::Size> window_size_;
-
-    geometry::Size window_size();
-    shell::SurfaceSpecification& spec();
-    void commit(WlSurfaceState const& state) override;
-
-private:
     SurfaceId surface_id_;
     std::unique_ptr<shell::SurfaceSpecification> pending_changes;
 
-    void create_mir_window();
-
     void visiblity(bool visible) override;
+
+    shell::SurfaceSpecification& spec();
+    void create_mir_window();
 };
 
 }

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -201,23 +201,17 @@ void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
 
 void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct wl_resource* positioner)
 {
-    auto* tmp = wl_resource_get_user_data(positioner);
     auto const* const pos = static_cast<WindowPositionerData*>(
                                 static_cast<XdgPositionerV6*>(
-                                    static_cast<wayland::XdgPositionerV6*>(tmp)));
+                                    static_cast<wayland::XdgPositionerV6*>(
+                                        wl_resource_get_user_data(positioner))));
 
-    auto const session = get_session(client);
     auto& parent_surface = *XdgSurfaceV6::from(parent);
 
     params->type = mir_window_type_freestyle;
     params->parent_id = parent_surface.surface_id();
-    if (pos->size.is_set()) params->size = pos->size.value();
-    params->aux_rect = pos->aux_rect;
-    params->surface_placement_gravity = pos->surface_placement_gravity;
-    params->aux_rect_placement_gravity = pos->aux_rect_placement_gravity;
-    params->aux_rect_placement_offset_x = pos->aux_rect_placement_offset_x;
-    params->aux_rect_placement_offset_y = pos->aux_rect_placement_offset_y;
-    params->placement_hints = mir_placement_hints_slide_any;
+
+    pos->apply_to(*params);
 
     new XdgPopupV6{client, parent, id, this};
     surface->set_role(this);

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -116,7 +116,7 @@ private:
     XdgSurfaceV6* const self;
 };
 
-class XdgPositionerV6 : public wayland::XdgPositionerV6, public WindowPositionerData
+class XdgPositionerV6 : public wayland::XdgPositionerV6, public WindowWlSurfaceRole::Positioner
 {
 public:
     XdgPositionerV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
@@ -201,7 +201,7 @@ void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
 
 void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct wl_resource* positioner)
 {
-    auto const* const pos = static_cast<WindowPositionerData*>(
+    auto const* const pos = static_cast<Positioner*>(
                                 static_cast<XdgPositionerV6*>(
                                     static_cast<wayland::XdgPositionerV6*>(
                                         wl_resource_get_user_data(positioner))));
@@ -211,7 +211,7 @@ void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct
     params->type = mir_window_type_freestyle;
     params->parent_id = parent_surface.surface_id();
 
-    pos->apply_to(*params);
+    apply_positioner(*pos);
 
     new XdgPopupV6{client, parent, id, this};
     surface->set_role(this);

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -49,7 +49,7 @@ public:
 
     XdgSurfaceV6(wl_client* client, wl_resource* parent, uint32_t id, WlSurface* surface,
                  std::shared_ptr<Shell> const& shell, WlSeat& seat, OutputManager* output_manager);
-    ~XdgSurfaceV6() override;
+    ~XdgSurfaceV6() = default;
 
     void destroy() override;
     void get_toplevel(uint32_t id) override;
@@ -192,11 +192,6 @@ mf::XdgSurfaceV6::XdgSurfaceV6(wl_client* client, wl_resource* parent, uint32_t 
       parent{parent},
       shell{shell}
 {
-}
-
-mf::XdgSurfaceV6::~XdgSurfaceV6()
-{
-    surface->clear_role();
 }
 
 void mf::XdgSurfaceV6::destroy()

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -564,7 +564,6 @@ void mf::XdgPositionerV6::set_constraint_adjustment(uint32_t constraint_adjustme
 
 void mf::XdgPositionerV6::set_offset(int32_t x, int32_t y)
 {
-    aux_rect_placement_offset_x = x;
-    aux_rect_placement_offset_y = y;
+    aux_rect_placement_offset = geometry::Displacement{x, y};
 }
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -196,7 +196,7 @@ void mf::XdgSurfaceV6::destroy()
 void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
 {
     new XdgToplevelV6{client, parent, id, shell, this};
-    surface->set_role(this);
+    become_surface_role();
 }
 
 void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct wl_resource* positioner)
@@ -215,7 +215,7 @@ void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct
     apply_spec(*specification);
 
     new XdgPopupV6{client, parent, id, this};
-    surface->set_role(this);
+    become_surface_role();
 }
 
 void mf::XdgSurfaceV6::set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
@@ -328,8 +328,8 @@ void mf::XdgSurfaceV6::commit(mf::WlSurfaceState const& state)
 
 void mf::XdgSurfaceV6::handle_resize(geometry::Size const& new_size)
 {
-    auto const action = [notify_resize=notify_resize, new_size, sink=sink]
-        { notify_resize(new_size, sink->state(), sink->is_active()); };
+    auto const action = [notify_resize=notify_resize, new_size, state=window_state(), is_active=is_active()]
+        { notify_resize(new_size, state, is_active); };
 
     auto const serial = wl_display_next_serial(wl_client_get_display(client));
     action();

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -116,11 +116,12 @@ private:
     XdgSurfaceV6* const self;
 };
 
-class XdgPositionerV6 : public wayland::XdgPositionerV6
+class XdgPositionerV6 : public wayland::XdgPositionerV6, public WindowPositionerData
 {
 public:
     XdgPositionerV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
 
+private:
     void destroy() override;
     void set_size(int32_t width, int32_t height) override;
     void set_anchor_rect(int32_t x, int32_t y, int32_t width, int32_t height) override;
@@ -128,13 +129,6 @@ public:
     void set_gravity(uint32_t gravity) override;
     void set_constraint_adjustment(uint32_t constraint_adjustment) override;
     void set_offset(int32_t x, int32_t y) override;
-
-    optional_value<geometry::Size> size;
-    optional_value<geometry::Rectangle> aux_rect;
-    optional_value<MirPlacementGravity> surface_placement_gravity;
-    optional_value<MirPlacementGravity> aux_rect_placement_gravity;
-    optional_value<int> aux_rect_placement_offset_x;
-    optional_value<int> aux_rect_placement_offset_y;
 };
 
 }
@@ -208,7 +202,9 @@ void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
 void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct wl_resource* positioner)
 {
     auto* tmp = wl_resource_get_user_data(positioner);
-    auto const* const pos =  static_cast<XdgPositionerV6*>(static_cast<wayland::XdgPositionerV6*>(tmp));
+    auto const* const pos = static_cast<WindowPositionerData*>(
+                                static_cast<XdgPositionerV6*>(
+                                    static_cast<wayland::XdgPositionerV6*>(tmp)));
 
     auto const session = get_session(client);
     auto& parent_surface = *XdgSurfaceV6::from(parent);

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -469,12 +469,14 @@ void mf::XdgToplevelV6::set_min_size(int32_t width, int32_t height)
 
 void mf::XdgToplevelV6::set_maximized()
 {
-    self->set_maximized();
+    // We must process this request immediately (i.e. don't defer until commit())
+    self->set_state_now(mir_window_state_maximized);
 }
 
 void mf::XdgToplevelV6::unset_maximized()
 {
-    self->unset_maximized();
+    // We must process this request immediately (i.e. don't defer until commit())
+    self->set_state_now(mir_window_state_restored);
 }
 
 void mf::XdgToplevelV6::set_fullscreen(std::experimental::optional<struct wl_resource*> const& output)
@@ -484,12 +486,15 @@ void mf::XdgToplevelV6::set_fullscreen(std::experimental::optional<struct wl_res
 
 void mf::XdgToplevelV6::unset_fullscreen()
 {
-    self->unset_fullscreen();
+    // We must process this request immediately (i.e. don't defer until commit())
+    // TODO: should we instead restore the previous state?
+    self->set_state_now(mir_window_state_restored);
 }
 
 void mf::XdgToplevelV6::set_minimized()
 {
-    self->set_minimized();
+    // We must process this request immediately (i.e. don't defer until commit())
+    self->set_state_now(mir_window_state_minimized);
 }
 
 mf::XdgToplevelV6* mf::XdgToplevelV6::from(wl_resource* surface)

--- a/src/server/scene/surface_creation_parameters.cpp
+++ b/src/server/scene/surface_creation_parameters.cpp
@@ -17,9 +17,11 @@
  */
 
 #include "mir/scene/surface_creation_parameters.h"
+#include "mir/shell/surface_specification.h"
 
 namespace mg = mir::graphics;
 namespace ms = mir::scene;
+namespace msh = mir::shell;
 namespace mi = mir::input;
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
@@ -132,6 +134,73 @@ ms::SurfaceCreationParameters& ms::SurfaceCreationParameters::with_buffer_stream
 {
     content_id = id;
     return *this;
+}
+
+void ms::SurfaceCreationParameters::update_from(msh::SurfaceSpecification const& that)
+{
+    if (that.width.is_set() && that.height.is_set())
+        size = geom::Size{that.width.value(), that.height.value()};
+    if (that.pixel_format.is_set())
+        pixel_format = that.pixel_format.value();
+    if (that.buffer_usage.is_set())
+        buffer_usage = that.buffer_usage.value();
+    if (that.name.is_set())
+        name = that.name;
+    if (that.output_id.is_set())
+        output_id = that.output_id.value();
+    if (that.type.is_set())
+        type = that.type;
+    if (that.state.is_set())
+        state = that.state;
+    if (that.preferred_orientation.is_set())
+        preferred_orientation = that.preferred_orientation;
+    if (that.parent_id.is_set())
+        parent_id = that.parent_id;
+    if (that.aux_rect.is_set())
+        aux_rect = that.aux_rect;
+    if (that.edge_attachment.is_set())
+        edge_attachment = that.edge_attachment;
+    if (that.placement_hints.is_set())
+        placement_hints = that.placement_hints;
+    if (that.surface_placement_gravity.is_set())
+        surface_placement_gravity = that.surface_placement_gravity;
+    if (that.aux_rect_placement_gravity.is_set())
+        aux_rect_placement_gravity = that.aux_rect_placement_gravity;
+    if (that.aux_rect_placement_offset_x.is_set())
+        aux_rect_placement_offset_x = that.aux_rect_placement_offset_x;
+    if (that.aux_rect_placement_offset_y.is_set())
+        aux_rect_placement_offset_y = that.aux_rect_placement_offset_y;
+    if (that.min_width.is_set())
+        min_width = that.min_width;
+    if (that.min_height.is_set())
+        min_height = that.min_height;
+    if (that.max_width.is_set())
+        max_width = that.max_width;
+    if (that.max_height.is_set())
+        max_height = that.max_height;
+    if (that.width_inc.is_set())
+        width_inc = that.width_inc;
+    if (that.height_inc.is_set())
+        height_inc = that.height_inc;
+    if (that.min_aspect.is_set())
+        min_aspect = that.min_aspect;
+    if (that.max_aspect.is_set())
+        max_aspect = that.max_aspect;
+    if (that.streams.is_set())
+        streams = that.streams;
+    if (that.parent.is_set())
+        parent = that.parent.value();
+    if (that.input_shape.is_set())
+        input_shape = that.input_shape;
+    if (that.shell_chrome.is_set())
+        shell_chrome = that.shell_chrome;
+    if (that.confine_pointer.is_set())
+        confine_pointer = that.confine_pointer;
+    // TODO: should SurfaceCreationParameters support cursors?
+//     if (that.cursor_image.is_set())
+//         cursor_image = that.cursor_image;
+//     if (that.stream_cursor.is_set())
+//         stream_cursor = that.stream_cursor;
 }
 
 bool ms::operator==(

--- a/src/server/shell/surface_specification.cpp
+++ b/src/server/shell/surface_specification.cpp
@@ -49,3 +49,71 @@ bool msh::SurfaceSpecification::is_empty() const
         !input_shape.is_set() &&
         !shell_chrome.is_set();
 }
+
+void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
+{
+    if (that.width.is_set())
+        width = that.width;
+    if (that.height.is_set())
+        height = that.height;
+    if (that.pixel_format.is_set())
+        pixel_format = that.pixel_format;
+    if (that.buffer_usage.is_set())
+        buffer_usage = that.buffer_usage;
+    if (that.name.is_set())
+        name = that.name;
+    if (that.output_id.is_set())
+        output_id = that.output_id;
+    if (that.type.is_set())
+        type = that.type;
+    if (that.state.is_set())
+        state = that.state;
+    if (that.preferred_orientation.is_set())
+        preferred_orientation = that.preferred_orientation;
+    if (that.parent_id.is_set())
+        parent_id = that.parent_id;
+    if (that.aux_rect.is_set())
+        aux_rect = that.aux_rect;
+    if (that.edge_attachment.is_set())
+        edge_attachment = that.edge_attachment;
+    if (that.placement_hints.is_set())
+        placement_hints = that.placement_hints;
+    if (that.surface_placement_gravity.is_set())
+        surface_placement_gravity = that.surface_placement_gravity;
+    if (that.aux_rect_placement_gravity.is_set())
+        aux_rect_placement_gravity = that.aux_rect_placement_gravity;
+    if (that.aux_rect_placement_offset_x.is_set())
+        aux_rect_placement_offset_x = that.aux_rect_placement_offset_x;
+    if (that.aux_rect_placement_offset_y.is_set())
+        aux_rect_placement_offset_y = that.aux_rect_placement_offset_y;
+    if (that.min_width.is_set())
+        min_width = that.min_width;
+    if (that.min_height.is_set())
+        min_height = that.min_height;
+    if (that.max_width.is_set())
+        max_width = that.max_width;
+    if (that.max_height.is_set())
+        max_height = that.max_height;
+    if (that.width_inc.is_set())
+        width_inc = that.width_inc;
+    if (that.height_inc.is_set())
+        height_inc = that.height_inc;
+    if (that.min_aspect.is_set())
+        min_aspect = that.min_aspect;
+    if (that.max_aspect.is_set())
+        max_aspect = that.max_aspect;
+    if (that.streams.is_set())
+        streams = that.streams;
+    if (that.parent.is_set())
+        parent = that.parent;
+    if (that.input_shape.is_set())
+        input_shape = that.input_shape;
+    if (that.shell_chrome.is_set())
+        shell_chrome = that.shell_chrome;
+    if (that.confine_pointer.is_set())
+        confine_pointer = that.confine_pointer;
+    if (that.cursor_image.is_set())
+        cursor_image = that.cursor_image;
+    if (that.stream_cursor.is_set())
+        stream_cursor = that.stream_cursor;
+}


### PR DESCRIPTION
More cleanup of `WindowWlSurfaceRole` and the shell surface classes that are derived from it. The basic idea is that all general window logic should be taken care of by `WindowWlSurfaceRole`, leaving the derived classes to exclusively take care of the protocols they implement. This makes XDG shell stable easy.