### PR TITLE
LogindConsoleServices: Support VT switching

### DIFF
--- a/include/platform/mir/console_services.h
+++ b/include/platform/mir/console_services.h
@@ -105,7 +105,7 @@ public:
      */
     virtual void switch_to(
         int vt_number,
-        std::function<void(std::exception const& error)> const& error_handler) = 0;
+        std::function<void(std::exception const&)> error_handler) = 0;
 
 protected:
     VTSwitcher() = default;

--- a/include/platform/mir/console_services.h
+++ b/include/platform/mir/console_services.h
@@ -85,6 +85,36 @@ public:
     };
 };
 
+class VTSwitcher
+{
+public:
+    virtual ~VTSwitcher() = default;
+
+    /**
+     * Initiate a switch to the specified VT
+     *
+     * \note    On all current platforms this call is *not* synchronous; it will
+     *          initiate the request for a VT switch, but not wait until the switch
+     *          has completed. The switch from Mir's VT can be detected with the
+     *          from the switch_away callback of
+     *          ConsoleServices::register_switch_handlers()
+     * \note    It is *not* an error to call this with the number of the active VT.
+     *          This will be a no-op.
+     * \param vt_number     [in] Number of the VT to switch to
+     * \param error_handler [in] Functor to call should an asynchronous error occur.
+     */
+    virtual void switch_to(
+        int vt_number,
+        std::function<void(std::exception const& error)> const& error_handler) = 0;
+
+protected:
+    VTSwitcher() = default;
+
+private:
+    VTSwitcher(VTSwitcher const&) = delete;
+    VTSwitcher& operator=(VTSwitcher const&) = delete;
+};
+
 class ConsoleServices
 {
 public:
@@ -95,6 +125,16 @@ public:
         std::function<bool()> const& switch_away,
         std::function<bool()> const& switch_back) = 0;
     virtual void restore() = 0;
+
+    /**
+     * Construct a VTSwitcher
+     *
+     * \return  A VTSwitcher instance if the current environment and ConsoleServices
+     *          implementation support it.
+     * \throws  A std::runtime_error if either the ConsoleServices implementation
+     *          or the current environment do not support VT switching.
+     */
+    virtual std::unique_ptr<VTSwitcher> create_vt_switcher() = 0;
 
     /**
      * Asynchronously acquire access to a device node.

--- a/include/server/mir/input/composite_event_filter.h
+++ b/include/server/mir/input/composite_event_filter.h
@@ -28,11 +28,30 @@ namespace mir
 namespace input
 {
 
+/**
+ * Apply a chain of filters to events
+ *
+ * This composite filter offers the event to each filter in turn until one consumes it.
+ */
 class CompositeEventFilter : public EventFilter
 {
 public:
-    virtual void append(std::shared_ptr<EventFilter> const& filter) = 0;
-    virtual void prepend(std::shared_ptr<EventFilter> const& filter) = 0;
+    /**
+     * Add a filter to the end of the chain; it will be offered each event after any existing filters.
+     *
+     * The filter will be removed when the lifetime of the underlying object ends.
+     *
+     * \param [in] filter   Filter to append to chain.
+     */
+    virtual void append(std::weak_ptr<EventFilter> const& filter) = 0;
+    /**
+     * Add a filter to the beginning of the chain; it will be offered each event before any existing filters.
+     *
+     * The filter will be removed when the lifetime of the underlying object ends.
+     *
+     * \param [in] filter   Filter to prepend to chain.
+     */
+    virtual void prepend(std::weak_ptr<EventFilter> const& filter) = 0;
 };
 
 }

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -454,7 +454,7 @@ protected:
 
 private:
     std::shared_ptr<options::Configuration> const configuration_options;
-    std::shared_ptr<input::EventFilter> const default_filter;
+    std::shared_ptr<input::EventFilter> default_filter;
     CachedPtr<ObserverMultiplexer<graphics::DisplayConfigurationObserver>>
         display_configuration_observer_multiplexer;
     CachedPtr<ObserverMultiplexer<input::SeatObserver>>

