### PR TITLE
Fix racy shutdown

### DIFF
--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -443,7 +443,7 @@ void mir::Server::stop()
 {
     mir::log_info("Stopping");
     if (self->server_config)
-        if (auto const main_loop = the_main_loop())
+        if (auto const main_loop = the_main_loop().get())
         {
             self->stop_callback();
             main_loop->stop();


### PR DESCRIPTION
We must not extend the life of the main loop when stopping the server. (Fixes #543)