### PR TITLE
Provide a configuration mechanism for enabling the supported Wayland extensions

### DIFF
--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -312,3 +312,12 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"miral::X11Support::~X11Support()@MIRAL_2.4" 2.4.0
  (c++)"miral::X11Support::X11Support()@MIRAL_2.4" 2.4.0
  (c++)"miral::X11Support::X11Support(miral::X11Support const&)@MIRAL_2.4" 2.4.0
+ (c++)"miral::WaylandExtensions::WaylandExtensions(miral::WaylandExtensions const&)@MIRAL_2.4" 2.4.0
+ (c++)"miral::WaylandExtensions::WaylandExtensions()@MIRAL_2.4" 2.4.0
+ (c++)"miral::WaylandExtensions::WaylandExtensions(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIRAL_2.4" 2.4.0
+ (c++)"miral::WaylandExtensions::WaylandExtensions(miral::WaylandExtensions const&)@MIRAL_2.4" 2.4.0
+ (c++)"miral::WaylandExtensions::WaylandExtensions()@MIRAL_2.4" 2.4.0
+ (c++)"miral::WaylandExtensions::~WaylandExtensions()@MIRAL_2.4" 2.4.0
+ (c++)"miral::WaylandExtensions::operator=(miral::WaylandExtensions const&)@MIRAL_2.4" 2.4.0
+ (c++)"miral::WaylandExtensions::supported_extensions[abi:cxx11]() const@MIRAL_2.4" 2.4.0
+ (c++)"miral::WaylandExtensions::operator()(mir::Server&) const@MIRAL_2.4" 2.4.0

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -30,6 +30,7 @@
 #include <miral/command_line_option.h>
 #include <miral/cursor_theme.h>
 #include <miral/keymap.h>
+#include <miral/wayland_extensions.h>
 
 #include <linux/input.h>
 
@@ -83,6 +84,7 @@ int main(int argc, char const* argv[])
             CommandLineOption{[&](std::string const& ) { },
                               "desktop_file_hint", "Ignored for Unity8 compatibility", "miral-shell.desktop"},
             CursorTheme{"default:DMZ-White"},
+            WaylandExtensions{},
             window_managers,
             display_configuration_options,
             launcher,

--- a/include/miral/miral/wayland_extensions.h
+++ b/include/miral/miral/wayland_extensions.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#ifndef MIRAL_WAYLAND_EXTENSIONS_H
+#define MIRAL_WAYLAND_EXTENSIONS_H
+
+#include <memory>
+#include <string>
+
+namespace mir { class Server; }
+
+namespace miral
+{
+/// Add a user configuration option to Mir's option handling to select
+/// the supported Wayland extensions.
+/// This adds the command line option '--wayland-extensions' the corresponding
+/// MIR_SERVER_WAYLAND_EXTENSIONS environment variable, and the wayland-extensions
+/// config line.
+/// \remark Since MirAL 2.4
+class WaylandExtensions
+{
+public:
+    /// Default extensions supported by Mir
+    WaylandExtensions();
+
+    /// Provide a custom set of default extensions (colon separated list)
+    /// \note This can only be a subset of supported_extensions().
+    explicit WaylandExtensions(std::string const& default_value);
+
+    void operator()(mir::Server& server) const;
+
+    /// All extensions extensions supported by Mir (colon separated list)
+    auto supported_extensions() const -> std::string;
+
+    ~WaylandExtensions();
+    WaylandExtensions(WaylandExtensions const&);
+    auto operator=(WaylandExtensions const&) -> WaylandExtensions&;
+
+private:
+    struct Self;
+    std::shared_ptr<Self> self;
+};
+}
+
+#endif //MIRAL_WAYLAND_EXTENSIONS_H

--- a/src/include/platform/mir/options/configuration.h
+++ b/src/include/platform/mir/options/configuration.h
@@ -54,6 +54,8 @@ extern char const* const debug_opt;
 extern char const* const composite_delay_opt;
 extern char const* const enable_key_repeat_opt;
 extern char const* const x11_display_opt;
