### PR TITLE
Build eglstreams on Fedora

### DIFF
--- a/doc/getting_involved_in_mir.md
+++ b/doc/getting_involved_in_mir.md
@@ -36,7 +36,7 @@ You’ll need some development tools and packages installed:
     libinput-devel libxml++-devel libuuid-devel libxkbcommon-devel \
     freetype-devel lttng-ust-devel libatomic qterminal qt5-qtwayland \
     python3-pillow libevdev-devel umockdev-devel gtest-devel gmock-devel \
-    libXcursor-devel yaml-cpp-devel
+    libXcursor-devel yaml-cpp-devel egl-wayland-devel
 
 With these installed you can checkout Mir:
 

--- a/spread/build/fedora/task.yaml
+++ b/spread/build/fedora/task.yaml
@@ -51,7 +51,8 @@ execute: |
         python3-dbus \
         mesa-libwayland-egl-devel\
         libXcursor-devel \
-        yaml-cpp-devel
+        yaml-cpp-devel\
+        egl-wayland-devel
 
     BUILD_DIR=$(mktemp --directory)
     cmake -H$SPREAD_PATH -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DMIR_USE_LD_GOLD=ON


### PR DESCRIPTION
This builds on Fedora 29 with egl-wayland-devel 1.1.0-0.2.20181015git0eb29d4.fc29.

As that egl-wayland-devel is currently on updates-testing, we should wait for that to reach archive before attempting to land this. (See https://bodhi.fedoraproject.org/updates/FEDORA-2018-82fe88f036)