### PR TITLE
Don't call pthread_rwlockattr_setkind_np() on systems where it is not defined.

### DIFF
--- a/src/common/posix_rw_mutex.cpp
+++ b/src/common/posix_rw_mutex.cpp
@@ -63,7 +63,9 @@ mir::PosixRWMutex::PosixRWMutex(Type type)
             std::system_category(),
             "Failed to init pthread attrs"}));
     }
-#ifdef __GLIBC__
+
+// pthread_rwlockattr_setkind_np() does not exist on e.g. musl
+#if  _XOPEN_SOURCE >= 500 || _POSIX_C_SOURCE >= 200809L
     int pthread_type;
     switch(type)
     {
@@ -89,6 +91,7 @@ mir::PosixRWMutex::PosixRWMutex(Type type)
             break;
 #endif
     }
+
     err = pthread_rwlockattr_setkind_np(&attr, pthread_type);
     if (err != 0)
     {
@@ -98,6 +101,7 @@ mir::PosixRWMutex::PosixRWMutex(Type type)
             "Failed to set preferred rw-lock mode"}));
     }
 #endif
+
     err = pthread_rwlock_init(&mutex, &attr);
     if (err != 0)
     {

--- a/src/common/posix_rw_mutex.cpp
+++ b/src/common/posix_rw_mutex.cpp
@@ -52,6 +52,18 @@ mir::PosixRWMutex::PosixRWMutex()
 
 mir::PosixRWMutex::PosixRWMutex(Type type)
 {
+    pthread_rwlockattr_t attr;
+    int err;
+
+    err = pthread_rwlockattr_init(&attr);
+    if (err != 0)
+    {
+        BOOST_THROW_EXCEPTION((std::system_error{
+            err,
+            std::system_category(),
+            "Failed to init pthread attrs"}));
+    }
+#ifdef __GLIBC__
     int pthread_type;
     switch(type)
     {
@@ -77,18 +89,6 @@ mir::PosixRWMutex::PosixRWMutex(Type type)
             break;
 #endif
     }
-
-    pthread_rwlockattr_t attr;
-    int err;
-
-    err = pthread_rwlockattr_init(&attr);
-    if (err != 0)
-    {
-        BOOST_THROW_EXCEPTION((std::system_error{
-            err,
-            std::system_category(),
-            "Failed to init pthread attrs"}));
-    }
     err = pthread_rwlockattr_setkind_np(&attr, pthread_type);
     if (err != 0)
     {
@@ -97,6 +97,7 @@ mir::PosixRWMutex::PosixRWMutex(Type type)
             std::system_category(),
             "Failed to set preferred rw-lock mode"}));
     }
+#endif
     err = pthread_rwlock_init(&mutex, &attr);
     if (err != 0)
     {


### PR DESCRIPTION
Don't call pthread_rwlockattr_setkind_np() on systems where it is not defined.

(One of the Musl build issues.)