### PR TITLE
[spread] fix fedora rawhide and add 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ env:
   - SYSTEM=google:ubuntu-18.04-64 VARIANT=clang
   - SYSTEM=google:ubuntu-18.10-64 VARIANT=amd64
   - SYSTEM=google:fedora-28-64 VARIANT=amd64
+  - SYSTEM=google:fedora-29-64 VARIANT=amd64
 
 before_install:
 - mkdir -p ${SPREAD_PATH}

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,6 +1,6 @@
 project: mir
 
-kill-timeout: 50m
+kill-timeout: 45m
 
 backends:
     lxd:

--- a/spread.yaml
+++ b/spread.yaml
@@ -10,10 +10,7 @@ backends:
             - ubuntu-18.10
             - ubuntu-devel:
                image: ubuntu-daily:devel/amd64
-            - fedora-27
             - fedora-28
-            - fedora-rawhide:
-                image: images:fedora/28/amd64
     google:
         key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
         plan: n1-highcpu-8
@@ -28,8 +25,7 @@ backends:
             - ubuntu-devel-64:
                 image: ubuntu-os-cloud/ubuntu-1810
             - fedora-28-64
-            - fedora-rawhide-64:
-                image: fedora-28-64
+            - fedora-rawhide-64
 
 environment:
     ARCH: amd64

--- a/spread.yaml
+++ b/spread.yaml
@@ -11,6 +11,7 @@ backends:
             - ubuntu-devel:
                image: ubuntu-daily:devel/amd64
             - fedora-28
+            - fedora-29
     google:
         key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
         plan: n1-highcpu-8
@@ -25,6 +26,7 @@ backends:
             - ubuntu-devel-64:
                 image: ubuntu-os-cloud/ubuntu-1810
             - fedora-28-64
+            - fedora-29-64
             - fedora-rawhide-64
 
 environment:

--- a/spread/build/fedora/task.yaml
+++ b/spread/build/fedora/task.yaml
@@ -2,15 +2,6 @@ summary: Build (on Fedora)
 systems: [fedora-*]
 
 execute: |
-    if [ "${SPREAD_SYSTEM}" = "fedora-rawhide-64" -a "${SPREAD_REBOOT}" -eq 0 ]; then
-      # upgrade to rawhide
-      dnf upgrade --assumeyes --refresh
-      dnf install --assumeyes fedora-gpg-keys
-      # rawhide being rolling breaks from time to time, fall through an incomplete upgrade
-      dnf distro-sync --assumeyes --releasever=rawhide || /bin/true
-      REBOOT
-    fi
-
     dnf install --assumeyes \
         cmake \
         make \


### PR DESCRIPTION
Upgrading proved to be unreliable, on the google provider we can use a
pre-built rawhide image instead.

There is now a Fedora 29 image, too, so use it.

Also reduce the spread timeout so it fits under travis's one.