### PR TITLE
ServerConfiguration: Add an option to select the ConsoleServices provider

### DIFF
--- a/examples/miral-shell/miral-desktop.sh
+++ b/examples/miral-shell/miral-desktop.sh
@@ -50,7 +50,7 @@ vt_login_session=$(who -u | grep tty${vt} | grep ${USER} | wc -l)
 if [ "${vt_login_session}" == "0" ]; then echo "Error: please log into tty${vt} first"; exit 1 ;fi
 
 oldvt=$(sudo fgconsole)
-sudo --preserve-env sh -c "${bindir}${miral_server} --wayland-socket-name ${wayland_display} --vt ${vt} --arw-file --file ${socket} $*&\
+sudo --preserve-env sh -c "${bindir}${miral_server} --wayland-socket-name ${wayland_display} --console-provider=vt --vt ${vt} --arw-file --file ${socket} $*&\
     while [ ! -e \"${socket}\" ]; do echo \"waiting for ${socket}\"; sleep 1 ;done;\
     su -c \"MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=${gdk_backend} QT_QPA_PLATFORM=${qt_qpa} SDL_VIDEODRIVER=${sdl_videodriver} WAYLAND_DISPLAY=${wayland_display} NO_AT_BRIDGE=1 dbus-run-session -- ${launcher}\" $USER;\
     (sudo killall -w ${bindir}${miral_server} || sudo killall -w ${bindir}${miral_server}.bin); chvt ${oldvt}"

--- a/src/include/platform/mir/options/configuration.h
+++ b/src/include/platform/mir/options/configuration.h
@@ -67,6 +67,13 @@ extern char const* const lttng_opt_value;
 extern char const* const platform_graphics_lib;
 extern char const* const platform_input_lib;
 extern char const* const platform_path;
+
+extern char const* const console_provider;
+extern char const* const logind_console;
+extern char const* const vt_console;
+extern char const* const null_console;
+extern char const* const auto_console;
+
 extern char const* const vt_option_name;
 
 class Configuration

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -64,6 +64,13 @@ char const* const mo::lttng_opt_value = "lttng";
 char const* const mo::platform_graphics_lib = "platform-graphics-lib";
 char const* const mo::platform_input_lib = "platform-input-lib";
 char const* const mo::platform_path = "platform-path";
+
+char const* const mo::console_provider = "console-provider";
+char const* const mo::logind_console = "logind";
+char const* const mo::vt_console = "vt";
+char const* const mo::null_console = "none";
+char const* const mo::auto_console = "auto";
+
 char const* const mo::vt_option_name = "vt";
 
 
@@ -205,9 +212,19 @@ mo::DefaultConfiguration::DefaultConfiguration(
             "in unexpected ways] throw an exception (instead of a core dump)")
         (debug_opt, "Enable extra development debugging. "
             "This is only interesting for people doing Mir server or client development.")
+        (console_provider,
+            po::value<std::string>()->default_value("auto"),
+            "Console device handling\n"
+            "How Mir handles console-related tasks (device handling, VT switching, etc)\n"
+            "Options:\n"
+            "logind: use logind\n"
+            "vt: use the Linux VT subsystem. Requires root.\n"
+            "none: support no console-related tasks. Useful for nested platforms which do not "
+                "need raw device access and which don't have a VT concept\n"
+            "auto: detect the appropriate provider.")
         (vt_option_name,
             boost::program_options::value<int>()->default_value(0),
-            "When running on a VT, VT to run on or 0 to use current.");
+            "[requires --console-provider=vt] VT to run on or 0 to use current.");
 
         add_platform_options();
 }

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -192,5 +192,10 @@ MIR_PLATFORM_0.32.1 {
  global:
   extern "C++" {
     mir::options::x11_display_opt*;
+    mir::options::console_provider*;
+    mir::options::auto_console*;
+    mir::options::logind_console*;
+    mir::options::vt_console*;
+    mir::options::null_console*
   };
 } MIR_PLATFORM_0.33;

