### PR TITLE
Clarify and fix focus switching logic.

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -535,15 +535,27 @@ void miral::BasicWindowManager::focus_next_application()
             }
             while (focus_controller->focused_session() != prev.application());
         }
+        else
+        {
+            do
+            {
+                focus_controller->focus_next_session();
 
+                if (can_activate_window_for_session(focus_controller->focused_session()))
+                    return;
+            }
+            while (focus_controller->focused_session() != prev.application());
+        }
+    }
+    else
+    {
+        focus_controller->focus_next_session();
+
+        if (can_activate_window_for_session(focus_controller->focused_session()))
+            return;
     }
 
-    focus_controller->focus_next_session();
-
-    if (can_activate_window_for_session(focus_controller->focused_session()))
-        return;
-
-    // Last resort: accept wherever focus_controller placed focus
+    // Last resort: accept wherever focus_controller places focus
     auto const focussed_surface = focus_controller->focused_surface();
     select_active_window(focussed_surface ? info_for(focussed_surface).window() : Window{});
 }


### PR DESCRIPTION
I've seen some weird focus behaviour the most obvious case being when there is a single application in egmde and pressing Alt-Tab.

I tracked this down to this code: the problem is less obvious in miral-shell because egmde doesn't use workspaces and skips the initial loop (which masks the broken logic).

(I hope reviewers consider the lack of tests to be "pre-existing" as setting up a test fixture for this code is more work than I have headspace for today.)