--- a/src/include/server/mir/input/vt_filter.h
+++ b/src/include/server/mir/input/vt_filter.h
@@ -21,15 +21,24 @@
 
 #include "mir/input/event_filter.h"
 
+#include <memory>
+
 namespace mir
 {
+class VTSwitcher;
+
 namespace input
 {
 
 class VTFilter : public EventFilter
 {
 public:
+    VTFilter(std::unique_ptr<VTSwitcher> switcher);
+
     bool handle(MirEvent const& event) override;
+
+private:
+    std::unique_ptr<VTSwitcher> const switcher;
 };
 
 }

--- a/src/platforms/evdev/platform.cpp
+++ b/src/platforms/evdev/platform.cpp
@@ -469,6 +469,7 @@ void mie::Platform::stop()
 {
     // This must only be called from the dispatch thread, so this doesn't race
     device_watchers.clear();
+    pending_devices.clear();
 
     if (action_queue)
     {

--- a/src/server/console/CMakeLists.txt
+++ b/src/server/console/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(
   logind-seat.c                             logind-seat.h
   logind-session.c                          logind-session.h
   default_configuration.cpp
-)
+  ioctl_vt_switcher.cpp                     ioctl_vt_switcher.h)
 
 set_source_files_properties(
   logind-seat.c

--- a/src/server/console/ioctl_vt_switcher.cpp
+++ b/src/server/console/ioctl_vt_switcher.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#include "ioctl_vt_switcher.h"
+
+#include <boost/exception/enable_error_info.hpp>
+#include <boost/exception/info.hpp>
+
+#include <sys/ioctl.h>
+#include <sys/vt.h>
+
+mir::console::IoctlVTSwitcher::IoctlVTSwitcher(mir::Fd vt_fd)
+    : vt_fd{std::move(vt_fd)}
+{
+}
+
+void mir::console::IoctlVTSwitcher::switch_to(
+    int vt_number,
+    std::function<void(std::exception const&)> const& error_handler)
+{
+    if (ioctl(vt_fd, VT_ACTIVATE, vt_number) == -1)
+    {
+        auto const error = boost::enable_error_info(
+            std::system_error{
+                errno,
+                std::system_category(),
+                "Kernel request to change VT switch failed"})
+                << boost::throw_line(__LINE__)
+                << boost::throw_function(__PRETTY_FUNCTION__)
+                << boost::throw_file(__FILE__);
+        error_handler(error);
+    }
+}

--- a/src/server/console/ioctl_vt_switcher.cpp
+++ b/src/server/console/ioctl_vt_switcher.cpp
@@ -31,7 +31,7 @@ mir::console::IoctlVTSwitcher::IoctlVTSwitcher(mir::Fd vt_fd)
 
 void mir::console::IoctlVTSwitcher::switch_to(
     int vt_number,
-    std::function<void(std::exception const&)> const& error_handler)
+    std::function<void(std::exception const&)> error_handler)
 {
     if (ioctl(vt_fd, VT_ACTIVATE, vt_number) == -1)
     {

--- a/src/server/console/ioctl_vt_switcher.h
+++ b/src/server/console/ioctl_vt_switcher.h
@@ -33,7 +33,7 @@ public:
 
     void switch_to(
         int vt_number,
-        std::function<void(std::exception const&)> const& error_handler) override;
+        std::function<void(std::exception const&)> error_handler) override;
 
 private:
     mir::Fd const vt_fd;

--- a/src/server/console/ioctl_vt_switcher.h
+++ b/src/server/console/ioctl_vt_switcher.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef MIR_CONSOLE_IOCTL_VT_SWITCHER_H
+#define MIR_CONSOLE_IOCTL_VT_SWITCHER_H
+
+#include "mir/console_services.h"
+#include "mir/fd.h"
+
+namespace mir
+{
+namespace console
+{
+class IoctlVTSwitcher : public VTSwitcher
+{
+public:
+    IoctlVTSwitcher(mir::Fd vt_fd);
+
+    void switch_to(
+        int vt_number,
+        std::function<void(std::exception const&)> const& error_handler) override;
+
+private:
+    mir::Fd const vt_fd;
+};
+}
+}
+
+#endif //MIR_CONSOLE_IOCTL_VT_SWITCHER_H

--- a/src/server/console/linux_virtual_terminal.cpp
+++ b/src/server/console/linux_virtual_terminal.cpp
@@ -21,6 +21,7 @@
 #include "mir/graphics/event_handler_register.h"
 #include "mir/fd.h"
 #include "mir/emergency_cleanup_registry.h"
+#include "ioctl_vt_switcher.h"
 #include "mir/raii.h"
 
 #define MIR_LOG_COMPONTENT "VT-handler"
@@ -688,4 +689,19 @@ std::future<std::unique_ptr<mir::Device>> mir::LinuxVirtualTerminal::acquire_dev
     }
 
     return device_promise.get_future();
+}
+
+std::unique_ptr<mir::VTSwitcher> mir::LinuxVirtualTerminal::create_vt_switcher()
+{
+    mir::Fd control_fd{fcntl(vt_fd.fd(), F_DUPFD_CLOEXEC, 0)};
+    if (control_fd == mir::Fd::invalid)
+    {
+        BOOST_THROW_EXCEPTION((
+            std::system_error{
+                errno,
+                std::system_category(),
+                "Failed to duplicate file descriptor for VT control fd"}));
+    }
+
+    return std::make_unique<console::IoctlVTSwitcher>(control_fd);
 }

--- a/src/server/console/linux_virtual_terminal.h
+++ b/src/server/console/linux_virtual_terminal.h
@@ -93,6 +93,7 @@ public:
         std::function<bool()> const& switch_away,
         std::function<bool()> const& switch_back) override;
     void restore() override;