--- a/src/server/console/default_configuration.cpp
+++ b/src/server/console/default_configuration.cpp
@@ -99,44 +99,106 @@ std::shared_ptr<mir::ConsoleServices> mir::DefaultServerConfiguration::the_conso
     return console_services(
         [this]() -> std::shared_ptr<ConsoleServices>
         {
+            auto const provider = the_options()->get<std::string>(options::console_provider);
             auto const vt = the_options()->get<int>(options::vt_option_name);
 
-            if (!vt)
+            auto const logind_constructor =
+                [this]()
+                {
+                    try
+                    {
+                        auto const vt_services = std::make_shared<mir::LogindConsoleServices>(
+                            std::dynamic_pointer_cast<mir::GLibMainLoop>(the_main_loop()));
+                        mir::log_debug("Using logind for session management");
+                        return vt_services;
+                    }
+                    catch (std::exception const& e)
+                    {
+                        mir::log_debug(
+                            "Not using logind for session management: %s",
+                            e.what());
+                        throw;
+                    }
+                };
+
+            auto const linux_vt_constructor =
+                [this](int vt)
+                {
+                    try
+                    {
+                        auto const vt_services = std::make_shared<mir::LinuxVirtualTerminal>(
+                            std::make_unique<RealVTFileOperations>(),
+                            std::make_unique<RealPosixProcessOperations>(),
+                            vt,
+                            *the_emergency_cleanup(),
+                            the_display_report());
+                        mir::log_debug("Using Linux VT subsystem for session management");
+                        return vt_services;
+                    }
+                    catch (std::exception const& e)
+                    {
+                        mir::log_debug(
+                            "Not using Linux VT subsystem for session management: %s",
+                            e.what());
+                        throw;
+                    }
+                };
+
+            auto const null_constructor =
+                []()
+                {
+                    mir::log_debug("No session management supported");
+                    return std::make_shared<mir::NullConsoleServices>();
+                };
+
+            if (provider == options::auto_console)
             {
+                if (vt)
+                {
+                    BOOST_THROW_EXCEPTION((
+                        std::runtime_error{"--vt option requires --console-provider=vt"}));
+                }
                 try
                 {
-                    auto const vt_services = std::make_shared<mir::LogindConsoleServices>(
-                        std::dynamic_pointer_cast<mir::GLibMainLoop>(the_main_loop()));
-                    mir::log_debug("Using logind for session management");
-                    return vt_services;
+                    return logind_constructor();
                 }
-                catch (std::exception const& e)
+                catch (std::exception const&)
                 {
-                    mir::log_debug(
-                        "Not using logind for session management: %s",
-                        boost::diagnostic_information(e).c_str());
                 }
+                try
+                {
+                    return linux_vt_constructor(vt);
+                }
+                catch (std::exception const&)
+                {
+                }
+                return null_constructor();
+            }
+            else if (provider == options::logind_console)
+            {
+                if (vt)
+                {
+                    BOOST_THROW_EXCEPTION((
+                        std::runtime_error{"--vt option requires --console-provider=vt"}));
+                }
+                return logind_constructor();
+            }
+            else if (provider == options::vt_console)
+            {
+                return linux_vt_constructor(vt);
+            }
+            else if (provider == options::null_console)
+            {
+                if (vt)
+                {
+                    BOOST_THROW_EXCEPTION((
+                        std::runtime_error{"--vt option requires --console-provider=vt"}));
+                }
+                return null_constructor();
             }
 
-            try
-            {
-                auto const vt_services = std::make_shared<mir::LinuxVirtualTerminal>(
-                    std::make_unique<RealVTFileOperations>(),
-                    std::make_unique<RealPosixProcessOperations>(),
-                    vt,
-                    *the_emergency_cleanup(),
-                    the_display_report());
-                mir::log_debug("Using Linux VT subsystem for session management");
-                return vt_services;
-            }
-            catch (std::exception const& e)
-            {
-                mir::log_debug(
-                    "Not using Linux VT subsystem for session management: %s",
-                    boost::diagnostic_information(e).c_str());
-            }
-
-            mir::log_debug("No session management supported");
-            return std::make_shared<mir::NullConsoleServices>();
+            BOOST_THROW_EXCEPTION((
+                std::runtime_error{
+                    std::string{"Unknown console provider: "} + provider}));
         });
 }

