### PR TITLE
Strip internal tests from mir-test-tools package

### DIFF
--- a/debian/mir-demos.install
+++ b/debian/mir-demos.install
@@ -1,5 +1,4 @@
 usr/bin/mir_demo_*
-usr/lib/*/libmir_demo_*
 usr/bin/miral-shell
 usr/bin/miral-run
 usr/bin/miral-kiosk


### PR DESCRIPTION
Strip internal tests from mir-test-tools package. (Fix mir-demos too)