### PR TITLE
Fix FTBFS on Fedora 29 caused by glib's variadic macros.

### DIFF
--- a/examples/miral-shell/spinner/CMakeLists.txt
+++ b/examples/miral-shell/spinner/CMakeLists.txt
@@ -60,6 +60,10 @@ add_library(miral-spinner STATIC
   ${CMAKE_CURRENT_BINARY_DIR}/spinner_glow.h
 )
 
+set_property(
+  SOURCE eglspinner.cpp
+  PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
+
 pkg_check_modules(WAYLAND_EGL REQUIRED wayland-egl)
 
 target_link_libraries(miral-spinner

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -74,6 +74,10 @@ add_library(mirserverobjects OBJECT
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/synchronised.h
 )
 
+set_property(
+    SOURCE glib_main_loop.cpp glib_main_loop_sources.cpp default_server_configuration.cpp
+    PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
+
 set(MIR_SERVER_OBJECTS
   $<TARGET_OBJECTS:mirserverobjects>
   $<TARGET_OBJECTS:mirinput>

--- a/src/server/console/CMakeLists.txt
+++ b/src/server/console/CMakeLists.txt
@@ -23,6 +23,10 @@ set_source_files_properties(
     "${CMAKE_C_FLAGS} -Wno-unused-parameter -Wno-unused-function"
 )
 
+set_property(
+    SOURCE logind_console_services.cpp default_configuration.cpp
+    PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
+
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/logind-seat.h
   COMMAND

--- a/src/server/input/CMakeLists.txt
+++ b/src/server/input/CMakeLists.txt
@@ -30,6 +30,10 @@ set(
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/input/input_probe.h
 )
 
+set_property(
+    SOURCE default_configuration.cpp
+    PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
+
 add_library(
   mirinput OBJECT
 

--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -63,6 +63,10 @@ add_library(mir-public-test-framework OBJECT
   input_device_faker.cpp ${PROJECT_SOURCE_DIR}/include/test/mir_test_framework/input_device_faker.h
 )
 
+set_property(
+    SOURCE udev_environment.cpp
+    PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
+
 # Umockdev uses glib, which uses the deprecated "register" storage qualifier
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Dregister=")
 

--- a/tests/umock-acceptance-tests/CMakeLists.txt
+++ b/tests/umock-acceptance-tests/CMakeLists.txt
@@ -13,6 +13,10 @@ mir_add_wrapped_executable(mir_umock_acceptance_tests NOINSTALL
   $<TARGET_OBJECTS:mir-umock-test-framework>
   )
 
+set_property(
+  SOURCE test_libinput.cpp
+  PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
+
 add_dependencies(mir_umock_acceptance_tests GMock)
 
 target_link_libraries(mir_umock_acceptance_tests

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -111,6 +111,14 @@ mir_add_wrapped_executable(mir_unit_tests NOINSTALL
   ${MIR_PLATFORM_OBJECTS}
 )
 
+set_property(
+  SOURCE test_udev_wrapper.cpp test_glib_main_loop.cpp
+  SOURCE console/test_logind_console_services.cpp
+  SOURCE input/test_logind_console_services.cpp input/test_input_platform_probing.cpp
+  SOURCE input/evdev/test_evdev_input_platform.cpp
+  SOURCE graphics/test_platform_prober.cpp
+  PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
+
 mir_precompiled_header(mir_unit_tests ${CMAKE_CURRENT_SOURCE_DIR}/precompiled.hpp)
 
 add_dependencies(mir_unit_tests GMock)

--- a/tests/unit-tests/platforms/mesa/kms/CMakeLists.txt
+++ b/tests/unit-tests/platforms/mesa/kms/CMakeLists.txt
@@ -21,6 +21,12 @@ mir_add_wrapped_executable(mir_unit_tests_mesa-kms NOINSTALL
   $<TARGET_OBJECTS:mir-umock-test-framework>
 )
 
+set_property(
+  SOURCE test_gbm_buffer.cpp test_platform.cpp test_graphics_platform.cpp test_buffer_allocator.cpp
+         test_display.cpp test_display_generic.cpp test_display_multi_monitor.cpp test_display_configuration.cpp
+         test_display_buffer.cpp test_drm_helper.cpp
+  PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
+
 add_dependencies(mir_unit_tests_mesa-kms GMock)
 
 target_link_libraries(

--- a/tests/unit-tests/platforms/mesa/x11/CMakeLists.txt
+++ b/tests/unit-tests/platforms/mesa/x11/CMakeLists.txt
@@ -9,6 +9,10 @@ mir_add_wrapped_executable(mir_unit_tests_mesa-x11 NOINSTALL
   $<TARGET_OBJECTS:mirnullreport>  # Sub-optimal. We really want to link a lib
 )
 
+set_property(
+  SOURCE test_platform.cpp test_graphics_platform.cpp test_display_generic.cpp
+  PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
+
 add_dependencies(mir_unit_tests_mesa-x11 GMock)
 
 target_link_libraries(


### PR DESCRIPTION
Fix FTBFS on Fedora 29 caused by glib's variadic macros.

Unfortunately this doesn't seem fixable by wrapping the glib headers
with #pragma, "-Wno-variadic-macros" needs to be applied to the whole
translation unit.