### PR TITLE
mesa-kms: Don't try to manage drmMaster

### DIFF
--- a/src/platforms/mesa/server/kms/display.cpp
+++ b/src/platforms/mesa/server/kms/display.cpp
@@ -54,12 +54,6 @@ namespace geom = mir::geometry;
 namespace
 {
 
-int errno_from_exception(std::exception const& e)
-{
-    auto errno_ptr = boost::get_error_info<boost::errinfo_errno>(e);
-    return (errno_ptr != nullptr) ? *errno_ptr : -1;
-}
-
 class GBMGLContext : public mir::renderer::gl::Context
 {
 public:
@@ -292,32 +286,11 @@ void mgm::Display::register_pause_resume_handlers(
 
 void mgm::Display::pause()
 {
-    try
-    {
-        if (auto c = cursor.lock()) c->suspend();
-        for (auto& helper : drm)
-            helper->drop_master();
-    }
-    catch(std::runtime_error const& e)
-    {
-        listener->report_drm_master_failure(errno_from_exception(e));
-        throw;
-    }
+    if (auto c = cursor.lock()) c->suspend();
 }
 
 void mgm::Display::resume()
 {
-    try
-    {
-        for (auto& helper : drm)
-            helper->set_master();
-    }
-    catch(std::runtime_error const& e)
-    {
-        listener->report_drm_master_failure(errno_from_exception(e));
-        throw;
-    }
-
     {
         std::lock_guard<std::mutex> lg{configuration_mutex};
 

--- a/tests/unit-tests/platforms/mesa/kms/test_display.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_display.cpp
@@ -651,18 +651,6 @@ TEST_F(MesaDisplayTest, for_each_display_buffer_calls_callback)
     EXPECT_NE(0, callback_count);
 }
 
-TEST_F(MesaDisplayTest, pause_drops_drm_master)
-{
-    using namespace testing;
-
-    EXPECT_CALL(mock_drm, drmDropMaster(_))
-        .Times(2);
-
-    auto display = create_display(create_platform());
-
-    display->pause();
-}
-
 TEST_F(MesaDisplayTest, configuration_change_registers_video_devices_handler)
 {
     using namespace testing;


### PR DESCRIPTION
The ConsoleServices implementation now ensures DRM master is acquired upon resume and
dropped upon suspend; trying to do so again will result in failures in drmDropMaster.