### PR TITLE
Generate and use event methods

### DIFF
--- a/src/server/frontend_wayland/data_device.cpp
+++ b/src/server/frontend_wayland/data_device.cpp
@@ -56,7 +56,7 @@ struct DataOffer : mf::wayland::DataOffer
     DataSource* const source;
 };
 
-class DataSource : mf::wayland::DataSource
+struct DataSource : mf::wayland::DataSource
 {
 public:
     DataSource(struct wl_client* client, struct wl_resource* parent, uint32_t id, DataDeviceManager* manager)

--- a/src/server/frontend_wayland/data_device.cpp
+++ b/src/server/frontend_wayland/data_device.cpp
@@ -56,11 +56,12 @@ struct DataOffer : mf::wayland::DataOffer
     DataSource* const source;
 };
 
-struct DataSource : mf::wayland::DataSource
+class DataSource : mf::wayland::DataSource
 {
-    DataSource(struct wl_client* client, struct wl_resource* parent, uint32_t id, DataDeviceManager* manager) :
-        mf::wayland::DataSource{client, parent, id},
-        manager{manager}
+public:
+    DataSource(struct wl_client* client, struct wl_resource* parent, uint32_t id, DataDeviceManager* manager)
+        : mf::wayland::DataSource{client, parent, id},
+          manager{manager}
     {
     }
 

--- a/src/server/frontend_wayland/data_device.cpp
+++ b/src/server/frontend_wayland/data_device.cpp
@@ -77,7 +77,7 @@ struct DataSource : mf::wayland::DataSource
     void send_cancelled() const
     {
         if (!destroyed)
-            wl_data_source_send_cancelled(resource);
+            send_cancelled_event();
     }
 
     void add_listener(DataOffer* listener);
@@ -159,7 +159,7 @@ void DataSource::destroy()
 {
     destroyed = true;
     manager->notify_destroyed(this);
-    wl_resource_destroy(resource);
+    destroy_wayland_object();
 }
 
 void DataSource::add_listener(DataOffer* listener)
@@ -174,7 +174,7 @@ void DataSource::remove_listener(DataOffer* listener)
 
 void DataSource::send_send(std::string const& mime_type, mir::Fd fd)
 {
-    wl_data_source_send_send(resource, mime_type.c_str(), fd);
+    send_send_event(mime_type.c_str(), fd);
 }
 
 DataSource::~DataSource()
@@ -269,7 +269,7 @@ void DataDevice::notify_destroyed(DataSource* source)
     {
         current_source = nullptr;
         current_offer = nullptr;
-        wl_data_device_send_selection(resource, 0);
+        send_selection_event(std::experimental::nullopt);
     }
 }
 
@@ -277,7 +277,7 @@ void DataDevice::release()
 {
     manager->remove_listener(this);
     seat->remove_focus_listener(this);
-    wl_resource_destroy(resource);
+    destroy_wayland_object();
 }
 
 void DataDevice::focus_on(wl_client* focus)
