### PR TITLE
Make sure we set raw_fd outside of the if's scope

### DIFF
--- a/src/core/anonymous_shm_file.cpp
+++ b/src/core/anonymous_shm_file.cpp
@@ -56,7 +56,7 @@ mir::Fd create_anonymous_file(size_t size)
     auto raw_fd = memfd_create("mir-buffer", MFD_CLOEXEC);
     if (raw_fd == -1 && errno == ENOSYS)
     {
-        auto raw_fd = open("/dev/shm", O_TMPFILE | O_RDWR | O_EXCL | O_CLOEXEC, S_IRWXU);
+        raw_fd = open("/dev/shm", O_TMPFILE | O_RDWR | O_EXCL | O_CLOEXEC, S_IRWXU);
 
         // Workaround for filesystems that don't support O_TMPFILE
         if (raw_fd == -1 && error_indicates_tmpfile_not_supported(errno))


### PR DESCRIPTION
if not raw_fd will only be set inside if's scope, once outside if's
scope it will use the raw_fd set by memfd_create