### PR TITLE
Don't call dlvsym() when it's unavailable.

### DIFF
--- a/src/common/sharedlibrary/CMakeLists.txt
+++ b/src/common/sharedlibrary/CMakeLists.txt
@@ -20,6 +20,11 @@ add_library(mirsharedsharedlibrary OBJECT
   shared_library_prober.cpp
 )
 
+# we overload dlvsym() for systems that don't have it
+set_source_files_properties(shared_library.cpp
+  PROPERTIES COMPILE_FLAGS "-Wno-unused-function"
+)
+
 list(APPEND MIR_COMMON_SOURCES
   $<TARGET_OBJECTS:mirsharedsharedlibrary>
 )

--- a/src/common/sharedlibrary/CMakeLists.txt
+++ b/src/common/sharedlibrary/CMakeLists.txt
@@ -20,11 +20,6 @@ add_library(mirsharedsharedlibrary OBJECT
   shared_library_prober.cpp
 )
 
-# we overload dlvsym() for systems that don't have it
-set_source_files_properties(shared_library.cpp
-  PROPERTIES COMPILE_FLAGS "-Wno-unused-function"
-)
-
 list(APPEND MIR_COMMON_SOURCES
   $<TARGET_OBJECTS:mirsharedsharedlibrary>
 )

--- a/src/common/sharedlibrary/shared_library.cpp
+++ b/src/common/sharedlibrary/shared_library.cpp
@@ -59,7 +59,7 @@ void* mir::SharedLibrary::load_symbol(char const* function_name) const
 //  - On gibc systems providing dlvsym() it is an unused overload,
 //  - On musl libc we fall back to  the no-version load_symbol() overload.
 int* dlvsym(void* so, const char* function_name, ...);
-static auto constexpr dlvsym_is_available = !std::is_same<int*, decltype(dlvsym(nullptr, nullptr, nullptr))>::value;
+static auto constexpr dlvsym_is_available = !std::is_same<int*, decltype(dlvsym(nullptr, "", ""))>::value;
 
 void* mir::SharedLibrary::load_symbol(char const* function_name, char const* version) const
 {

--- a/src/common/sharedlibrary/shared_library.cpp
+++ b/src/common/sharedlibrary/shared_library.cpp
@@ -59,11 +59,10 @@ void* mir::SharedLibrary::load_symbol(char const* function_name) const
 //  - On gibc systems providing dlvsym() it is an unused overload,
 //  - On musl libc we fall back to  the no-version load_symbol() overload.
 int* dlvsym(void* so, const char* function_name, ...);
+static auto constexpr dlvsym_is_available = !std::is_same<int*, decltype(dlvsym(nullptr, nullptr, nullptr))>::value;
 
 void* mir::SharedLibrary::load_symbol(char const* function_name, char const* version) const
 {
-    auto constexpr dlvsym_is_available = !std::is_same<int*, decltype(dlvsym(so, function_name, version))>::value;
-
     if (dlvsym_is_available)
     {
         if (void* result = dlvsym(so, function_name, version))

--- a/src/common/sharedlibrary/shared_library.cpp
+++ b/src/common/sharedlibrary/shared_library.cpp
@@ -54,6 +54,12 @@ void* mir::SharedLibrary::load_symbol(char const* function_name) const
     }
 }
 
+// On systems providing dlvsym() an unused overload, on musl libc it falls back to dlsym()
+inline static void dlvsym(void* so, const char* function_name, ...)
+{
+    dlsym(so, function_name);
+}
+
 void* mir::SharedLibrary::load_symbol(char const* function_name, char const* version) const
 {
     if (void* result = dlvsym(so, function_name, version))

--- a/src/common/sharedlibrary/shared_library.cpp
+++ b/src/common/sharedlibrary/shared_library.cpp
@@ -55,9 +55,9 @@ void* mir::SharedLibrary::load_symbol(char const* function_name) const
 }
 
 // On systems providing dlvsym() an unused overload, on musl libc it falls back to dlsym()
-inline static void dlvsym(void* so, const char* function_name, ...)
+inline static void* dlvsym(void* so, const char* function_name, ...)
 {
-    dlsym(so, function_name);
+    return dlsym(so, function_name);
 }
 
 void* mir::SharedLibrary::load_symbol(char const* function_name, char const* version) const


### PR DESCRIPTION
Required for compiling against the musl libc.

The effect of this is that on Alpine you won't be able to do the equivalent of installing "platforms" from multiple versions of Mir (e.g. `mir-platform-graphics-mesa-kms16` and `mir-platform-graphics-mesa-kms15`) which works on Ubuntu. Avoiding that is a packaging issue for Alpine.