### PR TITLE
Fix spurious symbols, take three (Fixes #475)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ if(HAS_W_PSABI)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi")
 endif()
 
-set(MIR_USE_LD ld CACHE STRING "Linker to use")
+set(MIR_USE_LD gold CACHE STRING "Linker to use")
 set_property(CACHE MIR_USE_LD PROPERTY STRINGS "ld;gold;lld")
 if(MIR_USE_LD MATCHES "gold")
   set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=gold")

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -25,8 +25,7 @@ add_library(miral-internal STATIC
                                         window_info_defaults.h
 )
 
-# For no obvious reason this has to be explicit on Cosmic and not implied
-# by the linker's symbol version script
+# Already implied by the linker's symbol version script, but can avoid accidents
 set_target_properties(miral-internal
     PROPERTIES COMPILE_FLAGS "${CMAKE_CXXFLAGS}  -fvisibility=hidden")
 

--- a/src/miral/join_client_threads.h
+++ b/src/miral/join_client_threads.h
@@ -19,9 +19,6 @@
 #ifndef MIRAL_JOIN_CLIENT_THREADS_H
 #define MIRAL_JOIN_CLIENT_THREADS_H
 
-// For no obvious reason this has to be explicit on Cosmic and not implied
-// by the linker's symbol version script
-__attribute__ ((visibility("hidden")))
 void join_client_threads(mir::Server* server);
 
 #endif //MIRAL_JOIN_CLIENT_THREADS_H


### PR DESCRIPTION
Fix spurious symbols, take three (Fixes #475)

Workaround #475 in a way that doesn't require source changes.

Unlike Cosmic's bfd linker the gold linker doesn't add spurious debugging symbols. As an added bonus, the gold linker is roughly twice as fast as the bfd linker, and produces better warnings.