### PR TITLE
[wayland] Hook the OutputManager into display reconfiguration notifications. (Fixes #585)

### DIFF
--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(../frontend_xwayland)
 set(
   WAYLAND_SOURCES
 
+        mir_display.cpp mir_display.h
   wayland_default_configuration.cpp
   wayland_connector.cpp         wayland_connector.h
   wlshmbuffer.cpp               wlshmbuffer.h

--- a/src/server/frontend_wayland/mir_display.cpp
+++ b/src/server/frontend_wayland/mir_display.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "mir_display.h"
+
+#include <mir/frontend/display_changer.h>
+
+#include <mir/graphics/display_configuration.h>
+#include <mir/graphics/display_configuration_observer.h>
+
+#include <algorithm>
+#include <mutex>
+#include <vector>
+
+namespace mf = mir::frontend;
+namespace mg = mir::graphics;
+
+namespace 
+{
+struct DisplayConfigurationObserverAdapter : mg::DisplayConfigurationObserver
+{
+    std::weak_ptr<mf::OutputObserver> const wrapped;
+
+    DisplayConfigurationObserverAdapter(std::weak_ptr<mf::OutputObserver> const& adaptee) : 
+        wrapped{adaptee}
+    {
+    }
+
+    void initial_configuration(std::shared_ptr<mg::DisplayConfiguration const> const&) override
+    {
+    }
+
+    void configuration_applied(std::shared_ptr<mg::DisplayConfiguration const> const& config) override
+    {
+        if (auto const adaptee = wrapped.lock()) 
+            adaptee->handle_configuration_change(*config);
+    }
+
+    void base_configuration_updated(std::shared_ptr<mg::DisplayConfiguration const> const&) override
+    {
+    }
+
+    void session_configuration_applied(
+        std::shared_ptr<mf::Session> const&, std::shared_ptr<mg::DisplayConfiguration> const&) override
+    {
+    }
+
+    void session_configuration_removed(std::shared_ptr<mir::frontend::Session> const&) override
+    {
+    }
+
+    void configuration_failed(
+        std::shared_ptr<mg::DisplayConfiguration const> const&,
+        std::exception const&) override
+    {
+    }
+
+    void catastrophic_configuration_error(
+        std::shared_ptr<mg::DisplayConfiguration const> const&,
+        std::exception const&) override
+    {
+    }
+};
+}
+
+struct mf::MirDisplay::Self
+{
+    std::shared_ptr<DisplayChanger> const changer;
+    std::shared_ptr<ObserverRegistrar<mg::DisplayConfigurationObserver>> const registrar;
+
+    Self(
+        std::shared_ptr<DisplayChanger> const& changer,
+        std::shared_ptr<ObserverRegistrar<mg::DisplayConfigurationObserver>> const& registrar) :
+        changer{changer}, registrar{registrar} {}
+
+    std::mutex mutable mutex;
+    std::vector<std::shared_ptr<DisplayConfigurationObserverAdapter>> adapters;
+};
+
+mf::MirDisplay::MirDisplay(
+    std::shared_ptr<DisplayChanger> const& changer,
+    std::shared_ptr<ObserverRegistrar<mg::DisplayConfigurationObserver>> const& registrar) :
+    self{std::make_unique<Self>(changer, registrar)}
+{
+}
+
+//std::shared_ptr<mir::ObserverRegistrar<mg::DisplayConfigurationObserver>>
+//mir::DefaultServerConfiguration::the_display_configuration_observer_registrar()
+
+void mf::MirDisplay::register_interest(std::weak_ptr<OutputObserver> const& observer)
+{
+    auto const adapter = std::make_shared<DisplayConfigurationObserverAdapter>(observer);
+
+    std::lock_guard<decltype(self->mutex)> lock{self->mutex};
+    self->adapters.push_back(adapter);
+    self->registrar->register_interest(adapter);
+}
+
+void mf::MirDisplay::unregister_interest(OutputObserver* observer)
+{
+    std::lock_guard<decltype(self->mutex)> lock{self->mutex};
+
+    self->adapters.erase(
+        std::remove_if(
+            begin(self->adapters),
+            end(self->adapters),
+            [observer, registrar = self->registrar](auto const& adapter)
+                {
+                    auto const adaptee = adapter->wrapped.lock().get();
+
+                    if (adaptee == nullptr)
+                    {
+                        return true;
+                    }
+                    else if (adaptee == observer)
+                    {
+                        registrar->unregister_interest(*adapter);
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }),
+        end(self->adapters));
+}
+
+mf::MirDisplay::~MirDisplay()
+{
+    std::lock_guard<decltype(self->mutex)> lock{self->mutex};
+    for (auto const& adapter : self->adapters)
+    {
+        if (adapter)
+            self->registrar->unregister_interest(*adapter);
+    }
+}
+
+void mf::MirDisplay::for_each_output(std::function<void(mg::DisplayConfigurationOutput const&)> f) const
+{
+    // Not only is this a train-wreck, it also does not use the *current* configuration.
+    // OTOH is replicates the functionality it replaces and "session" display configs
+    // are only supported through the Mir client API. (For now.)
+    self->changer->base_configuration()->for_each_output(f);
+}

--- a/src/server/frontend_wayland/mir_display.cpp
+++ b/src/server/frontend_wayland/mir_display.cpp
@@ -34,9 +34,9 @@ namespace
 {
 struct DisplayConfigurationObserverAdapter : mg::DisplayConfigurationObserver
 {
-    std::weak_ptr<mf::OutputObserver> const wrapped;
+    mf::OutputObserver* const wrapped;
 
-    DisplayConfigurationObserverAdapter(std::weak_ptr<mf::OutputObserver> const& adaptee) : 
+    DisplayConfigurationObserverAdapter(mf::OutputObserver* adaptee) :
         wrapped{adaptee}
     {
     }
@@ -47,8 +47,7 @@ struct DisplayConfigurationObserverAdapter : mg::DisplayConfigurationObserver
 
     void configuration_applied(std::shared_ptr<mg::DisplayConfiguration const> const& config) override
     {
-        if (auto const adaptee = wrapped.lock()) 
-            adaptee->handle_configuration_change(*config);
+        wrapped->handle_configuration_change(*config);
     }
 
     void base_configuration_updated(std::shared_ptr<mg::DisplayConfiguration const> const&) override
@@ -99,10 +98,7 @@ mf::MirDisplay::MirDisplay(
 {
 }
 
-//std::shared_ptr<mir::ObserverRegistrar<mg::DisplayConfigurationObserver>>
-//mir::DefaultServerConfiguration::the_display_configuration_observer_registrar()
-
-void mf::MirDisplay::register_interest(std::weak_ptr<OutputObserver> const& observer)
+void mf::MirDisplay::register_interest(OutputObserver* observer)
 {
     auto const adapter = std::make_shared<DisplayConfigurationObserverAdapter>(observer);
 
@@ -121,7 +117,7 @@ void mf::MirDisplay::unregister_interest(OutputObserver* observer)
             end(self->adapters),
             [observer, registrar = self->registrar](auto const& adapter)
                 {
-                    auto const adaptee = adapter->wrapped.lock().get();
+                    auto const adaptee = adapter->wrapped;
 
                     if (adaptee == nullptr)
                     {

--- a/src/server/frontend_wayland/mir_display.h
+++ b/src/server/frontend_wayland/mir_display.h
@@ -62,7 +62,7 @@ public:
 
     void for_each_output(std::function<void(graphics::DisplayConfigurationOutput const&)> f) const;
 
-    void register_interest(std::weak_ptr<OutputObserver> const& observer);
+    void register_interest(OutputObserver* observer);
     void unregister_interest(OutputObserver* observer);
 
 private:

--- a/src/server/frontend_wayland/mir_display.h
+++ b/src/server/frontend_wayland/mir_display.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#ifndef MIR_FRONTEND_DISPLAY_H_
+#define MIR_FRONTEND_DISPLAY_H_
+
+#include <mir/observer_registrar.h>
+
+#include <functional>
+#include <memory>
+
+namespace mir
+{
+namespace graphics
+{
+struct DisplayConfiguration;
+struct DisplayConfigurationOutput;
+class DisplayConfigurationObserver;
+}
+}
+
+namespace mir
+{
+namespace frontend
+{
+class DisplayChanger;
+
+class OutputObserver
+{
+public:
+    virtual void handle_configuration_change(graphics::DisplayConfiguration const& config) = 0;
+
+    OutputObserver() = default;
+    virtual ~OutputObserver() = default;
+    OutputObserver(OutputObserver const&) = delete;
+    OutputObserver& operator=(OutputObserver const&) = delete;
+};
+
+class MirDisplay
+{
+public:
+    MirDisplay(
+        std::shared_ptr<DisplayChanger> const& changer,
+        std::shared_ptr<ObserverRegistrar<graphics::DisplayConfigurationObserver>>const& registrar);
+
+    ~MirDisplay();
+
+    void for_each_output(std::function<void(graphics::DisplayConfigurationOutput const&)> f) const;
+
+    void register_interest(std::weak_ptr<OutputObserver> const& observer);
+    void unregister_interest(OutputObserver* observer);
+
+private:
+
+    struct Self;
+    std::unique_ptr<Self> const self;
+};
+}
+}
+
+#endif //MIR_FRONTEND_DISPLAY_H_

--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -34,8 +34,16 @@ mf::Output::~Output()
     wl_global_destroy(output);
 }
 
-void mf::Output::handle_configuration_changed(mg::DisplayConfigurationOutput const& /*config*/)
+void mf::Output::handle_configuration_changed(mg::DisplayConfigurationOutput const& config)
 {
+    for (auto const& client : resource_map)
+    {
+        for (auto const& resource : client.second)
+        {
+            // Possibly not optimal
+            send_initial_config(resource, config);
+        }
+    }
 }
 
 bool mf::Output::matches_client_resource(wl_client* client, struct wl_resource* resource) const

--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -18,8 +18,6 @@
 
 #include "output_manager.h"
 
-#include "mir_display.h"
-
 #include <algorithm>
 
 namespace mf = mir::frontend;
@@ -133,8 +131,13 @@ mf::OutputManager::OutputManager(wl_display* display, std::shared_ptr<MirDisplay
     display_config{display_config},
     display{display}
 {
-    // TODO: Also register display configuration listeners
+    display_config->register_interest(this);
     display_config->for_each_output(std::bind(&OutputManager::create_output, this, std::placeholders::_1));
+}
+
+mf::OutputManager::~OutputManager()
+{
+    display_config->unregister_interest(this);
 }
 
 auto mf::OutputManager::output_id_for(

--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -18,7 +18,7 @@
 
 #include "output_manager.h"
 
-#include "mir/frontend/display_changer.h"
+#include "mir_display.h"
 
 #include <algorithm>
 
@@ -129,12 +129,12 @@ void mf::Output::resource_destructor(wl_resource* resource)
 }
 
 
-mf::OutputManager::OutputManager(wl_display* display, mf::DisplayChanger& display_config) :
+mf::OutputManager::OutputManager(wl_display* display, std::shared_ptr<MirDisplay> const& display_config) :
+    display_config{display_config},
     display{display}
 {
     // TODO: Also register display configuration listeners
-    display_config.base_configuration()
-        ->for_each_output(std::bind(&OutputManager::create_output, this, std::placeholders::_1));
+    display_config->for_each_output(std::bind(&OutputManager::create_output, this, std::placeholders::_1));
 }
 
 auto mf::OutputManager::output_id_for(

--- a/src/server/frontend_wayland/output_manager.h
+++ b/src/server/frontend_wayland/output_manager.h
@@ -21,6 +21,8 @@
 
 #include <mir/graphics/display_configuration.h>
 
+#include "mir_display.h"
+
 #include <wayland-server-core.h>
 #include <wayland-server-protocol.h>
 
@@ -62,10 +64,11 @@ private:
     std::unordered_map<wl_client*, std::vector<wl_resource*>> resource_map;
 };
 
-class OutputManager
+class OutputManager : public OutputObserver
 {
 public:
     OutputManager(wl_display* display, std::shared_ptr<MirDisplay> const& display_config);
+    ~OutputManager();
 
     auto output_id_for(wl_client* client, std::experimental::optional<struct wl_resource*> const& /*output*/) const
         -> optional_value<graphics::DisplayConfigurationOutputId>;
@@ -76,7 +79,7 @@ public:
 private:
     void create_output(graphics::DisplayConfigurationOutput const& initial_config);
 
-    void handle_configuration_change(graphics::DisplayConfiguration const& config);
+    void handle_configuration_change(graphics::DisplayConfiguration const& config) override;
 
     std::shared_ptr<MirDisplay> const display_config;
     wl_display* const display;

--- a/src/server/frontend_wayland/output_manager.h
+++ b/src/server/frontend_wayland/output_manager.h
@@ -34,7 +34,7 @@ namespace mir
 {
 namespace frontend
 {
-class DisplayChanger;
+class MirDisplay;
 
 class Output
 {
@@ -65,7 +65,7 @@ private:
 class OutputManager
 {
 public:
-    OutputManager(wl_display* display, DisplayChanger& display_config);
+    OutputManager(wl_display* display, std::shared_ptr<MirDisplay> const& display_config);
 
     auto output_id_for(wl_client* client, std::experimental::optional<struct wl_resource*> const& /*output*/) const
         -> optional_value<graphics::DisplayConfigurationOutputId>;
@@ -78,6 +78,7 @@ private:
 
     void handle_configuration_change(graphics::DisplayConfiguration const& config);
 
+    std::shared_ptr<MirDisplay> const display_config;
     wl_display* const display;
     std::unordered_map<graphics::DisplayConfigurationOutputId, std::unique_ptr<Output>> outputs;
 };

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -584,7 +584,7 @@ auto mir::frontend::WaylandExtensions::get_extension(std::string const& name) co
 mf::WaylandConnector::WaylandConnector(
     optional_value<std::string> const& display_name,
     std::shared_ptr<mf::Shell> const& shell,
-    DisplayChanger& display_config,
+    std::shared_ptr<MirDisplay> const& display_config,
     std::shared_ptr<mi::InputDeviceHub> const& input_hub,
     std::shared_ptr<mi::Seat> const& seat,
     std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -52,7 +52,7 @@ class WlSeat;
 class OutputManager;
 
 class Shell;
-class DisplayChanger;
+class MirDisplay;
 class SessionAuthorizer;
 class DataDeviceManager;
 
@@ -83,7 +83,7 @@ public:
     WaylandConnector(
         optional_value<std::string> const& display_name,
         std::shared_ptr<Shell> const& shell,
-        DisplayChanger& display_config,
+        std::shared_ptr<MirDisplay> const& display_config,
         std::shared_ptr<input::InputDeviceHub> const& input_hub,
         std::shared_ptr<input::Seat> const& seat,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -21,8 +21,8 @@
 #include "xdg_shell_v6.h"
 #include "xdg_shell_stable.h"
 #include "xwayland_wm_shell.h"
+#include "mir_display.h"
 
-#include "mir/frontend/display_changer.h"
 #include "mir/graphics/platform.h"
 #include "mir/options/default_configuration.h"
 
@@ -82,7 +82,6 @@ auto configure_wayland_extensions(std::string extensions, bool x11_enabled) -> s
 std::shared_ptr<mf::Connector>
     mir::DefaultServerConfiguration::the_wayland_connector()
 {
-
     return wayland_connector(
         [this]() -> std::shared_ptr<mf::Connector>
         {
@@ -97,10 +96,14 @@ std::shared_ptr<mf::Connector>
             auto const wayland_extensions =
                 options->get(mo::wayland_extensions_opt, mo::wayland_extensions_value);
 
+            auto const display_config = std::make_shared<mf::MirDisplay>(
+                the_frontend_display_changer(),
+                the_display_configuration_observer_registrar());
+
             return std::make_shared<mf::WaylandConnector>(
                 display_name,
                 the_frontend_shell(),
-                *the_frontend_display_changer(),
+                display_config,
                 the_input_device_hub(),
                 the_seat(),
                 the_buffer_allocator(),


### PR DESCRIPTION
[wayland] Hook the OutputManager into display reconfiguration notifications. (Fixes #585)