### PR TITLE
More XDG shell cleanup

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -363,7 +363,6 @@ protected:
         int32_t y,
         uint32_t flags) override
     {
-        auto const session = get_session(client);
         auto& parent_surface = *WlSurface::from(parent);
 
         mir::shell::SurfaceSpecification mods;
@@ -448,8 +447,6 @@ protected:
     void set_class(std::string const& /*class_*/) override
     {
     }
-
-    using WindowWlSurfaceRole::client;
 };
 
 class WlShell : public wayland::Shell

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -84,7 +84,6 @@ public:
 
 protected:
     std::shared_ptr<bool> const destroyed;
-    wl_client* const client;
 
     geometry::Size window_size();
     MirWindowState window_state();
@@ -94,6 +93,7 @@ protected:
     void commit(WlSurfaceState const& state) override;
 
 private:
+    wl_client* const client;
     WlSurface* const surface;
     std::shared_ptr<frontend::Shell> const shell;
     OutputManager* output_manager;

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -18,17 +18,10 @@
 
 #include "xdg_shell_v6.h"
 
-#include "wayland_utils.h"
-#include "wl_surface_event_sink.h"
-#include "wl_seat.h"
 #include "wl_surface.h"
 #include "window_wl_surface_role.h"
 
-#include "mir/scene/surface_creation_parameters.h"
-#include "mir/frontend/session.h"
-#include "mir/scene/surface.h"
-#include "mir/frontend/shell.h"
-#include "mir/optional_value.h"
+#include "mir/shell/surface_specification.h"
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -66,8 +66,6 @@ public:
                                               bool active)> notify_resize);
     void send_configure();
 
-    using WindowWlSurfaceRole::client;
-
     struct wl_resource* const parent;
     std::shared_ptr<Shell> const shell;
     std::function<void(std::experimental::optional<geometry::Point> const& new_top_left,
@@ -196,7 +194,7 @@ void mf::XdgSurfaceV6::destroy()
 
 void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
 {
-    new XdgToplevelV6{client, parent, id, shell, this};
+    new XdgToplevelV6{wayland::XdgSurfaceV6::client, parent, id, shell, this};
     become_surface_role();
 }
 
@@ -215,7 +213,7 @@ void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct
 
     apply_spec(*specification);
 
-    new XdgPopupV6{client, parent, id, this};
+    new XdgPopupV6{wayland::XdgSurfaceV6::client, parent, id, this};
     become_surface_role();
 }
 
@@ -241,7 +239,7 @@ void mf::XdgSurfaceV6::set_notify_resize(
 
 void mf::XdgSurfaceV6::send_configure()
 {
-    auto const serial = wl_display_next_serial(wl_client_get_display(client));
+    auto const serial = wl_display_next_serial(wl_client_get_display(wayland::XdgSurfaceV6::client));
     zxdg_surface_v6_send_configure(resource, serial);
 }
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -67,7 +67,6 @@ public:
     void send_configure();
 
     struct wl_resource* const parent;
-    std::shared_ptr<Shell> const shell;
     std::function<void(std::experimental::optional<geometry::Point> const& new_top_left,
                        geometry::Size const& new_size,
                        MirWindowState state,
@@ -90,8 +89,7 @@ private:
 class XdgToplevelV6 : public wayland::XdgToplevelV6
 {
 public:
-    XdgToplevelV6(struct wl_client* client, struct wl_resource* parent, uint32_t id,
-                  std::shared_ptr<frontend::Shell> const& shell, XdgSurfaceV6* self);
+    XdgToplevelV6(struct wl_client* client, struct wl_resource* parent, uint32_t id, XdgSurfaceV6* self);
 
     void destroy() override;
     void set_parent(std::experimental::optional<struct wl_resource*> const& parent) override;
@@ -111,7 +109,6 @@ public:
 private:
     static XdgToplevelV6* from(wl_resource* surface);
 
-    std::shared_ptr<frontend::Shell> const shell;
     XdgSurfaceV6* const self;
 };
 
@@ -182,8 +179,7 @@ mf::XdgSurfaceV6::XdgSurfaceV6(wl_client* client, wl_resource* parent, uint32_t 
                                std::shared_ptr<mf::Shell> const& shell, WlSeat& seat, OutputManager* output_manager)
     : wayland::XdgSurfaceV6(client, parent, id),
       WindowWlSurfaceRole{&seat, client, surface, shell, output_manager},
-      parent{parent},
-      shell{shell}
+      parent{parent}
 {
 }
 
@@ -194,7 +190,7 @@ void mf::XdgSurfaceV6::destroy()
 
 void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
 {
-    new XdgToplevelV6{wayland::XdgSurfaceV6::client, parent, id, shell, this};
+    new XdgToplevelV6{wayland::XdgSurfaceV6::client, parent, id, this};
     become_surface_role();
 }
 
@@ -295,10 +291,8 @@ void mf::XdgPopupV6::destroy()
 
 // XdgToplevelV6
 
-mf::XdgToplevelV6::XdgToplevelV6(struct wl_client* client, struct wl_resource* parent, uint32_t id,
-                                 std::shared_ptr<mf::Shell> const& shell, XdgSurfaceV6* self)
+mf::XdgToplevelV6::XdgToplevelV6(struct wl_client* client, struct wl_resource* parent, uint32_t id, XdgSurfaceV6* self)
     : wayland::XdgToplevelV6(client, parent, id),
-      shell{shell},
       self{self}
 {
     self->set_notify_resize(

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -66,7 +66,6 @@ public:
                                               bool active)> notify_resize);
     void send_configure();
 
-    struct wl_resource* const parent;
     std::function<void(std::experimental::optional<geometry::Point> const& new_top_left,
                        geometry::Size const& new_size,
                        MirWindowState state,
@@ -178,8 +177,7 @@ mf::XdgSurfaceV6* mf::XdgSurfaceV6::from(wl_resource* surface)
 mf::XdgSurfaceV6::XdgSurfaceV6(wl_client* client, wl_resource* parent, uint32_t id, WlSurface* surface,
                                std::shared_ptr<mf::Shell> const& shell, WlSeat& seat, OutputManager* output_manager)
     : wayland::XdgSurfaceV6(client, parent, id),
-      WindowWlSurfaceRole{&seat, client, surface, shell, output_manager},
-      parent{parent}
+      WindowWlSurfaceRole{&seat, client, surface, shell, output_manager}
 {
 }
 
@@ -190,7 +188,7 @@ void mf::XdgSurfaceV6::destroy()
 
 void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
 {
-    new XdgToplevelV6{wayland::XdgSurfaceV6::client, parent, id, this};
+    new XdgToplevelV6{wayland::XdgSurfaceV6::client, resource, id, this};
     become_surface_role();
 }
 

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
@@ -58,7 +58,6 @@ protected:
     void set_transient(struct wl_resource* parent, int32_t x, int32_t y, uint32_t flags);
     void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left, geometry::Size const& new_size) override;
 
-    using WindowWlSurfaceRole::client;
     using WindowWlSurfaceRole::surface_id;
 
 private:


### PR DESCRIPTION
As the commit log says:
* made client private in `WindowWlSurfaceRole`, and switched to using `wayland::XdgSurfaceV6::client`
* stopped using `Shell`s where they weren't needed
* fixed an issue where we were not using the correct parent object (no change in behavior is detectable)