### PR TITLE
Track whether there's a usable pointing device and hide/show cursor accordingly. (Fixes #594)

### DIFF
--- a/src/include/server/mir/input/cursor_listener.h
+++ b/src/include/server/mir/input/cursor_listener.h
@@ -32,6 +32,8 @@ public:
     virtual ~CursorListener() = default;
 
     virtual void cursor_moved_to(float abs_x, float abs_y) = 0;
+    virtual void pointer_usable() = 0;
+    virtual void pointer_unusable() = 0;
 
 protected:
     CursorListener() = default;

--- a/src/platforms/evdev/platform.cpp
+++ b/src/platforms/evdev/platform.cpp
@@ -395,8 +395,7 @@ void mie::Platform::process_input_events()
         }
         else
         {
-            auto dev = find_device(
-                libinput_device_get_device_group(device));
+            auto dev = find_device(device);
             if (dev != end(devices))
                 (*dev)->process_event(ev.get());
         }
@@ -417,7 +416,7 @@ void mie::Platform::device_added(libinput_device* dev)
 
     log_info("Added %s", describe(dev).c_str());
 
-    auto device_it = find_device(libinput_device_get_device_group(device_ptr.get()));
+    auto device_it = find_device(device_ptr.get());
     if (end(devices) != device_it)
     {
         (*device_it)->add_device_of_group(move(device_ptr));
@@ -441,7 +440,7 @@ void mie::Platform::device_added(libinput_device* dev)
 
 void mie::Platform::device_removed(libinput_device* dev)
 {
-    auto known_device_pos = find_device(libinput_device_get_device_group(dev));
+    auto known_device_pos = find_device(dev);
 
     if (known_device_pos == end(devices))
         return;
@@ -452,16 +451,14 @@ void mie::Platform::device_removed(libinput_device* dev)
     log_info("Removed %s", describe(dev).c_str());
 }
 
-auto mie::Platform::find_device(libinput_device_group const* devgroup) -> decltype(devices)::iterator
+auto mie::Platform::find_device(libinput_device* dev) -> decltype(devices)::iterator
 {
-    if (devgroup == nullptr)
-        return end(devices);
     return std::find_if(
         begin(devices),
         end(devices),
-        [devgroup](auto const& item)
+        [dev](auto const& item)
         {
-            return devgroup == item->group();
+            return dev == item->device();
         });
 }
 

--- a/src/platforms/evdev/platform.h
+++ b/src/platforms/evdev/platform.h
@@ -90,7 +90,7 @@ private:
     std::unordered_map<dev_t, std::unique_ptr<mir::Device>> device_watchers;
 
     std::vector<std::shared_ptr<LibInputDevice>> devices;
-    auto find_device(libinput_device_group const* group) -> decltype(devices)::iterator;
+    auto find_device(libinput_device* dev) -> decltype(devices)::iterator;
 };
 }
 }

