### PR TITLE
{eglstream,mesa}-kms: Ensure queried nodes actually support modesetting.

### DIFF
--- a/tests/include/mir/test/doubles/mock_drm.h
+++ b/tests/include/mir/test/doubles/mock_drm.h
@@ -159,6 +159,7 @@ public:
     MOCK_METHOD1(drmGetVersion, drmVersionPtr(int));
     MOCK_METHOD1(drmFreeVersion, void(drmVersionPtr));
 
+    MOCK_METHOD1(drmCheckModesettingSupported, int(char const*));
 
     void add_crtc(
         char const* device,

--- a/tests/include/mir/test/doubles/mock_drm.h
+++ b/tests/include/mir/test/doubles/mock_drm.h
@@ -69,6 +69,7 @@ public:
                                        uint32_t clock, uint16_t htotal, uint16_t vtotal,
                                        ModePreference preferred);
 
+    bool drm_setversion_called{false};
 private:
     int pipe_fds[2];
 

--- a/tests/mir_test_doubles/mock_drm.cpp
+++ b/tests/mir_test_doubles/mock_drm.cpp
@@ -329,6 +329,9 @@ mtd::MockDRM::MockDRM()
     };
     ON_CALL(*this, drmGetVersion(_))
         .WillByDefault(Return(const_cast<drmVersionPtr>(&version)));
+
+    ON_CALL(*this, drmCheckModesettingSupported(_))
+    .WillByDefault(Return(0));
 }
 
 mtd::MockDRM::~MockDRM() noexcept
@@ -699,3 +702,7 @@ char* drmGetDeviceNameFromFd(int fd)
     return global_mock->drmGetDeviceNameFromFd(fd);
 }
 
+int drmCheckModesettingSupported(char const* busid)
+{
+    return global_mock->drmCheckModesettingSupported(busid);
+}

--- a/tests/mir_test_doubles/mock_drm.cpp
+++ b/tests/mir_test_doubles/mock_drm.cpp
@@ -308,13 +308,35 @@ mtd::MockDRM::MockDRM()
         .WillByDefault(Return(&empty_object_props));
 
     ON_CALL(*this, drmSetInterfaceVersion(_, _))
-    .WillByDefault(Return(0));
+        .WillByDefault(
+            Invoke(
+                [this](auto fd, auto version)
+                {
+                    if (version->drm_di_major != 1 || version->drm_di_minor != 4)
+                    {
+                        ADD_FAILURE() << "We should only ever request DRM version 1.4";
+                        errno = EINVAL;
+                        return -1;
+                    }
+
+                    fd_to_drm.at(fd).drm_setversion_called = true;
+                    return 0;
+                }));
 
     ON_CALL(*this, drmGetBusid(_))
-    .WillByDefault(WithoutArgs(Invoke([]{ return static_cast<char*>(malloc(10)); })));
+        .WillByDefault(
+            Invoke(
+                [this](auto fd) -> char*
+                {
+                    if (!fd_to_drm.at(fd).drm_setversion_called)
+                    {
+                        return nullptr;
+                    }
+                    return static_cast<char*>(malloc(10));
+                }));
 
     ON_CALL(*this, drmFreeBusid(_))
-    .WillByDefault(WithArg<0>(Invoke([&](const char* busid){ free(const_cast<char*>(busid)); })));
+        .WillByDefault(WithArg<0>(Invoke([&](const char* busid) { free(const_cast<char*>(busid)); })));
 
     static drmVersion const version{
         1,
@@ -330,8 +352,10 @@ mtd::MockDRM::MockDRM()
     ON_CALL(*this, drmGetVersion(_))
         .WillByDefault(Return(const_cast<drmVersionPtr>(&version)));
 
-    ON_CALL(*this, drmCheckModesettingSupported(_))
-    .WillByDefault(Return(0));
+    ON_CALL(*this, drmCheckModesettingSupported(NotNull()))
+        .WillByDefault(Return(0));
+    ON_CALL(*this, drmCheckModesettingSupported(IsNull()))
+        .WillByDefault(Return(-EINVAL));
 }
 
 mtd::MockDRM::~MockDRM() noexcept

--- a/tests/unit-tests/platforms/mesa/kms/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_platform.cpp
@@ -237,3 +237,18 @@ TEST_F(MesaGraphicsPlatform, probe_returns_unsupported_when_gbm_platform_not_sup
     auto probe = platform_lib.load_function<mg::PlatformProbe>(probe_platform);
     EXPECT_EQ(mg::PlatformPriority::unsupported, probe(stub_vt, options));
 }
+
+TEST_F(MesaGraphicsPlatform, probe_returns_unsupported_when_modesetting_is_not_supported)
+{
+    using namespace testing;
+
+    boost::program_options::options_description po;
+    mir::options::ProgramOption options;
+    auto const stub_vt = std::make_shared<mtd::StubConsoleServices>();
+
+    ON_CALL(mock_drm, drmCheckModesettingSupported(_)).WillByDefault(Return(-ENOSYS));
+
+    mir::SharedLibrary platform_lib{mtf::server_platform("graphics-mesa-kms")};
+    auto probe = platform_lib.load_function<mg::PlatformProbe>(probe_platform);
+    EXPECT_EQ(mg::PlatformPriority::unsupported, probe(stub_vt, options));
+}


### PR DESCRIPTION
If the NVIDIA drivers are in use, but the experimental KMS support is not enabled,
the eglstream-kms driver would still bind to the device as the EGL implementation
claims to support everything we need.

Check explicitly for modesetting support on the node we're planning to use, so
we can fall back to something that might work. (Fixes: #672)