### PR TITLE
removed become_surface_role()

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -302,7 +302,6 @@ public:
         : ShellSurface(client, parent, id),
           WindowWlSurfaceRole{&seat, client, surface, shell, output_manager}
     {
-        become_surface_role();
     }
 
     ~WlShellSurface() = default;

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -56,6 +56,7 @@ mf::WindowWlSurfaceRole::WindowWlSurfaceRole(WlSeat* seat, wl_client* client, Wl
           params{std::make_unique<scene::SurfaceCreationParameters>(
                  scene::SurfaceCreationParameters().of_type(mir_window_type_freestyle))}
 {
+    surface->set_role(this);
 }
 
 mf::WindowWlSurfaceRole::~WindowWlSurfaceRole()
@@ -86,11 +87,6 @@ void mf::WindowWlSurfaceRole::refresh_surface_data_now()
     shell::SurfaceSpecification surface_data_spec;
     populate_spec_with_surface_data(surface_data_spec);
     shell->modify_surface(get_session(client), surface_id_, surface_data_spec);
-}
-
-void mf::WindowWlSurfaceRole::become_surface_role()
-{
-    surface->set_role(this);
 }
 
 void mf::WindowWlSurfaceRole::apply_spec(mir::shell::SurfaceSpecification const& new_spec)

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -65,7 +65,6 @@ public:
 
     void populate_spec_with_surface_data(shell::SurfaceSpecification& spec);
     void refresh_surface_data_now() override;
-    void become_surface_role();
 
     void apply_spec(shell::SurfaceSpecification const& new_spec);
     void set_geometry(int32_t x, int32_t y, int32_t width, int32_t height);

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -207,7 +207,6 @@ void mf::XdgSurfaceV6::destroy()
 void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
 {
     new XdgToplevelV6{client, parent, id, shell, this};
-    become_surface_role();
 }
 
 void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct wl_resource* positioner)
@@ -226,7 +225,6 @@ void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct
     apply_spec(*specification);
 
     new XdgPopupV6{client, parent, id, this};
-    become_surface_role();
 }
 
 void mf::XdgSurfaceV6::set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height)

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.cpp
@@ -52,7 +52,6 @@ void mf::XWaylandWMShellSurface::destroy()
 
 void mf::XWaylandWMShellSurface::set_toplevel()
 {
-    become_surface_role();
     set_state_now(MirWindowState::mir_window_state_restored);
 }
 


### PR DESCRIPTION
Removed the `become_surface_role()` function and added its functionality (`surface->set_role(this)`) to the `WindowWlSurfaceRole` constructor.