+extern char const* const wayland_extensions_opt;
+extern char const* const wayland_extensions_value;
 
 extern char const* const name_opt;
 extern char const* const offscreen_opt;

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(miral SHARED
     display_configuration_option.cpp    ${miral_include}/miral/display_configuration_option.h
     output.cpp                          ${miral_include}/miral/output.h
     append_event_filter.cpp             ${miral_include}/miral/append_event_filter.h
+    wayland_extensions.cpp              ${miral_include}/miral/wayland_extensions.h
     window.cpp                          ${miral_include}/miral/window.h
     window_info.cpp                     ${miral_include}/miral/window_info.h
     window_management_options.cpp       ${miral_include}/miral/window_management_options.h

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -347,10 +347,16 @@ global:
 MIRAL_2.4 {
 global:
   extern "C++" {
+    miral::WaylandExtensions::?WaylandExtensions*;
+    miral::WaylandExtensions::WaylandExtensions*;
+    miral::WaylandExtensions::operator*;
+    miral::WaylandExtensions::supported_extensions*;
     miral::X11Support::?X11Support*;
     miral::X11Support::X11Support*;
     miral::X11Support::operator*;
+    typeinfo?for?miral::WaylandExtensions;
     typeinfo?for?miral::X11Support;
+    vtable?for?miral::WaylandExtensions;
     vtable?for?miral::X11Support;
   };
 } MIRAL_2.3;

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "miral/wayland_extensions.h"
+
+#include <mir/server.h>
+#include <mir/options/option.h>
+#include <mir/options/configuration.h>
+
+#include <set>
+#include <mir/abnormal_exit.h>
+
+namespace mo = mir::options;
+
+struct miral::WaylandExtensions::Self
+{
+    Self(std::string const& default_value) : default_value{default_value}
+    {
+        validate(default_value);
+    }
+
+    void callback(mir::Server& server) const
+    {
+        validate(server.get_options()->get<std::string>(mo::wayland_extensions_opt));
+    }
+
+    std::string const default_value;
+
+    void validate(std::string extensions) const
+    {
+        std::set<std::string> selected_extension;
+        auto extensions_ = extensions + ':';
+
+        for (char const* start = extensions_.c_str(); char const* end = strchr(start, ':'); start = end+1)
+        {
+            if (start != end)
+                selected_extension.insert(std::string{start, end});
+        }
+
+        std::set<std::string> supported_extension;
+        std::string available_extensions = mo::wayland_extensions_value;
+        available_extensions += ':';
+
+        for (char const* start = available_extensions.c_str(); char const* end = strchr(start, ':'); start = end+1)
+        {
+            if (start != end)
+                supported_extension.insert(std::string{start, end});
+        }
+
+        std::set<std::string> errors;
+
+        set_difference(begin(selected_extension), end(selected_extension),
+                       begin(supported_extension), end(supported_extension),
+                       std::inserter(errors, begin(errors)));
+
+        if (!errors.empty())
+        {
+            throw mir::AbnormalExit{"Unsupported wayland extensions in: " + extensions};
+        }
+    }
+};
+
+miral::WaylandExtensions::WaylandExtensions() :
+    WaylandExtensions{mo::wayland_extensions_value}
+{
+}
+
+miral::WaylandExtensions::WaylandExtensions(std::string const& default_value) :
+    self{std::make_shared<Self>(default_value)}
+{
+}
+
+auto miral::WaylandExtensions::supported_extensions() const -> std::string
+{
+    return mo::wayland_extensions_value;
+}
+
+void miral::WaylandExtensions::operator()(mir::Server& server) const
+{
+    server.add_configuration_option(mo::wayland_extensions_opt, "Wayland extensions to enable", self->default_value);
+
+    server.add_init_callback([this, &server]{ self->callback(server); });
+}
+
+miral::WaylandExtensions::~WaylandExtensions() = default;
+miral::WaylandExtensions::WaylandExtensions(WaylandExtensions const&) = default;
+auto miral::WaylandExtensions::operator=(WaylandExtensions const&) -> WaylandExtensions& = default;

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -56,6 +56,8 @@ char const* const mo::debug_opt                   = "debug";
 char const* const mo::composite_delay_opt         = "composite-delay";
 char const* const mo::enable_key_repeat_opt       = "enable-key-repeat";
 char const* const mo::x11_display_opt             = "x11-display-experimental";
+char const* const mo::wayland_extensions_opt      = "wayland_extensions";
+char const* const mo::wayland_extensions_value    = "xdg_shell:zxdg_shell_v6";
 
 char const* const mo::off_opt_value = "off";
 char const* const mo::log_opt_value = "log";

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -57,7 +57,7 @@ char const* const mo::composite_delay_opt         = "composite-delay";
 char const* const mo::enable_key_repeat_opt       = "enable-key-repeat";
 char const* const mo::x11_display_opt             = "x11-display-experimental";
 char const* const mo::wayland_extensions_opt      = "wayland_extensions";
-char const* const mo::wayland_extensions_value    = "wl_shell:xdg_shell:zxdg_shell_v6";
+char const* const mo::wayland_extensions_value    = "wl_shell:xdg_wm_base:zxdg_shell_v6";
 
 char const* const mo::off_opt_value = "off";
 char const* const mo::log_opt_value = "log";

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -57,7 +57,7 @@ char const* const mo::composite_delay_opt         = "composite-delay";
 char const* const mo::enable_key_repeat_opt       = "enable-key-repeat";
 char const* const mo::x11_display_opt             = "x11-display-experimental";
 char const* const mo::wayland_extensions_opt      = "wayland_extensions";
-char const* const mo::wayland_extensions_value    = "xdg_shell:zxdg_shell_v6";
+char const* const mo::wayland_extensions_value    = "wl_shell:xdg_shell:zxdg_shell_v6";
 
 char const* const mo::off_opt_value = "off";
 char const* const mo::log_opt_value = "log";

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -188,14 +188,16 @@ MIR_PLATFORM_0.33 {
   };
 } MIR_PLATFORM_0.32;
 
