### PR TITLE
Dont clean generated files (better)

### DIFF
--- a/src/server/console/CMakeLists.txt
+++ b/src/server/console/CMakeLists.txt
@@ -74,3 +74,5 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/logind-session.xml
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM 1)

--- a/src/server/frontend_wayland/generator/CMakeLists.txt
+++ b/src/server/frontend_wayland/generator/CMakeLists.txt
@@ -48,7 +48,7 @@ macro(GENERATE_PROTOCOL NAME_PREFIX PROTOCOL_NAME)
     DEPENDS "${PROTOCOL_PATH}"
     DEPENDS wrapper-generator
   )
-  set(GENERATED_FILES ${GENERATED_FILES} "${OUTPUT_PATH_H}" "${OUTPUT_PATH_C}" "${OUTPUT_PATH_HEADER}" "${OUTPUT_PATH_SRC}")
+  set(GENERATED_FILES ${GENERATED_FILES} "${OUTPUT_PATH_HEADER}" "${OUTPUT_PATH_SRC}")
 endmacro()
 
 # when adding a protocol, don't forget to add the generated .c file to CMake

--- a/src/server/frontend_wayland/generator/CMakeLists.txt
+++ b/src/server/frontend_wayland/generator/CMakeLists.txt
@@ -63,3 +63,4 @@ add_custom_target(refresh-wayland-wrapper
   SOURCES ${GENERATED_FILES}
 )
 
+set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM 1)


### PR DESCRIPTION
Stop deleting generated Wayland and dbus protocol files in a `make clean`, replaces #690.