+    std::unique_ptr<VTSwitcher> create_vt_switcher() override;
     std::future<std::unique_ptr<mir::Device>> acquire_device(
         int major, int minor,
         std::unique_ptr<mir::Device::Observer> observer) override;

--- a/src/server/console/logind_console_services.cpp
+++ b/src/server/console/logind_console_services.cpp
@@ -755,6 +755,7 @@ GDBusMessage* mir::LogindConsoleServices::resume_device_dbus_filter(
     g_object_unref(message);
     return nullptr;
 }
+#endif
 
 namespace
 {
@@ -826,5 +827,3 @@ std::unique_ptr<mir::VTSwitcher> mir::LogindConsoleServices::create_vt_switcher(
             &g_object_unref},
         ml);
 }
-
-#endif

--- a/src/server/console/logind_console_services.cpp
+++ b/src/server/console/logind_console_services.cpp
@@ -503,7 +503,11 @@ std::future<std::unique_ptr<mir::Device>> mir::LogindConsoleServices::acquire_de
                 }
             }
         });
-    acquired_devices.insert(std::make_pair(makedev(major, minor), context->device.get()));
+
+    if (!acquired_devices.insert(std::make_pair(makedev(major, minor), context->device.get())).second)
+    {
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Attempted to acquire a device multiple times"}));
+    }
 
     auto future = context->promise.get_future();
 

