### PR TITLE
Refactor creation of Wayland extensions so that the connector doesn't need to know what they are.

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -25,7 +25,6 @@
 #include "wl_subcompositor.h"
 #include "wl_surface.h"
 #include "wl_seat.h"
-#include "xdg_shell_v6.h"
 #include "wl_region.h"
 
 #include "null_event_sink.h"
@@ -560,6 +559,23 @@ std::shared_ptr<mg::WaylandAllocator> allocator_for_display(
 }
 }
 
+void mf::WaylandExtensions::init(wl_display* display, std::shared_ptr<Shell> const& shell, WlSeat* seat, OutputManager* const output_manager)
+{
+
+    add_extension("wl_shell", std::make_shared<mf::WlShell>(display, shell, *seat, output_manager));
+
+    custom_extensions(display, shell, seat, output_manager);
+}
+
+void mf::WaylandExtensions::add_extension(std::string const name, std::shared_ptr<void> implementation)
+{
+    extension_protocols[std::move(name)] = std::move(implementation);
+}
+
+void mf::WaylandExtensions::custom_extensions(wl_display*, std::shared_ptr<Shell> const&, WlSeat*, OutputManager* const)
+{
+}
+
 mf::WaylandConnector::WaylandConnector(
     optional_value<std::string> const& display_name,
     std::shared_ptr<mf::Shell> const& shell,
@@ -568,10 +584,12 @@ mf::WaylandConnector::WaylandConnector(
     std::shared_ptr<mi::Seat> const& seat,
     std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
     std::shared_ptr<mf::SessionAuthorizer> const& session_authorizer,
-    bool arw_socket)
+    bool arw_socket,
+    std::unique_ptr<WaylandExtensions> extensions_)
     : display{wl_display_create(), &cleanup_display},
       pause_signal{eventfd(0, EFD_CLOEXEC | EFD_SEMAPHORE)},
-      allocator{allocator_for_display(allocator, display.get())}
+      allocator{allocator_for_display(allocator, display.get())},
+      extensions{std::move(extensions_)}
 {
     if (pause_signal == mir::Fd::invalid)
     {
@@ -606,10 +624,10 @@ mf::WaylandConnector::WaylandConnector(
     output_manager = std::make_unique<mf::OutputManager>(
         display.get(),
         display_config);
-    shell_global = std::make_unique<mf::WlShell>(display.get(), shell, *seat_global, output_manager.get());
+
     data_device_manager_global = mf::create_data_device_manager(display.get());
-    if (!getenv("MIR_DISABLE_XDG_SHELL_V6_UNSTABLE"))
-        xdg_shell_global = std::make_unique<XdgShellV6>(display.get(), shell, *seat_global, output_manager.get());
+
+    extensions->init(display.get(), shell, seat_global.get(), output_manager.get());
 
     wl_display_init_shm(display.get());
 

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -48,8 +48,6 @@ namespace frontend
 class WlCompositor;
 class WlSubcompositor;
 class WlApplication;
-class WlShell;
-class XdgShellV6;
 class WlSeat;
 class OutputManager;
 
@@ -57,6 +55,25 @@ class Shell;
 class DisplayChanger;
 class SessionAuthorizer;
 class DataDeviceManager;
+
+class WaylandExtensions
+{
+public:
+    WaylandExtensions() = default;
+    virtual ~WaylandExtensions() = default;
+    WaylandExtensions(WaylandExtensions const&) = delete;
+    WaylandExtensions& operator=(WaylandExtensions const&) = delete;
+
+    void init(wl_display* display, std::shared_ptr<Shell> const& shell, WlSeat* seat, OutputManager* const output_manager);
+
+protected:
+
+    virtual void add_extension(std::string const name, std::shared_ptr<void> implementation);
+    virtual void custom_extensions(wl_display* display, std::shared_ptr<Shell> const& shell, WlSeat* seat, OutputManager* const output_manager);
+
+private:
+    std::unordered_map<std::string, std::shared_ptr<void>> extension_protocols;
+};
 
 class WaylandConnector : public Connector
 {
@@ -69,7 +86,8 @@ public:
         std::shared_ptr<input::Seat> const& seat,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
         std::shared_ptr<SessionAuthorizer> const& session_authorizer,
-        bool arw_socket);
+        bool arw_socket,
+        std::unique_ptr<WaylandExtensions> extensions);
 
     ~WaylandConnector() override;
 
@@ -93,9 +111,8 @@ private:
     std::unique_ptr<WlSeat> seat_global;
     std::unique_ptr<OutputManager> output_manager;
     std::shared_ptr<graphics::WaylandAllocator> const allocator;
-    std::unique_ptr<WlShell> shell_global;
     std::unique_ptr<DataDeviceManager> data_device_manager_global;
-    std::unique_ptr<XdgShellV6> xdg_shell_global;
+    std::unique_ptr<WaylandExtensions> const extensions;
     std::thread dispatch_thread;
     wl_event_source* pause_source;
     std::string wayland_display;


### PR DESCRIPTION
Refactor creation of Wayland extensions so that the connector doesn't need to know what they are.

This is a small step towards towards shells being able to specify the extensions Mir enables.