--- a/src/server/input/basic_seat.cpp
+++ b/src/server/input/basic_seat.cpp
@@ -192,10 +192,14 @@ mi::BasicSeat::BasicSeat(std::shared_ptr<mi::InputDispatcher> const& dispatcher,
 void mi::BasicSeat::add_device(input::Device const& device)
 {
     input_state_tracker.add_device(device.id());
+    if (contains(device.capabilities(), mi::DeviceCapability::pointer))
+        input_state_tracker.add_pointing_device();
 }
 
 void mi::BasicSeat::remove_device(input::Device const& device)
 {
+    if (contains(device.capabilities(), mi::DeviceCapability::pointer))
+        input_state_tracker.remove_pointing_device();
     input_state_tracker.remove_device(device.id());
 }
 

--- a/src/server/input/cursor_controller.cpp
+++ b/src/server/input/cursor_controller.cpp
@@ -205,6 +205,7 @@ mi::CursorController::CursorController(std::shared_ptr<mi::Scene> const& input_t
         default_cursor_image(default_cursor_image),
         current_cursor(default_cursor_image)
 {
+    cursor->hide(); // Cursor should be hidden unless there's a pointing device
     // TODO: Add observer could return weak_ptr to eliminate this
     // pattern
     auto strong_observer = std::make_shared<UpdateCursorOnSceneChanges>(this);
@@ -237,7 +238,12 @@ void mi::CursorController::set_cursor_image_locked(std::unique_lock<std::mutex>&
     lock.unlock();
 
     if (image && !is_empty(image))
-        cursor->show(*image);
+    {
+        if (usable)
+            cursor->show(*image);
+        else
+            pending_image = image;
+    }
     else
         cursor->hide();
 }
@@ -274,4 +280,31 @@ void mi::CursorController::cursor_moved_to(float abs_x, float abs_y)
     }
 
     cursor->move_to(new_location);
+}
+
+void mir::input::CursorController::pointer_usable()
+{
+    bool became_usable = false;
+    std::shared_ptr<mg::CursorImage> image;
+    {
+        std::lock_guard<std::mutex> lock(cursor_state_guard);
+        became_usable = !usable;
+        image = current_cursor;
+        usable = true;
+    }
+
+    if (became_usable)
+    {
+        if (image && !is_empty(image))
+            cursor->show(*image);
+    }
+}
+
+void mir::input::CursorController::pointer_unusable()
+{
+    {
+        std::lock_guard<std::mutex> lock(cursor_state_guard);
+        usable = false;
+    }
+    cursor->hide();
 }

--- a/src/server/input/cursor_controller.cpp
+++ b/src/server/input/cursor_controller.cpp
@@ -234,6 +234,7 @@ void mi::CursorController::set_cursor_image_locked(std::unique_lock<std::mutex>&
     }
 
     current_cursor = image;
+    auto const usable = this->usable;
 
     lock.unlock();
 
@@ -241,8 +242,6 @@ void mi::CursorController::set_cursor_image_locked(std::unique_lock<std::mutex>&
     {
         if (usable)
             cursor->show(*image);
-        else
-            pending_image = image;
     }
     else
         cursor->hide();

--- a/src/server/input/cursor_controller.cpp
+++ b/src/server/input/cursor_controller.cpp
@@ -283,6 +283,7 @@ void mi::CursorController::cursor_moved_to(float abs_x, float abs_y)
 
 void mir::input::CursorController::pointer_usable()
 {
+    std::lock_guard<std::mutex> lock(serialize_pointer_usable_unusable);
     bool became_usable = false;
     std::shared_ptr<mg::CursorImage> image;
     {
@@ -301,6 +302,7 @@ void mir::input::CursorController::pointer_usable()
 
 void mir::input::CursorController::pointer_unusable()
 {
+    std::lock_guard<std::mutex> lock(serialize_pointer_usable_unusable);
     {
         std::lock_guard<std::mutex> lock(cursor_state_guard);
         usable = false;

--- a/src/server/input/cursor_controller.h
+++ b/src/server/input/cursor_controller.h
@@ -49,11 +49,15 @@ public:
         std::shared_ptr<graphics::CursorImage> const& default_cursor_image);
     virtual ~CursorController();
 
-    void cursor_moved_to(float abs_x, float abs_y);
+    void cursor_moved_to(float abs_x, float abs_y) override;
 
     // Trigger an update of the cursor image without cursor motion, e.g.
     // in response to scene changes.
     void update_cursor_image();
+
+    void pointer_usable() override;
+
+    void pointer_unusable() override;
 
 private:
     std::shared_ptr<Scene> const input_targets;
@@ -63,9 +67,11 @@ private:
     std::mutex cursor_state_guard;
     geometry::Point cursor_location;
     std::shared_ptr<graphics::CursorImage> current_cursor;
+    std::shared_ptr<graphics::CursorImage> pending_image;
+
 
     std::weak_ptr<scene::Observer> observer;
-    
+    bool usable = false;
 
     void update_cursor_image_locked(std::unique_lock<std::mutex>&);
     void set_cursor_image_locked(std::unique_lock<std::mutex>&, std::shared_ptr<graphics::CursorImage> const& image);

--- a/src/server/input/cursor_controller.h
+++ b/src/server/input/cursor_controller.h
@@ -63,13 +63,15 @@ private:
     std::shared_ptr<Scene> const input_targets;
     std::shared_ptr<graphics::Cursor> const cursor;
     std::shared_ptr<graphics::CursorImage> const default_cursor_image;
+    std::weak_ptr<scene::Observer> observer;    // Not mutated after construction
 
     std::mutex cursor_state_guard;
     geometry::Point cursor_location;
     std::shared_ptr<graphics::CursorImage> current_cursor;
-
-    std::weak_ptr<scene::Observer> observer;
     bool usable = false;
+
+    // Used only to serialize calls to pointer_usable()/pointer_unusable()
+    std::mutex serialize_pointer_usable_unusable;
 
     void update_cursor_image_locked(std::unique_lock<std::mutex>&);
     void set_cursor_image_locked(std::unique_lock<std::mutex>&, std::shared_ptr<graphics::CursorImage> const& image);

--- a/src/server/input/cursor_controller.h
+++ b/src/server/input/cursor_controller.h
@@ -67,8 +67,6 @@ private:
     std::mutex cursor_state_guard;
     geometry::Point cursor_location;
     std::shared_ptr<graphics::CursorImage> current_cursor;
-    std::shared_ptr<graphics::CursorImage> pending_image;
-
 
     std::weak_ptr<scene::Observer> observer;
     bool usable = false;

--- a/src/server/input/seat_input_device_tracker.cpp
+++ b/src/server/input/seat_input_device_tracker.cpp
@@ -365,6 +365,22 @@ void mi::SeatInputDeviceTracker::set_cursor_position(float x, float y)
     observer->seat_set_cursor_position(x, y);
 }
 
+void mir::input::SeatInputDeviceTracker::add_pointing_device()
+{
+    if (!num_pointing_devices++)
+    {
+        cursor_listener->pointer_usable();
+    }
+}
+
+void mir::input::SeatInputDeviceTracker::remove_pointing_device()
+{
+    if (!--num_pointing_devices)
+    {
+        cursor_listener->pointer_unusable();
+    }
+}
+
 bool mi::SeatInputDeviceTracker::DeviceData::allowed_scan_code_action(MirKeyboardEvent const* event) const
 {
     auto const action = mir_keyboard_event_action(event);

--- a/src/server/input/seat_input_device_tracker.h
+++ b/src/server/input/seat_input_device_tracker.h
@@ -27,6 +27,7 @@
 #include "mir/optional_value.h"
 #include "mir_toolkit/event.h"
 
+#include <atomic>
 #include <unordered_map>
 #include <memory>
 #include <mutex>
@@ -63,6 +64,8 @@ public:
                            std::shared_ptr<SeatObserver> const& observer);
     void add_device(MirInputDeviceId);
     void remove_device(MirInputDeviceId);
+    void add_pointing_device();
+    void remove_pointing_device();
 
     void dispatch(std::shared_ptr<MirEvent> const& event);
 
@@ -112,6 +115,7 @@ private:
     // Libinput's acceleration curve means the cursor moves by non-integer
     // increments, and often less than 1.0, so float is required...
     float cursor_x = 0.0f, cursor_y = 0.0f;
+    std::atomic<unsigned int> num_pointing_devices{0};
 
     MirPointerButtons buttons;
     std::unordered_map<MirInputDeviceId, DeviceData> device_data;

--- a/tests/acceptance-tests/server_configuration_wrapping.cpp
+++ b/tests/acceptance-tests/server_configuration_wrapping.cpp
@@ -52,6 +52,9 @@ struct MyCursorListener : mi::CursorListener
 
     MOCK_METHOD2(cursor_moved_to, void(float abs_x, float abs_y));
 
+    void pointer_usable() { wrapped->pointer_usable(); }
+    void pointer_unusable() { wrapped->pointer_unusable(); }
+
     std::shared_ptr<mi::CursorListener> const wrapped;
 };
 

--- a/tests/include/mir/test/doubles/mock_cursor_listener.h
+++ b/tests/include/mir/test/doubles/mock_cursor_listener.h
@@ -34,6 +34,8 @@ struct MockCursorListener : public input::CursorListener
 {
     MOCK_METHOD2(cursor_moved_to, void(float, float));
     ~MockCursorListener() noexcept {}
+    void pointer_usable() {}
+    void pointer_unusable() {}
 };
 
 }

--- a/tests/integration-tests/input/test_cursor_listener.cpp
+++ b/tests/integration-tests/input/test_cursor_listener.cpp
@@ -54,6 +54,9 @@ struct MockCursorListener : public mi::CursorListener
     MOCK_METHOD2(cursor_moved_to, void(float, float));
 
     ~MockCursorListener() noexcept {}
+
+    void pointer_usable() {}
+    void pointer_unusable() {}
 };
 
 struct CursorListenerIntegrationTest : testing::Test, mtf::FakeInputServerConfiguration

--- a/tests/mir_test_framework/test_wlcs_display_server.cpp
+++ b/tests/mir_test_framework/test_wlcs_display_server.cpp
@@ -854,6 +854,9 @@ miral::TestWlcsDisplayServer::TestWlcsDisplayServer(int argc, char const** argv)
                             wrapped->cursor_moved_to(abs_x, abs_y);
                         }
 