--- a/src/server/console/logind_console_services.cpp
+++ b/src/server/console/logind_console_services.cpp
@@ -268,7 +268,7 @@ mir::LogindConsoleServices::LogindConsoleServices(std::shared_ptr<mir::GLibMainL
 
     g_signal_connect(
         G_OBJECT(session_proxy.get()),
-        "notify::state",
+        "notify::active",
         G_CALLBACK(&LogindConsoleServices::on_state_change),
         this);
     g_signal_connect(
@@ -593,8 +593,8 @@ void mir::LogindConsoleServices::on_state_change(
     // No threadsafety concerns, as this is only ever called from the glib mainloop.
     auto me = static_cast<LogindConsoleServices*>(ctx);
 
-    auto const state = logind_session_get_state(LOGIND_SESSION(session_proxy));
-    if (strncmp(state, "active", strlen("active")) == 0)
+    auto const active = logind_session_get_active(LOGIND_SESSION(session_proxy));
+    if (active)
     {
         // “active” means running and foregrounded.
         if (!me->active)

--- a/src/server/console/logind_console_services.cpp
+++ b/src/server/console/logind_console_services.cpp
@@ -666,10 +666,32 @@ void mir::LogindConsoleServices::on_pause_device(
         }
         else if ("gone"s == suspend_type)
         {
+            if (major == 226)
+            {
+                /* This is a DRM device.
+                 *
+                 * During startup, we TakeDevice during probe() to check that we can
+                 * actually use the DRM device; we ReleaseDevice it before returning from probe().
+                 *
+                 * Then, during Platform construction we TakeDevice again.
+                 * For some reason, logind feels the need to send a “gone” signal after the
+                 * second TakeDevice call, which would result in us dropping the device and
+                 * everything breaking.
+                 *
+                 * A DRM device is quite unlikely to *actually* be gone, so just ignore
+                 * PauseDevice("gone") signals for DRM devices.
+                 */
+                mir::log_debug(
+                    "Ignoring logind PauseDevice(\"gone\") event for DRM device %i:%i",
+                    major, minor);
+                return;
+            }
             it->second->emit_removed();
             // The device is gone; logind promises not to send further events for it
             me->acquired_devices.erase(it);
             // …unfortunately, logind is a FILTHY LIAR.
+            // We're safe to call this asynchronously; there must be a running main loop,
+            // because we've been dispatched from it.
             logind_session_call_release_device(
                 me->session_proxy.get(),
                 major, minor,

--- a/src/server/console/logind_console_services.cpp
+++ b/src/server/console/logind_console_services.cpp
@@ -772,10 +772,10 @@ public:
 
     void switch_to(
         int vt_number,
-        std::function<void(std::exception const&)> const& error_handler) override
+        std::function<void(std::exception const&)> error_handler) override
     {
         ml->run_with_context_as_thread_default(
-            [this, vt_number, &error_handler]()
+            [this, vt_number, error_handler = std::move(error_handler)]()
             {
                 logind_seat_call_switch_to(
                     seat_proxy.get(),
@@ -783,7 +783,7 @@ public:
                     nullptr,
                     &LogindVTSwitcher::complete_switch_to,
                     new std::function<void(std::exception const&)>{error_handler});
-            });
+            }); // No need to wait for this to run; drop the std::future on the floor
     }
 
 private:

--- a/src/server/console/logind_console_services.cpp
+++ b/src/server/console/logind_console_services.cpp
@@ -669,6 +669,13 @@ void mir::LogindConsoleServices::on_pause_device(
             it->second->emit_removed();
             // The device is gone; logind promises not to send further events for it
             me->acquired_devices.erase(it);
+            // …unfortunately, logind is a FILTHY LIAR.
+            logind_session_call_release_device(
+                me->session_proxy.get(),
+                major, minor,
+                nullptr,
+                &complete_release_device_call,
+                nullptr);
         }
         else
         {

--- a/src/server/console/logind_console_services.h
+++ b/src/server/console/logind_console_services.h
@@ -42,6 +42,8 @@ public:
 
     void restore() override;
 
+    std::unique_ptr<VTSwitcher> create_vt_switcher() override;
+
     std::future<std::unique_ptr<mir::Device>> acquire_device(
         int major, int minor,
         std::unique_ptr<Device::Observer> observer) override;

--- a/src/server/console/null_console_services.h
+++ b/src/server/console/null_console_services.h
@@ -19,6 +19,7 @@
 #ifndef MIR_NULL_CONSOLE_SERVICES_H_
 #define MIR_NULL_CONSOLE_SERVICES_H_
 
+#include <boost/throw_exception.hpp>
 #include <future>
 #include "mir/console_services.h"
 #include "mir/fd.h"
@@ -35,6 +36,12 @@ public:
     }
 
     void restore() override {}
+
+    std::unique_ptr<VTSwitcher> create_vt_switcher() override
+    {
+        BOOST_THROW_EXCEPTION((
+            std::runtime_error{"NullConsoleServices does not support VT switching"}));
+    }
 
     std::future<std::unique_ptr<Device>> acquire_device(
         int, int,

--- a/src/server/default_server_configuration.cpp
+++ b/src/server/default_server_configuration.cpp
@@ -69,7 +69,7 @@ mir::DefaultServerConfiguration::DefaultServerConfiguration(int argc, char const
 
 mir::DefaultServerConfiguration::DefaultServerConfiguration(std::shared_ptr<mo::Configuration> const& configuration_options) :
     configuration_options(configuration_options),
-    default_filter(std::make_shared<mi::VTFilter>())
+    default_filter(std::make_shared<mi::VTFilter>(the_console_services()->create_vt_switcher()))
 {
 }
 

--- a/src/server/default_server_configuration.cpp
+++ b/src/server/default_server_configuration.cpp
@@ -68,8 +68,7 @@ mir::DefaultServerConfiguration::DefaultServerConfiguration(int argc, char const
 }
 
 mir::DefaultServerConfiguration::DefaultServerConfiguration(std::shared_ptr<mo::Configuration> const& configuration_options) :
-    configuration_options(configuration_options),
-    default_filter(std::make_shared<mi::VTFilter>(the_console_services()->create_vt_switcher()))
+    configuration_options(configuration_options)
 {
 }
 

--- a/src/server/input/default_configuration.cpp
+++ b/src/server/input/default_configuration.cpp
@@ -76,8 +76,10 @@ mir::DefaultServerConfiguration::the_event_filter_chain_dispatcher()
     return event_filter_chain_dispatcher(
         [this]() -> std::shared_ptr<mi::EventFilterChainDispatcher>
         {
-            std::initializer_list<std::shared_ptr<mi::EventFilter> const> filter_list {default_filter};
-            return std::make_shared<mi::EventFilterChainDispatcher>(filter_list, the_surface_input_dispatcher());
+            std::vector<std::weak_ptr<mi::EventFilter>> filter_list {default_filter};
+            return std::make_shared<mi::EventFilterChainDispatcher>(
+                std::move(filter_list),
+                the_surface_input_dispatcher());
         });
 }
 

--- a/src/server/input/default_configuration.cpp
+++ b/src/server/input/default_configuration.cpp
@@ -38,6 +38,7 @@
 #include "mir/input/input_probe.h"
 #include "mir/input/platform.h"
 #include "mir/input/xkb_mapper.h"
+#include "mir/input/vt_filter.h"
 #include "mir/options/configuration.h"
 #include "mir/options/option.h"
 #include "mir/dispatch/multiplexing_dispatchable.h"
@@ -49,6 +50,8 @@
 #include "mir/log.h"
 #include "mir/shared_library.h"
 #include "mir/dispatch/action_queue.h"
+#include "mir/console_services.h"
+#include "mir/log.h"
 
 #include "mir_toolkit/cursors.h"
 
@@ -76,9 +79,27 @@ mir::DefaultServerConfiguration::the_event_filter_chain_dispatcher()
     return event_filter_chain_dispatcher(
         [this]() -> std::shared_ptr<mi::EventFilterChainDispatcher>
         {
-            std::vector<std::weak_ptr<mi::EventFilter>> filter_list {default_filter};
+            auto const make_default_filter_list =
+                [this]() -> std::vector<std::weak_ptr<mi::EventFilter>>
+                {
+                    try
+                    {
+                        default_filter = std::make_shared<mi::VTFilter>(
+                            the_console_services()->create_vt_switcher());
+                    }
+                    catch (std::exception const& err)
+                    {
+                        mir::log(
+                            mir::logging::Severity::informational,
+                            "VT switch key handler",
+                            "No VT switching support available: %s",
+                            err.what());
+                        return {};
+                    }
+                    return {default_filter};
+                };
             return std::make_shared<mi::EventFilterChainDispatcher>(
-                std::move(filter_list),
+                make_default_filter_list(),
                 the_surface_input_dispatcher());
         });
 }

--- a/src/server/input/event_filter_chain_dispatcher.cpp
+++ b/src/server/input/event_filter_chain_dispatcher.cpp
@@ -48,14 +48,14 @@ bool mi::EventFilterChainDispatcher::handle(MirEvent const& event)
     return false;
 }
 
-void mi::EventFilterChainDispatcher::append(std::shared_ptr<EventFilter> const& filter)
+void mi::EventFilterChainDispatcher::append(std::weak_ptr<EventFilter> const& filter)
 {
     std::lock_guard<std::mutex> lg(filter_guard);
 
     filters.push_back(filter);
 }
 
-void mi::EventFilterChainDispatcher::prepend(std::shared_ptr<EventFilter> const& filter)
+void mi::EventFilterChainDispatcher::prepend(std::weak_ptr<EventFilter> const& filter)
 {
     std::lock_guard<std::mutex> lg(filter_guard);
         

--- a/src/server/input/event_filter_chain_dispatcher.cpp
+++ b/src/server/input/event_filter_chain_dispatcher.cpp
@@ -21,9 +21,9 @@
 namespace mi = mir::input;
 
 mi::EventFilterChainDispatcher::EventFilterChainDispatcher(
-    std::initializer_list<std::shared_ptr<mi::EventFilter> const> const& values,
+    std::vector<std::weak_ptr<mi::EventFilter>> initial_filters,
     std::shared_ptr<mi::InputDispatcher> const& next_dispatcher)
-    : filters(values.begin(), values.end()),
+    : filters(std::move(initial_filters)),
       next_dispatcher(next_dispatcher)
 {
 }

--- a/src/server/input/event_filter_chain_dispatcher.h
+++ b/src/server/input/event_filter_chain_dispatcher.h
@@ -34,7 +34,7 @@ class EventFilterChainDispatcher : public CompositeEventFilter, public mir::inpu
 {
 public:
     EventFilterChainDispatcher(
-        std::initializer_list<std::shared_ptr<EventFilter> const> const& values,
+        std::vector<std::weak_ptr<EventFilter>> initial_filters,
         std::shared_ptr<InputDispatcher> const& next_dispatcher);
 
     // CompositeEventFilter

--- a/src/server/input/event_filter_chain_dispatcher.h
+++ b/src/server/input/event_filter_chain_dispatcher.h
@@ -39,8 +39,8 @@ public:
 
     // CompositeEventFilter
     bool handle(MirEvent const& event) override;
-    void append(std::shared_ptr<EventFilter> const& filter) override;
-    void prepend(std::shared_ptr<EventFilter> const& filter) override;
+    void append(std::weak_ptr<EventFilter> const& filter) override;
+    void prepend(std::weak_ptr<EventFilter> const& filter) override;
 
     // InputDispatcher
     bool dispatch(std::shared_ptr<MirEvent const> const& event) override;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -52,11 +52,11 @@ namespace
 struct TemporaryCompositeEventFilter : public mi::CompositeEventFilter
 {
     bool handle(MirEvent const&) override { return false; }
-    void append(std::shared_ptr<mi::EventFilter> const& filter) override
+    void append(std::weak_ptr<mi::EventFilter> const& filter) override
     {
         append_event_filters.push_back(filter);
     }
-    void prepend(std::shared_ptr<mi::EventFilter> const& filter) override
+    void prepend(std::weak_ptr<mi::EventFilter> const& filter) override
     {
         prepend_event_filters.push_back(filter);
     }
@@ -72,8 +72,8 @@ struct TemporaryCompositeEventFilter : public mi::CompositeEventFilter
         append_event_filters.clear();
         prepend_event_filters.clear();
     }
-    std::vector<std::shared_ptr<mi::EventFilter>> prepend_event_filters;
-    std::vector<std::shared_ptr<mi::EventFilter>> append_event_filters;
+    std::vector<std::weak_ptr<mi::EventFilter>> prepend_event_filters;
+    std::vector<std::weak_ptr<mi::EventFilter>> append_event_filters;
 };
 }
 

--- a/tests/include/mir/test/doubles/null_console_services.h
+++ b/tests/include/mir/test/doubles/null_console_services.h
@@ -22,6 +22,8 @@
 #include "mir/fd.h"
 #include "mir/console_services.h"
 
+#include <boost/throw_exception.hpp>
+
 namespace mir
 {
 namespace test
@@ -39,6 +41,12 @@ public:
     }
 
     void restore() override {}
+
+    std::unique_ptr<VTSwitcher> create_vt_switcher() override
+    {
+        BOOST_THROW_EXCEPTION((
+            std::runtime_error{"NullConsoleServices does not implement VT switching"}));
+    }
 
     std::future<std::unique_ptr<Device>> acquire_device(
         int, int,

--- a/tests/include/mir/test/doubles/stub_console_services.h
+++ b/tests/include/mir/test/doubles/stub_console_services.h
@@ -41,6 +41,7 @@ public:
 
     void restore() override;
 
+    std::unique_ptr<VTSwitcher> create_vt_switcher() override;
 
     std::future<std::unique_ptr<mir::Device>> acquire_device(
         int major, int minor,

--- a/tests/mir_test_doubles/stub_console_services.cpp
+++ b/tests/mir_test_doubles/stub_console_services.cpp
@@ -20,6 +20,7 @@
 
 #include "mir/fd.h"
 
+#include <boost/throw_exception.hpp>
 #include <sys/sysmacros.h>
 #include <fcntl.h>
 #include <xf86drm.h>
@@ -94,4 +95,10 @@ char const* mtd::StubConsoleServices::devnode_for_devnum(int major, int minor)
         devnode = devnodes[devnum];
     }
     return devnode.c_str();
+}
+
+std::unique_ptr<mir::VTSwitcher> mir::test::doubles::StubConsoleServices::create_vt_switcher()
+{
+    BOOST_THROW_EXCEPTION((
+        std::runtime_error{"StubConsoleServices does not support VT switching"}));
 }

--- a/tests/unit-tests/console/test_logind_console_services.cpp
+++ b/tests/unit-tests/console/test_logind_console_services.cpp
@@ -721,6 +721,37 @@ public:
         }
     }
 
