### PR TITLE
Fixup X11 related config names

### DIFF
--- a/src/miral/x11_support.cpp
+++ b/src/miral/x11_support.cpp
@@ -34,7 +34,9 @@ miral::X11Support::X11Support() : self{std::make_shared<Self>()}
 
 void miral::X11Support::operator()(mir::Server& server) const
 {
-    server.add_configuration_option(mo::x11_display_opt, "Socket to use for X11 DISPLAY (default: none).", mir::OptionType::integer);
+    server.add_configuration_option(
+        mo::x11_display_opt,
+        "DISPLAY socket to use for experimental X11 support (default: none).", mir::OptionType::integer);
 }
 
 miral::X11Support::~X11Support() = default;

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -55,7 +55,7 @@ char const* const mo::fatal_except_opt            = "on-fatal-error-except";
 char const* const mo::debug_opt                   = "debug";
 char const* const mo::composite_delay_opt         = "composite-delay";
 char const* const mo::enable_key_repeat_opt       = "enable-key-repeat";
-char const* const mo::x11_display_opt             = "display";
+char const* const mo::x11_display_opt             = "x11-display-experimental";
 
 char const* const mo::off_opt_value = "off";
 char const* const mo::log_opt_value = "log";

--- a/src/platforms/mesa/server/x11/graphics/graphics.cpp
+++ b/src/platforms/mesa/server/x11/graphics/graphics.cpp
@@ -39,7 +39,7 @@ mx::X11Resources x11_resources;
 
 namespace
 {
-char const* x11_displays_option_name{"x11-displays"};
+char const* x11_displays_option_name{"x11-output"};
 }
 
 mir::UniqueModulePtr<mg::Platform> create_host_platform(
@@ -51,12 +51,12 @@ mir::UniqueModulePtr<mg::Platform> create_host_platform(
 {
     mir::assert_entry_point_signature<mg::CreateHostPlatform>(&create_host_platform);
     if (!x11_resources.get_conn())
-        BOOST_THROW_EXCEPTION(std::runtime_error("Need valid x11 display"));
+        BOOST_THROW_EXCEPTION(std::runtime_error("Need valid x11 output"));
 
     auto display_dims_str = options->get<std::string>(x11_displays_option_name);
     auto pos = display_dims_str.find('x');
     if (pos == std::string::npos)
-        BOOST_THROW_EXCEPTION(std::runtime_error("Malformed display size option"));
+        BOOST_THROW_EXCEPTION(std::runtime_error("Malformed output size option"));
 
     return mir::make_module_ptr<mgx::Platform>(
         x11_resources.get_conn(),
@@ -73,7 +73,7 @@ void add_graphics_platform_options(boost::program_options::options_description& 
     config.add_options()
         (x11_displays_option_name,
          boost::program_options::value<std::string>()->default_value("1280x1024"),
-         "[mir-on-X specific] WIDTHxHEIGHT of \"display\" window.");
+         "[mir-on-X specific] WIDTHxHEIGHT of \"output\" window.");
 }
 
 mg::PlatformPriority probe_graphics_platform(
@@ -126,12 +126,12 @@ mir::UniqueModulePtr<mir::graphics::DisplayPlatform> create_display_platform(
     mir::assert_entry_point_signature<mg::CreateDisplayPlatform>(&create_display_platform);
 
     if (!x11_resources.get_conn())
-        BOOST_THROW_EXCEPTION(std::runtime_error("Need valid x11 display"));
+        BOOST_THROW_EXCEPTION(std::runtime_error("Need valid x11 output"));
 
     auto display_dims_str = options->get<std::string>(x11_displays_option_name);
     auto pos = display_dims_str.find('x');
     if (pos == std::string::npos)
-        BOOST_THROW_EXCEPTION(std::runtime_error("Malformed display size option"));
+        BOOST_THROW_EXCEPTION(std::runtime_error("Malformed output size option"));
 
     return mir::make_module_ptr<mgx::Platform>(
                x11_resources.get_conn(),


### PR DESCRIPTION
1. rename pre-existing "--x11-displays" to "--x11-output" for Mir-on-X11
2. rename new "--display" to "--x11-display-experimental" for Xwayland display

Note that we can use "--x11-display" in scripts already as boost.Options will resolve that to "--x11-display-experimental".