### PR TITLE
Do not select mesa-kms when Xorg owns DRM master

### DIFF
--- a/src/platform/graphics/platform_probe.cpp
+++ b/src/platform/graphics/platform_probe.cpp
@@ -91,11 +91,12 @@ mir::graphics::module_for_device(
                     }
                 }() ;
             auto desc = describe();
-            mir::log_info("Found graphics driver: %s (version %d.%d.%d)",
+            mir::log_info("Found graphics driver: %s (version %d.%d.%d) Support priority: %d",
                           desc->name,
                           desc->major_version,
                           desc->minor_version,
-                          desc->micro_version);
+                          desc->micro_version,
+                          module_priority);
         }
         catch (std::runtime_error const&)
         {

--- a/src/server/console/minimal_console_services.cpp
+++ b/src/server/console/minimal_console_services.cpp
@@ -138,6 +138,12 @@ std::future<std::unique_ptr<mir::Device>> mir::MinimalConsoleServices::acquire_d
              */
             if (auto ret = drmSetMaster(fd))
             {
+                // If DISPLAY is set, then X11 probably has DRM master
+                if (getenv("DISPLAY"))
+                {
+                    BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to acquire DRM master"}));
+                }
+
                 mir::log(
                     mir::logging::Severity::warning,
                     "MinimalConsoleServices",


### PR DESCRIPTION
When probing platforms we can (depending on the order mesa-kms and mesa-x11 are
probed - they both return "supported") select mesa-kms despite X11 owning DRM master. (Fixes #644)

Unsurprisingly, mesa-kms does not work without DRM Master.