### PR TITLE
miral/eglapp: Accept EGL versions ≥ 1.4

### DIFF
--- a/examples/miral-shell/spinner/miregl.cpp
+++ b/examples/miral-shell/spinner/miregl.cpp
@@ -340,8 +340,8 @@ MirEglApp::MirEglApp(struct wl_display* display) :
     if (!eglInitialize(egldisplay, &major, &minor))
         throw std::runtime_error("Can't eglInitialize");
 
-    if (major != 1 || minor != 4)
-        throw std::runtime_error("EGL version is not 1.4");
+    if (major != 1 || minor < 4)
+        throw std::runtime_error("EGL version is not at least 1.4");
 
     if (!eglChooseConfig(egldisplay, attribs, &eglconfig, 1, &neglconfigs))
         throw std::runtime_error("Could not eglChooseConfig");


### PR DESCRIPTION
There's no need to reject EGL 1.5 here.

Since the NVIDIA driver now supports 1.5, this causes the spinner
to bail on startup on the eglstream-kms platform. (Fixes #661)