### PR TITLE
[miral-shell] DecorationProvider: Respond to output events

### DIFF
--- a/examples/example-server-lib/decoration_provider.cpp
+++ b/examples/example-server-lib/decoration_provider.cpp
@@ -25,6 +25,7 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
+#include <sys/poll.h>
 #include <locale>
 #include <codecvt>
 #include <map>
@@ -376,11 +377,16 @@ void DecorationProvider::operator()(struct wl_display* display)
     std::unique_lock<decltype(mutex)> lock{mutex};
     running = true;
 
+    pollfd fd = { wl_display_get_fd(display), POLLIN, 0 };
+    // TODO: use an additional FD pair to exit loop
+
     do
     {
         lock.unlock();
         while (wl_display_prepare_read(display) != 0)
             wl_display_dispatch_pending(display);
+
+        poll(&fd, 1, 200);
         wl_display_read_events(display);
         lock.lock();
     }

--- a/examples/example-server-lib/decoration_provider.cpp
+++ b/examples/example-server-lib/decoration_provider.cpp
@@ -388,16 +388,16 @@ void DecorationProvider::operator()(struct wl_display* display)
     self->init(display);
 
     enum FdIndices {
-        Display = 0,
-        Shutdown,
-        NumIndices
+        display_fd = 0,
+        shutdown,
+        indices
     };
 
-    pollfd fds[NumIndices];
-    fds[Display] = {wl_display_get_fd(display), POLLIN, 0};
-    fds[Shutdown] = {shutdown_signal, POLLIN, 0};
+    pollfd fds[indices];
+    fds[display_fd] = {wl_display_get_fd(display), POLLIN, 0};
+    fds[shutdown] = {shutdown_signal, POLLIN, 0};
 
-    while (!(fds[Shutdown].revents & (POLLIN | POLLERR)))
+    while (!(fds[shutdown].revents & (POLLIN | POLLERR)))
     {
         while (wl_display_prepare_read(display) != 0)
         {
@@ -408,14 +408,14 @@ void DecorationProvider::operator()(struct wl_display* display)
             }
         }
 
-        if (poll(fds, NumIndices, -1) == -1)
+        if (poll(fds, indices, -1) == -1)
         {
             wl_display_cancel_read(display);
             BOOST_THROW_EXCEPTION((
                 std::system_error{errno, std::system_category(), "Failed to wait for event"}));
         }
 
-        if (fds[Display].revents & (POLLIN | POLLERR))
+        if (fds[display_fd].revents & (POLLIN | POLLERR))
         {
             if (wl_display_read_events(display))
             {

--- a/examples/example-server-lib/decoration_provider.h
+++ b/examples/example-server-lib/decoration_provider.h
@@ -22,7 +22,6 @@
 
 #include <miral/window_manager_tools.h>
 
-#include <condition_variable>
 #include <mutex>
 
 class DecorationProvider
@@ -46,7 +45,6 @@ private:
 
     std::mutex mutable mutex;
     bool running{false};
-    std::condition_variable running_cv;
     std::weak_ptr<mir::scene::Session> weak_session;
 };
 

--- a/examples/example-server-lib/decoration_provider.h
+++ b/examples/example-server-lib/decoration_provider.h
@@ -21,6 +21,7 @@
 
 
 #include <miral/window_manager_tools.h>
+#include <mir/fd.h>
 
 #include <mutex>
 
@@ -44,7 +45,7 @@ private:
     std::shared_ptr<Self> const self;
 
     std::mutex mutable mutex;
-    bool running{false};
+    mir::Fd shutdown_signal;
     std::weak_ptr<mir::scene::Session> weak_session;
 };
 

--- a/examples/example-server-lib/decoration_provider.h
+++ b/examples/example-server-lib/decoration_provider.h
@@ -41,11 +41,9 @@ public:
     bool is_decoration(miral::Window const& window) const;
 
 private:
-    struct Self;
-    std::shared_ptr<Self> const self;
+    mir::Fd const shutdown_signal;
 
     std::mutex mutable mutex;
-    mir::Fd shutdown_signal;
     std::weak_ptr<mir::scene::Session> weak_session;
 };
 

--- a/examples/example-server-lib/wayland_helpers.cpp
+++ b/examples/example-server-lib/wayland_helpers.cpp
@@ -75,12 +75,13 @@ void output_geometry(
     int32_t /*subpixel*/,
     const char */*make*/,
     const char */*model*/,
-    int32_t /*transform*/)
+    int32_t transform)
 {
     auto output = static_cast<Output*>(data);
 
     output->x = x;
     output->y = y;
+    output->transform = transform;
 }
 
 

--- a/examples/example-server-lib/wayland_helpers.cpp
+++ b/examples/example-server-lib/wayland_helpers.cpp
@@ -139,7 +139,8 @@ Globals::Globals(
     std::function<void(Output const&)> on_new_output,
     std::function<void(Output const&)> on_output_changed,
     std::function<void(Output const&)> on_output_gone)
-    : on_new_output{std::move(on_new_output)},
+    : registry{nullptr, [](auto){}},
+      on_new_output{std::move(on_new_output)},
       on_output_changed{std::move(on_output_changed)},
       on_output_gone{std::move(on_output_gone)}
 {
@@ -206,12 +207,7 @@ void Globals::global_remove(
 
 void Globals::init(struct wl_display* display)
 {
-    wl_registry_listener const registry_listener = {
-        new_global,
-        global_remove
-    };
-
-    auto const registry = make_scoped(wl_display_get_registry(display), &wl_registry_destroy);
+    registry = {wl_display_get_registry(display), &wl_registry_destroy};
 
     wl_registry_add_listener(registry.get(), &registry_listener, this);
     wl_display_roundtrip(display);

--- a/examples/example-server-lib/wayland_helpers.cpp
+++ b/examples/example-server-lib/wayland_helpers.cpp
@@ -217,4 +217,5 @@ void Globals::init(struct wl_display* display)
 void Globals::teardown()
 {
     bound_outputs.clear();
+    registry.reset();
 }

--- a/examples/example-server-lib/wayland_helpers.h
+++ b/examples/example-server-lib/wayland_helpers.h
@@ -50,6 +50,7 @@ public:
 
     int32_t x, y;
     int32_t width, height;
+    int32_t transform;
     wl_output* output;
 private:
     static void output_done(void* data, wl_output* output);

--- a/examples/example-server-lib/wayland_helpers.h
+++ b/examples/example-server-lib/wayland_helpers.h
@@ -90,6 +90,13 @@ private:
         struct wl_registry* registry,
         uint32_t name);
 
+    wl_registry_listener const registry_listener = {
+        new_global,
+        global_remove
+    };
+
+    std::unique_ptr<wl_registry, decltype(&wl_registry_destroy)> registry;
+
     std::unordered_map<uint32_t, std::unique_ptr<Output>> bound_outputs;
 
     std::function<void(Output const&)> const on_new_output;


### PR DESCRIPTION
This fixes the background when the screen is rotated left or right:

    miral-app

(in the session)

    mirout output 1 rotate left

The client wasn't receiving notifications of output reconfiguration because it wasn't running an event loop.