+                        void pointer_usable() override { wrapped->pointer_usable(); }
+                        void pointer_unusable() override { wrapped->pointer_unusable(); }
+
                     private:
                         TestWlcsDisplayServer* const runner;
                         std::shared_ptr<mir::input::CursorListener> const wrapped;

--- a/tests/unit-tests/input/evdev/test_evdev_input_platform.cpp
+++ b/tests/unit-tests/input/evdev/test_evdev_input_platform.cpp
@@ -251,11 +251,11 @@ TEST_F(EvdevInputPlatform, register_ungrouped_devices)
     run_dispatchable(*platform);
 }
 
-TEST_F(EvdevInputPlatform, ignore_devices_from_same_group)
+TEST_F(EvdevInputPlatform, devices_from_same_group)
 {
     auto platform = create_input_platform();
 
-    EXPECT_CALL(mock_registry, add_device(_)).Times(1);
+    EXPECT_CALL(mock_registry, add_device(_)).Times(2);
 
     ON_CALL(li_mock, libinput_path_add_device(fake_context, _))
         .WillByDefault(

--- a/tests/unit-tests/input/test_cursor_controller.cpp
+++ b/tests/unit-tests/input/test_cursor_controller.cpp
@@ -356,7 +356,7 @@ TEST_F(TestCursorController, updates_cursor_image_when_entering_surface)
 
     TestController controller{targets, cursor, default_cursor_image};
 
-    EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
+    EXPECT_CALL(cursor, move_to(_)).Times(AtLeast(1));
     EXPECT_CALL(cursor, show(CursorNamed(cursor_name_1))).Times(1);
 
     controller.cursor_moved_to(1.0f, 1.0f);
@@ -370,7 +370,7 @@ TEST_F(TestCursorController, surface_with_no_cursor_image_hides_cursor)
 
     TestController controller{targets, cursor, default_cursor_image};
 
-    EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
+    EXPECT_CALL(cursor, move_to(_)).Times(AtLeast(1));
     EXPECT_CALL(cursor, hide()).Times(1);
 
     controller.cursor_moved_to(1.0f, 1.0f);
@@ -384,7 +384,7 @@ TEST_F(TestCursorController, takes_cursor_image_from_topmost_surface)
 
     TestController controller{targets, cursor, default_cursor_image};
 
-    EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
+    EXPECT_CALL(cursor, move_to(_)).Times(AtLeast(1));
     EXPECT_CALL(cursor, show(CursorNamed(cursor_name_2))).Times(1);
 
     controller.cursor_moved_to(1.0f, 1.0f);
@@ -398,7 +398,7 @@ TEST_F(TestCursorController, restores_cursor_when_leaving_surface)
 
     TestController controller{targets, cursor, default_cursor_image};
 
-    EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
+    EXPECT_CALL(cursor, move_to(_)).Times(AtLeast(1));
 
     {
         InSequence seq;
@@ -418,7 +418,7 @@ TEST_F(TestCursorController, change_in_cursor_request_triggers_image_update_with
 
     TestController controller{targets, cursor, default_cursor_image};
 
-    EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
+    EXPECT_CALL(cursor, move_to(_)).Times(AtLeast(1));
     {
         InSequence seq;
         EXPECT_CALL(cursor, show(CursorNamed(cursor_name_1))).Times(1);
@@ -438,7 +438,6 @@ TEST_F(TestCursorController, change_in_scene_triggers_image_update)
 
     TestController controller{targets, cursor, default_cursor_image};
 
-    EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
     EXPECT_CALL(cursor, show(CursorNamed(cursor_name_1))).Times(1);
 
     targets.add_surface(mt::fake_shared(surface));
@@ -455,7 +454,6 @@ TEST_F(TestCursorController, cursor_image_not_reset_needlessly)
 
     TestController controller{targets, cursor, default_cursor_image};
 
-    EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
     EXPECT_CALL(cursor, show(CursorNamed(cursor_name_1))).Times(1);
 
     targets.add_surface(mt::fake_shared(surface1));
@@ -493,7 +491,6 @@ TEST_F(TestCursorController, zero_sized_image_hides_cursor)
 
     TestController controller{targets, cursor, default_cursor_image};
 
-    EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
     EXPECT_CALL(cursor, hide()).Times(1);
 
     targets.add_surface(mt::fake_shared(surface));

--- a/tests/unit-tests/input/test_cursor_controller.cpp
+++ b/tests/unit-tests/input/test_cursor_controller.cpp
@@ -49,6 +49,8 @@ namespace geom = mir::geometry;
 namespace mt = mir::test;
 namespace mtd = mt::doubles;
 
+using namespace ::testing;
+
 namespace
 {
 
@@ -257,17 +259,86 @@ struct TestCursorController : public testing::Test
     MockCursor cursor;
     std::shared_ptr<mg::CursorImage> const default_cursor_image;
 };
+}
 
+TEST_F(TestCursorController, cursor_is_initially_hidden)
+{
+    StubScene targets({});
+
+    EXPECT_CALL(cursor, hide()).Times(1);
+
+    mi::CursorController controller{ mt::fake_shared(targets), mt::fake_shared(cursor), default_cursor_image};
+}
+
+TEST_F(TestCursorController, cursor_is_shown_when_pointing_becomes_usable)
+{
+    StubScene targets({});
+    EXPECT_CALL(cursor, hide()).Times(1);
+    mi::CursorController controller{ mt::fake_shared(targets), mt::fake_shared(cursor), default_cursor_image};
+    Mock::VerifyAndClearExpectations(&cursor);
+
+    EXPECT_CALL(cursor, show(_)).Times(1);
+    controller.pointer_usable();
+}
+
+TEST_F(TestCursorController, cursor_is_hidden_when_pointing_becomes_unusable)
+{
+    StubScene targets({});
+    EXPECT_CALL(cursor, hide()).Times(1);
+    mi::CursorController controller{ mt::fake_shared(targets), mt::fake_shared(cursor), default_cursor_image};
+    EXPECT_CALL(cursor, show(_)).Times(1);
+    controller.pointer_usable();
+    Mock::VerifyAndClearExpectations(&cursor);
+
+    EXPECT_CALL(cursor, hide()).Times(1);
+    controller.pointer_unusable();
+}
+
+TEST_F(TestCursorController, changed_cursor_image_is_not_shown_until_pointing_becomes_usable)
+{
+    StubInputSurface surface{rect_0_0_1_1,
+                             std::make_shared<NamedCursorImage>(cursor_name_1)};
+    StubScene targets({mt::fake_shared(surface)});
+
+    EXPECT_CALL(cursor, hide()).Times(AnyNumber());
+    mi::CursorController controller{ mt::fake_shared(targets), mt::fake_shared(cursor), default_cursor_image};
+
+    surface.set_cursor_image_without_notifications(
+        std::make_shared<NamedCursorImage>(cursor_name_2));
+    surface.post_frame();
+    Mock::VerifyAndClearExpectations(&cursor);
+
+    EXPECT_CALL(cursor, show(CursorNamed(cursor_name_2))).Times(1);
+    controller.pointer_usable();
+}
+
+namespace
+{
+// We wrap mi::CursorController to simplify the setup expected by the majority of tests
+struct TestController : mi::CursorController
+{
+    TestController(
+        mi::Scene& targets,
+        MockCursor& cursor,
+        std::shared_ptr<mg::CursorImage> const& default_cursor_image) :
+        CursorController(
+            (EXPECT_CALL(cursor, hide()).Times(AnyNumber()), mt::fake_shared(targets)),
+            mt::fake_shared(cursor),
+            default_cursor_image)
+    {
+        EXPECT_CALL(cursor, show()).Times(AnyNumber());
+        EXPECT_CALL(cursor, show(_)).Times(AnyNumber());
+        pointer_usable();
+        Mock::VerifyAndClearExpectations(&cursor);
+    }
+};
 }
 
 TEST_F(TestCursorController, moves_cursor)
 {
-    using namespace ::testing;
-
     StubScene targets({});
 
-    mi::CursorController controller(mt::fake_shared(targets),
-        mt::fake_shared(cursor), default_cursor_image);
+    TestController controller{targets, cursor, default_cursor_image};
 
     InSequence seq;
     EXPECT_CALL(cursor, move_to(geom::Point{geom::X{1.0f}, geom::Y{1.0f}}));
@@ -279,14 +350,11 @@ TEST_F(TestCursorController, moves_cursor)
 
 TEST_F(TestCursorController, updates_cursor_image_when_entering_surface)
 {
-    using namespace ::testing;
-
     StubInputSurface surface{rect_1_1_1_1,
         std::make_shared<NamedCursorImage>(cursor_name_1)};
     StubScene targets({mt::fake_shared(surface)});
 
-    mi::CursorController controller(mt::fake_shared(targets),
-        mt::fake_shared(cursor), default_cursor_image);
+    TestController controller{targets, cursor, default_cursor_image};
 
     EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
     EXPECT_CALL(cursor, show(CursorNamed(cursor_name_1))).Times(1);
@@ -296,14 +364,11 @@ TEST_F(TestCursorController, updates_cursor_image_when_entering_surface)
 
 TEST_F(TestCursorController, surface_with_no_cursor_image_hides_cursor)
 {
-    using namespace ::testing;
-
     StubInputSurface surface{rect_1_1_1_1,
         nullptr};
     StubScene targets({mt::fake_shared(surface)});
 
-    mi::CursorController controller(mt::fake_shared(targets),
-        mt::fake_shared(cursor), default_cursor_image);
+    TestController controller{targets, cursor, default_cursor_image};
 
     EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
     EXPECT_CALL(cursor, hide()).Times(1);
@@ -313,14 +378,11 @@ TEST_F(TestCursorController, surface_with_no_cursor_image_hides_cursor)
 
 TEST_F(TestCursorController, takes_cursor_image_from_topmost_surface)
 {
-    using namespace ::testing;
-
     StubInputSurface surface_1{rect_1_1_1_1, std::make_shared<NamedCursorImage>(cursor_name_1)};
     StubInputSurface surface_2{rect_1_1_1_1, std::make_shared<NamedCursorImage>(cursor_name_2)};
     StubScene targets({mt::fake_shared(surface_1), mt::fake_shared(surface_2)});
 
-    mi::CursorController controller(mt::fake_shared(targets),
-        mt::fake_shared(cursor), default_cursor_image);
+    TestController controller{targets, cursor, default_cursor_image};
 
     EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
     EXPECT_CALL(cursor, show(CursorNamed(cursor_name_2))).Times(1);
@@ -330,14 +392,11 @@ TEST_F(TestCursorController, takes_cursor_image_from_topmost_surface)
 
 TEST_F(TestCursorController, restores_cursor_when_leaving_surface)
 {
-    using namespace ::testing;
-
     StubInputSurface surface{rect_1_1_1_1,
         std::make_shared<NamedCursorImage>(cursor_name_1)};
     StubScene targets({mt::fake_shared(surface)});
 
-    mi::CursorController controller(mt::fake_shared(targets),
-        mt::fake_shared(cursor), default_cursor_image);
+    TestController controller{targets, cursor, default_cursor_image};
 
     EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
 
@@ -353,14 +412,11 @@ TEST_F(TestCursorController, restores_cursor_when_leaving_surface)
 
 TEST_F(TestCursorController, change_in_cursor_request_triggers_image_update_without_cursor_motion)
 {
-    using namespace ::testing;
-
     StubInputSurface surface{rect_1_1_1_1,
         std::make_shared<NamedCursorImage>(cursor_name_1)};
     StubScene targets({mt::fake_shared(surface)});
 
-    mi::CursorController controller(mt::fake_shared(targets),
-        mt::fake_shared(cursor), default_cursor_image);
+    TestController controller{targets, cursor, default_cursor_image};
 
     EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
     {
@@ -375,15 +431,12 @@ TEST_F(TestCursorController, change_in_cursor_request_triggers_image_update_with
 
 TEST_F(TestCursorController, change_in_scene_triggers_image_update)
 {
-    using namespace ::testing;
-
     // Here we also demonstrate that the cursor begins at 0,0.
     StubInputSurface surface{rect_0_0_1_1,
         std::make_shared<NamedCursorImage>(cursor_name_1)};
     StubScene targets({});
 
-    mi::CursorController controller(mt::fake_shared(targets),
-        mt::fake_shared(cursor), default_cursor_image);
+    TestController controller{targets, cursor, default_cursor_image};
 
     EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
     EXPECT_CALL(cursor, show(CursorNamed(cursor_name_1))).Times(1);
@@ -393,8 +446,6 @@ TEST_F(TestCursorController, change_in_scene_triggers_image_update)
 
 TEST_F(TestCursorController, cursor_image_not_reset_needlessly)
 {
-    using namespace ::testing;
-
     auto image = std::make_shared<NamedCursorImage>(cursor_name_1);
 
     // Here we also demonstrate that the cursor begins at 0,0.
@@ -402,8 +453,7 @@ TEST_F(TestCursorController, cursor_image_not_reset_needlessly)
     StubInputSurface surface2{rect_0_0_1_1, image};
     StubScene targets({});
 
-    mi::CursorController controller(mt::fake_shared(targets),
-        mt::fake_shared(cursor), default_cursor_image);
+    TestController controller{targets, cursor, default_cursor_image};
 
     EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
     EXPECT_CALL(cursor, show(CursorNamed(cursor_name_1))).Times(1);
@@ -414,20 +464,11 @@ TEST_F(TestCursorController, cursor_image_not_reset_needlessly)
 
 TEST_F(TestCursorController, updates_cursor_image_when_surface_posts_first_frame)
 {
-    using namespace ::testing;
-
     StubInputSurface surface{rect_0_0_1_1,
         std::make_shared<NamedCursorImage>(cursor_name_1)};
     StubScene targets({mt::fake_shared(surface)});
 
-    // Cursor is set when we first create the controller
-    // because of the existing surface
-    EXPECT_CALL(cursor, show(CursorNamed(cursor_name_1))).Times(1);
-
-    mi::CursorController controller(mt::fake_shared(targets),
-        mt::fake_shared(cursor), default_cursor_image);
-
-    Mock::VerifyAndClearExpectations(&cursor);
+    TestController controller{targets, cursor, default_cursor_image};
 
     surface.set_cursor_image_without_notifications(
         std::make_shared<NamedCursorImage>(cursor_name_2));
@@ -444,16 +485,13 @@ TEST_F(TestCursorController, updates_cursor_image_when_surface_posts_first_frame
 
 TEST_F(TestCursorController, zero_sized_image_hides_cursor)
 {
-    using namespace ::testing;
-
     auto image = std::make_shared<ZeroSizedCursorImage>();
 
     // Here we also demonstrate that the cursor begins at 0,0.
     StubInputSurface surface{rect_0_0_1_1, image};
     StubScene targets({});
 
-    mi::CursorController controller(mt::fake_shared(targets),
-        mt::fake_shared(cursor), default_cursor_image);
+    TestController controller{targets, cursor, default_cursor_image};
 
     EXPECT_CALL(cursor, move_to(_)).Times(AnyNumber());
     EXPECT_CALL(cursor, hide()).Times(1);


### PR DESCRIPTION
Track whether there's a usable pointing device and hide/show cursor accordingly. (Fixes #594, fixes #1660)
