### PR TITLE
 [travis] fix snap triggering rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ branches:
   - /^v[\d\.]+$/
 
 stages:
+- name: process snaps
+  if: repo = MirServer/mir
 - name: test
   # don't test on pushes to master or release pull requests or tag events
   # TODO: enable release pull request testing when we have more CI power
@@ -23,8 +25,6 @@ stages:
       AND ( branch = master
             OR branch =~ ^release/[\d\.]+$
             OR tag =~ ^v[\d\.]+$ )
-- name: process snaps
-  if: repo = MirServer/mir
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,10 @@ branches:
 
 stages:
 - name: process snaps
-  if: repo = MirServer/mir
+  if: (type = pull_request
+        AND head_repo = MirServer/mir)
+      OR (type != pull_request
+        AND repo = MirServer/mir)
 - name: test
   # don't test on pushes to master or release pull requests or tag events
   # TODO: enable release pull request testing when we have more CI power


### PR DESCRIPTION
- process snaps first
- don't do it if outside of `MirServer/mir`, otherwise we don't have credentials