-MIR_PLATFORM_0.32.1 {
+MIR_PLATFORM_0.32.3 {
  global:
   extern "C++" {
-    mir::options::x11_display_opt*;
-    mir::options::console_provider*;
-    mir::options::auto_console*;
-    mir::options::logind_console*;
-    mir::options::vt_console*;
-    mir::options::null_console*
+    mir::options::auto_console;
+    mir::options::console_provider;
+    mir::options::logind_console;
+    mir::options::null_console;
+    mir::options::vt_console;
+    mir::options::wayland_extensions_opt;
+    mir::options::wayland_extensions_value;
+    mir::options::x11_display_opt;
   };
 } MIR_PLATFORM_0.33;

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -552,11 +552,14 @@ std::shared_ptr<mg::WaylandAllocator> allocator_for_display(
 }
 }
 
+auto mf::create_wl_shell(wl_display* display, std::shared_ptr<Shell> const& shell, WlSeat* seat, OutputManager* const output_manager)
+-> std::shared_ptr<void>
+{
+    return std::make_shared<mf::WlShell>(display, shell, *seat, output_manager);
+}
+
 void mf::WaylandExtensions::init(wl_display* display, std::shared_ptr<Shell> const& shell, WlSeat* seat, OutputManager* const output_manager)
 {
-
-    add_extension("wl_shell", std::make_shared<mf::WlShell>(display, shell, *seat, output_manager));
-
     custom_extensions(display, shell, seat, output_manager);
 }
 

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -125,6 +125,9 @@ private:
     // Only accessed on event loop
     std::unordered_map<int, std::function<void(std::shared_ptr<Session> const& session)>> mutable connect_handlers;
 };
