### PR TITLE
Add missing include

### DIFF
--- a/tests/include/mir_test_framework/open_wrapper.h
+++ b/tests/include/mir_test_framework/open_wrapper.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <memory>
 #include <experimental/optional>
+#include <sys/stat.h>
 
 namespace mir_test_framework
 {


### PR DESCRIPTION
Required for compiling against the musl libc