### PR TITLE
mt::Barrier: Drop invalid defaulted CopyAssign.

### DIFF
--- a/tests/include/mir/test/barrier.h
+++ b/tests/include/mir/test/barrier.h
@@ -46,9 +46,9 @@ public:
             throw std::runtime_error("Timeout");
     }
 
+    Barrier(Barrier const&) = delete;
+    Barrier& operator=(Barrier const&) = delete;
 private:
-    Barrier(Barrier const&) = default;
-    Barrier& operator=(Barrier const&) = default;
     unsigned wait_threads;
     std::mutex mutex;
     std::condition_variable cv;


### PR DESCRIPTION
Barrier contains a std::mutex, which is a non-copyable type, so the `= default` CopyAssign
we have is effectively an `= delete`. Make this explicit.

Caught by Clang 8.0