### PR TITLE
mg::ProgramFactory: Use a uniform array of textures, rather than tex, tex1, tex2

### DIFF
--- a/include/platform/mir/graphics/program_factory.h
+++ b/include/platform/mir/graphics/program_factory.h
@@ -47,7 +47,7 @@ public:
      *                                          vec4 sample_to_rgba(in vec2 texcoord)
      *                                          returning a vector containing the RGBA value at texcoord.
      *                                          The elements of the uniform array tex[n] will be bound to
-     *                                          GL_TEXTURE0, GL_TEXTURE1, …, GL_TEXTUREn. (n <= 8)
+     *                                          GL_TEXTURE0, GL_TEXTURE1, …, GL_TEXTURE(n-1). (n <= 8)
      * \return  A fully compiled and linked Program
      */
     virtual std::unique_ptr<Program> compile_fragment_shader(

--- a/include/platform/mir/graphics/program_factory.h
+++ b/include/platform/mir/graphics/program_factory.h
@@ -46,8 +46,8 @@ public:
      *                                          fragment defining a function:
      *                                          vec4 sample_to_rgba(in vec2 texcoord)
      *                                          returning a vector containing the RGBA value at texcoord.
-     *                                          The uniforms tex, tex1, and tex2 will be bound to
-     *                                          GL_TEXTURE0, GL_TEXTURE1 and GL_TEXTURE2.
+     *                                          The elements of the uniform array tex[n] will be bound to
+     *                                          GL_TEXTURE0, GL_TEXTURE1, …, GL_TEXTUREn. (n <= 8)
      * \return  A fully compiled and linked Program
      */
     virtual std::unique_ptr<Program> compile_fragment_shader(

--- a/src/renderers/gl/renderer.cpp
+++ b/src/renderers/gl/renderer.cpp
@@ -319,21 +319,13 @@ mrg::Renderer::Program::Program(GLuint program_id)
     id = program_id;
     position_attr = glGetAttribLocation(id, "position");
     texcoord_attr = glGetAttribLocation(id, "texcoord");
-    for (int i = 0; i < 8 ; ++i)
+    for (auto i = 0u; i < tex_uniforms.size() ; ++i)
     {
         /* You can reference uniform arrays as tex[0], tex[1], tex[2], … until you
          * hit the end of the array, which will return -1 as the location.
          */
         auto const uniform_name = std::string{"tex["} + std::to_string(i) + "]";
-        auto const uniform_loc = glGetUniformLocation(id, uniform_name.c_str());
-        if (uniform_loc == -1)
-        {
-            break;
-        }
-        else
-        {
-            tex_uniforms.push_back(uniform_loc);
-        }
+        tex_uniforms[i] = glGetUniformLocation(id, uniform_name.c_str());
     }
     centre_uniform = glGetUniformLocation(id, "centre");
     display_transform_uniform = glGetUniformLocation(id, "display_transform");
@@ -491,7 +483,10 @@ void mrg::Renderer::draw(mg::Renderable const& renderable) const
         prog.last_used_frameno = frameno;
         for (auto i = 0u; i < prog.tex_uniforms.size(); ++i)
         {
-            glUniform1i(prog.tex_uniforms[i], i);
+            if (prog.tex_uniforms[i] != -1)
+            {
+                glUniform1i(prog.tex_uniforms[i], i);
+            }
         }
         glUniformMatrix4fv(prog.display_transform_uniform, 1, GL_FALSE,
                            glm::value_ptr(display_transform));

--- a/src/renderers/gl/renderer.cpp
+++ b/src/renderers/gl/renderer.cpp
@@ -319,9 +319,22 @@ mrg::Renderer::Program::Program(GLuint program_id)
     id = program_id;
     position_attr = glGetAttribLocation(id, "position");
     texcoord_attr = glGetAttribLocation(id, "texcoord");
-    tex_uniforms[0] = glGetUniformLocation(id, "tex");
-    tex_uniforms[1] = glGetUniformLocation(id, "tex1");
-    tex_uniforms[2] = glGetUniformLocation(id, "tex2");
+    for (int i = 0; i < 8 ; ++i)
+    {
+        /* You can reference uniform arrays as tex[0], tex[1], tex[2], … until you
+         * hit the end of the array, which will return -1 as the location.
+         */
+        auto const uniform_name = std::string{"tex["} + std::to_string(i) + "]";
+        auto const uniform_loc = glGetUniformLocation(id, uniform_name.c_str());
+        if (uniform_loc == -1)
+        {
+            break;
+        }
+        else
+        {
+            tex_uniforms.push_back(uniform_loc);
+        }
+    }
     centre_uniform = glGetUniformLocation(id, "centre");
     display_transform_uniform = glGetUniformLocation(id, "display_transform");
     transform_uniform = glGetUniformLocation(id, "transform");
@@ -476,7 +489,7 @@ void mrg::Renderer::draw(mg::Renderable const& renderable) const
     {   // Avoid reloading the screen-global uniforms on every renderable
         // TODO: We actually only need to bind these *once*, right? Not once per frame?
         prog.last_used_frameno = frameno;
-        for (int i = 0u; (i < 3 && prog.tex_uniforms[i] != -1); ++i)
+        for (auto i = 0u; i < prog.tex_uniforms.size(); ++i)
         {
             glUniform1i(prog.tex_uniforms[i], i);
         }

--- a/src/renderers/gl/renderer.h
+++ b/src/renderers/gl/renderer.h
@@ -73,7 +73,7 @@ public:
     struct Program
     {
         GLuint id = 0;
-        GLint tex_uniforms[3];
+        std::vector<GLint> tex_uniforms;
         GLint position_attr = -1;
         GLint texcoord_attr = -1;
         GLint centre_uniform = -1;

--- a/src/renderers/gl/renderer.h
+++ b/src/renderers/gl/renderer.h
@@ -73,7 +73,11 @@ public:
     struct Program
     {
         GLuint id = 0;
-        std::vector<GLint> tex_uniforms;
+        /* 8 is the minimum number of texture units a GL implementation can provide
+         * and should comfortably provide enough textures for any conceivable buffer
+         * format
+         */
+        std::array<GLint, 8> tex_uniforms;
         GLint position_attr = -1;
         GLint texcoord_attr = -1;
         GLint centre_uniform = -1;


### PR DESCRIPTION
This looks nicer, makes it possible for shaders to use more than the 3 textures we were defining.

As an added benefit, all our *existing* shaders don't notice, as looking up the uniform location for `tex[0]` resolves to the attribute location for `tex`.