### PR TITLE
[Wayland] Default for positioner gravity

### DIFF
--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -562,6 +562,9 @@ mf::XdgToplevelV6* mf::XdgToplevelV6::from(wl_resource* surface)
 mf::XdgPositionerV6::XdgPositionerV6(struct wl_client* client, struct wl_resource* parent, uint32_t id)
     : wayland::XdgPositionerV6(client, parent, id)
 {
+    // specifying gravity is not required by the xdg shell protocol, but is by Mir window managers
+    surface_placement_gravity = mir_placement_gravity_center;
+    aux_rect_placement_gravity = mir_placement_gravity_center;
 }
 
 void mf::XdgPositionerV6::destroy()


### PR DESCRIPTION
I haven't found an app in the wild that doesn't specify gravity, but you don't need to according to the protocol. Mir would crash (unwrap a null optional in the window manager) without this fix. I was hitting this on the popup defaults wlcs test, which is currently in a PR.