### PR TITLE
Disconnected hardware has no modes: invent a (slow) refresh rate. (Fixes #587)

### DIFF
--- a/src/platforms/mesa/server/kms/real_kms_output.cpp
+++ b/src/platforms/mesa/server/kms/real_kms_output.cpp
@@ -148,6 +148,9 @@ geom::Size mgm::RealKMSOutput::size() const
 
 int mgm::RealKMSOutput::max_refresh_rate() const
 {
+    if (connector->connection == DRM_MODE_DISCONNECTED)
+        return 1;
+
     drmModeModeInfo const& current_mode = connector->modes[mode_index];
     return current_mode.vrefresh;
 }


### PR DESCRIPTION
Disconnected hardware has no modes: invent a (slow) refresh rate. (Fixes #587)