### PR TITLE
Re-instate mir_demo_server (but only in mir-test-tools)

### DIFF
--- a/debian/mir-test-tools.install
+++ b/debian/mir-test-tools.install
@@ -3,3 +3,5 @@ usr/bin/mir_performance_tests
 usr/bin/mir-smoke-test-runner
 usr/lib/*/mir/tools/libmirclientlttng.so
 usr/lib/*/mir/tools/libmirserverlttng.so
+usr/bin/mir_demo_server
+usr/lib/*/libmir_demo_server_loadable.so

--- a/examples/mir_demo_server/CMakeLists.txt
+++ b/examples/mir_demo_server/CMakeLists.txt
@@ -34,7 +34,11 @@ target_link_libraries(mir_demo_server_loadable
   ${Boost_LIBRARIES}
 )
 
-mir_add_wrapped_executable(mir_demo_server NOINSTALL
+install(TARGETS mir_demo_server_loadable
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+mir_add_wrapped_executable(mir_demo_server
   mir_demo_server_loader.cpp
 )
 


### PR DESCRIPTION
Re-instate mir_demo_server (but only in mir-test-tools).

mir_demo_server is used by mir-smoke-test-runner