### PR TITLE
Support libcs with POSIX ioctl arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,19 @@ if(HAS_W_PSABI)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi")
 endif()
 
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles(
+    "
+    #include <sys/ioctl.h>
+    extern \"C\" int ioctl (int, int,...);
+    int main() {}
+    "
+    HAVE_POSIX_IOCTL)
+
+if(HAVE_POSIX_IOCTL)
+  add_compile_definitions(HAVE_POSIX_IOCTL)
+endif()
+
 set(MIR_USE_LD gold CACHE STRING "Linker to use")
 set_property(CACHE MIR_USE_LD PROPERTY STRINGS "ld;gold;lld")
 if(MIR_USE_LD MATCHES "gold")

--- a/tests/privileged-tests/ui_get_sysname_ioctl_override.cpp
+++ b/tests/privileged-tests/ui_get_sysname_ioctl_override.cpp
@@ -43,6 +43,7 @@
 #include <string>
 #include <iostream>
 
+#include <linux/ioctl.h>
 #include <linux/uinput.h>
 #include <dlfcn.h>
 #include <dirent.h>
@@ -93,12 +94,20 @@ bool request_is_ui_get_sysname(unsigned long int request)
 
 }
 
-extern "C" int ioctl(int fd, unsigned long int request, ...) __THROW
+#ifdef HAVE_POSIX_IOCTL
+extern "C" int ioctl(int fd, int request, ...)
+#else
+extern "C" int ioctl(int fd, unsigned long request, ...)
+#endif
 {
     va_list vargs;
     va_start(vargs, request);
 
-    using ioctl_func = int(*)(int, unsigned long int, void*);
+#ifdef HAVE_POSIX_IOCTL
+    using ioctl_func = int(*)(int, int, void*);
+#else
+    using ioctl_func = int(*)(int, unsigned long, void*);
+#endif
     static ioctl_func const real_ioctl =
         reinterpret_cast<ioctl_func>(dlsym(RTLD_NEXT, "ioctl"));
 


### PR DESCRIPTION
POSIX defines `ioctl()` with an `int` request parameter, while glibc
uses `unsigned long`.

----

Reference: https://github.com/martinpitt/umockdev/commit/e09dc8a6e63911298f1dd00ca9fbc90e02ff0297

Initially I wanted to create a patch like the following
```cmake
if(HAVE_POSIX_IOCTL)
  set(IOCTL_REQUEST_TYPE int)
else()
  set(IOCTL_REQUEST_TYPE "unsigned long")
endif()
add_compile_definitions(IOCTL_REQUEST_TYPE="${IOCTL_REQUEST_TYPE}")
```
and then use `IOCTL_REQUEST_TYPE` as type instead of ifdef'ing the whole line, but having spaces in the `add_compile_definitions` breaks everything apparently (and when it doesn't, I need the `unsigned long` literally without quotes, so not as a string. In the reference patch above (which is using GNU autotools) , the author uses `AC_DEFINE_UNQUOTED` but I didn't find an equivalent for CMake.