--- a/src/server/console/default_configuration.cpp
+++ b/src/server/console/default_configuration.cpp
@@ -21,6 +21,7 @@
 #include "mir/log.h"
 #include "mir/emergency_cleanup.h"
 #include "mir/glib_main_loop.h"
+#include "mir/abnormal_exit.h"
 
 #include "null_console_services.h"
 #include "linux_virtual_terminal.h"
@@ -155,8 +156,7 @@ std::shared_ptr<mir::ConsoleServices> mir::DefaultServerConfiguration::the_conso
             {
                 if (vt)
                 {
-                    BOOST_THROW_EXCEPTION((
-                        std::runtime_error{"--vt option requires --console-provider=vt"}));
+                    throw mir::AbnormalExit{"--vt option requires --console-provider=vt"};
                 }
                 try
                 {
@@ -178,8 +178,7 @@ std::shared_ptr<mir::ConsoleServices> mir::DefaultServerConfiguration::the_conso
             {
                 if (vt)
                 {
-                    BOOST_THROW_EXCEPTION((
-                        std::runtime_error{"--vt option requires --console-provider=vt"}));
+                    throw mir::AbnormalExit{"--vt option requires --console-provider=vt"};
                 }
                 return logind_constructor();
             }
@@ -191,8 +190,7 @@ std::shared_ptr<mir::ConsoleServices> mir::DefaultServerConfiguration::the_conso
             {
                 if (vt)
                 {
-                    BOOST_THROW_EXCEPTION((
-                        std::runtime_error{"--vt option requires --console-provider=vt"}));
+                    throw mir::AbnormalExit{"--vt option requires --console-provider=vt"};
                 }
                 return null_constructor();
             }

--- a/tests/mir_test_framework/headless_test.cpp
+++ b/tests/mir_test_framework/headless_test.cpp
@@ -34,6 +34,7 @@ mtf::HeadlessTest::HeadlessTest()
     add_to_environment("MIR_SERVER_PLATFORM_GRAPHICS_LIB", mtf::server_platform("graphics-dummy.so").c_str());
     add_to_environment("MIR_SERVER_PLATFORM_INPUT_LIB", mtf::server_platform("input-stub.so").c_str());
     add_to_environment("MIR_SERVER_ENABLE_KEY_REPEAT", "false");
+    add_to_environment("MIR_SERVER_CONSOLE_PROVIDER", "none");
     server.override_the_display_buffer_compositor_factory([]
     {
         return std::make_shared<mtf::HeadlessDisplayBufferCompositorFactory>();

--- a/tests/unit-tests/platforms/mesa/kms/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_platform.cpp
@@ -207,8 +207,6 @@ TEST_F(MesaGraphicsPlatform, probe_returns_unsupported_when_egl_client_extension
     mtf::UdevEnvironment udev_environment;
     boost::program_options::options_description po;
     mir::options::ProgramOption options;
-    const char *argv[] = {"dummy", "--vt"};
-    options.parse_arguments(po, 2, argv);
     auto const stub_vt = std::make_shared<mtd::StubConsoleServices>();
 
     udev_environment.add_standard_device("standard-drm-devices");
@@ -228,8 +226,6 @@ TEST_F(MesaGraphicsPlatform, probe_returns_unsupported_when_gbm_platform_not_sup
     mtf::UdevEnvironment udev_environment;
     boost::program_options::options_description po;
     mir::options::ProgramOption options;
-    const char *argv[] = {"dummy", "--vt"};
-    options.parse_arguments(po, 2, argv);
     auto const stub_vt = std::make_shared<mtd::StubConsoleServices>();
 
     udev_environment.add_standard_device("standard-drm-devices");


### PR DESCRIPTION
For display managers like LightDM or GDM this can let them explicitly select how they expect Mir to interact - via logind or to handle to console on its own.

For tests we can explicitly select the NullConsoleProvider, to speed up the tests and to ensure the tests don't accidentally modify the system they're running on.

Use this new configuration option in the test harness.