### PR TITLE
Made toplevels and popups window roles

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -302,7 +302,6 @@ public:
         : ShellSurface(client, parent, id),
           WindowWlSurfaceRole{&seat, client, surface, shell, output_manager}
     {
-        become_surface_role();
     }
 
     ~WlShellSurface() = default;

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -363,7 +363,6 @@ protected:
         int32_t y,
         uint32_t flags) override
     {
-        auto const session = get_session(client);
         auto& parent_surface = *WlSurface::from(parent);
 
         mir::shell::SurfaceSpecification mods;
@@ -448,8 +447,6 @@ protected:
     void set_class(std::string const& /*class_*/) override
     {
     }
-
-    using WindowWlSurfaceRole::client;
 };
 
 class WlShell : public wayland::Shell

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -56,6 +56,7 @@ mf::WindowWlSurfaceRole::WindowWlSurfaceRole(WlSeat* seat, wl_client* client, Wl
           params{std::make_unique<scene::SurfaceCreationParameters>(
                  scene::SurfaceCreationParameters().of_type(mir_window_type_freestyle))}
 {
+    surface->set_role(this);
 }
 
 mf::WindowWlSurfaceRole::~WindowWlSurfaceRole()
@@ -86,11 +87,6 @@ void mf::WindowWlSurfaceRole::refresh_surface_data_now()
     shell::SurfaceSpecification surface_data_spec;
     populate_spec_with_surface_data(surface_data_spec);
     shell->modify_surface(get_session(client), surface_id_, surface_data_spec);
-}
-
-void mf::WindowWlSurfaceRole::become_surface_role()
-{
-    surface->set_role(this);
 }
 
 void mf::WindowWlSurfaceRole::apply_spec(mir::shell::SurfaceSpecification const& new_spec)

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -61,11 +61,11 @@ public:
 
     ~WindowWlSurfaceRole() override;
 
+    std::shared_ptr<bool> destroyed_flag() const { return destroyed; }
     SurfaceId surface_id() const override { return surface_id_; };
 
     void populate_spec_with_surface_data(shell::SurfaceSpecification& spec);
     void refresh_surface_data_now() override;
-    void become_surface_role();
 
     void apply_spec(shell::SurfaceSpecification const& new_spec);
     void set_geometry(int32_t x, int32_t y, int32_t width, int32_t height);

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -84,7 +84,6 @@ public:
 
 protected:
     std::shared_ptr<bool> const destroyed;
-    wl_client* const client;
 
     geometry::Size window_size();
     MirWindowState window_state();
@@ -94,6 +93,7 @@ protected:
     void commit(WlSurfaceState const& state) override;
 
 private:
+    wl_client* const client;
     WlSurface* const surface;
     std::shared_ptr<frontend::Shell> const shell;
     OutputManager* output_manager;

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -18,17 +18,10 @@
 
 #include "xdg_shell_v6.h"
 
-#include "wayland_utils.h"
-#include "wl_surface_event_sink.h"
-#include "wl_seat.h"
 #include "wl_surface.h"
 #include "window_wl_surface_role.h"
 
-#include "mir/scene/surface_creation_parameters.h"
-#include "mir/frontend/session.h"
-#include "mir/scene/surface.h"
-#include "mir/frontend/shell.h"
-#include "mir/optional_value.h"
+#include "mir/shell/surface_specification.h"
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -66,8 +66,6 @@ public:
                                               bool active)> notify_resize);
     void send_configure();
 
-    using WindowWlSurfaceRole::client;
-
     struct wl_resource* const parent;
     std::shared_ptr<Shell> const shell;
     std::function<void(std::experimental::optional<geometry::Point> const& new_top_left,
@@ -196,7 +194,7 @@ void mf::XdgSurfaceV6::destroy()
 
 void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
 {
-    new XdgToplevelV6{client, parent, id, shell, this};
+    new XdgToplevelV6{wayland::XdgSurfaceV6::client, parent, id, shell, this};
     become_surface_role();
 }
 
@@ -215,7 +213,7 @@ void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent, struct
 
     apply_spec(*specification);
 
-    new XdgPopupV6{client, parent, id, this};
+    new XdgPopupV6{wayland::XdgSurfaceV6::client, parent, id, this};
     become_surface_role();
 }
 
