### PR TITLE
Debian packaging: Depend on libnvidia-egl-wayland-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -56,12 +56,7 @@ Build-Depends: cmake,
                libxcb-composite0-dev,
                libxcursor-dev,
                libyaml-cpp-dev,
-# WARNING: this is going to be annoying until the split-out
-# NVIDIA external EGL platform is in the archive.
-#
-# Abuse alternative dependencies here so that we can build on
-# Xenial (which doesn't have a new enough NVIDIA driver)
-               libnvidia-gl-390 [amd64 i386] | base-files (<< 10.1ubuntu2) [amd64 i386],
+               libnvidia-egl-wayland-dev,
 Standards-Version: 3.9.4
 Homepage: https://launchpad.net/mir
 # If you aren't a member of ~mir-team but need to upload packaging changes,

--- a/debian/rules
+++ b/debian/rules
@@ -42,36 +42,19 @@ endif
 
 $(info COMMON_CONFIGURE_OPTIONS: ${COMMON_CONFIGURE_OPTIONS})
 
-ifneq ($(filter amd64 i386,$(DEB_HOST_ARCH)),)
-  ifeq ($(filter xenial,$(DEB_DISTRIBUTION)),)
-	  AVAILABLE_PLATFORMS=mesa-kms\;mesa-x11\;eglstream-kms
-  else
-	  AVAILABLE_PLATFORMS=mesa-kms\;mesa-x11
-  endif
-else
-	AVAILABLE_PLATFORMS=mesa-kms\;mesa-x11
-endif
-
 override_dh_auto_configure:
 ifneq ($(filter armhf,$(DEB_HOST_ARCH)),)
 	dh_auto_configure -- \
 	  $(COMMON_CONFIGURE_OPTIONS) \
 	  -DMIR_RUN_ACCEPTANCE_TESTS=OFF \
 	  -DMIR_RUN_INTEGRATION_TESTS=OFF \
-	  -DMIR_PLATFORM=$(AVAILABLE_PLATFORMS) \
-	  $(OVERRIDE_CONFIGURE_OPTIONS)
-else
-ifneq ($(filter amd64 i386,$(DEB_HOST_ARCH)),)
-	dh_auto_configure -- \
-	  $(COMMON_CONFIGURE_OPTIONS) \
-	  -DMIR_PLATFORM=$(AVAILABLE_PLATFORMS) \
+	  -DMIR_PLATFORM=mesa-kms\;mesa-x11\;eglstream-kms \
 	  $(OVERRIDE_CONFIGURE_OPTIONS)
 else
 	dh_auto_configure -- \
 	  $(COMMON_CONFIGURE_OPTIONS) \
-	  -DMIR_PLATFORM=$(AVAILABLE_PLATFORMS) \
+	  -DMIR_PLATFORM=mesa-kms\;mesa-x11\;eglstream-kms \
 	  $(OVERRIDE_CONFIGURE_OPTIONS)
-endif
 endif
 	# Run cmake again to pick up wlcs tests, because reasons?
 	cmake build-$(DEB_HOST_ARCH)

--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -7,6 +7,10 @@ systems: [ubuntu-*]
 summary: Build Ubuntu packages
 
 execute: |
+    # Get any out-of-archive dependencies
+    # (Currently just libnvidia-egl-wayland-dev)
+    add-apt-repository --yes ppa:mir-team/dev
+
     apt-get update
 
     # to get dpkg-architecture and mk-build-deps

--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -9,6 +9,7 @@ summary: Build Ubuntu packages
 execute: |
     # Get any out-of-archive dependencies
     # (Currently just libnvidia-egl-wayland-dev)
+    add-apt-repository --yes ppa:mir-team/release
     add-apt-repository --yes ppa:mir-team/dev
 
     apt-get update

--- a/tests/unit-tests/platforms/eglstream-kms/server/test_utils.cpp
+++ b/tests/unit-tests/platforms/eglstream-kms/server/test_utils.cpp
@@ -56,7 +56,7 @@ TEST(EGLStreamUtils, returns_empty_option_on_empty_string)
 TEST(EGLStreamUtils, returns_nvidia_driver_version)
 {
     auto const version = mge::parse_nvidia_version("4.5 NVIDIA 390.23");
-    EXPECT_TRUE(version);
+    EXPECT_TRUE(!!version);
     EXPECT_THAT(*version, Eq(mge::VersionInfo { 390, 23 }));
 }
 


### PR DESCRIPTION
This simplifies the mess of nvidia dependencies by depending
on something that exists in the PPA for *all* our supported
releases and on all our supported architectures.