+    void add_switch_to_to_seat(
+        char const* seat_path,
+        char const* mock_code)
+    {
+        auto result = std::unique_ptr<GVariant, decltype(&g_variant_unref)>{
+            g_dbus_connection_call_sync(
+                bus_connection.get(),
+                "org.freedesktop.login1",
+                seat_path,
+                "org.freedesktop.DBus.Mock",
+                "AddMethod",
+                g_variant_new(
+                    "(sssss)",
+                    "org.freedesktop.login1.Seat",
+                    "SwitchTo",
+                    "u",
+                    "",
+                    mock_code),
+                nullptr,
+                G_DBUS_CALL_FLAGS_NO_AUTO_START,
+                1000,
+                nullptr,
+                nullptr),
+            &g_variant_unref};
+
+        if (!result)
+        {
+            BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to add SwitchTo"}));
+        }
+    }
+
     struct CallInfo
     {
         using GVariantPtr = std::unique_ptr<GVariant, decltype(&g_variant_unref)>;
@@ -1435,6 +1466,101 @@ TEST_F(LogindConsoleServices, can_acquire_device_without_running_main_loop)
             [](){})).get();
 
     EXPECT_TRUE(device_acquired);
+    stop_mainloop();
+}
+
+TEST_F(LogindConsoleServices, creates_vt_switcher_when_vt_switching_possible)
+{
+    ensure_mock_logind();
+    add_any_active_session();
+
+    mir::LogindConsoleServices console{the_main_loop()};
+
+    EXPECT_THAT(console.create_vt_switcher(), NotNull());
+
+    stop_mainloop();
+}
+
+//TODO: Add test for create_vt_switcher() failing when Logind *can't* switch VTs
+
+TEST_F(LogindConsoleServices, vt_switcher_calls_error_handler_on_error)
+{
+    ensure_mock_logind();
+    add_seat("seat0");
+    add_session(
+        "s1",
+        "seat0",
+        1000,
+        "ubuntu",
+        true,
+        "");
+
+    add_switch_to_to_seat(
+        "/org/freedesktop/login1/seat/seat0",
+        "raise dbus.exceptions.DBusException('No such file or directory (2)', name='System.Error.ENOENT')");
+
+    mir::LogindConsoleServices console{the_main_loop()};
+    auto switcher = console.create_vt_switcher();
+
+    auto error_received = std::make_shared<mt::Signal>();
+
+    switcher->switch_to(
+        7,
+        [error_received](std::exception const& err)
+        {
+            EXPECT_THAT(dynamic_cast<std::runtime_error const*>(&err), NotNull());
+            EXPECT_THAT(err.what(), ContainsRegex(".*No such file or directory.*"));
+            error_received->raise();
+        });
+    EXPECT_TRUE(error_received->wait_for(30s));
+
+    stop_mainloop();
+}
+
+TEST_F(LogindConsoleServices, vt_switcher_calls_switch_to_with_correct_argument)
+{
+    ensure_mock_logind();
+    add_seat("seat0");
+    add_session(
+        "s1",
+        "seat0",
+        1000,
+        "ubuntu",
+        true,
+        "");
+
+    add_switch_to_to_seat(
+        "/org/freedesktop/login1/seat/seat0",
+        "");
+
+    mir::LogindConsoleServices console{the_main_loop()};
+    auto switcher = console.create_vt_switcher();
+
+    switcher->switch_to(
+        3,
+        [](auto){});
+
+    auto calls_made = get_calls_for_object("/org/freedesktop/login1/seat/seat0");
+
+    auto switch_to_call = std::find_if(
+        calls_made.begin(),
+        calls_made.end(),
+        [](CallInfo const& call)
+        {
+            return call.method_name == "SwitchTo";
+        });
+
+    ASSERT_THAT(switch_to_call, Not(Eq(calls_made.end())));
+    ASSERT_THAT(switch_to_call->arguments.size(), Eq(1));
+
+    unsigned vt_arg;
+    g_variant_get(
+        switch_to_call->arguments[0].get(),
+        "u",
+        &vt_arg);
+
+    EXPECT_THAT(vt_arg, Eq(3));
+
     stop_mainloop();
 }
 