@@ -241,7 +239,7 @@ void mf::XdgSurfaceV6::set_notify_resize(
 
 void mf::XdgSurfaceV6::send_configure()
 {
-    auto const serial = wl_display_next_serial(wl_client_get_display(client));
+    auto const serial = wl_display_next_serial(wl_client_get_display(wayland::XdgSurfaceV6::client));
     zxdg_surface_v6_send_configure(resource, serial);
 }
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -67,7 +67,6 @@ public:
     void send_configure();
 
     struct wl_resource* const parent;
-    std::shared_ptr<Shell> const shell;
     std::function<void(std::experimental::optional<geometry::Point> const& new_top_left,
                        geometry::Size const& new_size,
                        MirWindowState state,
@@ -90,8 +89,7 @@ private:
 class XdgToplevelV6 : public wayland::XdgToplevelV6
 {
 public:
-    XdgToplevelV6(struct wl_client* client, struct wl_resource* parent, uint32_t id,
-                  std::shared_ptr<frontend::Shell> const& shell, XdgSurfaceV6* self);
+    XdgToplevelV6(struct wl_client* client, struct wl_resource* parent, uint32_t id, XdgSurfaceV6* self);
 
     void destroy() override;
     void set_parent(std::experimental::optional<struct wl_resource*> const& parent) override;
@@ -111,7 +109,6 @@ public:
 private:
     static XdgToplevelV6* from(wl_resource* surface);
 
-    std::shared_ptr<frontend::Shell> const shell;
     XdgSurfaceV6* const self;
 };
 
@@ -182,8 +179,7 @@ mf::XdgSurfaceV6::XdgSurfaceV6(wl_client* client, wl_resource* parent, uint32_t 
                                std::shared_ptr<mf::Shell> const& shell, WlSeat& seat, OutputManager* output_manager)
     : wayland::XdgSurfaceV6(client, parent, id),
       WindowWlSurfaceRole{&seat, client, surface, shell, output_manager},
-      parent{parent},
-      shell{shell}
+      parent{parent}
 {
 }
 
@@ -194,7 +190,7 @@ void mf::XdgSurfaceV6::destroy()
 
 void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
 {
-    new XdgToplevelV6{wayland::XdgSurfaceV6::client, parent, id, shell, this};
+    new XdgToplevelV6{wayland::XdgSurfaceV6::client, parent, id, this};
     become_surface_role();
 }
 
@@ -295,10 +291,8 @@ void mf::XdgPopupV6::destroy()
 
 // XdgToplevelV6
 
-mf::XdgToplevelV6::XdgToplevelV6(struct wl_client* client, struct wl_resource* parent, uint32_t id,
-                                 std::shared_ptr<mf::Shell> const& shell, XdgSurfaceV6* self)
+mf::XdgToplevelV6::XdgToplevelV6(struct wl_client* client, struct wl_resource* parent, uint32_t id, XdgSurfaceV6* self)
     : wayland::XdgToplevelV6(client, parent, id),
-      shell{shell},
       self{self}
 {
     self->set_notify_resize(

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -66,7 +66,6 @@ public:
                                               bool active)> notify_resize);
     void send_configure();
 
-    struct wl_resource* const parent;
     std::function<void(std::experimental::optional<geometry::Point> const& new_top_left,
                        geometry::Size const& new_size,
                        MirWindowState state,
@@ -178,8 +177,7 @@ mf::XdgSurfaceV6* mf::XdgSurfaceV6::from(wl_resource* surface)
 mf::XdgSurfaceV6::XdgSurfaceV6(wl_client* client, wl_resource* parent, uint32_t id, WlSurface* surface,
                                std::shared_ptr<mf::Shell> const& shell, WlSeat& seat, OutputManager* output_manager)
     : wayland::XdgSurfaceV6(client, parent, id),
-      WindowWlSurfaceRole{&seat, client, surface, shell, output_manager},
-      parent{parent}
+      WindowWlSurfaceRole{&seat, client, surface, shell, output_manager}
 {
 }
 
@@ -190,7 +188,7 @@ void mf::XdgSurfaceV6::destroy()
 
 void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
 {
-    new XdgToplevelV6{wayland::XdgSurfaceV6::client, parent, id, this};
+    new XdgToplevelV6{wayland::XdgSurfaceV6::client, resource, id, this};
     become_surface_role();
 }
 

--- a/src/server/frontend_wayland/xdg_shell_v6.h
+++ b/src/server/frontend_wayland/xdg_shell_v6.h
@@ -42,10 +42,9 @@ public:
                          struct wl_resource* surface) override;
     void pong(struct wl_client* client, struct wl_resource* resource, uint32_t serial) override;
 
-private:
     std::shared_ptr<Shell> const shell;
     WlSeat& seat;
-    OutputManager* output_manager;
+    OutputManager* const output_manager;
 };
 
 }

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.cpp
@@ -52,7 +52,6 @@ void mf::XWaylandWMShellSurface::destroy()
 
 void mf::XWaylandWMShellSurface::set_toplevel()
 {
-    become_surface_role();
     set_state_now(MirWindowState::mir_window_state_restored);
 }
 

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
@@ -58,7 +58,6 @@ protected:
     void set_transient(struct wl_resource* parent, int32_t x, int32_t y, uint32_t flags);
     void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left, geometry::Size const& new_size) override;
 
-    using WindowWlSurfaceRole::client;
     using WindowWlSurfaceRole::surface_id;
 
 private:


### PR DESCRIPTION
Stacked on top of #515 

Made `XdgToplevelV6` and `XdgPopupV6` inherent from `WindowWlSurfaceRole` (`XdgSurfaceV6` used to inherit from it). Some advantages of this are:

* Eliminates the messy `notify_resize` `std::function` passing without the need of a new abstract class.
* Handles objects being destroyed more safely (this didn't seem to be a problem, but with the old system, it looked to me like there were some nasty segfault opportunists. They might not all be handled, but its definitely better)
* Matches what a surface role is in the protocol, specifically this, where I originally got the idea:
```
<request name="get_xdg_surface">
      <description summary="create a shell surface from a surface">
	This creates an xdg_surface for the given surface. While xdg_surface
	itself is not a role, the corresponding surface may only be assigned
	a role extending xdg_surface, such as xdg_toplevel or xdg_popup.
```