+
+auto create_wl_shell(wl_display* display, std::shared_ptr<Shell> const& shell, WlSeat* seat, OutputManager* const output_manager)
+    -> std::shared_ptr<void>;
 }
 }
 

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -32,7 +32,7 @@ namespace mo = mir::options;
 namespace
 {
 auto const wl_shell     = "wl_shell";
-auto const xdg_shell    = "xdg_shell";
+auto const xdg_shell    = "xdg_wm_base";
 auto const xdg_shell_v6 = "zxdg_shell_v6";
 
 auto configure_wayland_extensions(std::string extensions, bool x11_enabled) -> std::unique_ptr<mf::WaylandExtensions>

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -31,6 +31,7 @@ namespace mo = mir::options;
 
 namespace
 {
+auto const wl_shell     = "wl_shell";
 auto const xdg_shell    = "xdg_shell";
 auto const xdg_shell_v6 = "zxdg_shell_v6";
 
@@ -48,6 +49,9 @@ auto configure_wayland_extensions(std::string extensions, bool x11_enabled) -> s
             mf::WlSeat* seat,
             mf::OutputManager* const output_manager)
         {
+            if (extension.find(wl_shell) != extension.end())
+                add_extension(wl_shell, mf::create_wl_shell(display, shell, seat, output_manager));
+
             if (extension.find(xdg_shell_v6) != extension.end())
                 add_extension(xdg_shell_v6, std::make_shared<mf::XdgShellV6>(display, shell, *seat, output_manager));
 

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2017 Canonical Ltd.
+ * Copyright © 2015-2018 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,
@@ -29,12 +29,18 @@
 namespace mf = mir::frontend;
 namespace mo = mir::options;
 
-std::shared_ptr<mf::Connector>
-    mir::DefaultServerConfiguration::the_wayland_connector()
+namespace
+{
+auto const xdg_shell    = "xdg_shell";
+auto const xdg_shell_v6 = "zxdg_shell_v6";
+
+auto configure_wayland_extensions(std::string extensions, bool x11_enabled) -> std::unique_ptr<mf::WaylandExtensions>
 {
     struct WaylandExtensions : mf::WaylandExtensions
     {
-        WaylandExtensions(bool x11_enabled) : x11_enabled{x11_enabled} {}
+        WaylandExtensions(std::set<std::string> const& extension, bool x11_enabled) :
+            extension{extension}, x11_enabled{x11_enabled} {}
+
     protected:
         virtual void custom_extensions(
             wl_display* display,
@@ -42,18 +48,36 @@ std::shared_ptr<mf::Connector>
             mf::WlSeat* seat,
             mf::OutputManager* const output_manager)
         {
-            if (!getenv("MIR_DISABLE_XDG_SHELL_V6_UNSTABLE"))
-                add_extension("zxdg_shell_v6", std::make_shared<mf::XdgShellV6>(display, shell, *seat, output_manager));
+            if (extension.find(xdg_shell_v6) != extension.end())
+                add_extension(xdg_shell_v6, std::make_shared<mf::XdgShellV6>(display, shell, *seat, output_manager));
 
-            if (!getenv("MIR_DISABLE_XDG_SHELL_STABLE"))
-                add_extension("xdg_shell_stable",
-                              std::make_shared<mf::XdgShellStable>(display, shell, *seat,output_manager));
+            if (extension.find(xdg_shell) != extension.end())
+                add_extension(xdg_shell, std::make_shared<mf::XdgShellStable>(display, shell, *seat, output_manager));
 
             if (x11_enabled)
                 add_extension("x11-support", std::make_shared<mf::XWaylandWMShell>(shell, *seat, output_manager));
         }
+
+        std::set<std::string> const extension;
         const bool x11_enabled;
     };
+
+    std::set<std::string> extension;
+    extensions += ':';
+
+    for (char const* start = extensions.c_str(); char const* end = strchr(start, ':'); start = end+1)
+    {
+        if (start != end)
+            extension.insert(std::string{start, end});
+    }
+
+    return std::make_unique<WaylandExtensions>(extension, x11_enabled);
+}
+}
+
+std::shared_ptr<mf::Connector>
+    mir::DefaultServerConfiguration::the_wayland_connector()
+{
 
     return wayland_connector(
         [this]() -> std::shared_ptr<mf::Connector>
@@ -66,6 +90,9 @@ std::shared_ptr<mf::Connector>
             if (options->is_set(options::wayland_socket_name_opt))
                 display_name = options->get<std::string>(options::wayland_socket_name_opt);
 
+            auto const wayland_extensions =
+                options->get(mo::wayland_extensions_opt, mo::wayland_extensions_value);
+
             return std::make_shared<mf::WaylandConnector>(
                 display_name,
                 the_frontend_shell(),
@@ -75,6 +102,6 @@ std::shared_ptr<mf::Connector>
                 the_buffer_allocator(),
                 the_session_authorizer(),
                 arw_socket,
-                std::make_unique<WaylandExtensions>(options->is_set(mo::x11_display_opt)));
+                configure_wayland_extensions(wayland_extensions, options->is_set(mo::x11_display_opt)));
         });
 }


### PR DESCRIPTION
This provides a foundation for future development.

But this is likely to gain complexity over time:

  * A shell may want to validate the selected extensions.
  * Some extensions may be mutually incompatible.
  * We may want to change the default from "enable everything".