### PR TITLE
Strip out legacy titlebar logic

### DIFF
--- a/examples/example-server-lib/decoration_provider.h
+++ b/examples/example-server-lib/decoration_provider.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Canonical Ltd.
+ * Copyright © 2016-2018 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -66,36 +66,11 @@ public:
 
     auto session() const -> std::shared_ptr<mir::scene::Session>;
 
-    void create_titlebar_for(miral::Window const& window);
-    void place_new_decoration(miral::WindowSpecification& window_spec);
-    void paint_titlebar_for(miral::WindowInfo const& window, int intensity);
-    void destroy_titlebar_for(miral::Window const& window);
-    void resize_titlebar_for(miral::WindowInfo const& window_info, mir::geometry::Size const& size);
-    void advise_new_titlebar(miral::WindowInfo const& window_info);
-    void advise_state_change(miral::WindowInfo const& window_info, MirWindowState state);
-
     void stop();
 
     bool is_decoration(miral::Window const& window) const;
-    bool is_titlebar(miral::WindowInfo const& window_info) const;
 
 private:
-    struct Data
-    {
-        MirConnection* connection{nullptr};
-        mir::client::Surface surface;
-        MirBufferStream* stream{nullptr};
-        std::atomic<MirWindow*> titlebar{nullptr};
-        std::atomic<int> intensity{0xff};
-        std::function<void(MirWindow* surface)> on_create{[](MirWindow*){}};
-        miral::Window window;
-
-        ~Data();
-    };
-
-    using SurfaceMap = std::map<std::weak_ptr<mir::scene::Surface>, Data, std::owner_less<std::weak_ptr<mir::scene::Surface>>>;
-    using TitleMap = std::map<std::string, std::weak_ptr<mir::scene::Surface>>;
-
     miral::WindowManagerTools tools;
     std::mutex mutable mutex;
     mir::client::Connection connection;
@@ -103,14 +78,6 @@ private:
     std::vector<Wallpaper> wallpaper;
     std::weak_ptr<mir::scene::Session> weak_session;
 
-    SurfaceMap window_to_titlebar;
-    TitleMap windows_awaiting_titlebar;
-
-    static void insert(MirWindow* surface, Data* data);
-    Data* find_titlebar_data(miral::Window const& window);
-    miral::Window find_titlebar_window(miral::Window const& window) const;
-    void repaint_titlebar_for(miral::WindowInfo const& window_info);
-    static void handle_event(MirWindow* window, MirEvent const* ev, void* context_);
     static void handle_event_for_background(MirWindow* window, MirEvent const* event, void* context_);
     void handle_event_for_background(MirWindow* window, MirEvent const* ev);
 };


### PR DESCRIPTION
This simplifies the DecorationProvider code. (The mirclient API based "titlebar" logic ignores Wayland clients anyway).

We need to follow up with something similar to #666: This is the final "internal clients" needing to be migrated from the mirclient API to Wayland.

(Needed to function on Nvidia as mirclient API doesn't work on Nvidia.)