### PR TITLE
MinimalConsoleServices: Better check for DRM master.

### DIFF
--- a/src/server/console/minimal_console_services.cpp
+++ b/src/server/console/minimal_console_services.cpp
@@ -35,7 +35,8 @@
 #include <sys/types.h>
 #include <drm.h>
 
-#ifndef LIBDRM_HAS_IS_MASTER
+// TODO: once libdrm provides this symbol, we need a way to set MIR_LIBDRM_HAS_IS_MASTER
+#ifndef MIR_LIBDRM_HAS_IS_MASTER
 bool drmIsMaster(int fd)
 {
     struct drm_mode_mode_cmd cmd;


### PR DESCRIPTION
The original fix for #644 was acknowledged to be ugly. Upstream libdrm didn't have a
drmIsMaster() function which is what would be necessary to make a proper fix.

Import the `drmIsMaster()` call from https://lists.freedesktop.org/archives/dri-devel/2018-November/196972.html and use it
to make a proper fix.