### PR TITLE
[Wayland] When setting the pointer cursor it needs to be applied. (Fixes #555)

### DIFF
--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -261,6 +261,9 @@ void mf::WlPointer::set_cursor(uint32_t serial, std::experimental::optional<wl_r
         cursor = std::make_unique<WlHiddenCursor>(get_session(client));
     }
 
+    if (focused_surface)
+        cursor->apply_to(focused_surface.value());
+
     (void)serial;
 }
 


### PR DESCRIPTION
[Wayland] When setting the pointer cursor it needs to be applied. (Fixes #555)