--- a/tests/unit-tests/console/test_logind_console_services.cpp
+++ b/tests/unit-tests/console/test_logind_console_services.cpp
@@ -196,7 +196,7 @@ public:
     {
         // Tests cases *must* stop the mainloop thread before destroying
         // block scope objects that are referenced by enqueued logic.
-        ASSERT_TRUE(ml_thread_stopped);
+        EXPECT_TRUE(ml_thread_stopped);
 
         // Print the dbusmock output if we've failed.
         auto const test_info = ::testing::UnitTest::GetInstance()->current_test_info();

--- a/tests/unit-tests/graphics/test_platform_prober.cpp
+++ b/tests/unit-tests/graphics/test_platform_prober.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 #include <fcntl.h>
+#include <boost/throw_exception.hpp>
 
 #include "mir/graphics/platform.h"
 #include "mir/graphics/platform_probe.h"
@@ -115,6 +116,12 @@ public:
 
     void restore() override
     {
+    }
+
+    std::unique_ptr<mir::VTSwitcher> create_vt_switcher() override
+    {
+        BOOST_THROW_EXCEPTION((
+            std::runtime_error{"StubConsoleServices does not support VT switching"}));
     }
 
     std::future<std::unique_ptr<mir::Device>> acquire_device(


### PR DESCRIPTION
Add a `VTSwitcher` interface that can be provided by `ConsoleServices`, implement it for `LogindConsoleServices` and `LinuxVirtualTerminal`, and then use it in the `input::VTFilter` to switch VTs, rather than directly opening `/dev/tty0` and frobbing it.

Fixes #459.