### PR TITLE
Fix a couple of ubsan error reports

### DIFF
--- a/src/client/mir_connection.cpp
+++ b/src/client/mir_connection.cpp
@@ -1425,7 +1425,7 @@ auto MirConnection::create_render_surface_with_content(
     mir::protobuf::BufferStreamParameters params;
     params.set_width(logical_size.width.as_int());
     params.set_height(logical_size.height.as_int());
-    params.set_pixel_format(connect_result->surface_pixel_format(0));
+    params.set_pixel_format(mir_pixel_format_invalid);
     params.set_buffer_usage(-1);
 
     auto nw = platform->create_egl_native_window(nullptr);

--- a/src/client/mir_connection.cpp
+++ b/src/client/mir_connection.cpp
@@ -1425,7 +1425,7 @@ auto MirConnection::create_render_surface_with_content(
     mir::protobuf::BufferStreamParameters params;
     params.set_width(logical_size.width.as_int());
     params.set_height(logical_size.height.as_int());
-    params.set_pixel_format(-1);
+    params.set_pixel_format(connect_result->surface_pixel_format(0));
     params.set_buffer_usage(-1);
 
     auto nw = platform->create_egl_native_window(nullptr);

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -127,10 +127,14 @@ void mf::WlKeyboard::handle_window_event(MirWindowEvent const* event, WlSurface*
                 wl_resource_post_no_memory(resource);
                 BOOST_THROW_EXCEPTION(std::bad_alloc());
             }
-            std::memcpy(
-                array_storage,
-                keyboard_state.data(),
-                keyboard_state.size() * sizeof(decltype(keyboard_state)::value_type));
+
+            if (!keyboard_state.empty())
+            {
+                std::memcpy(
+                    array_storage,
+                    keyboard_state.data(),
+                    keyboard_state.size() * sizeof(decltype(keyboard_state)::value_type));
+            }
 
             // Rebuild xkb state
             state = decltype(state)(xkb_state_new(keymap.get()), &xkb_state_unref);


### PR DESCRIPTION
With #532 and this I can run the example shells and only see "-fsanitize=function" errors (mostly from function-signature punning in libmirclient).