### PR TITLE
Fix VT switching with LinuxVirtualTerminal

### DIFF
--- a/src/platforms/evdev/fd_store.cpp
+++ b/src/platforms/evdev/fd_store.cpp
@@ -21,6 +21,7 @@
 #define MIR_LOG_COMPONENT "evdev-input"
 #include "mir/log.h"
 
+#include <algorithm>
 #include <boost/throw_exception.hpp>
 
 namespace mie = mir::input::evdev;
@@ -41,4 +42,24 @@ mir::Fd mie::FdStore::take_fd(char const* path)
         mir::log_warning("Failed to find requested fd for path %s", path);
     }
     return mir::Fd{};
+}
+
+void mie::FdStore::remove_fd(int fd)
+{
+    auto element = std::find_if(
+        fds.begin(),
+        fds.end(),
+        [fd](auto const& pair)
+        {
+            return pair.second == fd;
+        });
+
+    if (element == fds.end())
+    {
+        mir::log_warning("Attempted to remove unmanaged fd %i", fd);
+    }
+    else
+    {
+        fds.erase(element);
+    }
 }

--- a/src/platforms/evdev/fd_store.h
+++ b/src/platforms/evdev/fd_store.h
@@ -36,6 +36,7 @@ public:
     FdStore() = default;
     void store_fd(char const* path, mir::Fd&& fd);
     mir::Fd take_fd(char const* path);
+    void remove_fd(int fd);
 
 private:
     FdStore(FdStore const&) = delete;

--- a/src/platforms/evdev/libinput_ptr.cpp
+++ b/src/platforms/evdev/libinput_ptr.cpp
@@ -48,9 +48,11 @@ int fd_open(const char* path, int flags, void* userdata)
     return fd_store->take_fd(path);
 }
 
-void fd_close(int fd, void* /*userdata*/)
+void fd_close(int fd, void* userdata)
 {
-    ::close(fd);
+    auto fd_store = static_cast<mie::FdStore*>(userdata);
+
+    fd_store->remove_fd(fd);
 }
 
 const libinput_interface fd_ops = {fd_open, fd_close};

--- a/src/platforms/evdev/platform.cpp
+++ b/src/platforms/evdev/platform.cpp
@@ -446,6 +446,9 @@ auto mie::Platform::find_device(libinput_device_group const* devgroup) -> declty
 
 void mie::Platform::stop()
 {
+    // This must only be called from the dispatch thread, so this doesn't race
+    device_watchers.clear();
+
     if (action_queue)
     {
         platform_dispatchable->remove_watch(action_queue);


### PR DESCRIPTION
This fixes a number of bugs in VT switching, and add some paranoia that will hopefully make us fail in a more easily-recoverable fashion if we fail.