### PR TITLE
tests: Use the correct package name to detect gtest on RPM distributions

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
     set(GTEST_DETECTION_METHOD "output of apt")
   elseif(RPM_EXECUTABLE)
     EXEC_PROGRAM(${RPM_EXECUTABLE} "/"
-      ARGS "-q" "libgtest-dev"
+      ARGS "-q" "gtest-devel"
       OUTPUT_VARIABLE GTEST_VERSION_STR)
     set(GTEST_DETECTION_METHOD "output of rpm")
   elseif(PACMAN_EXECUTABLE)


### PR DESCRIPTION
This check was incorrectly using the Debian package name (`libgtest-dev`) instead of the RPM package name (`gtest-devel`). Fixing this check makes Mir build properly against Google Test 1.8.1.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>