@@ -295,17 +295,18 @@ DataOffer::DataOffer(struct wl_client* client, struct wl_resource* parent, uint3
     source{source}
 {
     source->add_listener(this);
-    wl_data_device_send_data_offer(parent, resource);
+    auto device = mf::wayland::DataDevice::from(parent);
+    device->send_data_offer_event(resource);
     for (auto const& type : source->mime_types)
     {
-        wl_data_offer_send_offer(resource, type.c_str());
+        send_offer_event(type);
     }
-    wl_data_device_send_selection(parent, resource);
+    device->send_selection_event(resource);
 }
 
 void DataOffer::offer(std::string const& mime_type)
 {
-    wl_data_offer_send_offer(resource, mime_type.c_str());
+    send_offer_event(mime_type);
 }
 
 void DataOffer::receive(std::string const& mime_type, mir::Fd fd)
@@ -316,7 +317,7 @@ void DataOffer::receive(std::string const& mime_type, mir::Fd fd)
 void DataOffer::destroy()
 {
     source->remove_listener(this);
-    wl_resource_destroy(resource);
+    destroy_wayland_object();
 }
 
 auto mf::create_data_device_manager(struct wl_display* display)

--- a/src/server/frontend_wayland/data_device.cpp
+++ b/src/server/frontend_wayland/data_device.cpp
@@ -20,6 +20,7 @@
 #include "wl_seat.h"
 
 #include <vector>
+#include <algorithm>
 
 namespace mf = mir::frontend;
 

--- a/src/server/frontend_wayland/generated/wayland_wrapper.cpp
+++ b/src/server/frontend_wayland/generated/wayland_wrapper.cpp
@@ -37,7 +37,7 @@ mfw::Callback::Callback(struct wl_client* client, struct wl_resource* parent, ui
 
 void mfw::Callback::send_done_event(uint32_t callback_data) const
 {
-    wl_resource_post_event(resource, Opcode::DONE, callback_data);
+    wl_resource_post_event(resource, Opcode::done, callback_data);
 }
 
 void mfw::Callback::destroy_wayland_object() const
@@ -288,7 +288,7 @@ mfw::Shm::~Shm()
 
 void mfw::Shm::send_format_event(struct wl_resource* resource, uint32_t format) const
 {
-    wl_resource_post_event(resource, Opcode::FORMAT, format);
+    wl_resource_post_event(resource, Opcode::format, format);
 }
 
 void mfw::Shm::destroy_wayland_object(struct wl_resource* resource) const
@@ -344,7 +344,7 @@ mfw::Buffer::Buffer(struct wl_client* client, struct wl_resource* parent, uint32
 
 void mfw::Buffer::send_release_event() const
 {
-    wl_resource_post_event(resource, Opcode::RELEASE);
+    wl_resource_post_event(resource, Opcode::release);
 }
 
 void mfw::Buffer::destroy_wayland_object() const
@@ -471,7 +471,7 @@ mfw::DataOffer::DataOffer(struct wl_client* client, struct wl_resource* parent, 
 void mfw::DataOffer::send_offer_event(std::string const& mime_type) const
 {
     const char* mime_type_resolved = mime_type.c_str();
-    wl_resource_post_event(resource, Opcode::OFFER, mime_type_resolved);
+    wl_resource_post_event(resource, Opcode::offer, mime_type_resolved);
 }
 
 bool mfw::DataOffer::version_supports_source_actions()
@@ -481,7 +481,7 @@ bool mfw::DataOffer::version_supports_source_actions()
 
 void mfw::DataOffer::send_source_actions_event(uint32_t source_actions) const
 {
-    wl_resource_post_event(resource, Opcode::SOURCE_ACTIONS, source_actions);
+    wl_resource_post_event(resource, Opcode::source_actions, source_actions);
 }
 
 bool mfw::DataOffer::version_supports_action()
@@ -491,7 +491,7 @@ bool mfw::DataOffer::version_supports_action()
 
 void mfw::DataOffer::send_action_event(uint32_t dnd_action) const
 {
-    wl_resource_post_event(resource, Opcode::ACTION, dnd_action);
+    wl_resource_post_event(resource, Opcode::action, dnd_action);
 }
 
 void mfw::DataOffer::destroy_wayland_object() const
@@ -588,19 +588,19 @@ void mfw::DataSource::send_target_event(std::experimental::optional<std::string>
     {
         mime_type_resolved = mime_type.value().c_str();
     }
-    wl_resource_post_event(resource, Opcode::TARGET, mime_type_resolved);
+    wl_resource_post_event(resource, Opcode::target, mime_type_resolved);
 }
 
 void mfw::DataSource::send_send_event(std::string const& mime_type, mir::Fd fd) const
 {
     const char* mime_type_resolved = mime_type.c_str();
     int32_t fd_resolved{fd};
-    wl_resource_post_event(resource, Opcode::SEND, mime_type_resolved, fd_resolved);
+    wl_resource_post_event(resource, Opcode::send, mime_type_resolved, fd_resolved);
 }
 
 void mfw::DataSource::send_cancelled_event() const
 {
-    wl_resource_post_event(resource, Opcode::CANCELLED);
+    wl_resource_post_event(resource, Opcode::cancelled);
 }
 
 bool mfw::DataSource::version_supports_dnd_drop_performed()
@@ -610,7 +610,7 @@ bool mfw::DataSource::version_supports_dnd_drop_performed()
 
 void mfw::DataSource::send_dnd_drop_performed_event() const
 {
-    wl_resource_post_event(resource, Opcode::DND_DROP_PERFORMED);
+    wl_resource_post_event(resource, Opcode::dnd_drop_performed);
 }
 
 bool mfw::DataSource::version_supports_dnd_finished()
@@ -620,7 +620,7 @@ bool mfw::DataSource::version_supports_dnd_finished()
 
 void mfw::DataSource::send_dnd_finished_event() const
 {
-    wl_resource_post_event(resource, Opcode::DND_FINISHED);
+    wl_resource_post_event(resource, Opcode::dnd_finished);
 }
 
 bool mfw::DataSource::version_supports_action()
@@ -630,7 +630,7 @@ bool mfw::DataSource::version_supports_action()
 
 void mfw::DataSource::send_action_event(uint32_t dnd_action) const
 {
-    wl_resource_post_event(resource, Opcode::ACTION, dnd_action);
+    wl_resource_post_event(resource, Opcode::action, dnd_action);
 }
 
 void mfw::DataSource::destroy_wayland_object() const
@@ -735,7 +735,7 @@ mfw::DataDevice::DataDevice(struct wl_client* client, struct wl_resource* parent
 
 void mfw::DataDevice::send_data_offer_event(struct wl_resource* id) const
 {
-    wl_resource_post_event(resource, Opcode::DATA_OFFER, id);
+    wl_resource_post_event(resource, Opcode::data_offer, id);
 }
 
 void mfw::DataDevice::send_enter_event(uint32_t serial, struct wl_resource* surface, double x, double y, std::experimental::optional<struct wl_resource*> const& id) const
@@ -747,24 +747,24 @@ void mfw::DataDevice::send_enter_event(uint32_t serial, struct wl_resource* surf
     {
         id_resolved = id.value();
     }
-    wl_resource_post_event(resource, Opcode::ENTER, serial, surface, x_resolved, y_resolved, id_resolved);
+    wl_resource_post_event(resource, Opcode::enter, serial, surface, x_resolved, y_resolved, id_resolved);
 }
 
 void mfw::DataDevice::send_leave_event() const
 {
-    wl_resource_post_event(resource, Opcode::LEAVE);
+    wl_resource_post_event(resource, Opcode::leave);
 }
 
 void mfw::DataDevice::send_motion_event(uint32_t time, double x, double y) const
 {
     wl_fixed_t x_resolved{wl_fixed_from_double(x)};
     wl_fixed_t y_resolved{wl_fixed_from_double(y)};
-    wl_resource_post_event(resource, Opcode::MOTION, time, x_resolved, y_resolved);
+    wl_resource_post_event(resource, Opcode::motion, time, x_resolved, y_resolved);
 }
 
 void mfw::DataDevice::send_drop_event() const
 {
-    wl_resource_post_event(resource, Opcode::DROP);
+    wl_resource_post_event(resource, Opcode::drop);
 }
 
 void mfw::DataDevice::send_selection_event(std::experimental::optional<struct wl_resource*> const& id) const
@@ -774,7 +774,7 @@ void mfw::DataDevice::send_selection_event(std::experimental::optional<struct wl
     {
         id_resolved = id.value();
     }
-    wl_resource_post_event(resource, Opcode::SELECTION, id_resolved);
+    wl_resource_post_event(resource, Opcode::selection, id_resolved);
 }
 
 void mfw::DataDevice::destroy_wayland_object() const
@@ -1149,17 +1149,17 @@ mfw::ShellSurface::ShellSurface(struct wl_client* client, struct wl_resource* pa
 
 void mfw::ShellSurface::send_ping_event(uint32_t serial) const
 {
-    wl_resource_post_event(resource, Opcode::PING, serial);
+    wl_resource_post_event(resource, Opcode::ping, serial);
 }
 
 void mfw::ShellSurface::send_configure_event(uint32_t edges, int32_t width, int32_t height) const
 {
-    wl_resource_post_event(resource, Opcode::CONFIGURE, edges, width, height);
+    wl_resource_post_event(resource, Opcode::configure, edges, width, height);
 }
 
 void mfw::ShellSurface::send_popup_done_event() const
 {
-    wl_resource_post_event(resource, Opcode::POPUP_DONE);
+    wl_resource_post_event(resource, Opcode::popup_done);
 }
 
 void mfw::ShellSurface::destroy_wayland_object() const
@@ -1383,12 +1383,12 @@ mfw::Surface::Surface(struct wl_client* client, struct wl_resource* parent, uint
 
 void mfw::Surface::send_enter_event(struct wl_resource* output) const
 {
-    wl_resource_post_event(resource, Opcode::ENTER, output);
+    wl_resource_post_event(resource, Opcode::enter, output);
 }
 
 void mfw::Surface::send_leave_event(struct wl_resource* output) const
 {
-    wl_resource_post_event(resource, Opcode::LEAVE, output);
+    wl_resource_post_event(resource, Opcode::leave, output);
 }
 
 void mfw::Surface::destroy_wayland_object() const
@@ -1523,7 +1523,7 @@ mfw::Seat::~Seat()
 
 void mfw::Seat::send_capabilities_event(struct wl_resource* resource, uint32_t capabilities) const
 {
-    wl_resource_post_event(resource, Opcode::CAPABILITIES, capabilities);
+    wl_resource_post_event(resource, Opcode::capabilities, capabilities);
 }
 
 bool mfw::Seat::version_supports_name(struct wl_resource* resource)
@@ -1534,7 +1534,7 @@ bool mfw::Seat::version_supports_name(struct wl_resource* resource)
 void mfw::Seat::send_name_event(struct wl_resource* resource, std::string const& name) const
 {
     const char* name_resolved = name.c_str();
-    wl_resource_post_event(resource, Opcode::NAME, name_resolved);
+    wl_resource_post_event(resource, Opcode::name, name_resolved);
 }
 
 void mfw::Seat::destroy_wayland_object(struct wl_resource* resource) const
@@ -1616,30 +1616,30 @@ void mfw::Pointer::send_enter_event(uint32_t serial, struct wl_resource* surface
 {
     wl_fixed_t surface_x_resolved{wl_fixed_from_double(surface_x)};
     wl_fixed_t surface_y_resolved{wl_fixed_from_double(surface_y)};
-    wl_resource_post_event(resource, Opcode::ENTER, serial, surface, surface_x_resolved, surface_y_resolved);
+    wl_resource_post_event(resource, Opcode::enter, serial, surface, surface_x_resolved, surface_y_resolved);
 }
 
 void mfw::Pointer::send_leave_event(uint32_t serial, struct wl_resource* surface) const
 {
-    wl_resource_post_event(resource, Opcode::LEAVE, serial, surface);
+    wl_resource_post_event(resource, Opcode::leave, serial, surface);
 }
 
 void mfw::Pointer::send_motion_event(uint32_t time, double surface_x, double surface_y) const
 {
     wl_fixed_t surface_x_resolved{wl_fixed_from_double(surface_x)};
     wl_fixed_t surface_y_resolved{wl_fixed_from_double(surface_y)};
-    wl_resource_post_event(resource, Opcode::MOTION, time, surface_x_resolved, surface_y_resolved);
+    wl_resource_post_event(resource, Opcode::motion, time, surface_x_resolved, surface_y_resolved);
 }
 
 void mfw::Pointer::send_button_event(uint32_t serial, uint32_t time, uint32_t button, uint32_t state) const
 {
-    wl_resource_post_event(resource, Opcode::BUTTON, serial, time, button, state);
+    wl_resource_post_event(resource, Opcode::button, serial, time, button, state);
 }
 
 void mfw::Pointer::send_axis_event(uint32_t time, uint32_t axis, double value) const
 {
     wl_fixed_t value_resolved{wl_fixed_from_double(value)};
-    wl_resource_post_event(resource, Opcode::AXIS, time, axis, value_resolved);
+    wl_resource_post_event(resource, Opcode::axis, time, axis, value_resolved);
 }
 
 bool mfw::Pointer::version_supports_frame()
@@ -1649,7 +1649,7 @@ bool mfw::Pointer::version_supports_frame()
 
 void mfw::Pointer::send_frame_event() const
 {
-    wl_resource_post_event(resource, Opcode::FRAME);
+    wl_resource_post_event(resource, Opcode::frame);
 }
 
 bool mfw::Pointer::version_supports_axis_source()
@@ -1659,7 +1659,7 @@ bool mfw::Pointer::version_supports_axis_source()
 
 void mfw::Pointer::send_axis_source_event(uint32_t axis_source) const
 {
-    wl_resource_post_event(resource, Opcode::AXIS_SOURCE, axis_source);
+    wl_resource_post_event(resource, Opcode::axis_source, axis_source);
 }
 
 bool mfw::Pointer::version_supports_axis_stop()
@@ -1669,7 +1669,7 @@ bool mfw::Pointer::version_supports_axis_stop()
 
 void mfw::Pointer::send_axis_stop_event(uint32_t time, uint32_t axis) const
 {
-    wl_resource_post_event(resource, Opcode::AXIS_STOP, time, axis);
+    wl_resource_post_event(resource, Opcode::axis_stop, time, axis);
 }
 
 bool mfw::Pointer::version_supports_axis_discrete()
@@ -1679,7 +1679,7 @@ bool mfw::Pointer::version_supports_axis_discrete()
 
 void mfw::Pointer::send_axis_discrete_event(uint32_t axis, int32_t discrete) const
 {
-    wl_resource_post_event(resource, Opcode::AXIS_DISCRETE, axis, discrete);
+    wl_resource_post_event(resource, Opcode::axis_discrete, axis, discrete);
 }
 
 void mfw::Pointer::destroy_wayland_object() const
@@ -1737,27 +1737,27 @@ mfw::Keyboard::Keyboard(struct wl_client* client, struct wl_resource* parent, ui
 void mfw::Keyboard::send_keymap_event(uint32_t format, mir::Fd fd, uint32_t size) const
 {
     int32_t fd_resolved{fd};
-    wl_resource_post_event(resource, Opcode::KEYMAP, format, fd_resolved, size);
+    wl_resource_post_event(resource, Opcode::keymap, format, fd_resolved, size);
 }
 
 void mfw::Keyboard::send_enter_event(uint32_t serial, struct wl_resource* surface, struct wl_array* keys) const
 {
-    wl_resource_post_event(resource, Opcode::ENTER, serial, surface, keys);
+    wl_resource_post_event(resource, Opcode::enter, serial, surface, keys);
 }
 
 void mfw::Keyboard::send_leave_event(uint32_t serial, struct wl_resource* surface) const
 {
-    wl_resource_post_event(resource, Opcode::LEAVE, serial, surface);
+    wl_resource_post_event(resource, Opcode::leave, serial, surface);
 }
 
 void mfw::Keyboard::send_key_event(uint32_t serial, uint32_t time, uint32_t key, uint32_t state) const
 {
-    wl_resource_post_event(resource, Opcode::KEY, serial, time, key, state);
+    wl_resource_post_event(resource, Opcode::key, serial, time, key, state);
 }
 
 void mfw::Keyboard::send_modifiers_event(uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group) const
 {
-    wl_resource_post_event(resource, Opcode::MODIFIERS, serial, mods_depressed, mods_latched, mods_locked, group);
+    wl_resource_post_event(resource, Opcode::modifiers, serial, mods_depressed, mods_latched, mods_locked, group);
 }
 
 bool mfw::Keyboard::version_supports_repeat_info()
@@ -1767,7 +1767,7 @@ bool mfw::Keyboard::version_supports_repeat_info()
 
 void mfw::Keyboard::send_repeat_info_event(int32_t rate, int32_t delay) const
 {
-    wl_resource_post_event(resource, Opcode::REPEAT_INFO, rate, delay);
+    wl_resource_post_event(resource, Opcode::repeat_info, rate, delay);
 }
 
 void mfw::Keyboard::destroy_wayland_object() const
@@ -1825,29 +1825,29 @@ void mfw::Touch::send_down_event(uint32_t serial, uint32_t time, struct wl_resou
 {
     wl_fixed_t x_resolved{wl_fixed_from_double(x)};
     wl_fixed_t y_resolved{wl_fixed_from_double(y)};
-    wl_resource_post_event(resource, Opcode::DOWN, serial, time, surface, id, x_resolved, y_resolved);
+    wl_resource_post_event(resource, Opcode::down, serial, time, surface, id, x_resolved, y_resolved);
 }
 
 void mfw::Touch::send_up_event(uint32_t serial, uint32_t time, int32_t id) const
 {
-    wl_resource_post_event(resource, Opcode::UP, serial, time, id);
+    wl_resource_post_event(resource, Opcode::up, serial, time, id);
 }
 
 void mfw::Touch::send_motion_event(uint32_t time, int32_t id, double x, double y) const
 {
     wl_fixed_t x_resolved{wl_fixed_from_double(x)};
     wl_fixed_t y_resolved{wl_fixed_from_double(y)};
-    wl_resource_post_event(resource, Opcode::MOTION, time, id, x_resolved, y_resolved);
+    wl_resource_post_event(resource, Opcode::motion, time, id, x_resolved, y_resolved);
 }
 
 void mfw::Touch::send_frame_event() const
 {
-    wl_resource_post_event(resource, Opcode::FRAME);
+    wl_resource_post_event(resource, Opcode::frame);
 }
 
 void mfw::Touch::send_cancel_event() const
 {
-    wl_resource_post_event(resource, Opcode::CANCEL);
+    wl_resource_post_event(resource, Opcode::cancel);
 }
 
 bool mfw::Touch::version_supports_shape()
@@ -1859,7 +1859,7 @@ void mfw::Touch::send_shape_event(int32_t id, double major, double minor) const
 {
     wl_fixed_t major_resolved{wl_fixed_from_double(major)};
     wl_fixed_t minor_resolved{wl_fixed_from_double(minor)};
-    wl_resource_post_event(resource, Opcode::SHAPE, id, major_resolved, minor_resolved);
+    wl_resource_post_event(resource, Opcode::shape, id, major_resolved, minor_resolved);
 }
 
 bool mfw::Touch::version_supports_orientation()
@@ -1870,7 +1870,7 @@ bool mfw::Touch::version_supports_orientation()
 void mfw::Touch::send_orientation_event(int32_t id, double orientation) const
 {
     wl_fixed_t orientation_resolved{wl_fixed_from_double(orientation)};
-    wl_resource_post_event(resource, Opcode::ORIENTATION, id, orientation_resolved);
+    wl_resource_post_event(resource, Opcode::orientation, id, orientation_resolved);
 }
 
 void mfw::Touch::destroy_wayland_object() const
@@ -1950,12 +1950,12 @@ void mfw::Output::send_geometry_event(struct wl_resource* resource, int32_t x, i
 {
     const char* make_resolved = make.c_str();
     const char* model_resolved = model.c_str();
-    wl_resource_post_event(resource, Opcode::GEOMETRY, x, y, physical_width, physical_height, subpixel, make_resolved, model_resolved, transform);
+    wl_resource_post_event(resource, Opcode::geometry, x, y, physical_width, physical_height, subpixel, make_resolved, model_resolved, transform);
 }
 
 void mfw::Output::send_mode_event(struct wl_resource* resource, uint32_t flags, int32_t width, int32_t height, int32_t refresh) const
 {
-    wl_resource_post_event(resource, Opcode::MODE, flags, width, height, refresh);
+    wl_resource_post_event(resource, Opcode::mode, flags, width, height, refresh);
 }
 
 bool mfw::Output::version_supports_done(struct wl_resource* resource)
@@ -1965,7 +1965,7 @@ bool mfw::Output::version_supports_done(struct wl_resource* resource)
 
 void mfw::Output::send_done_event(struct wl_resource* resource) const
 {
-    wl_resource_post_event(resource, Opcode::DONE);
+    wl_resource_post_event(resource, Opcode::done);
 }
 
 bool mfw::Output::version_supports_scale(struct wl_resource* resource)
@@ -1975,7 +1975,7 @@ bool mfw::Output::version_supports_scale(struct wl_resource* resource)
 
 void mfw::Output::send_scale_event(struct wl_resource* resource, int32_t factor) const
 {
-    wl_resource_post_event(resource, Opcode::SCALE, factor);
+    wl_resource_post_event(resource, Opcode::scale, factor);
 }
 
 void mfw::Output::destroy_wayland_object(struct wl_resource* resource) const

--- a/src/server/frontend_wayland/generated/wayland_wrapper.cpp
+++ b/src/server/frontend_wayland/generated/wayland_wrapper.cpp
@@ -29,6 +29,11 @@ mfw::Callback::Callback(struct wl_client* client, struct wl_resource* parent, ui
     }
 }
 
+void mfw::Callback::send_done_event(uint32_t callback_data)
+{
+    wl_resource_post_event(resource, 0, callback_data);
+}
+
 // Compositor
 
 struct mfw::Compositor::Thunks
@@ -245,6 +250,11 @@ mfw::Shm::~Shm()
     wl_global_destroy(global);
 }
 
+void mfw::Shm::send_format_event(struct wl_resource* resource, uint32_t format)
+{
+    wl_resource_post_event(resource, 0, format);
+}
+
 struct wl_shm_interface const mfw::Shm::vtable = {
     Thunks::create_pool_thunk};
 
@@ -284,6 +294,11 @@ mfw::Buffer::Buffer(struct wl_client* client, struct wl_resource* parent, uint32
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+void mfw::Buffer::send_release_event()
+{
+    wl_resource_post_event(resource, 0);
 }
 
 struct wl_buffer_interface const mfw::Buffer::vtable = {
@@ -397,6 +412,21 @@ mfw::DataOffer::DataOffer(struct wl_client* client, struct wl_resource* parent, 
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+void mfw::DataOffer::send_offer_event(std::string const& mime_type)
+{
+    wl_resource_post_event(resource, 0, mime_type);
+}
+
+void mfw::DataOffer::send_source_actions_event(uint32_t source_actions)
+{
+    wl_resource_post_event(resource, 1, source_actions);
+}
+
+void mfw::DataOffer::send_action_event(uint32_t dnd_action)
+{
+    wl_resource_post_event(resource, 2, dnd_action);
+}
+
 struct wl_data_offer_interface const mfw::DataOffer::vtable = {
     Thunks::accept_thunk,
     Thunks::receive_thunk,
@@ -472,6 +502,36 @@ mfw::DataSource::DataSource(struct wl_client* client, struct wl_resource* parent
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+void mfw::DataSource::send_target_event(std::experimental::optional<std::string> const& mime_type)
+{
+    wl_resource_post_event(resource, 0, mime_type);
+}
+
+void mfw::DataSource::send_send_event(std::string const& mime_type, mir::Fd fd)
+{
+    wl_resource_post_event(resource, 1, mime_type, fd);
+}
+
+void mfw::DataSource::send_cancelled_event()
+{
+    wl_resource_post_event(resource, 2);
+}
+
+void mfw::DataSource::send_dnd_drop_performed_event()
+{
+    wl_resource_post_event(resource, 3);
+}
+
+void mfw::DataSource::send_dnd_finished_event()
+{
+    wl_resource_post_event(resource, 4);
+}
+
+void mfw::DataSource::send_action_event(uint32_t dnd_action)
+{
+    wl_resource_post_event(resource, 5, dnd_action);
 }
 
 struct wl_data_source_interface const mfw::DataSource::vtable = {
@@ -562,6 +622,36 @@ mfw::DataDevice::DataDevice(struct wl_client* client, struct wl_resource* parent
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+void mfw::DataDevice::send_data_offer_event(uint32_t id)
+{
+    wl_resource_post_event(resource, 0, id);
+}
+
+void mfw::DataDevice::send_enter_event(uint32_t serial, struct wl_resource* surface, wl_fixed_t x, wl_fixed_t y, std::experimental::optional<struct wl_resource*> const& id)
+{
+    wl_resource_post_event(resource, 1, serial, surface, x, y, id);
+}
+
+void mfw::DataDevice::send_leave_event()
+{
+    wl_resource_post_event(resource, 2);
+}
+
+void mfw::DataDevice::send_motion_event(uint32_t time, wl_fixed_t x, wl_fixed_t y)
+{
+    wl_resource_post_event(resource, 3, time, x, y);
+}
+
+void mfw::DataDevice::send_drop_event()
+{
+    wl_resource_post_event(resource, 4);
+}
+
+void mfw::DataDevice::send_selection_event(std::experimental::optional<struct wl_resource*> const& id)
+{
+    wl_resource_post_event(resource, 5, id);
 }
 
 struct wl_data_device_interface const mfw::DataDevice::vtable = {
@@ -904,6 +994,21 @@ mfw::ShellSurface::ShellSurface(struct wl_client* client, struct wl_resource* pa
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+void mfw::ShellSurface::send_ping_event(uint32_t serial)
+{
+    wl_resource_post_event(resource, 0, serial);
+}
+
+void mfw::ShellSurface::send_configure_event(uint32_t edges, int32_t width, int32_t height)
+{
+    wl_resource_post_event(resource, 1, edges, width, height);
+}
+
+void mfw::ShellSurface::send_popup_done_event()
+{
+    wl_resource_post_event(resource, 2);
+}
+
 struct wl_shell_surface_interface const mfw::ShellSurface::vtable = {
     Thunks::pong_thunk,
     Thunks::move_thunk,
@@ -1113,6 +1218,16 @@ mfw::Surface::Surface(struct wl_client* client, struct wl_resource* parent, uint
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+void mfw::Surface::send_enter_event(struct wl_resource* output)
+{
+    wl_resource_post_event(resource, 0, output);
+}
+
+void mfw::Surface::send_leave_event(struct wl_resource* output)
+{
+    wl_resource_post_event(resource, 1, output);
+}
+
 struct wl_surface_interface const mfw::Surface::vtable = {
     Thunks::destroy_thunk,
     Thunks::attach_thunk,
@@ -1233,6 +1348,16 @@ mfw::Seat::~Seat()
     wl_global_destroy(global);
 }
 
+void mfw::Seat::send_capabilities_event(struct wl_resource* resource, uint32_t capabilities)
+{
+    wl_resource_post_event(resource, 0, capabilities);
+}
+
+void mfw::Seat::send_name_event(struct wl_resource* resource, std::string const& name)
+{
+    wl_resource_post_event(resource, 1, name);
+}
+
 struct wl_seat_interface const mfw::Seat::vtable = {
     Thunks::get_pointer_thunk,
     Thunks::get_keyboard_thunk,
@@ -1298,6 +1423,51 @@ mfw::Pointer::Pointer(struct wl_client* client, struct wl_resource* parent, uint
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+void mfw::Pointer::send_enter_event(uint32_t serial, struct wl_resource* surface, wl_fixed_t surface_x, wl_fixed_t surface_y)
+{
+    wl_resource_post_event(resource, 0, serial, surface, surface_x, surface_y);
+}
+
+void mfw::Pointer::send_leave_event(uint32_t serial, struct wl_resource* surface)
+{
+    wl_resource_post_event(resource, 1, serial, surface);
+}
+
+void mfw::Pointer::send_motion_event(uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y)
+{
+    wl_resource_post_event(resource, 2, time, surface_x, surface_y);
+}
+
+void mfw::Pointer::send_button_event(uint32_t serial, uint32_t time, uint32_t button, uint32_t state)
+{
+    wl_resource_post_event(resource, 3, serial, time, button, state);
+}
+
+void mfw::Pointer::send_axis_event(uint32_t time, uint32_t axis, wl_fixed_t value)
+{
+    wl_resource_post_event(resource, 4, time, axis, value);
+}
+
+void mfw::Pointer::send_frame_event()
+{
+    wl_resource_post_event(resource, 5);
+}
+
+void mfw::Pointer::send_axis_source_event(uint32_t axis_source)
+{
+    wl_resource_post_event(resource, 6, axis_source);
+}
+
+void mfw::Pointer::send_axis_stop_event(uint32_t time, uint32_t axis)
+{
+    wl_resource_post_event(resource, 7, time, axis);
+}
+
+void mfw::Pointer::send_axis_discrete_event(uint32_t axis, int32_t discrete)
+{
+    wl_resource_post_event(resource, 8, axis, discrete);
+}
+
 struct wl_pointer_interface const mfw::Pointer::vtable = {
     Thunks::set_cursor_thunk,
     Thunks::release_thunk};
@@ -1340,6 +1510,36 @@ mfw::Keyboard::Keyboard(struct wl_client* client, struct wl_resource* parent, ui
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+void mfw::Keyboard::send_keymap_event(uint32_t format, mir::Fd fd, uint32_t size)
+{
+    wl_resource_post_event(resource, 0, format, fd, size);
+}
+
+void mfw::Keyboard::send_enter_event(uint32_t serial, struct wl_resource* surface, struct wl_array* keys)
+{
+    wl_resource_post_event(resource, 1, serial, surface, keys);
+}
+
+void mfw::Keyboard::send_leave_event(uint32_t serial, struct wl_resource* surface)
+{
+    wl_resource_post_event(resource, 2, serial, surface);
+}
+
+void mfw::Keyboard::send_key_event(uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
+{
+    wl_resource_post_event(resource, 3, serial, time, key, state);
+}
+
+void mfw::Keyboard::send_modifiers_event(uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group)
+{
+    wl_resource_post_event(resource, 4, serial, mods_depressed, mods_latched, mods_locked, group);
+}
+
+void mfw::Keyboard::send_repeat_info_event(int32_t rate, int32_t delay)
+{
+    wl_resource_post_event(resource, 5, rate, delay);
+}
+
 struct wl_keyboard_interface const mfw::Keyboard::vtable = {
     Thunks::release_thunk};
 
@@ -1379,6 +1579,41 @@ mfw::Touch::Touch(struct wl_client* client, struct wl_resource* parent, uint32_t
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+void mfw::Touch::send_down_event(uint32_t serial, uint32_t time, struct wl_resource* surface, int32_t id, wl_fixed_t x, wl_fixed_t y)
+{
+    wl_resource_post_event(resource, 0, serial, time, surface, id, x, y);
+}
+
+void mfw::Touch::send_up_event(uint32_t serial, uint32_t time, int32_t id)
+{
+    wl_resource_post_event(resource, 1, serial, time, id);
+}
+
+void mfw::Touch::send_motion_event(uint32_t time, int32_t id, wl_fixed_t x, wl_fixed_t y)
+{
+    wl_resource_post_event(resource, 2, time, id, x, y);
+}
+
+void mfw::Touch::send_frame_event()
+{
+    wl_resource_post_event(resource, 3);
+}
+
+void mfw::Touch::send_cancel_event()
+{
+    wl_resource_post_event(resource, 4);
+}
+
+void mfw::Touch::send_shape_event(int32_t id, wl_fixed_t major, wl_fixed_t minor)
+{
+    wl_resource_post_event(resource, 5, id, major, minor);
+}
+
+void mfw::Touch::send_orientation_event(int32_t id, wl_fixed_t orientation)
+{
+    wl_resource_post_event(resource, 6, id, orientation);
 }
 
 struct wl_touch_interface const mfw::Touch::vtable = {
@@ -1442,6 +1677,26 @@ mfw::Output::Output(struct wl_display* display, uint32_t max_version)
 mfw::Output::~Output()
 {
     wl_global_destroy(global);
+}
+
+void mfw::Output::send_geometry_event(struct wl_resource* resource, int32_t x, int32_t y, int32_t physical_width, int32_t physical_height, int32_t subpixel, std::string const& make, std::string const& model, int32_t transform)
+{
+    wl_resource_post_event(resource, 0, x, y, physical_width, physical_height, subpixel, make, model, transform);
+}
+
+void mfw::Output::send_mode_event(struct wl_resource* resource, uint32_t flags, int32_t width, int32_t height, int32_t refresh)
+{
+    wl_resource_post_event(resource, 1, flags, width, height, refresh);
+}
+
+void mfw::Output::send_done_event(struct wl_resource* resource)
+{
+    wl_resource_post_event(resource, 2);
+}
+
+void mfw::Output::send_scale_event(struct wl_resource* resource, int32_t factor)
+{
+    wl_resource_post_event(resource, 3, factor);
 }
 
 struct wl_output_interface const mfw::Output::vtable = {

--- a/src/server/frontend_wayland/generated/wayland_wrapper.cpp
+++ b/src/server/frontend_wayland/generated/wayland_wrapper.cpp
@@ -229,7 +229,7 @@ mfw::Shm* mfw::Shm::from(struct wl_resource* resource)
 
 struct mfw::Shm::Thunks
 {
-    static void create_pool_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, int fd, int32_t size)
+    static void create_pool_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, int32_t fd, int32_t size)
     {
         auto me = static_cast<Shm*>(wl_resource_get_user_data(resource));
         mir::Fd fd_resolved{fd};
@@ -385,7 +385,7 @@ struct mfw::DataOffer::Thunks
         }
     }
 
-    static void receive_thunk(struct wl_client*, struct wl_resource* resource, char const* mime_type, int fd)
+    static void receive_thunk(struct wl_client*, struct wl_resource* resource, char const* mime_type, int32_t fd)
     {
         auto me = static_cast<DataOffer*>(wl_resource_get_user_data(resource));
         mir::Fd fd_resolved{fd};
@@ -594,7 +594,8 @@ void mfw::DataSource::send_target_event(std::experimental::optional<std::string>
 void mfw::DataSource::send_send_event(std::string const& mime_type, mir::Fd fd) const
 {
     const char* mime_type_resolved = mime_type.c_str();
-    wl_resource_post_event(resource, Opcode::SEND, mime_type_resolved, fd);
+    int32_t fd_resolved{fd};
+    wl_resource_post_event(resource, Opcode::SEND, mime_type_resolved, fd_resolved);
 }
 
 void mfw::DataSource::send_cancelled_event() const
@@ -1735,7 +1736,8 @@ mfw::Keyboard::Keyboard(struct wl_client* client, struct wl_resource* parent, ui
 
 void mfw::Keyboard::send_keymap_event(uint32_t format, mir::Fd fd, uint32_t size) const
 {
-    wl_resource_post_event(resource, Opcode::KEYMAP, format, fd, size);
+    int32_t fd_resolved{fd};
+    wl_resource_post_event(resource, Opcode::KEYMAP, format, fd_resolved, size);
 }
 
 void mfw::Keyboard::send_enter_event(uint32_t serial, struct wl_resource* surface, struct wl_array* keys) const

--- a/src/server/frontend_wayland/generated/wayland_wrapper.h
+++ b/src/server/frontend_wayland/generated/wayland_wrapper.h
@@ -9,13 +9,29 @@
 #define MIR_FRONTEND_WAYLAND_WAYLAND_XML_WRAPPER
 
 #include <experimental/optional>
-#include <boost/throw_exception.hpp>
-#include <boost/exception/diagnostic_information.hpp>
-
-#include "wayland.h"
 
 #include "mir/fd.h"
-#include "mir/log.h"
+#include "../wayland_utils.h"
+
+struct wl_compositor_interface;
+struct wl_shm_pool_interface;
+struct wl_shm_interface;
+struct wl_buffer_interface;
+struct wl_data_offer_interface;
+struct wl_data_source_interface;
+struct wl_data_device_interface;
+struct wl_data_device_manager_interface;
+struct wl_shell_interface;
+struct wl_shell_surface_interface;
+struct wl_surface_interface;
+struct wl_seat_interface;
+struct wl_pointer_interface;
+struct wl_keyboard_interface;
+struct wl_touch_interface;
+struct wl_output_interface;
+struct wl_region_interface;
+struct wl_subcompositor_interface;
+struct wl_subsurface_interface;
 
 namespace mir
 {
@@ -26,23 +42,36 @@ namespace wayland
 
 class Callback
 {
-protected:
+public:
+    static Callback* from(struct wl_resource*);
+
     Callback(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Callback() = default;
 
-    void send_done_event(uint32_t callback_data);
+    void send_done_event(uint32_t callback_data) const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Opcode
+    {
+        static uint32_t const DONE = 0;
+    };
 
 private:
 };
 
 class Compositor
 {
-protected:
+public:
+    static Compositor* from(struct wl_resource*);
+
     Compositor(struct wl_display* display, uint32_t max_version);
     virtual ~Compositor();
+
+    void destroy_wayland_object(struct wl_resource* resource) const;
 
     struct wl_global* const global;
     uint32_t const max_version;
@@ -60,9 +89,13 @@ private:
 
 class ShmPool
 {
-protected:
+public:
+    static ShmPool* from(struct wl_resource*);
+
     ShmPool(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~ShmPool() = default;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -79,14 +112,92 @@ private:
 
 class Shm
 {
-protected:
+public:
+    static Shm* from(struct wl_resource*);
+
     Shm(struct wl_display* display, uint32_t max_version);
     virtual ~Shm();
 
-    void send_format_event(struct wl_resource* resource, uint32_t format);
+    void send_format_event(struct wl_resource* resource, uint32_t format) const;
+
+    void destroy_wayland_object(struct wl_resource* resource) const;
 
     struct wl_global* const global;
     uint32_t const max_version;
+
+    struct Error
+    {
+        static uint32_t const INVALID_FORMAT = 0;
+        static uint32_t const INVALID_STRIDE = 1;
+        static uint32_t const INVALID_FD = 2;
+    };
+
+    struct Format
+    {
+        static uint32_t const ARGB8888 = 0;
+        static uint32_t const XRGB8888 = 1;
+        static uint32_t const C8 = 0x20203843;
+        static uint32_t const RGB332 = 0x38424752;
+        static uint32_t const BGR233 = 0x38524742;
+        static uint32_t const XRGB4444 = 0x32315258;
+        static uint32_t const XBGR4444 = 0x32314258;
+        static uint32_t const RGBX4444 = 0x32315852;
+        static uint32_t const BGRX4444 = 0x32315842;
+        static uint32_t const ARGB4444 = 0x32315241;
+        static uint32_t const ABGR4444 = 0x32314241;
+        static uint32_t const RGBA4444 = 0x32314152;
+        static uint32_t const BGRA4444 = 0x32314142;
+        static uint32_t const XRGB1555 = 0x35315258;
+        static uint32_t const XBGR1555 = 0x35314258;
+        static uint32_t const RGBX5551 = 0x35315852;
+        static uint32_t const BGRX5551 = 0x35315842;
+        static uint32_t const ARGB1555 = 0x35315241;
+        static uint32_t const ABGR1555 = 0x35314241;
+        static uint32_t const RGBA5551 = 0x35314152;
+        static uint32_t const BGRA5551 = 0x35314142;
+        static uint32_t const RGB565 = 0x36314752;
+        static uint32_t const BGR565 = 0x36314742;
+        static uint32_t const RGB888 = 0x34324752;
+        static uint32_t const BGR888 = 0x34324742;
+        static uint32_t const XBGR8888 = 0x34324258;
+        static uint32_t const RGBX8888 = 0x34325852;
+        static uint32_t const BGRX8888 = 0x34325842;
+        static uint32_t const ABGR8888 = 0x34324241;
+        static uint32_t const RGBA8888 = 0x34324152;
+        static uint32_t const BGRA8888 = 0x34324142;
+        static uint32_t const XRGB2101010 = 0x30335258;
+        static uint32_t const XBGR2101010 = 0x30334258;
+        static uint32_t const RGBX1010102 = 0x30335852;
+        static uint32_t const BGRX1010102 = 0x30335842;
+        static uint32_t const ARGB2101010 = 0x30335241;
+        static uint32_t const ABGR2101010 = 0x30334241;
+        static uint32_t const RGBA1010102 = 0x30334152;
+        static uint32_t const BGRA1010102 = 0x30334142;
+        static uint32_t const YUYV = 0x56595559;
+        static uint32_t const YVYU = 0x55595659;
+        static uint32_t const UYVY = 0x59565955;
+        static uint32_t const VYUY = 0x59555956;
+        static uint32_t const AYUV = 0x56555941;
+        static uint32_t const NV12 = 0x3231564e;
+        static uint32_t const NV21 = 0x3132564e;
+        static uint32_t const NV16 = 0x3631564e;
+        static uint32_t const NV61 = 0x3136564e;
+        static uint32_t const YUV410 = 0x39565559;
+        static uint32_t const YVU410 = 0x39555659;
+        static uint32_t const YUV411 = 0x31315559;
+        static uint32_t const YVU411 = 0x31315659;
+        static uint32_t const YUV420 = 0x32315559;
+        static uint32_t const YVU420 = 0x32315659;
+        static uint32_t const YUV422 = 0x36315559;
+        static uint32_t const YVU422 = 0x36315659;
+        static uint32_t const YUV444 = 0x34325559;
+        static uint32_t const YVU444 = 0x34325659;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const FORMAT = 0;
+    };
 
 private:
     struct Thunks;
@@ -100,14 +211,23 @@ private:
 
 class Buffer
 {
-protected:
+public:
+    static Buffer* from(struct wl_resource*);
+
     Buffer(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Buffer() = default;
 
-    void send_release_event();
+    void send_release_event() const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Opcode
+    {
+        static uint32_t const RELEASE = 0;
+    };
 
 private:
     struct Thunks;
@@ -119,16 +239,37 @@ private:
 
 class DataOffer
 {
-protected:
+public:
+    static DataOffer* from(struct wl_resource*);
+
     DataOffer(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~DataOffer() = default;
 
-    void send_offer_event(std::string const& mime_type);
-    void send_source_actions_event(uint32_t source_actions);
-    void send_action_event(uint32_t dnd_action);
+    void send_offer_event(std::string const& mime_type) const;
+    bool version_supports_source_actions();
+    void send_source_actions_event(uint32_t source_actions) const;
+    bool version_supports_action();
+    void send_action_event(uint32_t dnd_action) const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Error
+    {
+        static uint32_t const INVALID_FINISH = 0;
+        static uint32_t const INVALID_ACTION_MASK = 1;
+        static uint32_t const INVALID_ACTION = 2;
+        static uint32_t const INVALID_OFFER = 3;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const OFFER = 0;
+        static uint32_t const SOURCE_ACTIONS = 1;
+        static uint32_t const ACTION = 2;
+    };
 
 private:
     struct Thunks;
@@ -144,19 +285,42 @@ private:
 
 class DataSource
 {
-protected:
+public:
+    static DataSource* from(struct wl_resource*);
+
     DataSource(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~DataSource() = default;
 
-    void send_target_event(std::experimental::optional<std::string> const& mime_type);
-    void send_send_event(std::string const& mime_type, mir::Fd fd);
-    void send_cancelled_event();
-    void send_dnd_drop_performed_event();
-    void send_dnd_finished_event();
-    void send_action_event(uint32_t dnd_action);
+    void send_target_event(std::experimental::optional<std::string> const& mime_type) const;
+    void send_send_event(std::string const& mime_type, mir::Fd fd) const;
+    void send_cancelled_event() const;
+    bool version_supports_dnd_drop_performed();
+    void send_dnd_drop_performed_event() const;
+    bool version_supports_dnd_finished();
+    void send_dnd_finished_event() const;
+    bool version_supports_action();
+    void send_action_event(uint32_t dnd_action) const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Error
+    {
+        static uint32_t const INVALID_ACTION_MASK = 0;
+        static uint32_t const INVALID_SOURCE = 1;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const TARGET = 0;
+        static uint32_t const SEND = 1;
+        static uint32_t const CANCELLED = 2;
+        static uint32_t const DND_DROP_PERFORMED = 3;
+        static uint32_t const DND_FINISHED = 4;
+        static uint32_t const ACTION = 5;
+    };
 
 private:
     struct Thunks;
@@ -170,19 +334,38 @@ private:
 
 class DataDevice
 {
-protected:
+public:
+    static DataDevice* from(struct wl_resource*);
+
     DataDevice(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~DataDevice() = default;
 
-    void send_data_offer_event(uint32_t id);
-    void send_enter_event(uint32_t serial, struct wl_resource* surface, wl_fixed_t x, wl_fixed_t y, std::experimental::optional<struct wl_resource*> const& id);
-    void send_leave_event();
-    void send_motion_event(uint32_t time, wl_fixed_t x, wl_fixed_t y);
-    void send_drop_event();
-    void send_selection_event(std::experimental::optional<struct wl_resource*> const& id);
+    void send_data_offer_event(struct wl_resource* id) const;
+    void send_enter_event(uint32_t serial, struct wl_resource* surface, double x, double y, std::experimental::optional<struct wl_resource*> const& id) const;
+    void send_leave_event() const;
+    void send_motion_event(uint32_t time, double x, double y) const;
+    void send_drop_event() const;
+    void send_selection_event(std::experimental::optional<struct wl_resource*> const& id) const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Error
+    {
+        static uint32_t const ROLE = 0;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const DATA_OFFER = 0;
+        static uint32_t const ENTER = 1;
+        static uint32_t const LEAVE = 2;
+        static uint32_t const MOTION = 3;
+        static uint32_t const DROP = 4;
+        static uint32_t const SELECTION = 5;
+    };
 
 private:
     struct Thunks;
@@ -196,12 +379,24 @@ private:
 
 class DataDeviceManager
 {
-protected:
+public:
+    static DataDeviceManager* from(struct wl_resource*);
+
     DataDeviceManager(struct wl_display* display, uint32_t max_version);
     virtual ~DataDeviceManager();
 
+    void destroy_wayland_object(struct wl_resource* resource) const;
+
     struct wl_global* const global;
     uint32_t const max_version;
+
+    struct DndAction
+    {
+        static uint32_t const NONE = 0;
+        static uint32_t const COPY = 1;
+        static uint32_t const MOVE = 2;
+        static uint32_t const ASK = 4;
+    };
 
 private:
     struct Thunks;
@@ -216,12 +411,21 @@ private:
 
 class Shell
 {
-protected:
+public:
+    static Shell* from(struct wl_resource*);
+
     Shell(struct wl_display* display, uint32_t max_version);
     virtual ~Shell();
 
+    void destroy_wayland_object(struct wl_resource* resource) const;
+
     struct wl_global* const global;
     uint32_t const max_version;
+
+    struct Error
+    {
+        static uint32_t const ROLE = 0;
+    };
 
 private:
     struct Thunks;
@@ -235,16 +439,53 @@ private:
 
 class ShellSurface
 {
-protected:
+public:
+    static ShellSurface* from(struct wl_resource*);
+
     ShellSurface(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~ShellSurface() = default;
 
-    void send_ping_event(uint32_t serial);
-    void send_configure_event(uint32_t edges, int32_t width, int32_t height);
-    void send_popup_done_event();
+    void send_ping_event(uint32_t serial) const;
+    void send_configure_event(uint32_t edges, int32_t width, int32_t height) const;
+    void send_popup_done_event() const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Resize
+    {
+        static uint32_t const NONE = 0;
+        static uint32_t const TOP = 1;
+        static uint32_t const BOTTOM = 2;
+        static uint32_t const LEFT = 4;
+        static uint32_t const TOP_LEFT = 5;
+        static uint32_t const BOTTOM_LEFT = 6;
+        static uint32_t const RIGHT = 8;
+        static uint32_t const TOP_RIGHT = 9;
+        static uint32_t const BOTTOM_RIGHT = 10;
+    };
+
+    struct Transient
+    {
+        static uint32_t const INACTIVE = 0x1;
+    };
+
+    struct FullscreenMethod
+    {
+        static uint32_t const DEFAULT = 0;
+        static uint32_t const SCALE = 1;
+        static uint32_t const DRIVER = 2;
+        static uint32_t const FILL = 3;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const PING = 0;
+        static uint32_t const CONFIGURE = 1;
+        static uint32_t const POPUP_DONE = 2;
+    };
 
 private:
     struct Thunks;
@@ -265,15 +506,31 @@ private:
 
 class Surface
 {
-protected:
+public:
+    static Surface* from(struct wl_resource*);
+
     Surface(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Surface() = default;
 
-    void send_enter_event(struct wl_resource* output);
-    void send_leave_event(struct wl_resource* output);
+    void send_enter_event(struct wl_resource* output) const;
+    void send_leave_event(struct wl_resource* output) const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Error
+    {
+        static uint32_t const INVALID_SCALE = 0;
+        static uint32_t const INVALID_TRANSFORM = 1;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const ENTER = 0;
+        static uint32_t const LEAVE = 1;
+    };
 
 private:
     struct Thunks;
@@ -294,15 +551,33 @@ private:
 
 class Seat
 {
-protected:
+public:
+    static Seat* from(struct wl_resource*);
+
     Seat(struct wl_display* display, uint32_t max_version);
     virtual ~Seat();
 
-    void send_capabilities_event(struct wl_resource* resource, uint32_t capabilities);
-    void send_name_event(struct wl_resource* resource, std::string const& name);
+    void send_capabilities_event(struct wl_resource* resource, uint32_t capabilities) const;
+    bool version_supports_name(struct wl_resource* resource);
+    void send_name_event(struct wl_resource* resource, std::string const& name) const;
+
+    void destroy_wayland_object(struct wl_resource* resource) const;
 
     struct wl_global* const global;
     uint32_t const max_version;
+
+    struct Capability
+    {
+        static uint32_t const POINTER = 1;
+        static uint32_t const KEYBOARD = 2;
+        static uint32_t const TOUCH = 4;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const CAPABILITIES = 0;
+        static uint32_t const NAME = 1;
+    };
 
 private:
     struct Thunks;
@@ -319,22 +594,68 @@ private:
 
 class Pointer
 {
-protected:
+public:
+    static Pointer* from(struct wl_resource*);
+
     Pointer(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Pointer() = default;
 
-    void send_enter_event(uint32_t serial, struct wl_resource* surface, wl_fixed_t surface_x, wl_fixed_t surface_y);
-    void send_leave_event(uint32_t serial, struct wl_resource* surface);
-    void send_motion_event(uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y);
-    void send_button_event(uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
-    void send_axis_event(uint32_t time, uint32_t axis, wl_fixed_t value);
-    void send_frame_event();
-    void send_axis_source_event(uint32_t axis_source);
-    void send_axis_stop_event(uint32_t time, uint32_t axis);
-    void send_axis_discrete_event(uint32_t axis, int32_t discrete);
+    void send_enter_event(uint32_t serial, struct wl_resource* surface, double surface_x, double surface_y) const;
+    void send_leave_event(uint32_t serial, struct wl_resource* surface) const;
+    void send_motion_event(uint32_t time, double surface_x, double surface_y) const;
+    void send_button_event(uint32_t serial, uint32_t time, uint32_t button, uint32_t state) const;
+    void send_axis_event(uint32_t time, uint32_t axis, double value) const;
+    bool version_supports_frame();
+    void send_frame_event() const;
+    bool version_supports_axis_source();
+    void send_axis_source_event(uint32_t axis_source) const;
+    bool version_supports_axis_stop();
+    void send_axis_stop_event(uint32_t time, uint32_t axis) const;
+    bool version_supports_axis_discrete();
+    void send_axis_discrete_event(uint32_t axis, int32_t discrete) const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Error
+    {
+        static uint32_t const ROLE = 0;
+    };
+
+    struct ButtonState
+    {
+        static uint32_t const RELEASED = 0;
+        static uint32_t const PRESSED = 1;
+    };
+
+    struct Axis
+    {
+        static uint32_t const VERTICAL_SCROLL = 0;
+        static uint32_t const HORIZONTAL_SCROLL = 1;
+    };
+
+    struct AxisSource
+    {
+        static uint32_t const WHEEL = 0;
+        static uint32_t const FINGER = 1;
+        static uint32_t const CONTINUOUS = 2;
+        static uint32_t const WHEEL_TILT = 3;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const ENTER = 0;
+        static uint32_t const LEAVE = 1;
+        static uint32_t const MOTION = 2;
+        static uint32_t const BUTTON = 3;
+        static uint32_t const AXIS = 4;
+        static uint32_t const FRAME = 5;
+        static uint32_t const AXIS_SOURCE = 6;
+        static uint32_t const AXIS_STOP = 7;
+        static uint32_t const AXIS_DISCRETE = 8;
+    };
 
 private:
     struct Thunks;
@@ -347,19 +668,46 @@ private:
 
 class Keyboard
 {
-protected:
+public:
+    static Keyboard* from(struct wl_resource*);
+
     Keyboard(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Keyboard() = default;
 
-    void send_keymap_event(uint32_t format, mir::Fd fd, uint32_t size);
-    void send_enter_event(uint32_t serial, struct wl_resource* surface, struct wl_array* keys);
-    void send_leave_event(uint32_t serial, struct wl_resource* surface);
-    void send_key_event(uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
-    void send_modifiers_event(uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group);
-    void send_repeat_info_event(int32_t rate, int32_t delay);
+    void send_keymap_event(uint32_t format, mir::Fd fd, uint32_t size) const;
+    void send_enter_event(uint32_t serial, struct wl_resource* surface, struct wl_array* keys) const;
+    void send_leave_event(uint32_t serial, struct wl_resource* surface) const;
+    void send_key_event(uint32_t serial, uint32_t time, uint32_t key, uint32_t state) const;
+    void send_modifiers_event(uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group) const;
+    bool version_supports_repeat_info();
+    void send_repeat_info_event(int32_t rate, int32_t delay) const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct KeymapFormat
+    {
+        static uint32_t const NO_KEYMAP = 0;
+        static uint32_t const XKB_V1 = 1;
+    };
+
+    struct KeyState
+    {
+        static uint32_t const RELEASED = 0;
+        static uint32_t const PRESSED = 1;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const KEYMAP = 0;
+        static uint32_t const ENTER = 1;
+        static uint32_t const LEAVE = 2;
+        static uint32_t const KEY = 3;
+        static uint32_t const MODIFIERS = 4;
+        static uint32_t const REPEAT_INFO = 5;
+    };
 
 private:
     struct Thunks;
@@ -371,20 +719,37 @@ private:
 
 class Touch
 {
-protected:
+public:
+    static Touch* from(struct wl_resource*);
+
     Touch(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Touch() = default;
 
-    void send_down_event(uint32_t serial, uint32_t time, struct wl_resource* surface, int32_t id, wl_fixed_t x, wl_fixed_t y);
-    void send_up_event(uint32_t serial, uint32_t time, int32_t id);
-    void send_motion_event(uint32_t time, int32_t id, wl_fixed_t x, wl_fixed_t y);
-    void send_frame_event();
-    void send_cancel_event();
-    void send_shape_event(int32_t id, wl_fixed_t major, wl_fixed_t minor);
-    void send_orientation_event(int32_t id, wl_fixed_t orientation);
+    void send_down_event(uint32_t serial, uint32_t time, struct wl_resource* surface, int32_t id, double x, double y) const;
+    void send_up_event(uint32_t serial, uint32_t time, int32_t id) const;
+    void send_motion_event(uint32_t time, int32_t id, double x, double y) const;
+    void send_frame_event() const;
+    void send_cancel_event() const;
+    bool version_supports_shape();
+    void send_shape_event(int32_t id, double major, double minor) const;
+    bool version_supports_orientation();
+    void send_orientation_event(int32_t id, double orientation) const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Opcode
+    {
+        static uint32_t const DOWN = 0;
+        static uint32_t const UP = 1;
+        static uint32_t const MOTION = 2;
+        static uint32_t const FRAME = 3;
+        static uint32_t const CANCEL = 4;
+        static uint32_t const SHAPE = 5;
+        static uint32_t const ORIENTATION = 6;
+    };
 
 private:
     struct Thunks;
@@ -396,17 +761,59 @@ private:
 
 class Output
 {
-protected:
+public:
+    static Output* from(struct wl_resource*);
+
     Output(struct wl_display* display, uint32_t max_version);
     virtual ~Output();
 
-    void send_geometry_event(struct wl_resource* resource, int32_t x, int32_t y, int32_t physical_width, int32_t physical_height, int32_t subpixel, std::string const& make, std::string const& model, int32_t transform);
-    void send_mode_event(struct wl_resource* resource, uint32_t flags, int32_t width, int32_t height, int32_t refresh);
-    void send_done_event(struct wl_resource* resource);
-    void send_scale_event(struct wl_resource* resource, int32_t factor);
+    void send_geometry_event(struct wl_resource* resource, int32_t x, int32_t y, int32_t physical_width, int32_t physical_height, int32_t subpixel, std::string const& make, std::string const& model, int32_t transform) const;
+    void send_mode_event(struct wl_resource* resource, uint32_t flags, int32_t width, int32_t height, int32_t refresh) const;
+    bool version_supports_done(struct wl_resource* resource);
+    void send_done_event(struct wl_resource* resource) const;
+    bool version_supports_scale(struct wl_resource* resource);
+    void send_scale_event(struct wl_resource* resource, int32_t factor) const;
+
+    void destroy_wayland_object(struct wl_resource* resource) const;
 
     struct wl_global* const global;
     uint32_t const max_version;
+
+    struct Subpixel
+    {
+        static uint32_t const UNKNOWN = 0;
+        static uint32_t const NONE = 1;
+        static uint32_t const HORIZONTAL_RGB = 2;
+        static uint32_t const HORIZONTAL_BGR = 3;
+        static uint32_t const VERTICAL_RGB = 4;
+        static uint32_t const VERTICAL_BGR = 5;
+    };
+
+    struct Transform
+    {
+        static uint32_t const NORMAL = 0;
+        static uint32_t const _0 = 1;
+        static uint32_t const _80 = 2;
+        static uint32_t const _70 = 3;
+        static uint32_t const FLIPPED = 4;
+        static uint32_t const FLIPPED_90 = 5;
+        static uint32_t const FLIPPED_180 = 6;
+        static uint32_t const FLIPPED_270 = 7;
+    };
+
+    struct Mode
+    {
+        static uint32_t const CURRENT = 0x1;
+        static uint32_t const PREFERRED = 0x2;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const GEOMETRY = 0;
+        static uint32_t const MODE = 1;
+        static uint32_t const DONE = 2;
+        static uint32_t const SCALE = 3;
+    };
 
 private:
     struct Thunks;
@@ -420,9 +827,13 @@ private:
 
 class Region
 {
-protected:
+public:
+    static Region* from(struct wl_resource*);
+
     Region(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Region() = default;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -439,12 +850,21 @@ private:
 
 class Subcompositor
 {
-protected:
+public:
+    static Subcompositor* from(struct wl_resource*);
+
     Subcompositor(struct wl_display* display, uint32_t max_version);
     virtual ~Subcompositor();
 
+    void destroy_wayland_object(struct wl_resource* resource) const;
+
     struct wl_global* const global;
     uint32_t const max_version;
+
+    struct Error
+    {
+        static uint32_t const BAD_SURFACE = 0;
+    };
 
 private:
     struct Thunks;
@@ -459,12 +879,21 @@ private:
 
 class Subsurface
 {
-protected:
+public:
+    static Subsurface* from(struct wl_resource*);
+
     Subsurface(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Subsurface() = default;
 
+    void destroy_wayland_object() const;
+
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Error
+    {
+        static uint32_t const BAD_SURFACE = 0;
+    };
 
 private:
     struct Thunks;

--- a/src/server/frontend_wayland/generated/wayland_wrapper.h
+++ b/src/server/frontend_wayland/generated/wayland_wrapper.h
@@ -30,6 +30,8 @@ protected:
     Callback(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Callback() = default;
 
+    void send_done_event(uint32_t callback_data);
+
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -81,6 +83,8 @@ protected:
     Shm(struct wl_display* display, uint32_t max_version);
     virtual ~Shm();
 
+    void send_format_event(struct wl_resource* resource, uint32_t format);
+
     struct wl_global* const global;
     uint32_t const max_version;
 
@@ -100,6 +104,8 @@ protected:
     Buffer(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Buffer() = default;
 
+    void send_release_event();
+
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -116,6 +122,10 @@ class DataOffer
 protected:
     DataOffer(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~DataOffer() = default;
+
+    void send_offer_event(std::string const& mime_type);
+    void send_source_actions_event(uint32_t source_actions);
+    void send_action_event(uint32_t dnd_action);
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -138,6 +148,13 @@ protected:
     DataSource(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~DataSource() = default;
 
+    void send_target_event(std::experimental::optional<std::string> const& mime_type);
+    void send_send_event(std::string const& mime_type, mir::Fd fd);
+    void send_cancelled_event();
+    void send_dnd_drop_performed_event();
+    void send_dnd_finished_event();
+    void send_action_event(uint32_t dnd_action);
+
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -156,6 +173,13 @@ class DataDevice
 protected:
     DataDevice(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~DataDevice() = default;
+
+    void send_data_offer_event(uint32_t id);
+    void send_enter_event(uint32_t serial, struct wl_resource* surface, wl_fixed_t x, wl_fixed_t y, std::experimental::optional<struct wl_resource*> const& id);
+    void send_leave_event();
+    void send_motion_event(uint32_t time, wl_fixed_t x, wl_fixed_t y);
+    void send_drop_event();
+    void send_selection_event(std::experimental::optional<struct wl_resource*> const& id);
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -215,6 +239,10 @@ protected:
     ShellSurface(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~ShellSurface() = default;
 
+    void send_ping_event(uint32_t serial);
+    void send_configure_event(uint32_t edges, int32_t width, int32_t height);
+    void send_popup_done_event();
+
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -240,6 +268,9 @@ class Surface
 protected:
     Surface(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Surface() = default;
+
+    void send_enter_event(struct wl_resource* output);
+    void send_leave_event(struct wl_resource* output);
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -267,6 +298,9 @@ protected:
     Seat(struct wl_display* display, uint32_t max_version);
     virtual ~Seat();
 
+    void send_capabilities_event(struct wl_resource* resource, uint32_t capabilities);
+    void send_name_event(struct wl_resource* resource, std::string const& name);
+
     struct wl_global* const global;
     uint32_t const max_version;
 
@@ -289,6 +323,16 @@ protected:
     Pointer(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Pointer() = default;
 
+    void send_enter_event(uint32_t serial, struct wl_resource* surface, wl_fixed_t surface_x, wl_fixed_t surface_y);
+    void send_leave_event(uint32_t serial, struct wl_resource* surface);
+    void send_motion_event(uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y);
+    void send_button_event(uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
+    void send_axis_event(uint32_t time, uint32_t axis, wl_fixed_t value);
+    void send_frame_event();
+    void send_axis_source_event(uint32_t axis_source);
+    void send_axis_stop_event(uint32_t time, uint32_t axis);
+    void send_axis_discrete_event(uint32_t axis, int32_t discrete);
+
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -307,6 +351,13 @@ protected:
     Keyboard(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Keyboard() = default;
 
+    void send_keymap_event(uint32_t format, mir::Fd fd, uint32_t size);
+    void send_enter_event(uint32_t serial, struct wl_resource* surface, struct wl_array* keys);
+    void send_leave_event(uint32_t serial, struct wl_resource* surface);
+    void send_key_event(uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
+    void send_modifiers_event(uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group);
+    void send_repeat_info_event(int32_t rate, int32_t delay);
+
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -324,6 +375,14 @@ protected:
     Touch(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~Touch() = default;
 
+    void send_down_event(uint32_t serial, uint32_t time, struct wl_resource* surface, int32_t id, wl_fixed_t x, wl_fixed_t y);
+    void send_up_event(uint32_t serial, uint32_t time, int32_t id);
+    void send_motion_event(uint32_t time, int32_t id, wl_fixed_t x, wl_fixed_t y);
+    void send_frame_event();
+    void send_cancel_event();
+    void send_shape_event(int32_t id, wl_fixed_t major, wl_fixed_t minor);
+    void send_orientation_event(int32_t id, wl_fixed_t orientation);
+
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -340,6 +399,11 @@ class Output
 protected:
     Output(struct wl_display* display, uint32_t max_version);
     virtual ~Output();
+
+    void send_geometry_event(struct wl_resource* resource, int32_t x, int32_t y, int32_t physical_width, int32_t physical_height, int32_t subpixel, std::string const& make, std::string const& model, int32_t transform);
+    void send_mode_event(struct wl_resource* resource, uint32_t flags, int32_t width, int32_t height, int32_t refresh);
+    void send_done_event(struct wl_resource* resource);
+    void send_scale_event(struct wl_resource* resource, int32_t factor);
 
     struct wl_global* const global;
     uint32_t const max_version;

--- a/src/server/frontend_wayland/generated/wayland_wrapper.h
+++ b/src/server/frontend_wayland/generated/wayland_wrapper.h
@@ -792,9 +792,9 @@ public:
     struct Transform
     {
         static uint32_t const NORMAL = 0;
-        static uint32_t const _0 = 1;
-        static uint32_t const _80 = 2;
-        static uint32_t const _70 = 3;
+        static uint32_t const _90 = 1;
+        static uint32_t const _180 = 2;
+        static uint32_t const _270 = 3;
         static uint32_t const FLIPPED = 4;
         static uint32_t const FLIPPED_90 = 5;
         static uint32_t const FLIPPED_180 = 6;

--- a/src/server/frontend_wayland/generated/wayland_wrapper.h
+++ b/src/server/frontend_wayland/generated/wayland_wrapper.h
@@ -57,7 +57,7 @@ public:
 
     struct Opcode
     {
-        static uint32_t const DONE = 0;
+        static uint32_t const done = 0;
     };
 
 private:
@@ -127,76 +127,76 @@ public:
 
     struct Error
     {
-        static uint32_t const INVALID_FORMAT = 0;
-        static uint32_t const INVALID_STRIDE = 1;
-        static uint32_t const INVALID_FD = 2;
+        static uint32_t const invalid_format = 0;
+        static uint32_t const invalid_stride = 1;
+        static uint32_t const invalid_fd = 2;
     };
 
     struct Format
     {
-        static uint32_t const ARGB8888 = 0;
-        static uint32_t const XRGB8888 = 1;
-        static uint32_t const C8 = 0x20203843;
-        static uint32_t const RGB332 = 0x38424752;
-        static uint32_t const BGR233 = 0x38524742;
-        static uint32_t const XRGB4444 = 0x32315258;
-        static uint32_t const XBGR4444 = 0x32314258;
-        static uint32_t const RGBX4444 = 0x32315852;
-        static uint32_t const BGRX4444 = 0x32315842;
-        static uint32_t const ARGB4444 = 0x32315241;
-        static uint32_t const ABGR4444 = 0x32314241;
-        static uint32_t const RGBA4444 = 0x32314152;
-        static uint32_t const BGRA4444 = 0x32314142;
-        static uint32_t const XRGB1555 = 0x35315258;
-        static uint32_t const XBGR1555 = 0x35314258;
-        static uint32_t const RGBX5551 = 0x35315852;
-        static uint32_t const BGRX5551 = 0x35315842;
-        static uint32_t const ARGB1555 = 0x35315241;
-        static uint32_t const ABGR1555 = 0x35314241;
-        static uint32_t const RGBA5551 = 0x35314152;
-        static uint32_t const BGRA5551 = 0x35314142;
-        static uint32_t const RGB565 = 0x36314752;
-        static uint32_t const BGR565 = 0x36314742;
-        static uint32_t const RGB888 = 0x34324752;
-        static uint32_t const BGR888 = 0x34324742;
-        static uint32_t const XBGR8888 = 0x34324258;
-        static uint32_t const RGBX8888 = 0x34325852;
-        static uint32_t const BGRX8888 = 0x34325842;
-        static uint32_t const ABGR8888 = 0x34324241;
-        static uint32_t const RGBA8888 = 0x34324152;
-        static uint32_t const BGRA8888 = 0x34324142;
-        static uint32_t const XRGB2101010 = 0x30335258;
-        static uint32_t const XBGR2101010 = 0x30334258;
-        static uint32_t const RGBX1010102 = 0x30335852;
-        static uint32_t const BGRX1010102 = 0x30335842;
-        static uint32_t const ARGB2101010 = 0x30335241;
-        static uint32_t const ABGR2101010 = 0x30334241;
-        static uint32_t const RGBA1010102 = 0x30334152;
-        static uint32_t const BGRA1010102 = 0x30334142;
-        static uint32_t const YUYV = 0x56595559;
-        static uint32_t const YVYU = 0x55595659;
-        static uint32_t const UYVY = 0x59565955;
-        static uint32_t const VYUY = 0x59555956;
-        static uint32_t const AYUV = 0x56555941;
-        static uint32_t const NV12 = 0x3231564e;
-        static uint32_t const NV21 = 0x3132564e;
-        static uint32_t const NV16 = 0x3631564e;
-        static uint32_t const NV61 = 0x3136564e;
-        static uint32_t const YUV410 = 0x39565559;
-        static uint32_t const YVU410 = 0x39555659;
-        static uint32_t const YUV411 = 0x31315559;
-        static uint32_t const YVU411 = 0x31315659;
-        static uint32_t const YUV420 = 0x32315559;
-        static uint32_t const YVU420 = 0x32315659;
-        static uint32_t const YUV422 = 0x36315559;
-        static uint32_t const YVU422 = 0x36315659;
-        static uint32_t const YUV444 = 0x34325559;
-        static uint32_t const YVU444 = 0x34325659;
+        static uint32_t const argb8888 = 0;
+        static uint32_t const xrgb8888 = 1;
+        static uint32_t const c8 = 0x20203843;
+        static uint32_t const rgb332 = 0x38424752;
+        static uint32_t const bgr233 = 0x38524742;
+        static uint32_t const xrgb4444 = 0x32315258;
+        static uint32_t const xbgr4444 = 0x32314258;
+        static uint32_t const rgbx4444 = 0x32315852;
+        static uint32_t const bgrx4444 = 0x32315842;
+        static uint32_t const argb4444 = 0x32315241;
+        static uint32_t const abgr4444 = 0x32314241;
+        static uint32_t const rgba4444 = 0x32314152;
+        static uint32_t const bgra4444 = 0x32314142;
+        static uint32_t const xrgb1555 = 0x35315258;
+        static uint32_t const xbgr1555 = 0x35314258;
+        static uint32_t const rgbx5551 = 0x35315852;
+        static uint32_t const bgrx5551 = 0x35315842;
+        static uint32_t const argb1555 = 0x35315241;
+        static uint32_t const abgr1555 = 0x35314241;
+        static uint32_t const rgba5551 = 0x35314152;
+        static uint32_t const bgra5551 = 0x35314142;
+        static uint32_t const rgb565 = 0x36314752;
+        static uint32_t const bgr565 = 0x36314742;
+        static uint32_t const rgb888 = 0x34324752;
+        static uint32_t const bgr888 = 0x34324742;
+        static uint32_t const xbgr8888 = 0x34324258;
+        static uint32_t const rgbx8888 = 0x34325852;
+        static uint32_t const bgrx8888 = 0x34325842;
+        static uint32_t const abgr8888 = 0x34324241;
+        static uint32_t const rgba8888 = 0x34324152;
+        static uint32_t const bgra8888 = 0x34324142;
+        static uint32_t const xrgb2101010 = 0x30335258;
+        static uint32_t const xbgr2101010 = 0x30334258;
+        static uint32_t const rgbx1010102 = 0x30335852;
+        static uint32_t const bgrx1010102 = 0x30335842;
+        static uint32_t const argb2101010 = 0x30335241;
+        static uint32_t const abgr2101010 = 0x30334241;
+        static uint32_t const rgba1010102 = 0x30334152;
+        static uint32_t const bgra1010102 = 0x30334142;
+        static uint32_t const yuyv = 0x56595559;
+        static uint32_t const yvyu = 0x55595659;
+        static uint32_t const uyvy = 0x59565955;
+        static uint32_t const vyuy = 0x59555956;
+        static uint32_t const ayuv = 0x56555941;
+        static uint32_t const nv12 = 0x3231564e;
+        static uint32_t const nv21 = 0x3132564e;
+        static uint32_t const nv16 = 0x3631564e;
+        static uint32_t const nv61 = 0x3136564e;
+        static uint32_t const yuv410 = 0x39565559;
+        static uint32_t const yvu410 = 0x39555659;
+        static uint32_t const yuv411 = 0x31315559;
+        static uint32_t const yvu411 = 0x31315659;
+        static uint32_t const yuv420 = 0x32315559;
+        static uint32_t const yvu420 = 0x32315659;
+        static uint32_t const yuv422 = 0x36315559;
+        static uint32_t const yvu422 = 0x36315659;
+        static uint32_t const yuv444 = 0x34325559;
+        static uint32_t const yvu444 = 0x34325659;
     };
 
     struct Opcode
     {
-        static uint32_t const FORMAT = 0;
+        static uint32_t const format = 0;
     };
 
 private:
@@ -226,7 +226,7 @@ public:
 
     struct Opcode
     {
-        static uint32_t const RELEASE = 0;
+        static uint32_t const release = 0;
     };
 
 private:
@@ -258,17 +258,17 @@ public:
 
     struct Error
     {
-        static uint32_t const INVALID_FINISH = 0;
-        static uint32_t const INVALID_ACTION_MASK = 1;
-        static uint32_t const INVALID_ACTION = 2;
-        static uint32_t const INVALID_OFFER = 3;
+        static uint32_t const invalid_finish = 0;
+        static uint32_t const invalid_action_mask = 1;
+        static uint32_t const invalid_action = 2;
+        static uint32_t const invalid_offer = 3;
     };
 
     struct Opcode
     {
-        static uint32_t const OFFER = 0;
-        static uint32_t const SOURCE_ACTIONS = 1;
-        static uint32_t const ACTION = 2;
+        static uint32_t const offer = 0;
+        static uint32_t const source_actions = 1;
+        static uint32_t const action = 2;
     };
 
 private:
@@ -308,18 +308,18 @@ public:
 
     struct Error
     {
-        static uint32_t const INVALID_ACTION_MASK = 0;
-        static uint32_t const INVALID_SOURCE = 1;
+        static uint32_t const invalid_action_mask = 0;
+        static uint32_t const invalid_source = 1;
     };
 
     struct Opcode
     {
-        static uint32_t const TARGET = 0;
-        static uint32_t const SEND = 1;
-        static uint32_t const CANCELLED = 2;
-        static uint32_t const DND_DROP_PERFORMED = 3;
-        static uint32_t const DND_FINISHED = 4;
-        static uint32_t const ACTION = 5;
+        static uint32_t const target = 0;
+        static uint32_t const send = 1;
+        static uint32_t const cancelled = 2;
+        static uint32_t const dnd_drop_performed = 3;
+        static uint32_t const dnd_finished = 4;
+        static uint32_t const action = 5;
     };
 
 private:
@@ -354,17 +354,17 @@ public:
 
     struct Error
     {
-        static uint32_t const ROLE = 0;
+        static uint32_t const role = 0;
     };
 
     struct Opcode
     {
-        static uint32_t const DATA_OFFER = 0;
-        static uint32_t const ENTER = 1;
-        static uint32_t const LEAVE = 2;
-        static uint32_t const MOTION = 3;
-        static uint32_t const DROP = 4;
-        static uint32_t const SELECTION = 5;
+        static uint32_t const data_offer = 0;
+        static uint32_t const enter = 1;
+        static uint32_t const leave = 2;
+        static uint32_t const motion = 3;
+        static uint32_t const drop = 4;
+        static uint32_t const selection = 5;
     };
 
 private:
@@ -392,10 +392,10 @@ public:
 
     struct DndAction
     {
-        static uint32_t const NONE = 0;
-        static uint32_t const COPY = 1;
-        static uint32_t const MOVE = 2;
-        static uint32_t const ASK = 4;
+        static uint32_t const none = 0;
+        static uint32_t const copy = 1;
+        static uint32_t const move = 2;
+        static uint32_t const ask = 4;
     };
 
 private:
@@ -424,7 +424,7 @@ public:
 
     struct Error
     {
-        static uint32_t const ROLE = 0;
+        static uint32_t const role = 0;
     };
 
 private:
@@ -456,35 +456,35 @@ public:
 
     struct Resize
     {
-        static uint32_t const NONE = 0;
-        static uint32_t const TOP = 1;
-        static uint32_t const BOTTOM = 2;
-        static uint32_t const LEFT = 4;
-        static uint32_t const TOP_LEFT = 5;
-        static uint32_t const BOTTOM_LEFT = 6;
-        static uint32_t const RIGHT = 8;
-        static uint32_t const TOP_RIGHT = 9;
-        static uint32_t const BOTTOM_RIGHT = 10;
+        static uint32_t const none = 0;
+        static uint32_t const top = 1;
+        static uint32_t const bottom = 2;
+        static uint32_t const left = 4;
+        static uint32_t const top_left = 5;
+        static uint32_t const bottom_left = 6;
+        static uint32_t const right = 8;
+        static uint32_t const top_right = 9;
+        static uint32_t const bottom_right = 10;
     };
 
     struct Transient
     {
-        static uint32_t const INACTIVE = 0x1;
+        static uint32_t const inactive = 0x1;
     };
 
     struct FullscreenMethod
     {
-        static uint32_t const DEFAULT = 0;
-        static uint32_t const SCALE = 1;
-        static uint32_t const DRIVER = 2;
-        static uint32_t const FILL = 3;
+        static uint32_t const default_ = 0;
+        static uint32_t const scale = 1;
+        static uint32_t const driver = 2;
+        static uint32_t const fill = 3;
     };
 
     struct Opcode
     {
-        static uint32_t const PING = 0;
-        static uint32_t const CONFIGURE = 1;
-        static uint32_t const POPUP_DONE = 2;
+        static uint32_t const ping = 0;
+        static uint32_t const configure = 1;
+        static uint32_t const popup_done = 2;
     };
 
 private:
@@ -522,14 +522,14 @@ public:
 
     struct Error
     {
-        static uint32_t const INVALID_SCALE = 0;
-        static uint32_t const INVALID_TRANSFORM = 1;
+        static uint32_t const invalid_scale = 0;
+        static uint32_t const invalid_transform = 1;
     };
 
     struct Opcode
     {
-        static uint32_t const ENTER = 0;
-        static uint32_t const LEAVE = 1;
+        static uint32_t const enter = 0;
+        static uint32_t const leave = 1;
     };
 
 private:
@@ -568,15 +568,15 @@ public:
 
     struct Capability
     {
-        static uint32_t const POINTER = 1;
-        static uint32_t const KEYBOARD = 2;
-        static uint32_t const TOUCH = 4;
+        static uint32_t const pointer = 1;
+        static uint32_t const keyboard = 2;
+        static uint32_t const touch = 4;
     };
 
     struct Opcode
     {
-        static uint32_t const CAPABILITIES = 0;
-        static uint32_t const NAME = 1;
+        static uint32_t const capabilities = 0;
+        static uint32_t const name = 1;
     };
 
 private:
@@ -621,40 +621,40 @@ public:
 
     struct Error
     {
-        static uint32_t const ROLE = 0;
+        static uint32_t const role = 0;
     };
 
     struct ButtonState
     {
-        static uint32_t const RELEASED = 0;
-        static uint32_t const PRESSED = 1;
+        static uint32_t const released = 0;
+        static uint32_t const pressed = 1;
     };
 
     struct Axis
     {
-        static uint32_t const VERTICAL_SCROLL = 0;
-        static uint32_t const HORIZONTAL_SCROLL = 1;
+        static uint32_t const vertical_scroll = 0;
+        static uint32_t const horizontal_scroll = 1;
     };
 
     struct AxisSource
     {
-        static uint32_t const WHEEL = 0;
-        static uint32_t const FINGER = 1;
-        static uint32_t const CONTINUOUS = 2;
-        static uint32_t const WHEEL_TILT = 3;
+        static uint32_t const wheel = 0;
+        static uint32_t const finger = 1;
+        static uint32_t const continuous = 2;
+        static uint32_t const wheel_tilt = 3;
     };
 
     struct Opcode
     {
-        static uint32_t const ENTER = 0;
-        static uint32_t const LEAVE = 1;
-        static uint32_t const MOTION = 2;
-        static uint32_t const BUTTON = 3;
-        static uint32_t const AXIS = 4;
-        static uint32_t const FRAME = 5;
-        static uint32_t const AXIS_SOURCE = 6;
-        static uint32_t const AXIS_STOP = 7;
-        static uint32_t const AXIS_DISCRETE = 8;
+        static uint32_t const enter = 0;
+        static uint32_t const leave = 1;
+        static uint32_t const motion = 2;
+        static uint32_t const button = 3;
+        static uint32_t const axis = 4;
+        static uint32_t const frame = 5;
+        static uint32_t const axis_source = 6;
+        static uint32_t const axis_stop = 7;
+        static uint32_t const axis_discrete = 8;
     };
 
 private:
@@ -689,24 +689,24 @@ public:
 
     struct KeymapFormat
     {
-        static uint32_t const NO_KEYMAP = 0;
-        static uint32_t const XKB_V1 = 1;
+        static uint32_t const no_keymap = 0;
+        static uint32_t const xkb_v1 = 1;
     };
 
     struct KeyState
     {
-        static uint32_t const RELEASED = 0;
-        static uint32_t const PRESSED = 1;
+        static uint32_t const released = 0;
+        static uint32_t const pressed = 1;
     };
 
     struct Opcode
     {
-        static uint32_t const KEYMAP = 0;
-        static uint32_t const ENTER = 1;
-        static uint32_t const LEAVE = 2;
-        static uint32_t const KEY = 3;
-        static uint32_t const MODIFIERS = 4;
-        static uint32_t const REPEAT_INFO = 5;
+        static uint32_t const keymap = 0;
+        static uint32_t const enter = 1;
+        static uint32_t const leave = 2;
+        static uint32_t const key = 3;
+        static uint32_t const modifiers = 4;
+        static uint32_t const repeat_info = 5;
     };
 
 private:
@@ -742,13 +742,13 @@ public:
 
     struct Opcode
     {
-        static uint32_t const DOWN = 0;
-        static uint32_t const UP = 1;
-        static uint32_t const MOTION = 2;
-        static uint32_t const FRAME = 3;
-        static uint32_t const CANCEL = 4;
-        static uint32_t const SHAPE = 5;
-        static uint32_t const ORIENTATION = 6;
+        static uint32_t const down = 0;
+        static uint32_t const up = 1;
+        static uint32_t const motion = 2;
+        static uint32_t const frame = 3;
+        static uint32_t const cancel = 4;
+        static uint32_t const shape = 5;
+        static uint32_t const orientation = 6;
     };
 
 private:
@@ -781,38 +781,38 @@ public:
 
     struct Subpixel
     {
-        static uint32_t const UNKNOWN = 0;
-        static uint32_t const NONE = 1;
-        static uint32_t const HORIZONTAL_RGB = 2;
-        static uint32_t const HORIZONTAL_BGR = 3;
-        static uint32_t const VERTICAL_RGB = 4;
-        static uint32_t const VERTICAL_BGR = 5;
+        static uint32_t const unknown = 0;
+        static uint32_t const none = 1;
+        static uint32_t const horizontal_rgb = 2;
+        static uint32_t const horizontal_bgr = 3;
+        static uint32_t const vertical_rgb = 4;
+        static uint32_t const vertical_bgr = 5;
     };
 
     struct Transform
     {
-        static uint32_t const NORMAL = 0;
+        static uint32_t const normal = 0;
         static uint32_t const _90 = 1;
         static uint32_t const _180 = 2;
         static uint32_t const _270 = 3;
-        static uint32_t const FLIPPED = 4;
-        static uint32_t const FLIPPED_90 = 5;
-        static uint32_t const FLIPPED_180 = 6;
-        static uint32_t const FLIPPED_270 = 7;
+        static uint32_t const flipped = 4;
+        static uint32_t const flipped_90 = 5;
+        static uint32_t const flipped_180 = 6;
+        static uint32_t const flipped_270 = 7;
     };
 
     struct Mode
     {
-        static uint32_t const CURRENT = 0x1;
-        static uint32_t const PREFERRED = 0x2;
+        static uint32_t const current = 0x1;
+        static uint32_t const preferred = 0x2;
     };
 
     struct Opcode
     {
-        static uint32_t const GEOMETRY = 0;
-        static uint32_t const MODE = 1;
-        static uint32_t const DONE = 2;
-        static uint32_t const SCALE = 3;
+        static uint32_t const geometry = 0;
+        static uint32_t const mode = 1;
+        static uint32_t const done = 2;
+        static uint32_t const scale = 3;
     };
 
 private:
@@ -863,7 +863,7 @@ public:
 
     struct Error
     {
-        static uint32_t const BAD_SURFACE = 0;
+        static uint32_t const bad_surface = 0;
     };
 
 private:
@@ -892,7 +892,7 @@ public:
 
     struct Error
     {
-        static uint32_t const BAD_SURFACE = 0;
+        static uint32_t const bad_surface = 0;
     };
 
 private:

--- a/src/server/frontend_wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
+++ b/src/server/frontend_wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
@@ -124,6 +124,11 @@ mfw::XdgShellV6::~XdgShellV6()
     wl_global_destroy(global);
 }
 
+void mfw::XdgShellV6::send_ping_event(struct wl_resource* resource, uint32_t serial)
+{
+    wl_resource_post_event(resource, 0, serial);
+}
+
 struct zxdg_shell_v6_interface const mfw::XdgShellV6::vtable = {
     Thunks::destroy_thunk,
     Thunks::create_positioner_thunk,
@@ -373,6 +378,11 @@ mfw::XdgSurfaceV6::XdgSurfaceV6(struct wl_client* client, struct wl_resource* pa
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+void mfw::XdgSurfaceV6::send_configure_event(uint32_t serial)
+{
+    wl_resource_post_event(resource, 0, serial);
 }
 
 struct zxdg_surface_v6_interface const mfw::XdgSurfaceV6::vtable = {
@@ -638,6 +648,16 @@ mfw::XdgToplevelV6::XdgToplevelV6(struct wl_client* client, struct wl_resource* 
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+void mfw::XdgToplevelV6::send_configure_event(int32_t width, int32_t height, struct wl_array* states)
+{
+    wl_resource_post_event(resource, 0, width, height, states);
+}
+
+void mfw::XdgToplevelV6::send_close_event()
+{
+    wl_resource_post_event(resource, 1);
+}
+
 struct zxdg_toplevel_v6_interface const mfw::XdgToplevelV6::vtable = {
     Thunks::destroy_thunk,
     Thunks::set_parent_thunk,
@@ -706,6 +726,16 @@ mfw::XdgPopupV6::XdgPopupV6(struct wl_client* client, struct wl_resource* parent
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+void mfw::XdgPopupV6::send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height)
+{
+    wl_resource_post_event(resource, 0, x, y, width, height);
+}
+
+void mfw::XdgPopupV6::send_popup_done_event()
+{
+    wl_resource_post_event(resource, 1);
 }
 
 struct zxdg_popup_v6_interface const mfw::XdgPopupV6::vtable = {

--- a/src/server/frontend_wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
+++ b/src/server/frontend_wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
@@ -132,7 +132,7 @@ mfw::XdgShellV6::~XdgShellV6()
 
 void mfw::XdgShellV6::send_ping_event(struct wl_resource* resource, uint32_t serial) const
 {
-    wl_resource_post_event(resource, Opcode::PING, serial);
+    wl_resource_post_event(resource, Opcode::ping, serial);
 }
 
 void mfw::XdgShellV6::destroy_wayland_object(struct wl_resource* resource) const
@@ -408,7 +408,7 @@ mfw::XdgSurfaceV6::XdgSurfaceV6(struct wl_client* client, struct wl_resource* pa
 
 void mfw::XdgSurfaceV6::send_configure_event(uint32_t serial) const
 {
-    wl_resource_post_event(resource, Opcode::CONFIGURE, serial);
+    wl_resource_post_event(resource, Opcode::configure, serial);
 }
 
 void mfw::XdgSurfaceV6::destroy_wayland_object() const
@@ -686,12 +686,12 @@ mfw::XdgToplevelV6::XdgToplevelV6(struct wl_client* client, struct wl_resource* 
 
 void mfw::XdgToplevelV6::send_configure_event(int32_t width, int32_t height, struct wl_array* states) const
 {
-    wl_resource_post_event(resource, Opcode::CONFIGURE, width, height, states);
+    wl_resource_post_event(resource, Opcode::configure, width, height, states);
 }
 
 void mfw::XdgToplevelV6::send_close_event() const
 {
-    wl_resource_post_event(resource, Opcode::CLOSE);
+    wl_resource_post_event(resource, Opcode::close);
 }
 
 void mfw::XdgToplevelV6::destroy_wayland_object() const
@@ -776,12 +776,12 @@ mfw::XdgPopupV6::XdgPopupV6(struct wl_client* client, struct wl_resource* parent
 
 void mfw::XdgPopupV6::send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const
 {
-    wl_resource_post_event(resource, Opcode::CONFIGURE, x, y, width, height);
+    wl_resource_post_event(resource, Opcode::configure, x, y, width, height);
 }
 
 void mfw::XdgPopupV6::send_popup_done_event() const
 {
-    wl_resource_post_event(resource, Opcode::POPUP_DONE);
+    wl_resource_post_event(resource, Opcode::popup_done);
 }
 
 void mfw::XdgPopupV6::destroy_wayland_object() const

--- a/src/server/frontend_wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
+++ b/src/server/frontend_wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
@@ -5,18 +5,24 @@
  * To regenerate, run the “refresh-wayland-wrapper” target.
  */
 
-#include <experimental/optional>
+#include "xdg-shell-unstable-v6_wrapper.h"
+#include "xdg-shell-unstable-v6.h"
+
 #include <boost/throw_exception.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 
-#include "xdg-shell-unstable-v6_wrapper.h"
+#include <wayland-server-core.h>
 
-#include "mir/fd.h"
 #include "mir/log.h"
 
 namespace mfw = mir::frontend::wayland;
 
 // XdgShellV6
+
+mfw::XdgShellV6* mfw::XdgShellV6::from(struct wl_resource* resource)
+{
+    return static_cast<XdgShellV6*>(wl_resource_get_user_data(resource));
+}
 
 struct mfw::XdgShellV6::Thunks
 {
@@ -124,9 +130,14 @@ mfw::XdgShellV6::~XdgShellV6()
     wl_global_destroy(global);
 }
 
-void mfw::XdgShellV6::send_ping_event(struct wl_resource* resource, uint32_t serial)
+void mfw::XdgShellV6::send_ping_event(struct wl_resource* resource, uint32_t serial) const
 {
-    wl_resource_post_event(resource, 0, serial);
+    wl_resource_post_event(resource, Opcode::PING, serial);
+}
+
+void mfw::XdgShellV6::destroy_wayland_object(struct wl_resource* resource) const
+{
+    wl_resource_destroy(resource);
 }
 
 struct zxdg_shell_v6_interface const mfw::XdgShellV6::vtable = {
@@ -136,6 +147,11 @@ struct zxdg_shell_v6_interface const mfw::XdgShellV6::vtable = {
     Thunks::pong_thunk};
 
 // XdgPositionerV6
+
+mfw::XdgPositionerV6* mfw::XdgPositionerV6::from(struct wl_resource* resource)
+{
+    return static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
+}
 
 struct mfw::XdgPositionerV6::Thunks
 {
@@ -269,6 +285,11 @@ mfw::XdgPositionerV6::XdgPositionerV6(struct wl_client* client, struct wl_resour
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+void mfw::XdgPositionerV6::destroy_wayland_object() const
+{
+    wl_resource_destroy(resource);
+}
+
 struct zxdg_positioner_v6_interface const mfw::XdgPositionerV6::vtable = {
     Thunks::destroy_thunk,
     Thunks::set_size_thunk,
@@ -279,6 +300,11 @@ struct zxdg_positioner_v6_interface const mfw::XdgPositionerV6::vtable = {
     Thunks::set_offset_thunk};
 
 // XdgSurfaceV6
+
+mfw::XdgSurfaceV6* mfw::XdgSurfaceV6::from(struct wl_resource* resource)
+{
+    return static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
+}
 
 struct mfw::XdgSurfaceV6::Thunks
 {
@@ -380,9 +406,14 @@ mfw::XdgSurfaceV6::XdgSurfaceV6(struct wl_client* client, struct wl_resource* pa
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
-void mfw::XdgSurfaceV6::send_configure_event(uint32_t serial)
+void mfw::XdgSurfaceV6::send_configure_event(uint32_t serial) const
 {
-    wl_resource_post_event(resource, 0, serial);
+    wl_resource_post_event(resource, Opcode::CONFIGURE, serial);
+}
+
+void mfw::XdgSurfaceV6::destroy_wayland_object() const
+{
+    wl_resource_destroy(resource);
 }
 
 struct zxdg_surface_v6_interface const mfw::XdgSurfaceV6::vtable = {
@@ -393,6 +424,11 @@ struct zxdg_surface_v6_interface const mfw::XdgSurfaceV6::vtable = {
     Thunks::ack_configure_thunk};
 
 // XdgToplevelV6
+
+mfw::XdgToplevelV6* mfw::XdgToplevelV6::from(struct wl_resource* resource)
+{
+    return static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
+}
 
 struct mfw::XdgToplevelV6::Thunks
 {
@@ -648,14 +684,19 @@ mfw::XdgToplevelV6::XdgToplevelV6(struct wl_client* client, struct wl_resource* 
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
-void mfw::XdgToplevelV6::send_configure_event(int32_t width, int32_t height, struct wl_array* states)
+void mfw::XdgToplevelV6::send_configure_event(int32_t width, int32_t height, struct wl_array* states) const
 {
-    wl_resource_post_event(resource, 0, width, height, states);
+    wl_resource_post_event(resource, Opcode::CONFIGURE, width, height, states);
 }
 
-void mfw::XdgToplevelV6::send_close_event()
+void mfw::XdgToplevelV6::send_close_event() const
 {
-    wl_resource_post_event(resource, 1);
+    wl_resource_post_event(resource, Opcode::CLOSE);
+}
+
+void mfw::XdgToplevelV6::destroy_wayland_object() const
+{
+    wl_resource_destroy(resource);
 }
 
 struct zxdg_toplevel_v6_interface const mfw::XdgToplevelV6::vtable = {
@@ -675,6 +716,11 @@ struct zxdg_toplevel_v6_interface const mfw::XdgToplevelV6::vtable = {
     Thunks::set_minimized_thunk};
 
 // XdgPopupV6
+
+mfw::XdgPopupV6* mfw::XdgPopupV6::from(struct wl_resource* resource)
+{
+    return static_cast<XdgPopupV6*>(wl_resource_get_user_data(resource));
+}
 
 struct mfw::XdgPopupV6::Thunks
 {
@@ -728,14 +774,19 @@ mfw::XdgPopupV6::XdgPopupV6(struct wl_client* client, struct wl_resource* parent
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
-void mfw::XdgPopupV6::send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height)
+void mfw::XdgPopupV6::send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const
 {
-    wl_resource_post_event(resource, 0, x, y, width, height);
+    wl_resource_post_event(resource, Opcode::CONFIGURE, x, y, width, height);
 }
 
-void mfw::XdgPopupV6::send_popup_done_event()
+void mfw::XdgPopupV6::send_popup_done_event() const
 {
-    wl_resource_post_event(resource, 1);
+    wl_resource_post_event(resource, Opcode::POPUP_DONE);
+}
+
+void mfw::XdgPopupV6::destroy_wayland_object() const
+{
+    wl_resource_destroy(resource);
 }
 
 struct zxdg_popup_v6_interface const mfw::XdgPopupV6::vtable = {

--- a/src/server/frontend_wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/server/frontend_wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -30,6 +30,8 @@ protected:
     XdgShellV6(struct wl_display* display, uint32_t max_version);
     virtual ~XdgShellV6();
 
+    void send_ping_event(struct wl_resource* resource, uint32_t serial);
+
     struct wl_global* const global;
     uint32_t const max_version;
 
@@ -75,6 +77,8 @@ protected:
     XdgSurfaceV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~XdgSurfaceV6() = default;
 
+    void send_configure_event(uint32_t serial);
+
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -95,6 +99,9 @@ class XdgToplevelV6
 protected:
     XdgToplevelV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~XdgToplevelV6() = default;
+
+    void send_configure_event(int32_t width, int32_t height, struct wl_array* states);
+    void send_close_event();
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -125,6 +132,9 @@ class XdgPopupV6
 protected:
     XdgPopupV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~XdgPopupV6() = default;
+
+    void send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height);
+    void send_popup_done_event();
 
     struct wl_client* const client;
     struct wl_resource* const resource;

--- a/src/server/frontend_wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/server/frontend_wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -43,17 +43,17 @@ public:
 
     struct Error
     {
-        static uint32_t const ROLE = 0;
-        static uint32_t const DEFUNCT_SURFACES = 1;
-        static uint32_t const NOT_THE_TOPMOST_POPUP = 2;
-        static uint32_t const INVALID_POPUP_PARENT = 3;
-        static uint32_t const INVALID_SURFACE_STATE = 4;
-        static uint32_t const INVALID_POSITIONER = 5;
+        static uint32_t const role = 0;
+        static uint32_t const defunct_surfaces = 1;
+        static uint32_t const not_the_topmost_popup = 2;
+        static uint32_t const invalid_popup_parent = 3;
+        static uint32_t const invalid_surface_state = 4;
+        static uint32_t const invalid_positioner = 5;
     };
 
     struct Opcode
     {
-        static uint32_t const PING = 0;
+        static uint32_t const ping = 0;
     };
 
 private:
@@ -84,36 +84,36 @@ public:
 
     struct Error
     {
-        static uint32_t const INVALID_INPUT = 0;
+        static uint32_t const invalid_input = 0;
     };
 
     struct Anchor
     {
-        static uint32_t const NONE = 0;
-        static uint32_t const TOP = 1;
-        static uint32_t const BOTTOM = 2;
-        static uint32_t const LEFT = 4;
-        static uint32_t const RIGHT = 8;
+        static uint32_t const none = 0;
+        static uint32_t const top = 1;
+        static uint32_t const bottom = 2;
+        static uint32_t const left = 4;
+        static uint32_t const right = 8;
     };
 
     struct Gravity
     {
-        static uint32_t const NONE = 0;
-        static uint32_t const TOP = 1;
-        static uint32_t const BOTTOM = 2;
-        static uint32_t const LEFT = 4;
-        static uint32_t const RIGHT = 8;
+        static uint32_t const none = 0;
+        static uint32_t const top = 1;
+        static uint32_t const bottom = 2;
+        static uint32_t const left = 4;
+        static uint32_t const right = 8;
     };
 
     struct ConstraintAdjustment
     {
-        static uint32_t const NONE = 0;
-        static uint32_t const SLIDE_X = 1;
-        static uint32_t const SLIDE_Y = 2;
-        static uint32_t const FLIP_X = 4;
-        static uint32_t const FLIP_Y = 8;
-        static uint32_t const RESIZE_X = 16;
-        static uint32_t const RESIZE_Y = 32;
+        static uint32_t const none = 0;
+        static uint32_t const slide_x = 1;
+        static uint32_t const slide_y = 2;
+        static uint32_t const flip_x = 4;
+        static uint32_t const flip_y = 8;
+        static uint32_t const resize_x = 16;
+        static uint32_t const resize_y = 32;
     };
 
 private:
@@ -147,14 +147,14 @@ public:
 
     struct Error
     {
-        static uint32_t const NOT_CONSTRUCTED = 1;
-        static uint32_t const ALREADY_CONSTRUCTED = 2;
-        static uint32_t const UNCONFIGURED_BUFFER = 3;
+        static uint32_t const not_constructed = 1;
+        static uint32_t const already_constructed = 2;
+        static uint32_t const unconfigured_buffer = 3;
     };
 
     struct Opcode
     {
-        static uint32_t const CONFIGURE = 0;
+        static uint32_t const configure = 0;
     };
 
 private:
@@ -187,29 +187,29 @@ public:
 
     struct ResizeEdge
     {
-        static uint32_t const NONE = 0;
-        static uint32_t const TOP = 1;
-        static uint32_t const BOTTOM = 2;
-        static uint32_t const LEFT = 4;
-        static uint32_t const TOP_LEFT = 5;
-        static uint32_t const BOTTOM_LEFT = 6;
-        static uint32_t const RIGHT = 8;
-        static uint32_t const TOP_RIGHT = 9;
-        static uint32_t const BOTTOM_RIGHT = 10;
+        static uint32_t const none = 0;
+        static uint32_t const top = 1;
+        static uint32_t const bottom = 2;
+        static uint32_t const left = 4;
+        static uint32_t const top_left = 5;
+        static uint32_t const bottom_left = 6;
+        static uint32_t const right = 8;
+        static uint32_t const top_right = 9;
+        static uint32_t const bottom_right = 10;
     };
 
     struct State
     {
-        static uint32_t const MAXIMIZED = 1;
-        static uint32_t const FULLSCREEN = 2;
-        static uint32_t const RESIZING = 3;
-        static uint32_t const ACTIVATED = 4;
+        static uint32_t const maximized = 1;
+        static uint32_t const fullscreen = 2;
+        static uint32_t const resizing = 3;
+        static uint32_t const activated = 4;
     };
 
     struct Opcode
     {
-        static uint32_t const CONFIGURE = 0;
-        static uint32_t const CLOSE = 1;
+        static uint32_t const configure = 0;
+        static uint32_t const close = 1;
     };
 
 private:
@@ -251,13 +251,13 @@ public:
 
     struct Error
     {
-        static uint32_t const INVALID_GRAB = 0;
+        static uint32_t const invalid_grab = 0;
     };
 
     struct Opcode
     {
-        static uint32_t const CONFIGURE = 0;
-        static uint32_t const POPUP_DONE = 1;
+        static uint32_t const configure = 0;
+        static uint32_t const popup_done = 1;
     };
 
 private:

--- a/src/server/frontend_wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/server/frontend_wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -9,13 +9,15 @@
 #define MIR_FRONTEND_WAYLAND_XDG_SHELL_UNSTABLE_V6_XML_WRAPPER
 
 #include <experimental/optional>
-#include <boost/throw_exception.hpp>
-#include <boost/exception/diagnostic_information.hpp>
-
-#include "xdg-shell-unstable-v6.h"
 
 #include "mir/fd.h"
-#include "mir/log.h"
+#include "../wayland_utils.h"
+
+struct zxdg_shell_v6_interface;
+struct zxdg_positioner_v6_interface;
+struct zxdg_surface_v6_interface;
+struct zxdg_toplevel_v6_interface;
+struct zxdg_popup_v6_interface;
 
 namespace mir
 {
@@ -26,14 +28,33 @@ namespace wayland
 
 class XdgShellV6
 {
-protected:
+public:
+    static XdgShellV6* from(struct wl_resource*);
+
     XdgShellV6(struct wl_display* display, uint32_t max_version);
     virtual ~XdgShellV6();
 
-    void send_ping_event(struct wl_resource* resource, uint32_t serial);
+    void send_ping_event(struct wl_resource* resource, uint32_t serial) const;
+
+    void destroy_wayland_object(struct wl_resource* resource) const;
 
     struct wl_global* const global;
     uint32_t const max_version;
+
+    struct Error
+    {
+        static uint32_t const ROLE = 0;
+        static uint32_t const DEFUNCT_SURFACES = 1;
+        static uint32_t const NOT_THE_TOPMOST_POPUP = 2;
+        static uint32_t const INVALID_POPUP_PARENT = 3;
+        static uint32_t const INVALID_SURFACE_STATE = 4;
+        static uint32_t const INVALID_POSITIONER = 5;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const PING = 0;
+    };
 
 private:
     struct Thunks;
@@ -50,12 +71,50 @@ private:
 
 class XdgPositionerV6
 {
-protected:
+public:
+    static XdgPositionerV6* from(struct wl_resource*);
+
     XdgPositionerV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~XdgPositionerV6() = default;
 
+    void destroy_wayland_object() const;
+
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Error
+    {
+        static uint32_t const INVALID_INPUT = 0;
+    };
+
+    struct Anchor
+    {
+        static uint32_t const NONE = 0;
+        static uint32_t const TOP = 1;
+        static uint32_t const BOTTOM = 2;
+        static uint32_t const LEFT = 4;
+        static uint32_t const RIGHT = 8;
+    };
+
+    struct Gravity
+    {
+        static uint32_t const NONE = 0;
+        static uint32_t const TOP = 1;
+        static uint32_t const BOTTOM = 2;
+        static uint32_t const LEFT = 4;
+        static uint32_t const RIGHT = 8;
+    };
+
+    struct ConstraintAdjustment
+    {
+        static uint32_t const NONE = 0;
+        static uint32_t const SLIDE_X = 1;
+        static uint32_t const SLIDE_Y = 2;
+        static uint32_t const FLIP_X = 4;
+        static uint32_t const FLIP_Y = 8;
+        static uint32_t const RESIZE_X = 16;
+        static uint32_t const RESIZE_Y = 32;
+    };
 
 private:
     struct Thunks;
@@ -73,14 +132,30 @@ private:
 
 class XdgSurfaceV6
 {
-protected:
+public:
+    static XdgSurfaceV6* from(struct wl_resource*);
+
     XdgSurfaceV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~XdgSurfaceV6() = default;
 
-    void send_configure_event(uint32_t serial);
+    void send_configure_event(uint32_t serial) const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Error
+    {
+        static uint32_t const NOT_CONSTRUCTED = 1;
+        static uint32_t const ALREADY_CONSTRUCTED = 2;
+        static uint32_t const UNCONFIGURED_BUFFER = 3;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const CONFIGURE = 0;
+    };
 
 private:
     struct Thunks;
@@ -96,15 +171,46 @@ private:
 
 class XdgToplevelV6
 {
-protected:
+public:
+    static XdgToplevelV6* from(struct wl_resource*);
+
     XdgToplevelV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~XdgToplevelV6() = default;
 
-    void send_configure_event(int32_t width, int32_t height, struct wl_array* states);
-    void send_close_event();
+    void send_configure_event(int32_t width, int32_t height, struct wl_array* states) const;
+    void send_close_event() const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct ResizeEdge
+    {
+        static uint32_t const NONE = 0;
+        static uint32_t const TOP = 1;
+        static uint32_t const BOTTOM = 2;
+        static uint32_t const LEFT = 4;
+        static uint32_t const TOP_LEFT = 5;
+        static uint32_t const BOTTOM_LEFT = 6;
+        static uint32_t const RIGHT = 8;
+        static uint32_t const TOP_RIGHT = 9;
+        static uint32_t const BOTTOM_RIGHT = 10;
+    };
+
+    struct State
+    {
+        static uint32_t const MAXIMIZED = 1;
+        static uint32_t const FULLSCREEN = 2;
+        static uint32_t const RESIZING = 3;
+        static uint32_t const ACTIVATED = 4;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const CONFIGURE = 0;
+        static uint32_t const CLOSE = 1;
+    };
 
 private:
     struct Thunks;
@@ -129,15 +235,30 @@ private:
 
 class XdgPopupV6
 {
-protected:
+public:
+    static XdgPopupV6* from(struct wl_resource*);
+
     XdgPopupV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~XdgPopupV6() = default;
 
-    void send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height);
-    void send_popup_done_event();
+    void send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const;
+    void send_popup_done_event() const;
+
+    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
+
+    struct Error
+    {
+        static uint32_t const INVALID_GRAB = 0;
+    };
+
+    struct Opcode
+    {
+        static uint32_t const CONFIGURE = 0;
+        static uint32_t const POPUP_DONE = 1;
+    };
 
 private:
     struct Thunks;

--- a/src/server/frontend_wayland/generated/xdg-shell_wrapper.cpp
+++ b/src/server/frontend_wayland/generated/xdg-shell_wrapper.cpp
@@ -132,7 +132,7 @@ mfw::XdgWmBase::~XdgWmBase()
 
 void mfw::XdgWmBase::send_ping_event(struct wl_resource* resource, uint32_t serial) const
 {
-    wl_resource_post_event(resource, Opcode::PING, serial);
+    wl_resource_post_event(resource, Opcode::ping, serial);
 }
 
 void mfw::XdgWmBase::destroy_wayland_object(struct wl_resource* resource) const
@@ -413,7 +413,7 @@ mfw::XdgSurface::XdgSurface(struct wl_client* client, struct wl_resource* parent
 
 void mfw::XdgSurface::send_configure_event(uint32_t serial) const
 {
-    wl_resource_post_event(resource, Opcode::CONFIGURE, serial);
+    wl_resource_post_event(resource, Opcode::configure, serial);
 }
 
 void mfw::XdgSurface::destroy_wayland_object() const
@@ -691,12 +691,12 @@ mfw::XdgToplevel::XdgToplevel(struct wl_client* client, struct wl_resource* pare
 
 void mfw::XdgToplevel::send_configure_event(int32_t width, int32_t height, struct wl_array* states) const
 {
-    wl_resource_post_event(resource, Opcode::CONFIGURE, width, height, states);
+    wl_resource_post_event(resource, Opcode::configure, width, height, states);
 }
 
 void mfw::XdgToplevel::send_close_event() const
 {
-    wl_resource_post_event(resource, Opcode::CLOSE);
+    wl_resource_post_event(resource, Opcode::close);
 }
 
 void mfw::XdgToplevel::destroy_wayland_object() const
@@ -781,12 +781,12 @@ mfw::XdgPopup::XdgPopup(struct wl_client* client, struct wl_resource* parent, ui
 
 void mfw::XdgPopup::send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const
 {
-    wl_resource_post_event(resource, Opcode::CONFIGURE, x, y, width, height);
+    wl_resource_post_event(resource, Opcode::configure, x, y, width, height);
 }
 
 void mfw::XdgPopup::send_popup_done_event() const
 {
-    wl_resource_post_event(resource, Opcode::POPUP_DONE);
+    wl_resource_post_event(resource, Opcode::popup_done);
 }
 
 void mfw::XdgPopup::destroy_wayland_object() const

--- a/src/server/frontend_wayland/generated/xdg-shell_wrapper.cpp
+++ b/src/server/frontend_wayland/generated/xdg-shell_wrapper.cpp
@@ -124,6 +124,11 @@ mfw::XdgWmBase::~XdgWmBase()
     wl_global_destroy(global);
 }
 
+void mfw::XdgWmBase::send_ping_event(struct wl_resource* resource, uint32_t serial)
+{
+    wl_resource_post_event(resource, 0, serial);
+}
+
 struct xdg_wm_base_interface const mfw::XdgWmBase::vtable = {
     Thunks::destroy_thunk,
     Thunks::create_positioner_thunk,
@@ -378,6 +383,11 @@ mfw::XdgSurface::XdgSurface(struct wl_client* client, struct wl_resource* parent
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+void mfw::XdgSurface::send_configure_event(uint32_t serial)
+{
+    wl_resource_post_event(resource, 0, serial);
 }
 
 struct xdg_surface_interface const mfw::XdgSurface::vtable = {
@@ -643,6 +653,16 @@ mfw::XdgToplevel::XdgToplevel(struct wl_client* client, struct wl_resource* pare
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+void mfw::XdgToplevel::send_configure_event(int32_t width, int32_t height, struct wl_array* states)
+{
+    wl_resource_post_event(resource, 0, width, height, states);
+}
+
+void mfw::XdgToplevel::send_close_event()
+{
+    wl_resource_post_event(resource, 1);
+}
+
 struct xdg_toplevel_interface const mfw::XdgToplevel::vtable = {
     Thunks::destroy_thunk,
     Thunks::set_parent_thunk,
@@ -711,6 +731,16 @@ mfw::XdgPopup::XdgPopup(struct wl_client* client, struct wl_resource* parent, ui
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, &vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+void mfw::XdgPopup::send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height)
+{
+    wl_resource_post_event(resource, 0, x, y, width, height);
+}
+
+void mfw::XdgPopup::send_popup_done_event()
+{
+    wl_resource_post_event(resource, 1);
 }
 
 struct xdg_popup_interface const mfw::XdgPopup::vtable = {

--- a/src/server/frontend_wayland/generated/xdg-shell_wrapper.h
+++ b/src/server/frontend_wayland/generated/xdg-shell_wrapper.h
@@ -30,6 +30,8 @@ protected:
     XdgWmBase(struct wl_display* display, uint32_t max_version);
     virtual ~XdgWmBase();
 
+    void send_ping_event(struct wl_resource* resource, uint32_t serial);
+
     struct wl_global* const global;
     uint32_t const max_version;
 
@@ -75,6 +77,8 @@ protected:
     XdgSurface(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~XdgSurface() = default;
 
+    void send_configure_event(uint32_t serial);
+
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -95,6 +99,9 @@ class XdgToplevel
 protected:
     XdgToplevel(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~XdgToplevel() = default;
+
+    void send_configure_event(int32_t width, int32_t height, struct wl_array* states);
+    void send_close_event();
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -125,6 +132,9 @@ class XdgPopup
 protected:
     XdgPopup(struct wl_client* client, struct wl_resource* parent, uint32_t id);
     virtual ~XdgPopup() = default;
+
+    void send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height);
+    void send_popup_done_event();
 
     struct wl_client* const client;
     struct wl_resource* const resource;

--- a/src/server/frontend_wayland/generated/xdg-shell_wrapper.h
+++ b/src/server/frontend_wayland/generated/xdg-shell_wrapper.h
@@ -43,17 +43,17 @@ public:
 
     struct Error
     {
-        static uint32_t const ROLE = 0;
-        static uint32_t const DEFUNCT_SURFACES = 1;
-        static uint32_t const NOT_THE_TOPMOST_POPUP = 2;
-        static uint32_t const INVALID_POPUP_PARENT = 3;
-        static uint32_t const INVALID_SURFACE_STATE = 4;
-        static uint32_t const INVALID_POSITIONER = 5;
+        static uint32_t const role = 0;
+        static uint32_t const defunct_surfaces = 1;
+        static uint32_t const not_the_topmost_popup = 2;
+        static uint32_t const invalid_popup_parent = 3;
+        static uint32_t const invalid_surface_state = 4;
+        static uint32_t const invalid_positioner = 5;
     };
 
     struct Opcode
     {
-        static uint32_t const PING = 0;
+        static uint32_t const ping = 0;
     };
 
 private:
@@ -84,44 +84,44 @@ public:
 
     struct Error
     {
-        static uint32_t const INVALID_INPUT = 0;
+        static uint32_t const invalid_input = 0;
     };
 
     struct Anchor
     {
-        static uint32_t const NONE = 0;
-        static uint32_t const TOP = 1;
-        static uint32_t const BOTTOM = 2;
-        static uint32_t const LEFT = 3;
-        static uint32_t const RIGHT = 4;
-        static uint32_t const TOP_LEFT = 5;
-        static uint32_t const BOTTOM_LEFT = 6;
-        static uint32_t const TOP_RIGHT = 7;
-        static uint32_t const BOTTOM_RIGHT = 8;
+        static uint32_t const none = 0;
+        static uint32_t const top = 1;
+        static uint32_t const bottom = 2;
+        static uint32_t const left = 3;
+        static uint32_t const right = 4;
+        static uint32_t const top_left = 5;
+        static uint32_t const bottom_left = 6;
+        static uint32_t const top_right = 7;
+        static uint32_t const bottom_right = 8;
     };
 
     struct Gravity
     {
-        static uint32_t const NONE = 0;
-        static uint32_t const TOP = 1;
-        static uint32_t const BOTTOM = 2;
-        static uint32_t const LEFT = 3;
-        static uint32_t const RIGHT = 4;
-        static uint32_t const TOP_LEFT = 5;
-        static uint32_t const BOTTOM_LEFT = 6;
-        static uint32_t const TOP_RIGHT = 7;
-        static uint32_t const BOTTOM_RIGHT = 8;
+        static uint32_t const none = 0;
+        static uint32_t const top = 1;
+        static uint32_t const bottom = 2;
+        static uint32_t const left = 3;
+        static uint32_t const right = 4;
+        static uint32_t const top_left = 5;
+        static uint32_t const bottom_left = 6;
+        static uint32_t const top_right = 7;
+        static uint32_t const bottom_right = 8;
     };
 
     struct ConstraintAdjustment
     {
-        static uint32_t const NONE = 0;
-        static uint32_t const SLIDE_X = 1;
-        static uint32_t const SLIDE_Y = 2;
-        static uint32_t const FLIP_X = 4;
-        static uint32_t const FLIP_Y = 8;
-        static uint32_t const RESIZE_X = 16;
-        static uint32_t const RESIZE_Y = 32;
+        static uint32_t const none = 0;
+        static uint32_t const slide_x = 1;
+        static uint32_t const slide_y = 2;
+        static uint32_t const flip_x = 4;
+        static uint32_t const flip_y = 8;
+        static uint32_t const resize_x = 16;
+        static uint32_t const resize_y = 32;
     };
 
 private:
@@ -155,14 +155,14 @@ public:
 
     struct Error
     {
-        static uint32_t const NOT_CONSTRUCTED = 1;
-        static uint32_t const ALREADY_CONSTRUCTED = 2;
-        static uint32_t const UNCONFIGURED_BUFFER = 3;
+        static uint32_t const not_constructed = 1;
+        static uint32_t const already_constructed = 2;
+        static uint32_t const unconfigured_buffer = 3;
     };
 
     struct Opcode
     {
-        static uint32_t const CONFIGURE = 0;
+        static uint32_t const configure = 0;
     };
 
 private:
@@ -195,29 +195,29 @@ public:
 
     struct ResizeEdge
     {
-        static uint32_t const NONE = 0;
-        static uint32_t const TOP = 1;
-        static uint32_t const BOTTOM = 2;
-        static uint32_t const LEFT = 4;
-        static uint32_t const TOP_LEFT = 5;
-        static uint32_t const BOTTOM_LEFT = 6;
-        static uint32_t const RIGHT = 8;
-        static uint32_t const TOP_RIGHT = 9;
-        static uint32_t const BOTTOM_RIGHT = 10;
+        static uint32_t const none = 0;
+        static uint32_t const top = 1;
+        static uint32_t const bottom = 2;
+        static uint32_t const left = 4;
+        static uint32_t const top_left = 5;
+        static uint32_t const bottom_left = 6;
+        static uint32_t const right = 8;
+        static uint32_t const top_right = 9;
+        static uint32_t const bottom_right = 10;
     };
 
     struct State
     {
-        static uint32_t const MAXIMIZED = 1;
-        static uint32_t const FULLSCREEN = 2;
-        static uint32_t const RESIZING = 3;
-        static uint32_t const ACTIVATED = 4;
+        static uint32_t const maximized = 1;
+        static uint32_t const fullscreen = 2;
+        static uint32_t const resizing = 3;
+        static uint32_t const activated = 4;
     };
 
     struct Opcode
     {
-        static uint32_t const CONFIGURE = 0;
-        static uint32_t const CLOSE = 1;
+        static uint32_t const configure = 0;
+        static uint32_t const close = 1;
     };
 
 private:
@@ -259,13 +259,13 @@ public:
 
     struct Error
     {
-        static uint32_t const INVALID_GRAB = 0;
+        static uint32_t const invalid_grab = 0;
     };
 
     struct Opcode
     {
-        static uint32_t const CONFIGURE = 0;
-        static uint32_t const POPUP_DONE = 1;
+        static uint32_t const configure = 0;
+        static uint32_t const popup_done = 1;
     };
 
 private:

--- a/src/server/frontend_wayland/generator/CMakeLists.txt
+++ b/src/server/frontend_wayland/generator/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(wrapper-generator
   utils.cpp                 utils.h
   argument.cpp              argument.h
   method.cpp                method.h
+  request.cpp               request.h
   interface.cpp             interface.h
   emitter.cpp               emitter.h
 )

--- a/src/server/frontend_wayland/generator/CMakeLists.txt
+++ b/src/server/frontend_wayland/generator/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(SYSTEM ${XMLPP_INCLUDE_DIRS})
 add_executable(wrapper-generator
   wrapper_generator.cpp
   utils.cpp                 utils.h
+  enum.cpp                  enum.h
   argument.cpp              argument.h
   method.cpp                method.h
   request.cpp               request.h

--- a/src/server/frontend_wayland/generator/CMakeLists.txt
+++ b/src/server/frontend_wayland/generator/CMakeLists.txt
@@ -50,13 +50,13 @@ macro(GENERATE_PROTOCOL NAME_PREFIX PROTOCOL_NAME)
   )
   add_custom_command(OUTPUT "${OUTPUT_PATH_HEADER}"
     VERBATIM
-    COMMAND "sh" "-c" "${CMAKE_BINARY_DIR}/bin/wrapper-generator ${NAME_PREFIX} ${PROTOCOL_NAME}.h ${PROTOCOL_PATH} header > ${OUTPUT_PATH_HEADER}"
+    COMMAND "sh" "-c" "${CMAKE_BINARY_DIR}/bin/wrapper-generator ${NAME_PREFIX} ${PROTOCOL_PATH} header > ${OUTPUT_PATH_HEADER}"
     DEPENDS "${PROTOCOL_PATH}"
     DEPENDS wrapper-generator
   )
   add_custom_command(OUTPUT "${OUTPUT_PATH_SRC}"
     VERBATIM
-    COMMAND "sh" "-c" "${CMAKE_BINARY_DIR}/bin/wrapper-generator ${NAME_PREFIX} ${PROTOCOL_NAME}_wrapper.h ${PROTOCOL_PATH} source > ${OUTPUT_PATH_SRC}"
+    COMMAND "sh" "-c" "${CMAKE_BINARY_DIR}/bin/wrapper-generator ${NAME_PREFIX} ${PROTOCOL_PATH} source > ${OUTPUT_PATH_SRC}"
     DEPENDS "${PROTOCOL_PATH}"
     DEPENDS wrapper-generator
   )

--- a/src/server/frontend_wayland/generator/CMakeLists.txt
+++ b/src/server/frontend_wayland/generator/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(wrapper-generator
   argument.cpp              argument.h
   method.cpp                method.h
   request.cpp               request.h
+  event.cpp                 event.h
   interface.cpp             interface.h
   emitter.cpp               emitter.h
 )

--- a/src/server/frontend_wayland/generator/CMakeLists.txt
+++ b/src/server/frontend_wayland/generator/CMakeLists.txt
@@ -51,6 +51,7 @@ macro(GENERATE_PROTOCOL NAME_PREFIX PROTOCOL_NAME)
     VERBATIM
     COMMAND "sh" "-c" "${CMAKE_BINARY_DIR}/bin/wrapper-generator ${NAME_PREFIX} ${PROTOCOL_NAME}.h ${PROTOCOL_PATH} header > ${OUTPUT_PATH_HEADER}"
     DEPENDS "${PROTOCOL_PATH}"
+    DEPENDS wrapper-generator
   )
   add_custom_command(OUTPUT "${OUTPUT_PATH_SRC}"
     VERBATIM

--- a/src/server/frontend_wayland/generator/argument.cpp
+++ b/src/server/frontend_wayland/generator/argument.cpp
@@ -31,6 +31,11 @@ Emitter fd_wl2mir(std::string name)
     return Line{"mir::Fd ", name, "_resolved{", name, "};"};
 }
 
+Emitter fd_mir2wl(std::string name)
+{
+    return Line{"int32_t ", name, "_resolved{", name, "};"};
+}
+
 Emitter fixed_wl2mir(std::string name)
 {
     return Line{"double ", name, "_resolved{wl_fixed_to_double(", name, ")};"};
@@ -95,7 +100,7 @@ Emitter optional_string_mir2wl(std::string name)
 std::unordered_map<std::string, Argument::TypeDescriptor const> const request_type_map = {
     { "uint", { "uint32_t", "uint32_t", {} }},
     { "int", { "int32_t", "int32_t", {} }},
-    { "fd", { "mir::Fd", "int", { fd_wl2mir } }},
+    { "fd", { "mir::Fd", "int32_t", { fd_wl2mir } }},
     { "object", { "struct wl_resource*", "struct wl_resource*", {} }},
     { "string", { "std::string const&", "char const*", {} }},
     { "new_id", { "uint32_t", "uint32_t", {} }},
@@ -111,7 +116,7 @@ std::unordered_map<std::string, Argument::TypeDescriptor const> const request_op
 std::unordered_map<std::string, Argument::TypeDescriptor const> const event_type_map = {
     { "uint", { "uint32_t", "uint32_t", {} }},
     { "int", { "int32_t", "int32_t", {} }},
-    { "fd", { "mir::Fd", "int", { /* converted implicitly */ } }},
+    { "fd", { "mir::Fd", "int32_t", { fd_mir2wl } }},
     { "object", { "struct wl_resource*", "struct wl_resource*", {} }},
     { "string", { "std::string const&", "char const*", { string_mir2wl } }},
     { "new_id", { "struct wl_resource*", "struct wl_resource*", {} }},

--- a/src/server/frontend_wayland/generator/argument.cpp
+++ b/src/server/frontend_wayland/generator/argument.cpp
@@ -55,17 +55,27 @@ Emitter Argument::mir_prototype() const
     return {descriptor.mir_type, " ", name};
 }
 
+Emitter Argument::wl_call_fragment() const
+{
+    return name;
+}
+
 Emitter Argument::mir_call_fragment() const
 {
     return descriptor.converter ? (name + "_resolved") : name;
 }
 
-std::experimental::optional<Emitter> Argument::converter() const
+std::experimental::optional<Emitter> Argument::wl_to_mir_converter() const
 {
     if (descriptor.converter)
         return descriptor.converter.value()(name);
     else
-        return {};
+        return std::experimental::nullopt;
+}
+
+std::experimental::optional<Emitter> Argument::mir_to_wl_converter() const
+{
+    return std::experimental::nullopt;
 }
 
 bool Argument::argument_is_optional(xmlpp::Element const& arg)

--- a/src/server/frontend_wayland/generator/argument.h
+++ b/src/server/frontend_wayland/generator/argument.h
@@ -37,30 +37,21 @@ public:
     {
         std::string mir_type;
         std::string wl_type;
-        std::experimental::optional<std::function<Emitter(std::string)>> wl2mir;
-        std::experimental::optional<std::function<Emitter(std::string)>> mir2wl;
+        std::experimental::optional<std::function<Emitter(std::string)>> converter;
     };
 
-    Argument(xmlpp::Element const& node);
+    Argument(xmlpp::Element const& node, bool is_event);
 
     Emitter wl_prototype() const;
     Emitter mir_prototype() const;
-    Emitter wl_call_fragment() const;
-    Emitter mir_call_fragment() const;
-    std::experimental::optional<Emitter> wl2mir_converter() const;
-    std::experimental::optional<Emitter> mir2wl_converter() const;
+    Emitter call_fragment() const;
+    std::experimental::optional<Emitter> converter() const;
 
 private:
-    static bool argument_is_optional(xmlpp::Element const& arg);
-    static Emitter fd_wl2mir(std::string name);
-    static Emitter optional_object_wl2mir(std::string name);
-    static Emitter optional_string_wl2mir(std::string name);
-
-    static std::unordered_map<std::string, Argument::TypeDescriptor const> const type_map;
-    static std::unordered_map<std::string, Argument::TypeDescriptor const> const optional_type_map;
+    static TypeDescriptor get_type(xmlpp::Element const& node, bool is_event);
 
     std::string const name;
-    TypeDescriptor const& descriptor;
+    TypeDescriptor descriptor;
 };
 
 #endif // MIR_WAYLAND_GENERATOR_ARGUMENT_H

--- a/src/server/frontend_wayland/generator/argument.h
+++ b/src/server/frontend_wayland/generator/argument.h
@@ -37,8 +37,8 @@ public:
     {
         std::string mir_type;
         std::string wl_type;
-        // wl to mir converter
-        std::experimental::optional<std::function<Emitter(std::string)>> converter;
+        std::experimental::optional<std::function<Emitter(std::string)>> wl2mir;
+        std::experimental::optional<std::function<Emitter(std::string)>> mir2wl;
     };
 
     Argument(xmlpp::Element const& node);
@@ -47,14 +47,14 @@ public:
     Emitter mir_prototype() const;
     Emitter wl_call_fragment() const;
     Emitter mir_call_fragment() const;
-    std::experimental::optional<Emitter> wl_to_mir_converter() const;
-    std::experimental::optional<Emitter> mir_to_wl_converter() const;
+    std::experimental::optional<Emitter> wl2mir_converter() const;
+    std::experimental::optional<Emitter> mir2wl_converter() const;
 
 private:
     static bool argument_is_optional(xmlpp::Element const& arg);
-    static Emitter fd_converter(std::string name);
-    static Emitter optional_object_converter(std::string name);
-    static Emitter optional_string_converter(std::string name);
+    static Emitter fd_wl2mir(std::string name);
+    static Emitter optional_object_wl2mir(std::string name);
+    static Emitter optional_string_wl2mir(std::string name);
 
     static std::unordered_map<std::string, Argument::TypeDescriptor const> const type_map;
     static std::unordered_map<std::string, Argument::TypeDescriptor const> const optional_type_map;

--- a/src/server/frontend_wayland/generator/argument.h
+++ b/src/server/frontend_wayland/generator/argument.h
@@ -45,8 +45,10 @@ public:
 
     Emitter wl_prototype() const;
     Emitter mir_prototype() const;
+    Emitter wl_call_fragment() const;
     Emitter mir_call_fragment() const;
-    std::experimental::optional<Emitter> converter() const;
+    std::experimental::optional<Emitter> wl_to_mir_converter() const;
+    std::experimental::optional<Emitter> mir_to_wl_converter() const;
 
 private:
     static bool argument_is_optional(xmlpp::Element const& arg);

--- a/src/server/frontend_wayland/generator/enum.cpp
+++ b/src/server/frontend_wayland/generator/enum.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored By: William Wold <william.wold@canonical.com>
+ */
+
+#include "enum.h"
+#include "utils.h"
+
+#include <libxml++/libxml++.h>
+
+Enum::Enum(xmlpp::Element const& node)
+    : name{sanitize_name(to_camel_case(node.get_attribute_value("name")))}
+{
+    for (auto const& child : node.get_children("entry"))
+    {
+        auto entry_node = dynamic_cast<xmlpp::Element const*>(child);
+        std::string entry_name = to_upper_case(entry_node->get_attribute_value("name"));
+        std::string entry_value_str = entry_node->get_attribute_value("value");
+        entries.emplace_back(Entry{entry_name, entry_value_str});
+    }
+}
+
+Emitter Enum::declaration() const
+{
+    std::vector<Emitter> body;
+    for (auto const& entry : entries)
+    {
+        body.push_back({"static uint32_t const ", entry.name, " = ", entry.value, ";"});
+    }
+
+    return Lines{
+        {"struct ", name},
+        {Block{
+            body
+        }, ";"}
+    };
+}

--- a/src/server/frontend_wayland/generator/enum.cpp
+++ b/src/server/frontend_wayland/generator/enum.cpp
@@ -27,7 +27,7 @@ Enum::Enum(xmlpp::Element const& node)
     for (auto const& child : node.get_children("entry"))
     {
         auto entry_node = dynamic_cast<xmlpp::Element const*>(child);
-        std::string entry_name = to_upper_case(entry_node->get_attribute_value("name"));
+        std::string entry_name = sanitize_name(entry_node->get_attribute_value("name"));
         std::string entry_value_str = entry_node->get_attribute_value("value");
         entries.emplace_back(Entry{entry_name, entry_value_str});
     }

--- a/src/server/frontend_wayland/generator/enum.h
+++ b/src/server/frontend_wayland/generator/enum.h
@@ -16,18 +16,32 @@
  * Authored By: William Wold <william.wold@canonical.com>
  */
 
-#include "method.h"
+#ifndef MIR_WAYLAND_GENERATOR_ENUM_H
+#define MIR_WAYLAND_GENERATOR_ENUM_H
 
-#include <libxml++/libxml++.h>
+#include "emitter.h"
 
-Method::Method(xmlpp::Element const& node, std::string const& class_name, bool is_global, bool is_event)
-    : name{node.get_attribute_value("name")},
-      class_name{class_name},
-      is_global{is_global}
+namespace xmlpp
 {
-    for (auto const& child : node.get_children("arg"))
-    {
-        auto arg_node = dynamic_cast<xmlpp::Element const*>(child);
-        arguments.emplace_back(std::ref(*arg_node), is_event);
-    }
+class Element;
 }
+
+class Enum
+{
+public:
+    struct Entry
+    {
+        std::string name;
+        std::string value;
+    };
+
+    Enum(xmlpp::Element const& node);
+
+    Emitter declaration() const;
+
+private:
+    std::string const name;
+    std::vector<Entry> entries;
+};
+
+#endif // MIR_WAYLAND_GENERATOR_ARGUMENT_H

--- a/src/server/frontend_wayland/generator/event.cpp
+++ b/src/server/frontend_wayland/generator/event.cpp
@@ -27,13 +27,13 @@ Event::Event(xmlpp::Element const& node, std::string const& class_name, bool is_
 // TODO: Decide whether to resolve wl_resource* to wrapped types (ie: Region, Surface, etc).
 Emitter Event::prototype() const
 {
-    return {"void send_", name, "(", mir_args(), ");"};
+    return {"void send_", name, "_event(", mir_args(), ");"};
 }
 
 // TODO: Decide whether to resolve wl_resource* to wrapped types (ie: Region, Surface, etc).
 Emitter Event::impl() const
 {
-    return {"static void send_", name, "(", mir_args(), ")",
+    return {"void mfw::", class_name, "::send_", name, "_event(", mir_args(), ")",
         Block{
             mir2wl_converters(),
             {"wl_resource_post_event(", wl_call_args(), ");"},
@@ -50,6 +50,20 @@ Emitter Event::mir2wl_converters() const
             thunk_converters.push_back(converter.value());
     }
     return Lines{thunk_converters};
+}
+
+Emitter Event::mir_args() const
+{
+    std::vector<Emitter> mir_args;
+    if (is_global)
+    {
+        mir_args.push_back("struct wl_resource* resource");
+    }
+    for (auto& i : arguments)
+    {
+        mir_args.push_back(i.mir_prototype());
+    }
+    return List{mir_args, ", "};
 }
 
 Emitter Event::wl_call_args() const

--- a/src/server/frontend_wayland/generator/event.cpp
+++ b/src/server/frontend_wayland/generator/event.cpp
@@ -30,7 +30,7 @@ Event::Event(xmlpp::Element const& node, std::string const& class_name, bool is_
 
 Emitter Event::opcode_declare() const
 {
-    return Line{"static uint32_t const ", to_upper_case(name), " = ", std::to_string(opcode), ";"};
+    return Line{"static uint32_t const ", sanitize_name(name), " = ", std::to_string(opcode), ";"};
 }
 
 // TODO: Decide whether to resolve wl_resource* to wrapped types (ie: Region, Surface, etc).
@@ -94,7 +94,7 @@ Emitter Event::mir_args() const
 
 Emitter Event::wl_call_args() const
 {
-    std::vector<Emitter> call_args{"resource", "Opcode::" + to_upper_case(name)};
+    std::vector<Emitter> call_args{"resource", "Opcode::" + sanitize_name(name)};
     for (auto& arg : arguments)
         call_args.push_back(arg.call_fragment());
     return List{call_args, ", "};

--- a/src/server/frontend_wayland/generator/event.cpp
+++ b/src/server/frontend_wayland/generator/event.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored By: William Wold <william.wold@canonical.com>
+ */
+
+#include "event.h"
+
+Event::Event(xmlpp::Element const& node, std::string const& class_name, bool is_global, int opcode)
+    : Method{node, class_name, is_global},
+      opcode{opcode}
+{
+}
+
+// TODO: Decide whether to resolve wl_resource* to wrapped types (ie: Region, Surface, etc).
+Emitter Event::prototype() const
+{
+    return {"void send_", name, "(", mir_args(), ");"};
+}
+
+// TODO: Decide whether to resolve wl_resource* to wrapped types (ie: Region, Surface, etc).
+Emitter Event::impl() const
+{
+    return {"static void send_", name, "(", mir_args(), ")",
+        Block{
+            mir_to_wl_converters(),
+            {"wl_resource_post_event(", wl_call_args(), ");"},
+        }
+    };
+}
+
+Emitter Event::mir_to_wl_converters() const
+{
+    std::vector<Emitter> thunk_converters;
+    for (auto const& arg : arguments)
+    {
+        if (auto converter = arg.mir_to_wl_converter())
+            thunk_converters.push_back(converter.value());
+    }
+    return Lines{thunk_converters};
+}
+
+Emitter Event::wl_call_args() const
+{
+    std::vector<Emitter> call_args{"resource", std::to_string(opcode)};
+    for (auto& arg : arguments)
+        call_args.push_back(arg.wl_call_fragment());
+    return List{call_args, ", "};
+}

--- a/src/server/frontend_wayland/generator/event.cpp
+++ b/src/server/frontend_wayland/generator/event.cpp
@@ -35,18 +35,18 @@ Emitter Event::impl() const
 {
     return {"static void send_", name, "(", mir_args(), ")",
         Block{
-            mir_to_wl_converters(),
+            mir2wl_converters(),
             {"wl_resource_post_event(", wl_call_args(), ");"},
         }
     };
 }
 
-Emitter Event::mir_to_wl_converters() const
+Emitter Event::mir2wl_converters() const
 {
     std::vector<Emitter> thunk_converters;
     for (auto const& arg : arguments)
     {
-        if (auto converter = arg.mir_to_wl_converter())
+        if (auto converter = arg.mir2wl_converter())
             thunk_converters.push_back(converter.value());
     }
     return Lines{thunk_converters};

--- a/src/server/frontend_wayland/generator/event.cpp
+++ b/src/server/frontend_wayland/generator/event.cpp
@@ -46,7 +46,7 @@ Emitter Event::mir2wl_converters() const
     std::vector<Emitter> thunk_converters;
     for (auto const& arg : arguments)
     {
-        if (auto converter = arg.mir2wl_converter())
+        if (auto converter = arg.converter())
             thunk_converters.push_back(converter.value());
     }
     return Lines{thunk_converters};

--- a/src/server/frontend_wayland/generator/event.h
+++ b/src/server/frontend_wayland/generator/event.h
@@ -33,6 +33,8 @@ protected:
     // converts wl input types to mir types
     Emitter mir2wl_converters() const;
 
+    Emitter mir_args() const;
+
     // arguments to call the virtual mir function call (just names, no types)
     Emitter wl_call_args() const;
 

--- a/src/server/frontend_wayland/generator/event.h
+++ b/src/server/frontend_wayland/generator/event.h
@@ -31,7 +31,7 @@ public:
 
 protected:
     // converts wl input types to mir types
-    Emitter mir_to_wl_converters() const;
+    Emitter mir2wl_converters() const;
 
     // arguments to call the virtual mir function call (just names, no types)
     Emitter wl_call_args() const;

--- a/src/server/frontend_wayland/generator/event.h
+++ b/src/server/frontend_wayland/generator/event.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored By: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_WAYLAND_GENERATOR_EVENT_H
+#define MIR_WAYLAND_GENERATOR_EVENT_H
+
+#include "method.h"
+
+class Event : public Method
+{
+public:
+    Event(xmlpp::Element const& node, std::string const& class_name, bool is_global, int opcode);
+
+    Emitter prototype() const;
+    Emitter impl() const;
+
+protected:
+    // converts wl input types to mir types
+    Emitter mir_to_wl_converters() const;
+
+    // arguments to call the virtual mir function call (just names, no types)
+    Emitter wl_call_args() const;
+
+    int const opcode;
+};
+
+#endif // MIR_WAYLAND_GENERATOR_EVENT_H

--- a/src/server/frontend_wayland/generator/event.h
+++ b/src/server/frontend_wayland/generator/event.h
@@ -26,6 +26,7 @@ class Event : public Method
 public:
     Event(xmlpp::Element const& node, std::string const& class_name, bool is_global, int opcode);
 
+    Emitter opcode_declare() const;
     Emitter prototype() const;
     Emitter impl() const;
 
@@ -38,7 +39,10 @@ protected:
     // arguments to call the virtual mir function call (just names, no types)
     Emitter wl_call_args() const;
 
+    static int get_since_version(xmlpp::Element const& node);
+
     int const opcode;
+    int const min_version;
 };
 
 #endif // MIR_WAYLAND_GENERATOR_EVENT_H

--- a/src/server/frontend_wayland/generator/interface.cpp
+++ b/src/server/frontend_wayland/generator/interface.cpp
@@ -46,6 +46,7 @@ Emitter Interface::declaration() const
                 constructor_prototype(),
                 destructor_prototype(),
             },
+            event_prototypes(),
             member_vars(),
         }, empty_line, Emitter::single_indent},
         empty_line,
@@ -54,7 +55,6 @@ Emitter Interface::declaration() const
             (thunks_impl_contents().is_valid() ? "struct Thunks;" : nullptr),
             (is_global ? bind_prototype() : nullptr),
             virtual_request_prototypes(),
-            event_prototypes(),
             (has_vtable ? vtable_declare() : nullptr),
         }, empty_line, Emitter::single_indent},
         "};"
@@ -70,6 +70,7 @@ Emitter Interface::implementation() const
             thunks_impl(),
             constructor_impl(),
             destructor_impl(),
+            event_impls(),
             (has_vtable ? vtable_init() : nullptr),
         }, empty_line},
     };
@@ -175,6 +176,16 @@ Emitter Interface::event_prototypes() const
         prototypes.push_back(event.prototype());
     }
     return Lines{prototypes};
+}
+
+Emitter Interface::event_impls() const
+{
+    std::vector<Emitter> impls;
+    for (auto const& event : events)
+    {
+        impls.push_back(event.impl());
+    }
+    return List{impls, empty_line};
 }
 
 Emitter Interface::member_vars() const

--- a/src/server/frontend_wayland/generator/interface.cpp
+++ b/src/server/frontend_wayland/generator/interface.cpp
@@ -82,10 +82,22 @@ Emitter Interface::implementation() const
         {"// ", generated_name},
         empty_line,
         List{{
+            Lines{
+                {"mfw::", generated_name, "* ", nmspace, "from(struct wl_resource* resource)"},
+                Block{
+                    {"return static_cast<", generated_name, "*>(wl_resource_get_user_data(resource));"}
+                }
+            },
             thunks_impl(),
             constructor_impl(),
             destructor_impl(),
             event_impls(),
+            Lines{
+                {"void ", nmspace, "destroy_wayland_object(", is_global ? "struct wl_resource* resource" : nullptr, ") const"},
+                Block{
+                    {"wl_resource_destroy(resource);"}
+                }
+            },
             (has_vtable ? vtable_init() : nullptr),
         }, empty_line},
     };

--- a/src/server/frontend_wayland/generator/interface.h
+++ b/src/server/frontend_wayland/generator/interface.h
@@ -42,6 +42,7 @@ public:
               std::function<std::string(std::string)> const& name_transform,
               std::unordered_set<std::string> const& constructable_interfaces);
 
+    Emitter global_namespace_forward_declarations() const;
     Emitter declaration() const;
     Emitter implementation() const;
 

--- a/src/server/frontend_wayland/generator/interface.h
+++ b/src/server/frontend_wayland/generator/interface.h
@@ -20,7 +20,7 @@
 #define MIR_WAYLAND_GENERATOR_INTERFACE_H
 
 #include "emitter.h"
-#include "method.h"
+#include "request.h"
 
 #include <experimental/optional>
 #include <functional>
@@ -50,7 +50,7 @@ private:
     Emitter destructor_prototype() const;
     Emitter destructor_impl() const;
     Emitter bind_prototype() const;
-    Emitter virtual_method_prototypes() const;
+    Emitter virtual_request_prototypes() const;
     Emitter member_vars() const;
     Emitter thunks_impl() const;
     Emitter thunks_impl_contents() const;
@@ -60,13 +60,13 @@ private:
     Emitter vtable_init() const;
     Emitter vtable_contents() const;
 
-    std::vector<Method> get_methods(xmlpp::Element const& node, bool is_global);
+    std::vector<Request> get_requests(xmlpp::Element const& node, bool is_global);
 
     std::string const wl_name;
     std::string const generated_name;
     std::string const nmspace;
     bool const is_global;
-    std::vector<Method> const methods;
+    std::vector<Request> const requests;
     bool const has_vtable;
 };
 

--- a/src/server/frontend_wayland/generator/interface.h
+++ b/src/server/frontend_wayland/generator/interface.h
@@ -21,6 +21,7 @@
 
 #include "emitter.h"
 #include "request.h"
+#include "event.h"
 
 #include <experimental/optional>
 #include <functional>
@@ -51,6 +52,7 @@ private:
     Emitter destructor_impl() const;
     Emitter bind_prototype() const;
     Emitter virtual_request_prototypes() const;
+    Emitter event_prototypes() const;
     Emitter member_vars() const;
     Emitter thunks_impl() const;
     Emitter thunks_impl_contents() const;
@@ -61,12 +63,14 @@ private:
     Emitter vtable_contents() const;
 
     std::vector<Request> get_requests(xmlpp::Element const& node, bool is_global);
+    std::vector<Event> get_events(xmlpp::Element const& node, bool is_global);
 
     std::string const wl_name;
     std::string const generated_name;
     std::string const nmspace;
     bool const is_global;
     std::vector<Request> const requests;
+    std::vector<Event> const events;
     bool const has_vtable;
 };
 

--- a/src/server/frontend_wayland/generator/interface.h
+++ b/src/server/frontend_wayland/generator/interface.h
@@ -53,6 +53,7 @@ private:
     Emitter bind_prototype() const;
     Emitter virtual_request_prototypes() const;
     Emitter event_prototypes() const;
+    Emitter event_impls() const;
     Emitter member_vars() const;
     Emitter thunks_impl() const;
     Emitter thunks_impl_contents() const;

--- a/src/server/frontend_wayland/generator/interface.h
+++ b/src/server/frontend_wayland/generator/interface.h
@@ -22,6 +22,7 @@
 #include "emitter.h"
 #include "request.h"
 #include "event.h"
+#include "enum.h"
 
 #include <experimental/optional>
 #include <functional>
@@ -55,16 +56,18 @@ private:
     Emitter event_prototypes() const;
     Emitter event_impls() const;
     Emitter member_vars() const;
+    Emitter enum_declarations() const;
+    Emitter event_opcodes() const;
     Emitter thunks_impl() const;
     Emitter thunks_impl_contents() const;
     Emitter bind_thunk() const;
     Emitter resource_destroyed_thunk() const;
-    Emitter vtable_declare() const;
     Emitter vtable_init() const;
     Emitter vtable_contents() const;
 
-    std::vector<Request> get_requests(xmlpp::Element const& node, bool is_global);
-    std::vector<Event> get_events(xmlpp::Element const& node, bool is_global);
+    static std::vector<Request> get_requests(xmlpp::Element const& node, std::string generated_name, bool is_global);
+    static std::vector<Event> get_events(xmlpp::Element const& node, std::string generated_name, bool is_global);
+    static std::vector<Enum> get_enums(xmlpp::Element const& node);
 
     std::string const wl_name;
     std::string const generated_name;
@@ -72,6 +75,7 @@ private:
     bool const is_global;
     std::vector<Request> const requests;
     std::vector<Event> const events;
+    std::vector<Enum> const enums;
     bool const has_vtable;
 };
 

--- a/src/server/frontend_wayland/generator/method.cpp
+++ b/src/server/frontend_wayland/generator/method.cpp
@@ -32,53 +32,6 @@ Method::Method(xmlpp::Element const& node, std::string const& class_name, bool i
     }
 }
 
-// TODO: Decide whether to resolve wl_resource* to wrapped types (ie: Region, Surface, etc).
-Emitter Method::virtual_mir_prototype() const
-{
-    return {"virtual void ", name, "(", mir_args(), ") = 0;"};
-}
-
-// TODO: Decide whether to resolve wl_resource* to wrapped types (ie: Region, Surface, etc).
-Emitter Method::thunk_impl() const
-{
-    return {"static void ", name, "_thunk(", wl_args(), ")",
-        Block{
-            {"auto me = static_cast<", class_name, "*>(wl_resource_get_user_data(resource));"},
-            converters(),
-            "try",
-            Block{
-                {"me->", name, "(", mir_call_args(), ");"}
-            },
-            "catch(...)",
-            Block{{
-                "::mir::log(",
-                    List{{"::mir::logging::Severity::critical",
-                          "\"frontend:Wayland\"",
-                          "std::current_exception()",
-                          {"\"Exception processing ", class_name, "::", name, "() request\""}},
-                        Line{{","}, false, true}, "           "},
-                ");"
-            }}
-        }
-    };
-}
-
-Emitter Method::vtable_initialiser() const
-{
-    return {name, "_thunk"};
-}
-
-Emitter Method::wl_args() const
-{
-    Emitter client_arg = "struct wl_client*";
-    if (is_global) // only bind it to a variable if we need it
-        client_arg = {client_arg, " client"};
-    std::vector<Emitter> wl_args{client_arg, "struct wl_resource* resource"};
-    for (auto const& arg : arguments)
-        wl_args.push_back(arg.wl_prototype());
-    return List{wl_args, ", "};
-}
-
 Emitter Method::mir_args() const
 {
     std::vector<Emitter> mir_args;
@@ -92,28 +45,4 @@ Emitter Method::mir_args() const
         mir_args.push_back(i.mir_prototype());
     }
     return List{mir_args, ", "};
-}
-
-Emitter Method::converters() const
-{
-    std::vector<Emitter> thunk_converters;
-    for (auto const& arg : arguments)
-    {
-        if (auto converter = arg.converter())
-            thunk_converters.push_back(converter.value());
-    }
-    return Lines{thunk_converters};
-}
-
-Emitter Method::mir_call_args() const
-{
-    std::vector<Emitter> call_args;
-    if (is_global)
-    {
-        call_args.push_back("client");
-        call_args.push_back("resource");
-    }
-    for (auto& arg : arguments)
-        call_args.push_back(arg.mir_call_fragment());
-    return List{call_args, ", "};
 }

--- a/src/server/frontend_wayland/generator/method.cpp
+++ b/src/server/frontend_wayland/generator/method.cpp
@@ -29,14 +29,14 @@ Method::Method(xmlpp::Element const& node, std::string const& class_name, bool i
 {
     for (auto const& child : node.get_children("arg"))
     {
+        auto arg_node = dynamic_cast<xmlpp::Element const*>(child);
         try
         {
-            auto arg_node = dynamic_cast<xmlpp::Element const*>(child);
             arguments.emplace_back(std::ref(*arg_node));
         }
         catch (std::out_of_range const& e)
         {
-            std::cerr << "failed to parse type" << std::endl;
+            std::cerr << "failed to parse type " << arg_node->get_attribute_value("type") << std::endl;
         }
     }
 }

--- a/src/server/frontend_wayland/generator/method.cpp
+++ b/src/server/frontend_wayland/generator/method.cpp
@@ -20,6 +20,8 @@
 
 #include <libxml++/libxml++.h>
 
+#include <iostream>
+
 Method::Method(xmlpp::Element const& node, std::string const& class_name, bool is_global)
     : name{node.get_attribute_value("name")},
       class_name{class_name},
@@ -27,8 +29,15 @@ Method::Method(xmlpp::Element const& node, std::string const& class_name, bool i
 {
     for (auto const& child : node.get_children("arg"))
     {
-        auto arg_node = dynamic_cast<xmlpp::Element const*>(child);
-        arguments.emplace_back(std::ref(*arg_node));
+        try
+        {
+            auto arg_node = dynamic_cast<xmlpp::Element const*>(child);
+            arguments.emplace_back(std::ref(*arg_node));
+        }
+        catch (std::out_of_range const& e)
+        {
+            std::cerr << "failed to parse type" << std::endl;
+        }
     }
 }
 

--- a/src/server/frontend_wayland/generator/method.cpp
+++ b/src/server/frontend_wayland/generator/method.cpp
@@ -30,13 +30,6 @@ Method::Method(xmlpp::Element const& node, std::string const& class_name, bool i
     for (auto const& child : node.get_children("arg"))
     {
         auto arg_node = dynamic_cast<xmlpp::Element const*>(child);
-        try
-        {
-            arguments.emplace_back(std::ref(*arg_node));
-        }
-        catch (std::out_of_range const& e)
-        {
-            std::cerr << "failed to parse type " << arg_node->get_attribute_value("type") << std::endl;
-        }
+        arguments.emplace_back(std::ref(*arg_node), is_event);
     }
 }

--- a/src/server/frontend_wayland/generator/method.cpp
+++ b/src/server/frontend_wayland/generator/method.cpp
@@ -40,18 +40,3 @@ Method::Method(xmlpp::Element const& node, std::string const& class_name, bool i
         }
     }
 }
-
-Emitter Method::mir_args() const
-{
-    std::vector<Emitter> mir_args;
-    if (is_global)
-    {
-        mir_args.push_back("struct wl_client* client");
-        mir_args.push_back("struct wl_resource* resource");
-    }
-    for (auto& i : arguments)
-    {
-        mir_args.push_back(i.mir_prototype());
-    }
-    return List{mir_args, ", "};
-}

--- a/src/server/frontend_wayland/generator/method.h
+++ b/src/server/frontend_wayland/generator/method.h
@@ -37,9 +37,6 @@ public:
     Method(xmlpp::Element const& node, std::string const& class_name, bool is_global);
 
 protected:
-    // arguments with the mir types
-    Emitter mir_args() const;
-
     std::string const name;
     std::string const class_name;
     bool const is_global;

--- a/src/server/frontend_wayland/generator/method.h
+++ b/src/server/frontend_wayland/generator/method.h
@@ -34,7 +34,7 @@ class Element;
 class Method
 {
 public:
-    Method(xmlpp::Element const& node, std::string const& class_name, bool is_global);
+    Method(xmlpp::Element const& node, std::string const& class_name, bool is_global, bool is_event);
 
 protected:
     std::string const name;

--- a/src/server/frontend_wayland/generator/method.h
+++ b/src/server/frontend_wayland/generator/method.h
@@ -31,34 +31,14 @@ namespace xmlpp
 class Element;
 }
 
-// represents an request handler on a Wayland object
 class Method
 {
 public:
     Method(xmlpp::Element const& node, std::string const& class_name, bool is_global);
 
-    // prototype of virtual function that is overridden in Mir
-    Emitter virtual_mir_prototype() const;
-
-    // the thunk is the static function that libwayland calls
-    // It does some type conversion and calls the virtual method, which should be overridden somewhere in Mir
-    Emitter thunk_impl() const;
-
-    // the bit of this objects vtable that holds this method
-    Emitter vtable_initialiser() const;
-
-private:
-    // arguments from libwayland to the thunk
-    Emitter wl_args() const;
-
-    // arguments of the mir virtual function to the thunk (names with types)
+protected:
+    // arguments with the mir types
     Emitter mir_args() const;
-
-    // converts wl input types to mir types
-    Emitter converters() const;
-
-    // arguments to call the virtual mir function call (just names, no types)
-    Emitter mir_call_args() const;
 
     std::string const name;
     std::string const class_name;

--- a/src/server/frontend_wayland/generator/request.cpp
+++ b/src/server/frontend_wayland/generator/request.cpp
@@ -70,6 +70,21 @@ Emitter Request::wl_args() const
     return List{wl_args, ", "};
 }
 
+Emitter Request::mir_args() const
+{
+    std::vector<Emitter> mir_args;
+    if (is_global)
+    {
+        mir_args.push_back("struct wl_client* client");
+        mir_args.push_back("struct wl_resource* resource");
+    }
+    for (auto& i : arguments)
+    {
+        mir_args.push_back(i.mir_prototype());
+    }
+    return List{mir_args, ", "};
+}
+
 Emitter Request::wl2mir_converters() const
 {
     std::vector<Emitter> thunk_converters;

--- a/src/server/frontend_wayland/generator/request.cpp
+++ b/src/server/frontend_wayland/generator/request.cpp
@@ -90,7 +90,7 @@ Emitter Request::wl2mir_converters() const
     std::vector<Emitter> thunk_converters;
     for (auto const& arg : arguments)
     {
-        if (auto converter = arg.wl2mir_converter())
+        if (auto converter = arg.converter())
             thunk_converters.push_back(converter.value());
     }
     return Lines{thunk_converters};
@@ -105,6 +105,6 @@ Emitter Request::mir_call_args() const
         call_args.push_back("resource");
     }
     for (auto& arg : arguments)
-        call_args.push_back(arg.mir_call_fragment());
+        call_args.push_back(arg.call_fragment());
     return List{call_args, ", "};
 }

--- a/src/server/frontend_wayland/generator/request.cpp
+++ b/src/server/frontend_wayland/generator/request.cpp
@@ -19,7 +19,7 @@
 #include "request.h"
 
 Request::Request(xmlpp::Element const& node, std::string const& class_name, bool is_global)
-    : Method{node, class_name, is_global}
+    : Method{node, class_name, is_global, false}
 {
 }
 

--- a/src/server/frontend_wayland/generator/request.cpp
+++ b/src/server/frontend_wayland/generator/request.cpp
@@ -75,7 +75,7 @@ Emitter Request::wl_to_mir_converters() const
     std::vector<Emitter> thunk_converters;
     for (auto const& arg : arguments)
     {
-        if (auto converter = arg.converter())
+        if (auto converter = arg.wl_to_mir_converter())
             thunk_converters.push_back(converter.value());
     }
     return Lines{thunk_converters};

--- a/src/server/frontend_wayland/generator/request.cpp
+++ b/src/server/frontend_wayland/generator/request.cpp
@@ -35,7 +35,7 @@ Emitter Request::thunk_impl() const
     return {"static void ", name, "_thunk(", wl_args(), ")",
         Block{
             {"auto me = static_cast<", class_name, "*>(wl_resource_get_user_data(resource));"},
-            wl_to_mir_converters(),
+            wl2mir_converters(),
             "try",
             Block{
                 {"me->", name, "(", mir_call_args(), ");"}
@@ -70,12 +70,12 @@ Emitter Request::wl_args() const
     return List{wl_args, ", "};
 }
 
-Emitter Request::wl_to_mir_converters() const
+Emitter Request::wl2mir_converters() const
 {
     std::vector<Emitter> thunk_converters;
     for (auto const& arg : arguments)
     {
-        if (auto converter = arg.wl_to_mir_converter())
+        if (auto converter = arg.wl2mir_converter())
             thunk_converters.push_back(converter.value());
     }
     return Lines{thunk_converters};

--- a/src/server/frontend_wayland/generator/request.cpp
+++ b/src/server/frontend_wayland/generator/request.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored By: William Wold <william.wold@canonical.com>
+ */
+
+#include "request.h"
+
+Request::Request(xmlpp::Element const& node, std::string const& class_name, bool is_global)
+    : Method{node, class_name, is_global}
+{
+}
+
+// TODO: Decide whether to resolve wl_resource* to wrapped types (ie: Region, Surface, etc).
+Emitter Request::virtual_mir_prototype() const
+{
+    return {"virtual void ", name, "(", mir_args(), ") = 0;"};
+}
+
+// TODO: Decide whether to resolve wl_resource* to wrapped types (ie: Region, Surface, etc).
+Emitter Request::thunk_impl() const
+{
+    return {"static void ", name, "_thunk(", wl_args(), ")",
+        Block{
+            {"auto me = static_cast<", class_name, "*>(wl_resource_get_user_data(resource));"},
+            wl_to_mir_converters(),
+            "try",
+            Block{
+                {"me->", name, "(", mir_call_args(), ");"}
+            },
+            "catch(...)",
+            Block{{
+                "::mir::log(",
+                List{{"::mir::logging::Severity::critical",
+                    "\"frontend:Wayland\"",
+                    "std::current_exception()",
+                    {"\"Exception processing ", class_name, "::", name, "() request\""}},
+                    Line{{","}, false, true}, "           "},
+                    ");"
+            }}
+        }
+    };
+}
+
+Emitter Request::vtable_initialiser() const
+{
+    return {name, "_thunk"};
+}
+
+Emitter Request::wl_args() const
+{
+    Emitter client_arg = "struct wl_client*";
+    if (is_global) // only bind it to a variable if we need it
+        client_arg = {client_arg, " client"};
+    std::vector<Emitter> wl_args{client_arg, "struct wl_resource* resource"};
+    for (auto const& arg : arguments)
+        wl_args.push_back(arg.wl_prototype());
+    return List{wl_args, ", "};
+}
+
+Emitter Request::wl_to_mir_converters() const
+{
+    std::vector<Emitter> thunk_converters;
+    for (auto const& arg : arguments)
+    {
+        if (auto converter = arg.converter())
+            thunk_converters.push_back(converter.value());
+    }
+    return Lines{thunk_converters};
+}
+
+Emitter Request::mir_call_args() const
+{
+    std::vector<Emitter> call_args;
+    if (is_global)
+    {
+        call_args.push_back("client");
+        call_args.push_back("resource");
+    }
+    for (auto& arg : arguments)
+        call_args.push_back(arg.mir_call_fragment());
+    return List{call_args, ", "};
+}

--- a/src/server/frontend_wayland/generator/request.h
+++ b/src/server/frontend_wayland/generator/request.h
@@ -40,6 +40,9 @@ protected:
     // arguments from libwayland to the thunk
     Emitter wl_args() const;
 
+    // arguments for mir code
+    Emitter mir_args() const;
+
     // converts wl input types to mir types
     Emitter wl2mir_converters() const;
 

--- a/src/server/frontend_wayland/generator/request.h
+++ b/src/server/frontend_wayland/generator/request.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored By: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_WAYLAND_GENERATOR_REQUEST_H
+#define MIR_WAYLAND_GENERATOR_REQUEST_H
+
+#include "method.h"
+
+class Request : public Method
+{
+public:
+    Request(xmlpp::Element const& node, std::string const& class_name, bool is_global);
+
+    // prototype of virtual function that is overridden in Mir
+    Emitter virtual_mir_prototype() const;
+
+    // the thunk is the static function that libwayland calls
+    // It does some type conversion and calls the virtual method, which should be overridden somewhere in Mir
+    Emitter thunk_impl() const;
+
+    // the bit of this objects vtable that holds this method
+    Emitter vtable_initialiser() const;
+
+protected:
+    // arguments from libwayland to the thunk
+    Emitter wl_args() const;
+
+    // converts wl input types to mir types
+    Emitter wl_to_mir_converters() const;
+
+    // arguments to call the virtual mir function call (just names, no types)
+    Emitter mir_call_args() const;
+};
+
+#endif // MIR_WAYLAND_GENERATOR_REQUEST_H

--- a/src/server/frontend_wayland/generator/request.h
+++ b/src/server/frontend_wayland/generator/request.h
@@ -41,7 +41,7 @@ protected:
     Emitter wl_args() const;
 
     // converts wl input types to mir types
-    Emitter wl_to_mir_converters() const;
+    Emitter wl2mir_converters() const;
 
     // arguments to call the virtual mir function call (just names, no types)
     Emitter mir_call_args() const;

--- a/src/server/frontend_wayland/generator/utils.cpp
+++ b/src/server/frontend_wayland/generator/utils.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <locale>
 
-const std::vector<std::string> cpp_reserved_keywords = {"namespace", "class"}; // add to this on an as-needed basis
+const std::vector<std::string> cpp_reserved_keywords = {"namespace", "class", "default"}; // add to this on an as-needed basis
 
 std::string file_name_from_path(std::string const& path)
 {

--- a/src/server/frontend_wayland/generator/utils.cpp
+++ b/src/server/frontend_wayland/generator/utils.cpp
@@ -33,17 +33,39 @@ std::string file_name_from_path(std::string const& path)
         return path.substr(i + 1);
 }
 
-std::string sanitize_name(std::string const& name)
+std::string sanitize_name(std::string const& name_, bool escape_invalid)
 {
-    std::string ret = name;
+    std::string name = name_;
+    if (name.empty())
+        name = "__EMPTY_NAME";
+    if (name[0] >= '0' && name[0] <= '9')
+        name = "_" + name;
+    for (unsigned long i = 0; i < name.size(); i++)
+    {
+        char c = name[i];
+        if ((c >= 'a' && c <= 'z') ||
+            (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') ||
+            (c == '_'))
+        {
+            // all good
+        }
+        else
+        {
+            std::string replace_str = "_";
+            if (escape_invalid)
+                replace_str = "_ASC" + std::to_string((int)name[i]) + "_";
+            name.replace(i, 1, replace_str);
+        }
+    }
     for (auto const& i: cpp_reserved_keywords)
     {
         if (i == name)
         {
-            ret = name + "_";
+            name = name + "_";
         }
     }
-    return ret;
+    return name;
 }
 
 std::string to_upper_case(std::string const& name)
@@ -51,19 +73,9 @@ std::string to_upper_case(std::string const& name)
     std::string macro_name = "";
     for (unsigned i = 0; i < name.size(); i++)
     {
-        char c = name[i];
-        if ((c >= 'a' && c <= 'z') ||
-            (c >= 'A' && c <= 'Z') ||
-            (c >= '0' && c <= '9' && i > 0))
-        {
-            macro_name += std::toupper(c, std::locale("C"));
-        }
-        else
-        {
-            macro_name += '_';
-        }
+        macro_name += std::toupper(name[i], std::locale("C"));
     }
-    return macro_name;
+    return sanitize_name(macro_name, false);
 }
 
 std::string to_camel_case(std::string const& name)
@@ -81,6 +93,6 @@ std::string to_camel_case(std::string const& name)
         }
         next_underscore_offset = camel_cased_name.find('_', next_underscore_offset);
     }
-    return camel_cased_name;
+    return sanitize_name(camel_cased_name);
 }
 

--- a/src/server/frontend_wayland/generator/utils.h
+++ b/src/server/frontend_wayland/generator/utils.h
@@ -25,7 +25,7 @@
 std::string file_name_from_path(std::string const& path);
 
 // make sure the name is not a C++ reserved word, could be expanded to get rid of invalid characters if that was needed
-std::string sanitize_name(std::string const& name);
+std::string sanitize_name(std::string const& name, bool escape_invalid = true);
 
 // converts any string into a valid, all upper case macro name (replacing special chars with underscores)
 std::string to_upper_case(std::string const& name);

--- a/src/server/frontend_wayland/wayland_utils.h
+++ b/src/server/frontend_wayland/wayland_utils.h
@@ -19,12 +19,27 @@
 #ifndef MIR_FRONTEND_WAYLAND_UTILS_H
 #define MIR_FRONTEND_WAYLAND_UTILS_H
 
-#include "wayland_utils.h"
-
 #include <memory>
 
-struct wl_client;
 struct MirInputEvent;
+
+extern "C"
+{
+struct wl_client;
+struct wl_resource;
+struct wl_display;
+struct wl_global;
+struct wl_array;
+
+struct wl_display * wl_client_get_display(struct wl_client *client);
+uint32_t wl_display_next_serial(struct wl_display *display);
+uint32_t wl_display_get_serial(struct wl_display *display);
+
+void wl_array_init(struct wl_array *array);
+void wl_array_release(struct wl_array *array);
+
+#include <wayland-server-core.h>
+}
 
 namespace mir
 {

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -59,8 +59,8 @@ mf::WlKeyboard::WlKeyboard(
     set_keymap(initial_keymap);
 
     // I don't know where to get "real" rate and delay args. These are better than nothing.
-    if (wl_resource_get_version(resource) >= WL_KEYBOARD_REPEAT_INFO_SINCE_VERSION)
-        wl_keyboard_send_repeat_info(resource, 30, 200);
+    if (version_supports_repeat_info())
+        send_repeat_info_event(30, 200);
 }
 
 mf::WlKeyboard::~WlKeyboard()
@@ -82,19 +82,17 @@ void mf::WlKeyboard::handle_keyboard_event(MirKeyboardEvent const* key_event, Wl
     {
         case mir_keyboard_action_up:
             xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_UP);
-            wl_keyboard_send_key(resource,
-                serial,
-                mir_input_event_get_event_time_ms(input_ev),
-                mir_keyboard_event_scan_code(key_event),
-                WL_KEYBOARD_KEY_STATE_RELEASED);
+            send_key_event(serial,
+                           mir_input_event_get_event_time_ms(input_ev),
+                           mir_keyboard_event_scan_code(key_event),
+                           KeyState::RELEASED);
             break;
         case mir_keyboard_action_down:
             xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_DOWN);
-            wl_keyboard_send_key(resource,
-                serial,
-                mir_input_event_get_event_time_ms(input_ev),
-                mir_keyboard_event_scan_code(key_event),
-                WL_KEYBOARD_KEY_STATE_PRESSED);
+            send_key_event(serial,
+                           mir_input_event_get_event_time_ms(input_ev),
+                           mir_keyboard_event_scan_code(key_event),
+                           KeyState::PRESSED);
             break;
         default:
             break;
@@ -144,12 +142,12 @@ void mf::WlKeyboard::handle_window_event(MirWindowEvent const* event, WlSurface*
             }
             update_modifier_state();
 
-            wl_keyboard_send_enter(resource, serial, surface->raw_resource(), &key_state);
+            send_enter_event(serial, surface->raw_resource(), &key_state);
             wl_array_release(&key_state);
         }
         else
         {
-            wl_keyboard_send_leave(resource, serial, surface->raw_resource());
+            send_leave_event(serial, surface->raw_resource());
         }
     }
 }
@@ -164,11 +162,9 @@ void mf::WlKeyboard::handle_keymap_event(MirKeymapEvent const* event, WlSurface*
     mir::AnonymousShmFile shm_buffer{length};
     memcpy(shm_buffer.base_ptr(), buffer, length);
 
-    wl_keyboard_send_keymap(
-        resource,
-        WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1,
-        shm_buffer.fd(),
-        length);
+    send_keymap_event(KeymapFormat::XKB_V1,
+                      Fd{IntOwnedFd{shm_buffer.fd()}},
+                      length);
 
     keymap = decltype(keymap)(xkb_keymap_new_from_buffer(
         context.get(),
@@ -206,11 +202,9 @@ void mf::WlKeyboard::set_keymap(mir::input::Keymap const& new_keymap)
     mir::AnonymousShmFile shm_buffer{length};
     memcpy(shm_buffer.base_ptr(), buffer.get(), length);
 
-    wl_keyboard_send_keymap(
-        resource,
-        WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1,
-        shm_buffer.fd(),
-        length);
+    send_keymap_event(KeymapFormat::XKB_V1,
+                      Fd{IntOwnedFd{shm_buffer.fd()}},
+                      length);
 }
 
 void mf::WlKeyboard::update_modifier_state()
@@ -241,13 +235,11 @@ void mf::WlKeyboard::update_modifier_state()
         mods_locked = new_locked_mods;
         group = new_group;
 
-        wl_keyboard_send_modifiers(
-            resource,
-            wl_display_get_serial(wl_client_get_display(client)),
-            mods_depressed,
-            mods_latched,
-            mods_locked,
-            group);
+        send_modifiers_event(wl_display_get_serial(wl_client_get_display(client)),
+                             mods_depressed,
+                             mods_latched,
+                             mods_locked,
+                             group);
     }
 }
 

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -86,14 +86,14 @@ void mf::WlKeyboard::handle_keyboard_event(MirKeyboardEvent const* key_event, Wl
             send_key_event(serial,
                            mir_input_event_get_event_time_ms(input_ev),
                            mir_keyboard_event_scan_code(key_event),
-                           KeyState::RELEASED);
+                           KeyState::released);
             break;
         case mir_keyboard_action_down:
             xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_DOWN);
             send_key_event(serial,
                            mir_input_event_get_event_time_ms(input_ev),
                            mir_keyboard_event_scan_code(key_event),
-                           KeyState::PRESSED);
+                           KeyState::pressed);
             break;
         default:
             break;
@@ -163,7 +163,7 @@ void mf::WlKeyboard::handle_keymap_event(MirKeymapEvent const* event, WlSurface*
     mir::AnonymousShmFile shm_buffer{length};
     memcpy(shm_buffer.base_ptr(), buffer, length);
 
-    send_keymap_event(KeymapFormat::XKB_V1,
+    send_keymap_event(KeymapFormat::xkb_v1,
                       Fd{IntOwnedFd{shm_buffer.fd()}},
                       length);
 
@@ -203,7 +203,7 @@ void mf::WlKeyboard::set_keymap(mir::input::Keymap const& new_keymap)
     mir::AnonymousShmFile shm_buffer{length};
     memcpy(shm_buffer.base_ptr(), buffer.get(), length);
 
-    send_keymap_event(KeymapFormat::XKB_V1,
+    send_keymap_event(KeymapFormat::xkb_v1,
                       Fd{IntOwnedFd{shm_buffer.fd()}},
                       length);
 }

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -27,6 +27,7 @@
 #include "mir/input/keymap.h"
 
 #include <xkbcommon/xkbcommon.h>
+#include <boost/throw_exception.hpp>
 
 #include <cstring> // memcpy
 

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -22,6 +22,7 @@
 #include "generated/wayland_wrapper.h"
 
 #include <vector>
+#include <functional>
 
 // from <xkbcommon/xkbcommon.h>
 struct xkb_keymap;

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -95,11 +95,11 @@ void mf::WlPointer::handle_event(MirPointerEvent const* event, WlSurface* surfac
                 if (mapping.first & (current_pointer_buttons ^ last_buttons))
                 {
                     auto const state = (mapping.first & current_pointer_buttons) ?
-                        WL_POINTER_BUTTON_STATE_PRESSED :
-                        WL_POINTER_BUTTON_STATE_RELEASED;
+                        ButtonState::PRESSED :
+                        ButtonState::RELEASED;
 
                     auto const serial = wl_display_next_serial(display);
-                    wl_pointer_send_button(resource, serial, timestamp, mapping.second, state);
+                    send_button_event(serial, timestamp, mapping.second, state);
                     handle_frame();
                 }
             }
@@ -138,11 +138,9 @@ void mf::WlPointer::handle_event(MirPointerEvent const* event, WlSurface* surfac
             {
                 if (!last_position || transformed.position != last_position.value())
                 {
-                    wl_pointer_send_motion(
-                        resource,
-                        timestamp,
-                        wl_fixed_from_double(transformed.position.x.as_int()),
-                        wl_fixed_from_double(transformed.position.y.as_int()));
+                    send_motion_event(timestamp,
+                                      transformed.position.x.as_int(),
+                                      transformed.position.y.as_int());
                     last_position = transformed.position;
                     needs_frame = true;
                 }
@@ -158,22 +156,18 @@ void mf::WlPointer::handle_event(MirPointerEvent const* event, WlSurface* surfac
             auto hscroll = mir_pointer_event_axis_value(event, mir_pointer_axis_hscroll) * 10;
             if (hscroll != 0)
             {
-                wl_pointer_send_axis(
-                    resource,
-                    timestamp,
-                    WL_POINTER_AXIS_HORIZONTAL_SCROLL,
-                    wl_fixed_from_double(hscroll));
+                send_axis_event(timestamp,
+                                Axis::HORIZONTAL_SCROLL,
+                                hscroll);
                 needs_frame = true;
             }
 
             auto vscroll = mir_pointer_event_axis_value(event, mir_pointer_axis_vscroll) * 10;
             if (vscroll != 0)
             {
-                wl_pointer_send_axis(
-                    resource,
-                    timestamp,
-                    WL_POINTER_AXIS_VERTICAL_SCROLL,
-                    wl_fixed_from_double(vscroll));
+                send_axis_event(timestamp,
+                                Axis::VERTICAL_SCROLL,
+                                vscroll);
                 needs_frame = true;
             }
 
@@ -192,12 +186,10 @@ void mf::WlPointer::handle_enter(Point position, WlSurface* surface)
 {
     cursor->apply_to(surface);
     auto const serial = wl_display_next_serial(display);
-    wl_pointer_send_enter(
-        resource,
-        serial,
-        surface->raw_resource(),
-        wl_fixed_from_double(position.x.as_int()),
-        wl_fixed_from_double(position.y.as_int()));
+    send_enter_event(serial,
+                     surface->raw_resource(),
+                     position.x.as_int(),
+                     position.y.as_int());
     surface->add_destroy_listener(this, [this]()
         {
             handle_leave();
@@ -211,18 +203,16 @@ void mf::WlPointer::handle_leave()
         return;
     focused_surface.value()->remove_destroy_listener(this);
     auto const serial = wl_display_next_serial(display);
-    wl_pointer_send_leave(
-        resource,
-        serial,
-        focused_surface.value()->raw_resource());
+    send_leave_event(serial,
+                     focused_surface.value()->raw_resource());
     focused_surface = std::experimental::nullopt;
     last_position = std::experimental::nullopt;
 }
 
 void mf::WlPointer::handle_frame()
 {
-    if (wl_resource_get_version(resource) >= WL_POINTER_FRAME_SINCE_VERSION)
-        wl_pointer_send_frame(resource);
+    if (version_supports_frame())
+        send_frame_event();
 }
 
 namespace
@@ -266,7 +256,7 @@ void mf::WlPointer::set_cursor(uint32_t serial, std::experimental::optional<wl_r
 
 void mf::WlPointer::release()
 {
-    wl_resource_destroy(resource);
+    destroy_wayland_object();
 }
 
 WlStreamCursor::WlStreamCursor(

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -95,8 +95,8 @@ void mf::WlPointer::handle_event(MirPointerEvent const* event, WlSurface* surfac
                 if (mapping.first & (current_pointer_buttons ^ last_buttons))
                 {
                     auto const state = (mapping.first & current_pointer_buttons) ?
-                        ButtonState::PRESSED :
-                        ButtonState::RELEASED;
+                        ButtonState::pressed :
+                        ButtonState::released;
 
                     auto const serial = wl_display_next_serial(display);
                     send_button_event(serial, timestamp, mapping.second, state);
@@ -157,7 +157,7 @@ void mf::WlPointer::handle_event(MirPointerEvent const* event, WlSurface* surfac
             if (hscroll != 0)
             {
                 send_axis_event(timestamp,
-                                Axis::HORIZONTAL_SCROLL,
+                                Axis::horizontal_scroll,
                                 hscroll);
                 needs_frame = true;
             }
@@ -166,7 +166,7 @@ void mf::WlPointer::handle_event(MirPointerEvent const* event, WlSurface* surfac
             if (vscroll != 0)
             {
                 send_axis_event(timestamp,
-                                Axis::VERTICAL_SCROLL,
+                                Axis::vertical_scroll,
                                 vscroll);
                 needs_frame = true;
             }

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -23,6 +23,8 @@
 
 #include "generated/wayland_wrapper.h"
 
+#include <functional>
+
 struct MirInputEvent;
 typedef unsigned int MirPointerButtons;
 

--- a/src/server/frontend_wayland/wl_region.cpp
+++ b/src/server/frontend_wayland/wl_region.cpp
@@ -19,6 +19,8 @@
 
 #include "wl_region.h"
 
+#include <mir/log.h>
+
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
 

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -169,7 +169,7 @@ mf::WlSeat::~WlSeat()
 
 auto mf::WlSeat::from(struct wl_resource* seat) -> WlSeat*
 {
-    return static_cast<mf::WlSeat*>(static_cast<mf::wayland::Seat*>(wl_resource_get_user_data(seat)));
+    return static_cast<mf::WlSeat*>(wayland::Seat::from(seat));
 }
 
 void mf::WlSeat::for_each_listener(wl_client* client, std::function<void(WlPointer*)> func)
@@ -201,19 +201,10 @@ void mf::WlSeat::spawn(std::function<void()>&& work)
 void mf::WlSeat::bind(wl_client* /*client*/, wl_resource* resource)
 {
     // TODO: Read the actual capabilities. Do we have a keyboard? Mouse? Touch?
-    int version = wl_resource_get_version(resource);
-    if (version >= WL_SEAT_CAPABILITIES_SINCE_VERSION)
-    {
-        wl_seat_send_capabilities(
-            resource,
-            WL_SEAT_CAPABILITY_POINTER |
-            WL_SEAT_CAPABILITY_KEYBOARD |
-            WL_SEAT_CAPABILITY_TOUCH);
-    }
-    if (version >= WL_SEAT_NAME_SINCE_VERSION)
-    {
-        wl_seat_send_name(resource, "seat0");
-    }
+    send_capabilities_event(resource,
+                            Capability::POINTER | Capability::KEYBOARD | Capability::TOUCH);
+    if (version_supports_name(resource))
+        send_name_event(resource, "seat0");
 }
 
 void mf::WlSeat::get_pointer(wl_client* client, wl_resource* resource, uint32_t id)

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -203,7 +203,7 @@ void mf::WlSeat::bind(wl_client* /*client*/, wl_resource* resource)
 {
     // TODO: Read the actual capabilities. Do we have a keyboard? Mouse? Touch?
     send_capabilities_event(resource,
-                            Capability::POINTER | Capability::KEYBOARD | Capability::TOUCH);
+                            Capability::pointer | Capability::keyboard | Capability::touch);
     if (version_supports_name(resource))
         send_name_event(resource, "seat0");
 }

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -38,6 +38,7 @@
 
 #include <mutex>
 #include <unordered_set>
+#include <algorithm>
 
 namespace mf = mir::frontend;
 namespace mi = mir::input;

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -23,6 +23,7 @@
 
 #include <unordered_map>
 #include <vector>
+#include <functional>
 
 // from "mir_toolkit/events/event.h"
 struct MirInputEvent;

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -30,7 +30,7 @@ mf::WlSubcompositor::WlSubcompositor(struct wl_display* display)
 
 void mf::WlSubcompositor::destroy(struct wl_client* /*client*/, struct wl_resource* resource)
 {
-    wl_resource_destroy(resource);
+    destroy_wayland_object(resource);
 }
 
 void mf::WlSubcompositor::get_subsurface(struct wl_client* client, struct wl_resource* resource, uint32_t id,
@@ -119,7 +119,7 @@ void mf::WlSubsurface::set_desync()
 
 void mf::WlSubsurface::destroy()
 {
-    wl_resource_destroy(resource);
+    destroy_wayland_object();
 }
 
 void mf::WlSubsurface::refresh_surface_data_now()

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -212,8 +212,8 @@ void mf::WlSurface::send_frame_callbacks()
         if (!*frame.destroyed)
         {
             // TODO: argument should be a timestamp
-            wl_callback_send_done(frame.resource, 0);
-            wl_resource_destroy(frame.resource);
+            frame->send_done_event(0);
+            frame->destroy_wayland_object();
         }
     }
     frame_callbacks.clear();
@@ -222,7 +222,7 @@ void mf::WlSurface::send_frame_callbacks()
 void mf::WlSurface::destroy()
 {
     *destroyed = true;
-    wl_resource_destroy(resource);
+    destroy_wayland_object();
 }
 
 void mf::WlSurface::attach(std::experimental::optional<wl_resource*> const& buffer, int32_t x, int32_t y)
@@ -334,7 +334,7 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
                     {
                         executor->spawn(run_unless(
                             destroyed,
-                            [buffer](){ wl_resource_queue_event(buffer, WL_BUFFER_RELEASE); }));
+                            [buffer](){ wl_resource_queue_event(buffer, wayland::Buffer::Opcode::RELEASE); }));
                     };
 
                 mir_buffer = allocator->buffer_from_resource(

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -40,6 +40,12 @@
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
 
+mf::WlSurfaceState::Callback::Callback(struct wl_client* client, struct wl_resource* parent, uint32_t id)
+    : wayland::Callback{client, parent, id},
+      destroyed{deleted_flag_for_resource(resource)}
+{
+}
+
 void mf::WlSurfaceState::update_from(WlSurfaceState const& source)
 {
     if (source.buffer)
@@ -212,7 +218,7 @@ void mf::WlSurface::send_frame_callbacks()
 {
     for (auto const& frame : frame_callbacks)
     {
-        if (!*frame.destroyed)
+        if (!*frame->destroyed)
         {
             // TODO: argument should be a timestamp
             frame->send_done_event(0);
@@ -260,9 +266,7 @@ void mf::WlSurface::damage_buffer(int32_t x, int32_t y, int32_t width, int32_t h
 
 void mf::WlSurface::frame(uint32_t callback)
 {
-    auto callback_resource = wl_resource_create(client, &wl_callback_interface, 1, callback);
-    auto callback_destroyed = deleted_flag_for_resource(callback_resource);
-    pending.frame_callbacks.emplace_back(WlSurfaceState::Callback{callback_resource, callback_destroyed});
+    pending.frame_callbacks.push_back(std::make_shared<WlSurfaceState::Callback>(client, resource, callback));
 }
 
 void mf::WlSurface::set_opaque_region(std::experimental::optional<wl_resource*> const& region)

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -33,6 +33,9 @@
 #include "mir/executor.h"
 #include "mir/graphics/wayland_allocator.h"
 #include "mir/shell/surface_specification.h"
+#include "mir/log.h"
+
+#include <algorithm>
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -341,7 +341,7 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
                     {
                         executor->spawn(run_unless(
                             destroyed,
-                            [buffer](){ wl_resource_queue_event(buffer, wayland::Buffer::Opcode::RELEASE); }));
+                            [buffer](){ wl_resource_queue_event(buffer, wayland::Buffer::Opcode::release); }));
                     };
 
                 mir_buffer = allocator->buffer_from_resource(

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -59,9 +59,10 @@ class WlSubsurface;
 
 struct WlSurfaceState
 {
-    struct Callback
+    class Callback : public wayland::Callback
     {
-        wl_resource* resource;
+    public:
+        Callback(struct wl_client* client, struct wl_resource* parent, uint32_t id);
         std::shared_ptr<bool> destroyed;
     };
 
@@ -79,7 +80,7 @@ struct WlSurfaceState
 
     std::experimental::optional<geometry::Displacement> offset;
     std::experimental::optional<std::experimental::optional<std::vector<geometry::Rectangle>>> input_shape;
-    std::vector<Callback> frame_callbacks;
+    std::vector<std::shared_ptr<Callback>> frame_callbacks;
 
 private:
     // only set to true if invalidate_surface_data() is called
@@ -160,7 +161,7 @@ private:
     WlSurfaceState pending;
     geometry::Displacement offset_;
     std::experimental::optional<geometry::Size> buffer_size_;
-    std::vector<WlSurfaceState::Callback> frame_callbacks;
+    std::vector<std::shared_ptr<WlSurfaceState::Callback>> frame_callbacks;
     std::experimental::optional<std::vector<mir::geometry::Rectangle>> input_shape;
     std::map<void const*, std::function<void()>> destroy_listeners;
     std::shared_ptr<bool> const destroyed;

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -31,6 +31,7 @@
 #include "mir/geometry/point.h"
 
 #include <vector>
+#include <map>
 
 namespace mir
 {

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -23,6 +23,7 @@
 
 #include "mir/executor.h"
 #include "mir/client/event.h"
+#include "mir/log.h"
 
 namespace mf = mir::frontend;
 

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -78,11 +78,10 @@ void mf::WlTouch::handle_event(MirTouchEvent const* touch_ev, WlSurface* main_su
             else
             {
                 auto const transformed_point = current_surface->second->total_offset() + point;
-                wl_touch_send_motion(resource,
-                                     mir_input_event_get_event_time_ms(input_ev),
-                                     touch_id,
-                                     wl_fixed_from_double(transformed_point.x.as_int()),
-                                     wl_fixed_from_double(transformed_point.y.as_int()));
+                send_motion_event(mir_input_event_get_event_time_ms(input_ev),
+                                  touch_id,
+                                  transformed_point.x.as_int(),
+                                  transformed_point.y.as_int());
             }
             break;
         }
@@ -108,33 +107,33 @@ void mf::WlTouch::handle_event(MirTouchEvent const* touch_ev, WlSurface* main_su
          * Regardless, the Wayland protocol requires that there be at least
          * one event sent before we send the ending frame, so make that explicit.
          */
-        wl_touch_send_frame(resource);
+        send_frame_event();
     }
 }
 
 void mf::WlTouch::release()
 {
-    wl_resource_destroy(resource);
+    destroy_wayland_object();
 }
 
 void mf::WlTouch::handle_down(mir::geometry::Point position, WlSurface* surface, uint32_t time, int32_t id)
 {
     focused_surface_for_ids[id] = surface;
-    wl_touch_send_down(resource,
-                       wl_display_get_serial(wl_client_get_display(client)),
-                       time,
-                       surface->raw_resource(),
-                       id,
-                       wl_fixed_from_double(position.x.as_int()),
-                       wl_fixed_from_double(position.y.as_int()));
+    // TODO: Why is this not wl_display_next_serial()?
+    send_down_event(wl_display_get_serial(wl_client_get_display(client)),
+                    time,
+                    surface->raw_resource(),
+                    id,
+                    position.x.as_int(),
+                    position.y.as_int());
 }
 
 void mf::WlTouch::handle_up(uint32_t time, int32_t id)
 {
     focused_surface_for_ids.erase(id);
-    wl_touch_send_up(resource,
-                     wl_display_get_serial(wl_client_get_display(client)),
-                     time,
-                     id);
+    // TODO: Why is this not wl_display_next_serial()?
+    send_up_event(wl_display_get_serial(wl_client_get_display(client)),
+                  time,
+                  id);
 }
 

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -24,6 +24,7 @@
 #include "mir/geometry/point.h"
 
 #include <map>
+#include <functional>
 
 // from "mir_toolkit/events/event.h"
 struct MirTouchEvent;

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -371,35 +371,35 @@ void mf::XdgToplevelStable::resize(struct wl_resource* /*seat*/, uint32_t /*seri
 
     switch (edges)
     {
-    case ResizeEdge::TOP:
+    case ResizeEdge::top:
         edge = mir_resize_edge_north;
         break;
 
-    case ResizeEdge::BOTTOM:
+    case ResizeEdge::bottom:
         edge = mir_resize_edge_south;
         break;
 
-    case ResizeEdge::LEFT:
+    case ResizeEdge::left:
         edge = mir_resize_edge_west;
         break;
 
-    case ResizeEdge::RIGHT:
+    case ResizeEdge::right:
         edge = mir_resize_edge_east;
         break;
 
-    case ResizeEdge::TOP_LEFT:
+    case ResizeEdge::top_left:
         edge = mir_resize_edge_northwest;
         break;
 
-    case ResizeEdge::BOTTOM_LEFT:
+    case ResizeEdge::bottom_left:
         edge = mir_resize_edge_southwest;
         break;
 
-    case ResizeEdge::TOP_RIGHT:
+    case ResizeEdge::top_right:
         edge = mir_resize_edge_northeast;
         break;
 
-    case ResizeEdge::BOTTOM_RIGHT:
+    case ResizeEdge::bottom_right:
         edge = mir_resize_edge_southeast;
         break;
 
@@ -458,7 +458,7 @@ void mf::XdgToplevelStable::handle_resize(std::experimental::optional<geometry::
     if (is_active())
     {
         if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
-            *state = State::ACTIVATED;
+            *state = State::activated;
     }
 
     switch (window_state())
@@ -467,12 +467,12 @@ void mf::XdgToplevelStable::handle_resize(std::experimental::optional<geometry::
     case mir_window_state_horizmaximized:
     case mir_window_state_vertmaximized:
         if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
-            *state = State::MAXIMIZED;
+            *state = State::maximized;
         break;
 
     case mir_window_state_fullscreen:
         if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
-            *state = State::FULLSCREEN;
+            *state = State::fullscreen;
         break;
 
     default:
@@ -523,35 +523,35 @@ void mf::XdgPositionerStable::set_anchor(uint32_t anchor)
 
     switch (anchor)
     {
-        case Anchor::TOP:
+        case Anchor::top:
             placement = mir_placement_gravity_north;
             break;
 
-        case Anchor::BOTTOM:
+        case Anchor::bottom:
             placement = mir_placement_gravity_south;
             break;
 
-        case Anchor::LEFT:
+        case Anchor::left:
             placement = mir_placement_gravity_west;
             break;
 
-        case Anchor::RIGHT:
+        case Anchor::right:
             placement = mir_placement_gravity_east;
             break;
 
-        case Anchor::TOP_LEFT:
+        case Anchor::top_left:
             placement = mir_placement_gravity_northwest;
             break;
 
-        case Anchor::BOTTOM_LEFT:
+        case Anchor::bottom_left:
             placement = mir_placement_gravity_southwest;
             break;
 
-        case Anchor::TOP_RIGHT:
+        case Anchor::top_right:
             placement = mir_placement_gravity_northeast;
             break;
 
-        case Anchor::BOTTOM_RIGHT:
+        case Anchor::bottom_right:
             placement = mir_placement_gravity_southeast;
             break;
 
@@ -568,35 +568,35 @@ void mf::XdgPositionerStable::set_gravity(uint32_t gravity)
 
     switch (gravity)
     {
-        case Gravity::TOP:
+        case Gravity::top:
             placement = mir_placement_gravity_south;
             break;
 
-        case Gravity::BOTTOM:
+        case Gravity::bottom:
             placement = mir_placement_gravity_north;
             break;
 
-        case Gravity::LEFT:
+        case Gravity::left:
             placement = mir_placement_gravity_east;
             break;
 
-        case Gravity::RIGHT:
+        case Gravity::right:
             placement = mir_placement_gravity_west;
             break;
 
-        case Gravity::TOP_LEFT:
+        case Gravity::top_left:
             placement = mir_placement_gravity_southeast;
             break;
 
-        case Gravity::BOTTOM_LEFT:
+        case Gravity::bottom_left:
             placement = mir_placement_gravity_northeast;
             break;
 
-        case Gravity::TOP_RIGHT:
+        case Gravity::top_right:
             placement = mir_placement_gravity_southwest;
             break;
 
-        case Gravity::BOTTOM_RIGHT:
+        case Gravity::bottom_right:
             placement = mir_placement_gravity_northwest;
             break;
 

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -22,6 +22,7 @@
 #include "window_wl_surface_role.h"
 
 #include "mir/shell/surface_specification.h"
+#include "mir/log.h"
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -232,7 +232,7 @@ void mf::XdgSurfaceStable::ack_configure(uint32_t serial)
 void mf::XdgSurfaceStable::send_configure()
 {
     auto const serial = wl_display_next_serial(wl_client_get_display(wayland::XdgSurface::client));
-    xdg_surface_send_configure(resource, serial);
+    send_configure_event(serial);
 }
 
 std::experimental::optional<mf::WindowWlSurfaceRole*> const& mf::XdgSurfaceStable::window_role()
@@ -301,11 +301,10 @@ void mf::XdgPopupStable::handle_resize(const std::experimental::optional<geometr
 
     if (needs_configure && cached_top_left && cached_size)
     {
-        xdg_popup_send_configure(resource,
-                                 cached_top_left.value().x.as_int(),
-                                 cached_top_left.value().y.as_int(),
-                                 cached_size.value().width.as_int(),
-                                 cached_size.value().height.as_int());
+        send_configure_event(cached_top_left.value().x.as_int(),
+                             cached_top_left.value().y.as_int(),
+                             cached_size.value().width.as_int(),
+                             cached_size.value().height.as_int());
         xdg_surface->send_configure();
     }
 }
@@ -321,7 +320,7 @@ mf::XdgToplevelStable::XdgToplevelStable(struct wl_client* client, struct wl_res
 {
     wl_array states;
     wl_array_init(&states);
-    xdg_toplevel_send_configure(resource, 0, 0, &states);
+    send_configure_event(0, 0, &states);
     wl_array_release(&states);
     xdg_surface->send_configure();
 }
@@ -371,35 +370,35 @@ void mf::XdgToplevelStable::resize(struct wl_resource* /*seat*/, uint32_t /*seri
 
     switch (edges)
     {
-    case XDG_TOPLEVEL_RESIZE_EDGE_TOP:
+    case ResizeEdge::TOP:
         edge = mir_resize_edge_north;
         break;
 
-    case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM:
+    case ResizeEdge::BOTTOM:
         edge = mir_resize_edge_south;
         break;
 
-    case XDG_TOPLEVEL_RESIZE_EDGE_LEFT:
+    case ResizeEdge::LEFT:
         edge = mir_resize_edge_west;
         break;
 
-    case XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT:
-        edge = mir_resize_edge_northwest;
-        break;
-
-    case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT:
-        edge = mir_resize_edge_southwest;
-        break;
-
-    case XDG_TOPLEVEL_RESIZE_EDGE_RIGHT:
+    case ResizeEdge::RIGHT:
         edge = mir_resize_edge_east;
         break;
 
-    case XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT:
+    case ResizeEdge::TOP_LEFT:
+        edge = mir_resize_edge_northwest;
+        break;
+
+    case ResizeEdge::BOTTOM_LEFT:
+        edge = mir_resize_edge_southwest;
+        break;
+
+    case ResizeEdge::TOP_RIGHT:
         edge = mir_resize_edge_northeast;
         break;
 
-    case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT:
+    case ResizeEdge::BOTTOM_RIGHT:
         edge = mir_resize_edge_southeast;
         break;
 
@@ -458,7 +457,7 @@ void mf::XdgToplevelStable::handle_resize(std::experimental::optional<geometry::
     if (is_active())
     {
         if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
-            *state = XDG_TOPLEVEL_STATE_ACTIVATED;
+            *state = State::ACTIVATED;
     }
 
     switch (window_state())
@@ -467,19 +466,19 @@ void mf::XdgToplevelStable::handle_resize(std::experimental::optional<geometry::
     case mir_window_state_horizmaximized:
     case mir_window_state_vertmaximized:
         if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
-            *state = XDG_TOPLEVEL_STATE_MAXIMIZED;
+            *state = State::MAXIMIZED;
         break;
 
     case mir_window_state_fullscreen:
         if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
-            *state = XDG_TOPLEVEL_STATE_FULLSCREEN;
+            *state = State::FULLSCREEN;
         break;
 
     default:
         break;
     }
 
-    xdg_toplevel_send_configure(resource, new_size.width.as_int(), new_size.height.as_int(), &states);
+    send_configure_event(new_size.width.as_int(), new_size.height.as_int(), &states);
     wl_array_release(&states);
 
     xdg_surface->send_configure();
@@ -523,35 +522,35 @@ void mf::XdgPositionerStable::set_anchor(uint32_t anchor)
 
     switch (anchor)
     {
-        case XDG_POSITIONER_ANCHOR_TOP:
+        case Anchor::TOP:
             placement = mir_placement_gravity_north;
             break;
 
-        case XDG_POSITIONER_ANCHOR_BOTTOM:
+        case Anchor::BOTTOM:
             placement = mir_placement_gravity_south;
             break;
 
-        case XDG_POSITIONER_ANCHOR_LEFT:
+        case Anchor::LEFT:
             placement = mir_placement_gravity_west;
             break;
 
-        case XDG_POSITIONER_ANCHOR_RIGHT:
+        case Anchor::RIGHT:
             placement = mir_placement_gravity_east;
             break;
 
-        case XDG_POSITIONER_ANCHOR_TOP_LEFT:
+        case Anchor::TOP_LEFT:
             placement = mir_placement_gravity_northwest;
             break;
 
-        case XDG_POSITIONER_ANCHOR_BOTTOM_LEFT:
+        case Anchor::BOTTOM_LEFT:
             placement = mir_placement_gravity_southwest;
             break;
 
-        case XDG_POSITIONER_ANCHOR_TOP_RIGHT:
+        case Anchor::TOP_RIGHT:
             placement = mir_placement_gravity_northeast;
             break;
 
-        case XDG_POSITIONER_ANCHOR_BOTTOM_RIGHT:
+        case Anchor::BOTTOM_RIGHT:
             placement = mir_placement_gravity_southeast;
             break;
 
@@ -568,35 +567,35 @@ void mf::XdgPositionerStable::set_gravity(uint32_t gravity)
 
     switch (gravity)
     {
-        case XDG_POSITIONER_GRAVITY_TOP:
+        case Gravity::TOP:
             placement = mir_placement_gravity_south;
             break;
 
-        case XDG_POSITIONER_GRAVITY_BOTTOM:
+        case Gravity::BOTTOM:
             placement = mir_placement_gravity_north;
             break;
 
-        case XDG_POSITIONER_GRAVITY_LEFT:
+        case Gravity::LEFT:
             placement = mir_placement_gravity_east;
             break;
 
-        case XDG_POSITIONER_GRAVITY_RIGHT:
+        case Gravity::RIGHT:
             placement = mir_placement_gravity_west;
             break;
 
-        case XDG_POSITIONER_GRAVITY_TOP_LEFT:
+        case Gravity::TOP_LEFT:
             placement = mir_placement_gravity_southeast;
             break;
 
-        case XDG_POSITIONER_GRAVITY_BOTTOM_LEFT:
+        case Gravity::BOTTOM_LEFT:
             placement = mir_placement_gravity_northeast;
             break;
 
-        case XDG_POSITIONER_GRAVITY_TOP_RIGHT:
+        case Gravity::TOP_RIGHT:
             placement = mir_placement_gravity_southwest;
             break;
 
-        case XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT:
+        case Gravity::BOTTOM_RIGHT:
             placement = mir_placement_gravity_northwest;
             break;
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -357,35 +357,35 @@ void mf::XdgToplevelV6::resize(struct wl_resource* /*seat*/, uint32_t /*serial*/
 
     switch (edges)
     {
-    case ResizeEdge::TOP:
+    case ResizeEdge::top:
         edge = mir_resize_edge_north;
         break;
 
-    case ResizeEdge::BOTTOM:
+    case ResizeEdge::bottom:
         edge = mir_resize_edge_south;
         break;
 
-    case ResizeEdge::LEFT:
+    case ResizeEdge::left:
         edge = mir_resize_edge_west;
         break;
 
-    case ResizeEdge::RIGHT:
+    case ResizeEdge::right:
         edge = mir_resize_edge_east;
         break;
 
-    case ResizeEdge::TOP_LEFT:
+    case ResizeEdge::top_left:
         edge = mir_resize_edge_northwest;
         break;
 
-    case ResizeEdge::BOTTOM_LEFT:
+    case ResizeEdge::bottom_left:
         edge = mir_resize_edge_southwest;
         break;
 
-    case ResizeEdge::TOP_RIGHT:
+    case ResizeEdge::top_right:
         edge = mir_resize_edge_northeast;
         break;
 
-    case ResizeEdge::BOTTOM_RIGHT:
+    case ResizeEdge::bottom_right:
         edge = mir_resize_edge_southeast;
         break;
 
@@ -444,7 +444,7 @@ void mf::XdgToplevelV6::handle_resize(std::experimental::optional<geometry::Poin
     if (is_active())
     {
         if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
-            *state = State::ACTIVATED;
+            *state = State::activated;
     }
 
     switch (window_state())
@@ -453,12 +453,12 @@ void mf::XdgToplevelV6::handle_resize(std::experimental::optional<geometry::Poin
     case mir_window_state_horizmaximized:
     case mir_window_state_vertmaximized:
         if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
-            *state = State::MAXIMIZED;
+            *state = State::maximized;
         break;
 
     case mir_window_state_fullscreen:
         if (uint32_t *state = static_cast<decltype(state)>(wl_array_add(&states, sizeof *state)))
-            *state = State::FULLSCREEN;
+            *state = State::fullscreen;
         break;
 
     default:
@@ -507,16 +507,16 @@ void mf::XdgPositionerV6::set_anchor(uint32_t anchor)
 {
     MirPlacementGravity placement = mir_placement_gravity_center;
 
-    if (anchor & Anchor::TOP)
+    if (anchor & Anchor::top)
         placement = MirPlacementGravity(placement | mir_placement_gravity_north);
 
-    if (anchor & Anchor::BOTTOM)
+    if (anchor & Anchor::bottom)
         placement = MirPlacementGravity(placement | mir_placement_gravity_south);
 
-    if (anchor & Anchor::LEFT)
+    if (anchor & Anchor::left)
         placement = MirPlacementGravity(placement | mir_placement_gravity_west);
 
-    if (anchor & Anchor::RIGHT)
+    if (anchor & Anchor::right)
         placement = MirPlacementGravity(placement | mir_placement_gravity_east);
 
     aux_rect_placement_gravity = placement;
@@ -526,16 +526,16 @@ void mf::XdgPositionerV6::set_gravity(uint32_t gravity)
 {
     MirPlacementGravity placement = mir_placement_gravity_center;
 
-    if (gravity & Gravity::TOP)
+    if (gravity & Gravity::top)
         placement = MirPlacementGravity(placement | mir_placement_gravity_south);
 
-    if (gravity & Gravity::BOTTOM)
+    if (gravity & Gravity::bottom)
         placement = MirPlacementGravity(placement | mir_placement_gravity_north);
 
-    if (gravity & Gravity::LEFT)
+    if (gravity & Gravity::left)
         placement = MirPlacementGravity(placement | mir_placement_gravity_east);
 
-    if (gravity & Gravity::RIGHT)
+    if (gravity & Gravity::right)
         placement = MirPlacementGravity(placement | mir_placement_gravity_west);
 
     surface_placement_gravity = placement;

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -22,6 +22,7 @@
 #include "window_wl_surface_role.h"
 
 #include "mir/shell/surface_specification.h"
+#include "mir/log.h"
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -35,6 +35,7 @@
 #include <cstring>
 #include <poll.h>
 #include <sys/socket.h>
+#include <unistd.h>
 
 
 #ifndef ARRAY_LENGTH


### PR DESCRIPTION
Previously, requests were implemented as virtual methods to be overridden, but events were sent with the `wayland-scanner` generated C functions.

With this PR, event methods are generated and used, and the C headers are not included into any non-generated code. Enum constants are also now generated in the headers, and have a more C++ feel.

Other minor changes are making `WlSurfaceState::Callbacks` a proper wayland object (inheriting from `wayland::Callback`) and including some headers here and there that were picked up by the generated code previously (generated code needs less includes now).

Yet more needs to be done before we are completely free of `wayland-scanner` and the C files it generates, but this gets us close.