### PR TITLE
Don't hardcode request type for ioctl()

### DIFF
--- a/tests/privileged-tests/ui_get_sysname_ioctl_override.cpp
+++ b/tests/privileged-tests/ui_get_sysname_ioctl_override.cpp
@@ -43,8 +43,9 @@
 #include <string>
 #include <iostream>
 
-#include <linux/uinput.h>
 #include <sys/ioctl.h>
+#include <linux/ioctl.h>
+#include <linux/uinput.h>
 #include <dlfcn.h>
 #include <dirent.h>
 #include <time.h>

--- a/tests/privileged-tests/ui_get_sysname_ioctl_override.cpp
+++ b/tests/privileged-tests/ui_get_sysname_ioctl_override.cpp
@@ -44,6 +44,7 @@
 #include <iostream>
 
 #include <linux/uinput.h>
+#include <sys/ioctl.h>
 #include <dlfcn.h>
 #include <dirent.h>
 #include <time.h>
@@ -91,14 +92,16 @@ bool request_is_ui_get_sysname(unsigned long int request)
            static_cast<unsigned long>(UI_GET_SYSNAME(0));
 }
 
+template<typename Param1>
+auto request_param_type(int (* ioctl)(int, Param1, ...)) -> Param1;
 }
 
-extern "C" int ioctl(int fd, unsigned long int request, ...) __THROW
+extern "C" int ioctl(int fd, decltype(request_param_type(&ioctl)) request, ...) __THROW
 {
     va_list vargs;
     va_start(vargs, request);
 
-    using ioctl_func = int(*)(int, unsigned long int, void*);
+    using ioctl_func = decltype(&ioctl);
     static ioctl_func const real_ioctl =
         reinterpret_cast<ioctl_func>(dlsym(RTLD_NEXT, "ioctl"));
 

--- a/tests/privileged-tests/ui_get_sysname_ioctl_override.cpp
+++ b/tests/privileged-tests/ui_get_sysname_ioctl_override.cpp
@@ -94,10 +94,12 @@ bool request_is_ui_get_sysname(unsigned long int request)
 }
 
 template<typename Param1>
-auto request_param_type(int (* ioctl)(int, Param1, ...)) -> Param1;
+auto request_param_type(int (*ioctl)(int, Param1, ...)) -> Param1;
 }
 
-extern "C" int ioctl(int fd, decltype(request_param_type(&ioctl)) request, ...) noexcept
+using ioctl_request_t = decltype(request_param_type(&ioctl));
+
+extern "C" int ioctl(int fd, ioctl_request_t request, ...) noexcept
 {
     va_list vargs;
     va_start(vargs, request);

--- a/tests/privileged-tests/ui_get_sysname_ioctl_override.cpp
+++ b/tests/privileged-tests/ui_get_sysname_ioctl_override.cpp
@@ -96,7 +96,7 @@ template<typename Param1>
 auto request_param_type(int (* ioctl)(int, Param1, ...)) -> Param1;
 }
 
-extern "C" int ioctl(int fd, decltype(request_param_type(&ioctl)) request, ...) __THROW
+extern "C" int ioctl(int fd, decltype(request_param_type(&ioctl)) request, ...) noexcept
 {
     va_list vargs;
     va_start(vargs, request);


### PR DESCRIPTION
Support libcs with POSIX ioctl arguments

POSIX defines ioctl() with an int request parameter, while glibc uses unsigned long.