### PR TITLE
Prevent spurious symbols being exported on Cosmic. (Fixes #475)

### DIFF
--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -25,6 +25,11 @@ add_library(miral-internal STATIC
                                         window_info_defaults.h
 )
 
+# For no obvious reason this has to be explicit on Cosmic and not implied
+# by the linker's symbol version script
+set_target_properties(miral-internal
+    PROPERTIES COMPILE_FLAGS "${CMAKE_CXXFLAGS}  -fvisibility=hidden")
+
 set_source_files_properties(xcursor.c PROPERTIES COMPILE_DEFINITIONS _GNU_SOURCE)
 
 add_library(miral SHARED

--- a/src/miral/join_client_threads.h
+++ b/src/miral/join_client_threads.h
@@ -19,6 +19,9 @@
 #ifndef MIRAL_JOIN_CLIENT_THREADS_H
 #define MIRAL_JOIN_CLIENT_THREADS_H
 
+// For no obvious reason this has to be explicit on Cosmic and not implied
+// by the linker's symbol version script
+__attribute__ ((visibility("hidden")))
 void join_client_threads(mir::Server* server);
 
 #endif //MIRAL_JOIN_CLIENT_THREADS_H


### PR DESCRIPTION
Prevent spurious symbols being exported on Cosmic. (Fixes #475)