### PR TITLE
Only use dlvsym when it's available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,14 @@ include (cmake/MirCommon.cmake)
 include (GNUInstallDirs)
 include (cmake/Doxygen.cmake)
 
+include(CheckSymbolExists)
+set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+set(CMAKE_REQUIRED_LIBRARIES dl)
+check_symbol_exists(dlvsym dlfcn.h HAVE_DLVSYM)
+if(HAVE_DLVSYM)
+  add_compile_definitions(HAVE_DLVSYM)
+endif()
+
 set(build_types "None;Debug;Release;RelWithDebInfo;MinSizeRel;Coverage;AddressSanitizer;ThreadSanitizer;UBSanitizer")
 # Change informational string for CMAKE_BUILD_TYPE
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "${build_types}" FORCE)

--- a/src/common/sharedlibrary/shared_library.cpp
+++ b/src/common/sharedlibrary/shared_library.cpp
@@ -56,7 +56,11 @@ void* mir::SharedLibrary::load_symbol(char const* function_name) const
 
 void* mir::SharedLibrary::load_symbol(char const* function_name, char const* version) const
 {
+#ifdef HAVE_DLVSYM
     if (void* result = dlvsym(so, function_name, version))
+#else
+    if (void* result = dlsym(so, function_name))
+#endif
     {
         return result;
     }


### PR DESCRIPTION
Required for compiling against the musl libc

I don't know if there are any downsides of ignoring the version string, so please tell me if there are :)