### PR TITLE
Install & package the stub modules used by mir_performance_tests. (Fixes #675)

### DIFF
--- a/debian/mir-test-tools.install
+++ b/debian/mir-test-tools.install
@@ -6,3 +6,6 @@ usr/lib/*/mir/tools/libmirserverlttng.so
 usr/bin/mir_demo_client_*
 usr/bin/mir_demo_server
 usr/lib/*/libmir_demo_server_loadable.so
+usr/lib/*/mir/server-platform/graphics-dummy.so
+usr/lib/*/mir/server-platform/input-stub.so
+usr/lib/*/mir/client-platform/dummy.so

--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -176,6 +176,10 @@ set_target_properties(
   LINK_FLAGS "-Wl,--version-script,${server_symbol_map}"
 )
 
+install(TARGETS mirplatformgraphicsstub LIBRARY DESTINATION ${MIR_SERVER_PLATFORM_PATH})
+install(TARGETS mirplatforminputstub LIBRARY DESTINATION ${MIR_SERVER_PLATFORM_PATH})
+install(TARGETS mirclientplatformstub LIBRARY DESTINATION ${MIR_CLIENT_PLATFORM_PATH})
+
 add_library(
   mirplatformgraphicsthrow MODULE
   platform_graphics_throw.cpp


### PR DESCRIPTION
Install & package the stub modules used by mir_performance_tests. (Fixes #675)