### PR TITLE
[ABI break] Implement anchored surfaces for layer shell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,17 +66,11 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread -g -Wall -pedantic -Wextra -fPIC")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -g -std=c++14 -Wall -fno-strict-aliasing -pedantic -Wnon-virtual-dtor -Wextra -fPIC")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread -g -Werror -Wall -pedantic -Wextra -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -g -std=c++14 -Werror -Wall -fno-strict-aliasing -pedantic -Wnon-virtual-dtor -Wextra -fPIC")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--as-needed")
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--as-needed")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--as-needed")
-
-set(MIR_FATAL_COMPILE_WARNINGS ON CACHE BOOL "Should compiler warnings fail the build")
-if(MIR_FATAL_COMPILE_WARNINGS)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-endif()
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-Wmismatched-tags HAS_W_MISMATCHED_TAGS)
@@ -239,14 +233,6 @@ endif()
 list(GET MIR_PLATFORM 0 MIR_TEST_PLATFORM)
 
 option(MIR_ENABLE_TESTS "Build tests" ON)
-CMAKE_DEPENDENT_OPTION(
-  MIR_ENABLE_WLCS_TESTS "Also Build WLCS tests" ON
-  "MIR_ENABLE_TESTS" OFF
-)
-
-if (MIR_ENABLE_WLCS_TESTS)
-  pkg_check_modules(WLCS REQUIRED wlcs)
-endif()
 
 foreach(platform IN LISTS MIR_PLATFORM)
   if (platform STREQUAL "mesa-kms")

--- a/debian/control
+++ b/debian/control
@@ -82,7 +82,7 @@ Description: Display server for Ubuntu - RPC definitions
 
 #TODO: Packaging infrastructure for better dependency generation,
 #      ala pkg-xorg's xviddriver:Provides and ABI detection.
-Package: libmirserver47
+Package: libmirserver48
 Section: libs
 Architecture: linux-any
 Multi-Arch: same
@@ -161,7 +161,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirserver47 (= ${binary:Version}),
+Depends: libmirserver48 (= ${binary:Version}),
          libmirplatform-dev (= ${binary:Version}),
          libmircommon-dev (= ${binary:Version}),
          libglm-dev,

--- a/debian/libmirserver47.install
+++ b/debian/libmirserver47.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmirserver.so.47

--- a/debian/libmirserver48.install
+++ b/debian/libmirserver48.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmirserver.so.48

--- a/include/core/mir_toolkit/common.h
+++ b/include/core/mir_toolkit/common.h
@@ -118,6 +118,7 @@ typedef enum MirWindowType
     mir_window_type_satellite,    /**< AKA "toolbox"/"toolbar"             */
     mir_window_type_tip,          /**< AKA "tooltip"                       */
     mir_window_type_decoration,
+    mir_window_type_anchored,     /**< AKA "panel"/"notification"/"etc"    */
     mir_window_types
 } MirWindowType;
 

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -111,6 +111,12 @@ struct WindowInfo
     auto shell_chrome() const -> MirShellChrome;
     void shell_chrome(MirShellChrome chrome);
 
+    auto anchor_edge() const -> MirPlacementGravity;
+    void anchor_edge(MirPlacementGravity edge);
+
+    auto anchor_exclusive_zone() const -> int;
+    void anchor_exclusive_zone(int size);
+
     /// This can be used by client code to store window manager specific information
     auto userdata() const -> std::shared_ptr<void>;
     void userdata(std::shared_ptr<void> userdata);

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -90,12 +90,13 @@ public:
     auto height_inc() const -> mir::optional_value<DeltaY> const&;
     auto min_aspect() const -> mir::optional_value<AspectRatio> const&;
     auto max_aspect() const -> mir::optional_value<AspectRatio> const&;
-
     auto parent() const -> mir::optional_value<std::weak_ptr<mir::scene::Surface>> const&;
     auto input_shape() const -> mir::optional_value<std::vector<Rectangle>> const&;
     auto input_mode() const -> mir::optional_value<InputReceptionMode> const&;
     auto shell_chrome() const -> mir::optional_value<MirShellChrome> const&;
     auto confine_pointer() const -> mir::optional_value<MirPointerConfinementState> const&;
+    auto anchor_edge() const -> mir::optional_value<MirPlacementGravity> const&;
+    auto anchor_exclusive_zone() const -> mir::optional_value<int> const&;
     auto userdata() const -> mir::optional_value<std::shared_ptr<void>> const&;
 
     auto top_left() -> mir::optional_value<Point>&;
@@ -123,6 +124,8 @@ public:
     auto input_mode() -> mir::optional_value<InputReceptionMode>&;
     auto shell_chrome() -> mir::optional_value<MirShellChrome>&;
     auto confine_pointer() -> mir::optional_value<MirPointerConfinementState>&;
+    auto anchor_edge() -> mir::optional_value<MirPlacementGravity>&;
+    auto anchor_exclusive_zone() -> mir::optional_value<int>&;
     auto userdata() -> mir::optional_value<std::shared_ptr<void>>&;
 
 private:

--- a/include/server/mir/scene/surface_creation_parameters.h
+++ b/include/server/mir/scene/surface_creation_parameters.h
@@ -111,6 +111,10 @@ struct SurfaceCreationParameters
     mir::optional_value<MirShellChrome> shell_chrome;
     mir::optional_value<std::vector<shell::StreamSpecification>> streams;
     mir::optional_value<MirPointerConfinementState> confine_pointer;
+
+    // used for anchored surfaces
+    optional_value<MirPlacementGravity> anchor_edge;
+    optional_value<int> anchor_exclusive_zone;
 };
 
 bool operator==(const SurfaceCreationParameters& lhs, const SurfaceCreationParameters& rhs);

--- a/include/server/mir/shell/surface_specification.h
+++ b/include/server/mir/shell/surface_specification.h
@@ -98,7 +98,11 @@ struct SurfaceSpecification
     optional_value<MirShellChrome> shell_chrome;
     optional_value<MirPointerConfinementState> confine_pointer;
     optional_value<std::shared_ptr<graphics::CursorImage>> cursor_image;
-    optional_value<StreamCursor> stream_cursor; 
+    optional_value<StreamCursor> stream_cursor;
+
+    // used for anchored surfaces
+    optional_value<MirPlacementGravity> anchor_edge;
+    optional_value<int> anchor_exclusive_zone;
 };
 }
 }

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1011,14 +1011,34 @@ void miral::BasicWindowManager::place_and_size(WindowInfo& root, Point const& ne
 
 void miral::BasicWindowManager::place_anchored(WindowInfo& root)
 {
-    // We can't place the anchored window if there are'n any outputs
+    // We can't place the anchored window if there aren't any outputs
     if (root.type() != mir_window_type_anchored || outputs.size() == 0)
         return;
 
     MirPlacementGravity gravity = root.anchor_edge();
-    Size const size = root.window().size();
+    Size size = root.window().size();
     Rectangle output = *outputs.begin();
     Point top_left{};
+    bool needs_resize = true;
+
+    if ((gravity & mir_placement_gravity_west) &&
+        (gravity & mir_placement_gravity_east))
+    {
+        size.width = output.size.width;
+        needs_resize = true;
+    }
+
+    if ((gravity & mir_placement_gravity_north) &&
+        (gravity & mir_placement_gravity_south))
+    {
+        size.height = output.size.height;
+        needs_resize = true;
+    }
+
+    if (needs_resize)
+    {
+        root.window().resize(size);
+    }
 
     if (gravity & mir_placement_gravity_west)
         top_left.x = output.left();

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -826,6 +826,8 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
     COPY_IF_SET(output_id);
     COPY_IF_SET(preferred_orientation);
     COPY_IF_SET(confine_pointer);
+    COPY_IF_SET(anchor_edge);
+    COPY_IF_SET(anchor_exclusive_zone);
     COPY_IF_SET(userdata);
     COPY_IF_SET(shell_chrome);
 

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -933,11 +933,6 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
 
     Point new_pos = modifications.top_left().is_set() ? modifications.top_left().value() : window.top_left();
 
-    if (window_info.type() == mir_window_type_anchored && modifications.anchor_edge().is_set())
-    {
-        place_anchored(window_info);
-    }
-
     if (modifications.size().is_set())
     {
         place_and_size(window_info, new_pos, modifications.size().value());
@@ -954,6 +949,11 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
     else if (modifications.top_left().is_set())
     {
         place_and_size(window_info, new_pos, window.size());
+    }
+
+    if (window_info.type() == mir_window_type_anchored && modifications.anchor_edge().is_set())
+    {
+        place_anchored(window_info);
     }
 
     if (modifications.placement_hints().is_set())

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1360,6 +1360,7 @@ void miral::BasicWindowManager::drag_window(miral::Window const& window, Displac
     case mir_window_type_inputmethod:
     case mir_window_type_tip:
     case mir_window_type_decoration:
+    case mir_window_type_anchored:
     case mir_window_types:
         return;
     }
@@ -1928,6 +1929,7 @@ void miral::BasicWindowManager::validate_modification_request(WindowSpecificatio
         case mir_window_type_inputmethod:
         case mir_window_type_tip:
         case mir_window_type_decoration:
+        case mir_window_type_anchored:
             if (target_type != original_type)
                 BOOST_THROW_EXCEPTION(std::runtime_error("Invalid surface type change"));
             break;
@@ -1941,6 +1943,7 @@ void miral::BasicWindowManager::validate_modification_request(WindowSpecificatio
     {
     case mir_window_type_normal:
     case mir_window_type_utility:
+    case mir_window_type_anchored:
         if (modifications.parent().is_set() ? modifications.parent().value().lock() : window_info.parent())
             BOOST_THROW_EXCEPTION(std::runtime_error("Window type must not have a parent"));
         break;

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -254,6 +254,7 @@ private:
     void erase(miral::WindowInfo const& info);
     void validate_modification_request(WindowSpecification const& modifications, WindowInfo const& window_info) const;
     void place_and_size(WindowInfo& root, Point const& new_pos, Size const& new_size);
+    void place_anchored(WindowInfo& root);
     void set_state(miral::WindowInfo& window_info, MirWindowState value);
     auto fullscreen_rect_for(WindowInfo const& window_info) const -> Rectangle;
     void remove_window(Application const& application, miral::WindowInfo const& info);

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -393,5 +393,10 @@ global:
     typeinfo?for?miral::WaylandExtensions::Context;
     vtable?for?miral::WaylandExtensions::Builder;
     vtable?for?miral::WaylandExtensions::Context;
+    miral::WaylandExtensions::with_extension*;
+    miral::WindowInfo::anchor_edge*;
+    miral::WindowInfo::anchor_exclusive_zone*;
+    miral::WindowSpecification::anchor_edge*;
+    miral::WindowSpecification::anchor_exclusive_zone*;
   };
 } MIRAL_2.4;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -360,6 +360,10 @@ global:
     miral::WaylandExtensions::WaylandExtensions*;
     miral::WaylandExtensions::operator*;
     miral::WaylandExtensions::supported_extensions*;
+    miral::WindowInfo::anchor_edge*;
+    miral::WindowInfo::anchor_exclusive_zone*;
+    miral::WindowSpecification::anchor_edge*;
+    miral::WindowSpecification::anchor_exclusive_zone*;
     miral::X11Support::?X11Support*;
     miral::X11Support::X11Support*;
     miral::X11Support::operator*;

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -94,6 +94,9 @@ struct miral::WindowInfo::Self
     mir::optional_value<int> output_id;
     MirShellChrome shell_chrome;
     std::shared_ptr<void> userdata;
+
+    MirPlacementGravity anchor_edge;
+    int anchor_exclusive_zone;
 };
 
 miral::WindowInfo::Self::Self(Window window, WindowSpecification const& params) :
@@ -112,7 +115,9 @@ miral::WindowInfo::Self::Self(Window window, WindowSpecification const& params) 
     height_inc{optional_value_or_default(params.height_inc(), default_height_inc)},
     min_aspect(optional_value_or_default(params.min_aspect(), default_min_aspect_ratio)),
     max_aspect(optional_value_or_default(params.max_aspect(), default_max_aspect_ratio)),
-    shell_chrome(optional_value_or_default(params.shell_chrome(), mir_shell_chrome_normal))
+    shell_chrome(optional_value_or_default(params.shell_chrome(), mir_shell_chrome_normal)),
+    anchor_edge(optional_value_or_default(params.anchor_edge(), mir_placement_gravity_center)),
+    anchor_exclusive_zone(optional_value_or_default(params.anchor_exclusive_zone(), 0))
 {
     if (params.output_id().is_set())
         output_id = params.output_id().value();
@@ -606,6 +611,26 @@ auto miral::WindowInfo::shell_chrome() const -> MirShellChrome
 void miral::WindowInfo::shell_chrome(MirShellChrome chrome)
 {
     self->shell_chrome = chrome;
+}
+
+auto miral::WindowInfo::anchor_edge() const -> MirPlacementGravity
+{
+    return self->anchor_edge;
+}
+
+void miral::WindowInfo::anchor_edge(MirPlacementGravity edge)
+{
+    self->anchor_edge = edge;
+}
+
+auto miral::WindowInfo::anchor_exclusive_zone() const -> int
+{
+    return self->anchor_exclusive_zone;
+}
+
+void miral::WindowInfo::anchor_exclusive_zone(int size)
+{
+    self->anchor_exclusive_zone = size;
 }
 
 auto miral::WindowInfo::name() const -> std::string

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -170,7 +170,6 @@ bool miral::WindowInfo::can_be_active() const
     case mir_window_type_dialog:
     case mir_window_type_freestyle:
     case mir_window_type_menu:
-    case mir_window_type_anchored:
         return true;
 
     case mir_window_type_satellite:    /**< AKA "toolbox"/"toolbar"             */
@@ -178,6 +177,7 @@ bool miral::WindowInfo::can_be_active() const
     case mir_window_type_gloss:
     case mir_window_type_tip:          /**< AKA "tooltip"                       */
     case mir_window_type_decoration:
+    case mir_window_type_anchored:
     case mir_window_types:
         // Cannot have input focus
         break;

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -396,6 +396,7 @@ bool miral::WindowInfo::needs_titlebar(MirWindowType type)
     case mir_window_type_inputmethod:
     case mir_window_type_gloss:
     case mir_window_type_tip:
+    case mir_window_type_anchored:
         // No decorations for these surface types
         return false;
     default:

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -165,6 +165,7 @@ bool miral::WindowInfo::can_be_active() const
     case mir_window_type_dialog:
     case mir_window_type_freestyle:
     case mir_window_type_menu:
+    case mir_window_type_anchored:
         return true;
 
     case mir_window_type_satellite:    /**< AKA "toolbox"/"toolbar"             */
@@ -172,10 +173,11 @@ bool miral::WindowInfo::can_be_active() const
     case mir_window_type_gloss:
     case mir_window_type_tip:          /**< AKA "tooltip"                       */
     case mir_window_type_decoration:
-    default:
+    case mir_window_types:
         // Cannot have input focus
-        return false;
+        break;
     }
+    return false;
 }
 
 bool miral::WindowInfo::must_have_parent() const

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -59,6 +59,8 @@ struct miral::WindowSpecification::Self
     mir::optional_value<InputReceptionMode> input_mode;
     mir::optional_value<MirShellChrome> shell_chrome;
     mir::optional_value<MirPointerConfinementState> confine_pointer;
+    mir::optional_value<MirPlacementGravity> anchor_edge;
+    mir::optional_value<int> anchor_exclusive_zone;
     mir::optional_value<std::shared_ptr<void>> userdata;
 };
 
@@ -88,8 +90,10 @@ miral::WindowSpecification::Self::Self(mir::shell::SurfaceSpecification const& s
     parent(spec.parent),
     input_shape(spec.input_shape),
     input_mode(),
-    shell_chrome(spec.shell_chrome)
-    ,confine_pointer(spec.confine_pointer)
+    shell_chrome(spec.shell_chrome),
+    confine_pointer(spec.confine_pointer),
+    anchor_edge(spec.anchor_edge),
+    anchor_exclusive_zone(spec.anchor_exclusive_zone)
 {
     if (spec.aux_rect_placement_offset_x.is_set() && spec.aux_rect_placement_offset_y.is_set())
         aux_rect_placement_offset = Displacement{spec.aux_rect_placement_offset_x.value(), spec.aux_rect_placement_offset_y.value()};
@@ -213,8 +217,10 @@ miral::WindowSpecification::Self::Self(mir::scene::SurfaceCreationParameters con
     parent(params.parent),
     input_shape(params.input_shape),
     input_mode(static_cast<InputReceptionMode>(params.input_mode)),
-    shell_chrome(params.shell_chrome)
-    ,confine_pointer(params.confine_pointer)
+    shell_chrome(params.shell_chrome),
+    confine_pointer(params.confine_pointer),
+    anchor_edge(params.anchor_edge),
+    anchor_exclusive_zone(params.anchor_exclusive_zone)
 {
     if (params.aux_rect_placement_offset_x.is_set() && params.aux_rect_placement_offset_y.is_set())
         aux_rect_placement_offset = Displacement{params.aux_rect_placement_offset_x.value(), params.aux_rect_placement_offset_y.value()};
@@ -283,6 +289,8 @@ void miral::WindowSpecification::Self::update(mir::scene::SurfaceCreationParamet
     copy_if_set(params.placement_hints, placement_hints);
     copy_if_set(params.surface_placement_gravity, window_placement_gravity);
     copy_if_set(params.aux_rect_placement_gravity, aux_rect_placement_gravity);
+    copy_if_set(params.anchor_edge, anchor_edge);
+    copy_if_set(params.anchor_exclusive_zone, anchor_exclusive_zone);
 
     if (aux_rect_placement_offset.is_set())
     {
@@ -450,6 +458,16 @@ auto miral::WindowSpecification::confine_pointer() const -> mir::optional_value<
     return self->confine_pointer;
 }
 
+auto miral::WindowSpecification::anchor_edge() const -> mir::optional_value<MirPlacementGravity> const&
+{
+    return self->anchor_edge;
+}
+
+auto miral::WindowSpecification::anchor_exclusive_zone() const -> mir::optional_value<int> const&
+{
+    return self->anchor_exclusive_zone;
+}
+
 auto miral::WindowSpecification::userdata() const -> mir::optional_value<std::shared_ptr<void>> const&
 {
     return self->userdata;
@@ -578,6 +596,16 @@ auto miral::WindowSpecification::shell_chrome() -> mir::optional_value<MirShellC
 auto miral::WindowSpecification::confine_pointer() -> mir::optional_value<MirPointerConfinementState>&
 {
     return self->confine_pointer;
+}
+
+auto miral::WindowSpecification::anchor_edge() -> mir::optional_value<MirPlacementGravity>&
+{
+    return self->anchor_edge;
+}
+
+auto miral::WindowSpecification::anchor_exclusive_zone() -> mir::optional_value<int>&
+{
+    return self->anchor_exclusive_zone;
 }
 
 auto miral::WindowSpecification::userdata() -> mir::optional_value<std::shared_ptr<void>>&

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -161,7 +161,7 @@ install(DIRECTORY
   ${CMAKE_SOURCE_DIR}/include/server/mir DESTINATION "include/mirserver"
 )
 
-set(MIRSERVER_ABI 47) # Be sure to increment MIR_VERSION_MINOR at the same time
+set(MIRSERVER_ABI 48) # Be sure to increment MIR_VERSION_MINOR at the same time
 set(symbol_map ${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)
 
 set_target_properties(

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -113,6 +113,13 @@ mf::LayerSurfaceV1::LayerSurfaceV1(
 
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
 {
+    // HACK: Leaving zero sizes zero causes a validation error, and setting them to window_size() causes handle_resize()
+    //       To be suppressed when returning to a previous size
+    //       (don't ask me exactly why, but probably something to do with how event sink caches and checks)
+    if (width == 0)
+        width = 1;
+    if (height == 0)
+        height = 1;
     WindowWlSurfaceRole::set_geometry(0, 0, width, height);
 }
 

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -107,6 +107,8 @@ mf::LayerSurfaceV1::LayerSurfaceV1(
     shell::SurfaceSpecification spec;
     spec.type = mir_window_type_anchored;
     apply_spec(spec);
+    auto const serial = wl_display_next_serial(wl_client_get_display(wayland::LayerSurfaceV1::client));
+    send_configure_event (serial, 0, 0);
 }
 
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
@@ -182,5 +184,7 @@ void mf::LayerSurfaceV1::handle_resize(
     geometry::Size const& new_size)
 {
     (void)new_top_left;
-    (void)new_size;
+
+    auto const serial = wl_display_next_serial(wl_client_get_display(wayland::LayerSurfaceV1::client));
+    send_configure_event (serial, new_size.width.as_int(), new_size.height.as_int());
 }

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -35,8 +35,13 @@ namespace frontend
 class LayerSurfaceV1 : public wayland::LayerSurfaceV1, public WindowWlSurfaceRole
 {
 public:
-    LayerSurfaceV1(struct wl_client* client, struct wl_resource* parent_resource, uint32_t id, WlSurface* surface,
-                   LayerShellV1 const& layer_shell);
+    LayerSurfaceV1(
+        struct wl_client* client,
+        struct wl_resource* parent_resource,
+        uint32_t id,
+        WlSurface* surface,
+        LayerShellV1 const& layer_shell);
+
     ~LayerSurfaceV1() = default;
 
 private:
@@ -51,8 +56,9 @@ private:
     void destroy() override;
 
     // from WindowWlSurfaceRole
-    void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,
-                       geometry::Size const& new_size) override;
+    void handle_resize(
+        std::experimental::optional<geometry::Point> const& new_top_left,
+        geometry::Size const& new_size) override;
 };
 
 }
@@ -60,8 +66,11 @@ private:
 
 // LayerShellV1
 
-mf::LayerShellV1::LayerShellV1(struct wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat,
-                               OutputManager* output_manager)
+mf::LayerShellV1::LayerShellV1(
+    struct wl_display* display,
+    std::shared_ptr<Shell> const shell,
+    WlSeat& seat,
+    OutputManager* output_manager)
     : wayland::LayerShellV1(display, 1),
       shell{shell},
       seat{seat},
@@ -69,10 +78,14 @@ mf::LayerShellV1::LayerShellV1(struct wl_display* display, std::shared_ptr<Shell
 {
 }
 
-void mf::LayerShellV1::get_layer_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id,
-                                         struct wl_resource* surface,
-                                         std::experimental::optional<struct wl_resource*> const& output,
-                                         uint32_t layer, std::string const& namespace_)
+void mf::LayerShellV1::get_layer_surface(
+    struct wl_client* client,
+    struct wl_resource* resource,
+    uint32_t id,
+    struct wl_resource* surface,
+    std::experimental::optional<struct wl_resource*> const& output,
+    uint32_t layer,
+    std::string const& namespace_)
 {
     (void)output;
     (void)layer;
@@ -82,8 +95,12 @@ void mf::LayerShellV1::get_layer_surface(struct wl_client* client, struct wl_res
 
 // LayerSurfaceV1
 
-mf::LayerSurfaceV1::LayerSurfaceV1(struct wl_client* client, struct wl_resource* parent_resource, uint32_t id,
-                                   WlSurface* surface, LayerShellV1 const& layer_shell)
+mf::LayerSurfaceV1::LayerSurfaceV1(
+    struct wl_client* client,
+    struct wl_resource* parent_resource,
+    uint32_t id,
+    WlSurface* surface,
+    LayerShellV1 const& layer_shell)
     : wayland::LayerSurfaceV1(client, parent_resource, id),
       WindowWlSurfaceRole(&layer_shell.seat, client, surface, layer_shell.shell, layer_shell.output_manager)
 {
@@ -138,10 +155,11 @@ void mf::LayerSurfaceV1::set_keyboard_interactivity(uint32_t keyboard_interactiv
 
 void mf::LayerSurfaceV1::get_popup(struct wl_resource* popup)
 {
-    auto popup_window_role = static_cast<WindowWlSurfaceRole*>(
-                                 static_cast<XdgPopupStable*>(
-                                     static_cast<wayland::XdgPopup*>(
-                                         wl_resource_get_user_data(popup))));
+    auto popup_window_role =
+        static_cast<WindowWlSurfaceRole*>(
+            static_cast<XdgPopupStable*>(
+                static_cast<wayland::XdgPopup*>(
+                    wl_resource_get_user_data(popup))));
 
     mir::shell::SurfaceSpecification specification;
     specification.parent_id = surface_id();
@@ -159,8 +177,9 @@ void mf::LayerSurfaceV1::destroy()
     destroy_wayland_object();
 }
 
-void mf::LayerSurfaceV1::handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,
-                                       geometry::Size const& new_size)
+void mf::LayerSurfaceV1::handle_resize(
+    std::experimental::optional<geometry::Point> const& new_top_left,
+    geometry::Size const& new_size)
 {
     (void)new_top_left;
     (void)new_size;

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -93,13 +93,28 @@ mf::LayerSurfaceV1::LayerSurfaceV1(struct wl_client* client, struct wl_resource*
 
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
 {
-    (void)width;
-    (void)height;
+    WindowWlSurfaceRole::set_geometry(0, 0, width, height);
 }
 
 void mf::LayerSurfaceV1::set_anchor(uint32_t anchor)
 {
-    (void)anchor;
+    MirPlacementGravity gravity = mir_placement_gravity_center;
+
+    if (anchor & Anchor::top)
+        gravity = MirPlacementGravity(gravity | mir_placement_gravity_north);
+
+    if (anchor & Anchor::bottom)
+        gravity = MirPlacementGravity(gravity | mir_placement_gravity_south);
+
+    if (anchor & Anchor::left)
+        gravity = MirPlacementGravity(gravity | mir_placement_gravity_west);
+
+    if (anchor & Anchor::right)
+        gravity = MirPlacementGravity(gravity | mir_placement_gravity_east);
+
+    shell::SurfaceSpecification spec;
+    spec.anchor_edge = gravity;
+    apply_spec(spec);
 }
 
 void mf::LayerSurfaceV1::set_exclusive_zone(int32_t zone)

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -20,6 +20,7 @@
 
 #include "wl_surface.h"
 #include "window_wl_surface_role.h"
+#include "xdg_shell_stable.h"
 
 #include "mir/shell/surface_specification.h"
 
@@ -137,7 +138,15 @@ void mf::LayerSurfaceV1::set_keyboard_interactivity(uint32_t keyboard_interactiv
 
 void mf::LayerSurfaceV1::get_popup(struct wl_resource* popup)
 {
-    (void)popup;
+    auto popup_window_role = static_cast<WindowWlSurfaceRole*>(
+                                 static_cast<XdgPopupStable*>(
+                                     static_cast<wayland::XdgPopup*>(
+                                         wl_resource_get_user_data(popup))));
+
+    mir::shell::SurfaceSpecification specification;
+    specification.parent_id = surface_id();
+
+    popup_window_role->apply_spec(specification);
 }
 
 void mf::LayerSurfaceV1::ack_configure(uint32_t serial)

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -21,6 +21,8 @@
 #include "wl_surface.h"
 #include "window_wl_surface_role.h"
 
+#include "mir/shell/surface_specification.h"
+
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
 
@@ -84,6 +86,9 @@ mf::LayerSurfaceV1::LayerSurfaceV1(struct wl_client* client, struct wl_resource*
     : wayland::LayerSurfaceV1(client, parent_resource, id),
       WindowWlSurfaceRole(&layer_shell.seat, client, surface, layer_shell.shell, layer_shell.output_manager)
 {
+    shell::SurfaceSpecification spec;
+    spec.type = mir_window_type_anchored;
+    apply_spec(spec);
 }
 
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)

--- a/src/server/frontend_wayland/layer_shell_v1.h
+++ b/src/server/frontend_wayland/layer_shell_v1.h
@@ -33,11 +33,20 @@ class OutputManager;
 class LayerShellV1 : public wayland::LayerShellV1
 {
 public:
-    LayerShellV1(struct wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
+    LayerShellV1(
+        struct wl_display* display,
+        std::shared_ptr<Shell> const shell,
+        WlSeat& seat,
+        OutputManager* output_manager);
 
-    void get_layer_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id,
-                           struct wl_resource* surface, std::experimental::optional<struct wl_resource*> const& output,
-                           uint32_t layer, std::string const& namespace_) override;
+    void get_layer_surface(
+        struct wl_client* client,
+        struct wl_resource* resource,
+        uint32_t id,
+        struct wl_resource* surface,
+        std::experimental::optional<struct wl_resource*> const& output,
+        uint32_t layer,
+        std::string const& namespace_) override;
 
     std::shared_ptr<Shell> const shell;
     WlSeat& seat;

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -106,6 +106,12 @@ mf::WlSurface::~WlSurface()
         listener.second();
     }
 
+    if (role != &null_role)
+    {
+        log_warning("Surface role should have been destroyed before surface object, but was not");
+        // TODO: send protocol error?
+    }
+
     role->destroy();
     session->destroy_buffer_stream(stream_id);
 }

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -19,7 +19,6 @@
 #include "xdg_shell_stable.h"
 
 #include "wl_surface.h"
-#include "window_wl_surface_role.h"
 
 #include "mir/frontend/session.h"
 #include "mir/frontend/wayland.h"
@@ -66,26 +65,6 @@ private:
 
 public:
     XdgShellStable const& xdg_shell;
-};
-
-class XdgPopupStable : wayland::XdgPopup, public WindowWlSurfaceRole
-{
-public:
-    XdgPopupStable(struct wl_client* client, struct wl_resource* resource_parent, uint32_t id,
-                   XdgSurfaceStable* xdg_surface, WlSurfaceRole* parent_role, struct wl_resource* positioner,
-                   WlSurface* surface);
-
-    void grab(struct wl_resource* seat, uint32_t serial) override;
-    void destroy() override;
-
-    void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,
-                       geometry::Size const& new_size) override;
-
-private:
-    std::experimental::optional<geom::Point> cached_top_left;
-    std::experimental::optional<geom::Size> cached_size;
-
-    XdgSurfaceStable* const xdg_surface;
 };
 
 class XdgToplevelStable : wayland::XdgToplevel, public WindowWlSurfaceRole
@@ -201,24 +180,16 @@ void mf::XdgSurfaceStable::get_popup(uint32_t id,
                                      std::experimental::optional<struct wl_resource*> const& parent_surface,
                                      struct wl_resource* positioner)
 {
-    auto parent_xdg_surface = parent_surface ?
-                                  std::experimental::make_optional(XdgSurfaceStable::from(parent_surface.value()))
-                                  : std::experimental::nullopt;
-
-    auto parent_window_role = parent_xdg_surface ?
-                                  parent_xdg_surface.value()->window_role()
-                                  : std::experimental::nullopt;
-
-
-    if  (!parent_window_role)
+    std::experimental::optional<WindowWlSurfaceRole*> parent_window_role;
+    if (parent_surface)
     {
-        // When we implement layer shell, it will be more clear why this function might be called with a null parent,
-        // and we can revisit handling it then.
-        log_warning("tried to create XDG shell stable popup without a parent");
-        return;
+        XdgSurfaceStable* parent_xdg_surface = XdgSurfaceStable::from(parent_surface.value());
+        parent_window_role = parent_xdg_surface->window_role();
+        if (!parent_window_role)
+            log_warning("Parent window of a popup had no role");
     }
 
-    auto popup = new XdgPopupStable{wayland::XdgSurface::client, resource, id, this, parent_window_role.value(), positioner,
+    auto popup = new XdgPopupStable{wayland::XdgSurface::client, resource, id, this, parent_window_role, positioner,
                                     surface};
     set_window_role(popup);
 }
@@ -263,9 +234,11 @@ void mf::XdgSurfaceStable::set_window_role(WindowWlSurfaceRole* role)
 
 // XdgPopupStable
 
-mf::XdgPopupStable::XdgPopupStable(struct wl_client* client, struct wl_resource* resource_parent, uint32_t id,
+mf::XdgPopupStable::XdgPopupStable(struct wl_client* client,
+                                   struct wl_resource* resource_parent,
+                                   uint32_t id,
                                    XdgSurfaceStable* xdg_surface,
-                                   WlSurfaceRole* parent_role,
+                                   std::experimental::optional<WlSurfaceRole*> parent_role,
                                    struct wl_resource* positioner, WlSurface* surface)
     : wayland::XdgPopup(client, resource_parent, id),
       WindowWlSurfaceRole(&xdg_surface->xdg_shell.seat, client, surface, xdg_surface->xdg_shell.shell,
@@ -279,7 +252,8 @@ mf::XdgPopupStable::XdgPopupStable(struct wl_client* client, struct wl_resource*
 
     specification->type = mir_window_type_freestyle;
     specification->placement_hints = mir_placement_hints_slide_any;
-    specification->parent_id = parent_role->surface_id();
+    if (parent_role)
+        specification->parent_id = parent_role.value()->surface_id();
 
     apply_spec(*specification);
 }

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -20,6 +20,7 @@
 #define MIR_FRONTEND_XDG_SHELL_STABLE_H
 
 #include "xdg-shell_wrapper.h"
+#include "window_wl_surface_role.h"
 
 namespace mir
 {
@@ -30,6 +31,8 @@ class Shell;
 class Surface;
 class WlSeat;
 class OutputManager;
+class WlSurface;
+class XdgSurfaceStable;
 
 class XdgShellStable : public wayland::XdgWmBase
 {
@@ -46,6 +49,26 @@ public:
     std::shared_ptr<Shell> const shell;
     WlSeat& seat;
     OutputManager* const output_manager;
+};
+
+class XdgPopupStable : public wayland::XdgPopup, public WindowWlSurfaceRole
+{
+public:
+    XdgPopupStable(struct wl_client* client, struct wl_resource* resource_parent, uint32_t id,
+                   XdgSurfaceStable* xdg_surface, std::experimental::optional<WlSurfaceRole*> parent_role,
+                   struct wl_resource* positioner, WlSurface* surface);
+
+    void grab(struct wl_resource* seat, uint32_t serial) override;
+    void destroy() override;
+
+    void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,
+                       geometry::Size const& new_size) override;
+
+private:
+    std::experimental::optional<geometry::Point> cached_top_left;
+    std::experimental::optional<geometry::Size> cached_size;
+
+    XdgSurfaceStable* const xdg_surface;
 };
 
 }

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -217,6 +217,7 @@ std::shared_ptr<ms::Surface> ms::ApplicationSession::surface_after(std::shared_p
             case mir_window_type_freestyle:
             case mir_window_type_menu:
             case mir_window_type_inputmethod:  /**< AKA "OSK" or handwriting etc.       */
+            case mir_window_type_anchored:
                 return true;
 
             case mir_window_type_gloss:

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -222,10 +222,11 @@ std::shared_ptr<ms::Surface> ms::ApplicationSession::surface_after(std::shared_p
             case mir_window_type_gloss:
             case mir_window_type_tip:          /**< AKA "tooltip"                       */
             case mir_window_type_decoration:
-            default:
+            case mir_window_types:
                 // Cannot have input focus - skip it
-                return false;
+                break;
             }
+            return false;
         };
 
     auto next = std::find_if(++current, end(surfaces), can_take_focus);

--- a/src/server/scene/surface_creation_parameters.cpp
+++ b/src/server/scene/surface_creation_parameters.cpp
@@ -196,6 +196,10 @@ void ms::SurfaceCreationParameters::update_from(msh::SurfaceSpecification const&
         shell_chrome = that.shell_chrome;
     if (that.confine_pointer.is_set())
         confine_pointer = that.confine_pointer;
+    if (that.anchor_edge.is_set())
+        anchor_edge = that.anchor_edge;
+    if (that.anchor_exclusive_zone.is_set())
+        anchor_exclusive_zone = that.anchor_exclusive_zone;
     // TODO: should SurfaceCreationParameters support cursors?
 //     if (that.cursor_image.is_set())
 //         cursor_image = that.cursor_image;

--- a/src/server/shell/surface_specification.cpp
+++ b/src/server/shell/surface_specification.cpp
@@ -47,7 +47,9 @@ bool msh::SurfaceSpecification::is_empty() const
         !streams.is_set() &&
         !parent.is_set() &&
         !input_shape.is_set() &&
-        !shell_chrome.is_set();
+        !shell_chrome.is_set() &&
+        !anchor_edge.is_set() &&
+        !anchor_exclusive_zone.is_set();
 }
 
 void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
@@ -116,4 +118,10 @@ void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
         cursor_image = that.cursor_image;
     if (that.stream_cursor.is_set())
         stream_cursor = that.stream_cursor;
+    if (that.anchor_edge.is_set())
+        anchor_edge = that.anchor_edge;
+    if (that.anchor_edge.is_set())
+        anchor_edge = that.anchor_edge;
+    if (that.anchor_exclusive_zone.is_set())
+        anchor_exclusive_zone = that.anchor_exclusive_zone;
 }

--- a/src/server/shell/window_management_info.cpp
+++ b/src/server/shell/window_management_info.cpp
@@ -141,6 +141,7 @@ bool msh::SurfaceInfo::must_not_have_parent() const
     {
     case mir_window_type_normal:
     case mir_window_type_utility:
+    case mir_window_type_anchored:
         return true;
 
     default:

--- a/tests/mir_test_framework/canonical_window_manager.cpp
+++ b/tests/mir_test_framework/canonical_window_manager.cpp
@@ -48,6 +48,7 @@ bool must_not_have_parent(MirWindowType type)
     {
     case mir_window_type_normal:
     case mir_window_type_utility:
+    case mir_window_type_anchored:
         return true;
 
     default:

--- a/tests/mir_test_framework/open_wrapper.cpp
+++ b/tests/mir_test_framework/open_wrapper.cpp
@@ -18,7 +18,7 @@
 
 #include "mir_test_framework/open_wrapper.h"
 
-#include <list>
+#include <vector>
 #include <mutex>
 #include <unistd.h>
 #include <dlfcn.h>
@@ -28,7 +28,7 @@ namespace mtf = mir_test_framework;
 namespace
 {
 std::mutex handlers_mutex;
-std::list<mtf::OpenHandler> handlers;
+std::vector<mtf::OpenHandler> handlers;
 
 void remove_handler(void* iterator)
 {

--- a/tests/miral/drag_active_window.cpp
+++ b/tests/miral/drag_active_window.cpp
@@ -117,6 +117,7 @@ INSTANTIATE_TEST_CASE_P(DragActiveWindow, ForMoveableTypes, ::testing::Values(
 //    mir_window_type_inputmethod,
 //    mir_window_type_satellite,
 //    mir_window_type_tip,
+//    mir_window_type_anchored,
 //    mir_window_types
 ));
 


### PR DESCRIPTION
With this, layer shell surfaces are correctly anchored to an edge of a display.

This breaks ABI, but should not break API (at least not significantly). More ABI breaks may be required in the future as I add all layer shell features.