### PR TITLE
[mesa] Use both id and drm_fd as output identifier as we're not sure of the uniqueness of either. (Fixes #556)

### DIFF
--- a/src/platforms/mesa/server/kms/cursor.h
+++ b/src/platforms/mesa/server/kms/cursor.h
@@ -130,7 +130,9 @@ private:
         GBMBOWrapper(GBMBOWrapper const&) = delete;
         GBMBOWrapper& operator=(GBMBOWrapper const&) = delete;
     };
-    Mutex<std::vector<std::tuple<uint32_t, int, GBMBOWrapper>>> buffers;
+
+    using image_buffer = std::tuple<uint32_t, int, GBMBOWrapper>;
+    Mutex<std::vector<image_buffer>> buffers;
 
     uint32_t min_buffer_width;
     uint32_t min_buffer_height;

--- a/src/platforms/mesa/server/kms/cursor.h
+++ b/src/platforms/mesa/server/kms/cursor.h
@@ -130,7 +130,7 @@ private:
         GBMBOWrapper(GBMBOWrapper const&) = delete;
         GBMBOWrapper& operator=(GBMBOWrapper const&) = delete;
     };
-    Mutex<std::vector<std::pair<int, GBMBOWrapper>>> buffers;
+    Mutex<std::vector<std::tuple<uint32_t, int, GBMBOWrapper>>> buffers;
 
     uint32_t min_buffer_width;
     uint32_t min_buffer_height;


### PR DESCRIPTION
[mesa] Use both id and drm_fd as output identifier as we're not sure of the uniqueness of either. (Fixes #556)