### PR TITLE
Send popup configure events

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -341,7 +341,8 @@ protected:
         become_surface_role();
     }
 
-    void handle_resize(const geometry::Size & new_size) override
+    void handle_resize(std::experimental::optional<geometry::Point> const& /*new_top_left*/,
+                       geometry::Size const& new_size) override
     {
         wl_shell_surface_send_configure(resource, WL_SHELL_SURFACE_RESIZE_NONE, new_size.width.as_int(),
                                         new_size.height.as_int());

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -79,7 +79,8 @@ public:
 
     void set_state_now(MirWindowState state);
 
-    virtual void handle_resize(geometry::Size const& new_size) = 0;
+    virtual void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,
+                               geometry::Size const& new_size) = 0;
 
 protected:
     std::shared_ptr<bool> const destroyed;


### PR DESCRIPTION
* Send around an option `new_top_left` value with the resize calls
* If a top left is known, send a configure event to popup shell surfaces