### PR TITLE
mir::SharedLibrary: Only define stub dlvsym() when necessary.

### DIFF
--- a/src/common/sharedlibrary/CMakeLists.txt
+++ b/src/common/sharedlibrary/CMakeLists.txt
@@ -14,6 +14,24 @@
 #
 # Authored by: Alexandros Frantzis <alexandros.frantzis@canonical.com>
 
+include(CheckFunctionExists)
+
+list(APPEND CMAKE_REQUIRED_LIBRARIES dl)
+list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+
+# CMake docs suggests that we should, instead, be using check_symbol_exists.
+# The only problem there is that check_symbol_exists("dlvsym", "dlfcn.h", HAS_DLVSYM) never finds
+# the dlvsym symbol ☹.
+check_function_exists("dlvsym" HAS_DLVSYM)
+
+if (NOT HAS_DLVSYM)
+  add_compile_definitions(NEEDS_STUB_DLVSYM)
+  message(
+    WARNING
+    "dlvsym() not supported by libc. Mir may attempt to load ABI-incompatible platform modules"
+  )
+endif()
+
 add_library(mirsharedsharedlibrary OBJECT
   module_deleter.cpp
   shared_library.cpp

--- a/src/common/sharedlibrary/shared_library.cpp
+++ b/src/common/sharedlibrary/shared_library.cpp
@@ -54,6 +54,13 @@ void* mir::SharedLibrary::load_symbol(char const* function_name) const
     }
 }
 
+#ifdef NEEDS_STUB_DLVSYM
+static void* dlvsym(void* handle, char const* function_name, char const* /*version*/)
+{
+    return dlsym(handle, function_name);
+}
+#endif
+
 void* mir::SharedLibrary::load_symbol(char const* function_name, char const* version) const
 {
     if (void* result = dlvsym(so, function_name, version))


### PR DESCRIPTION
This is required for compiling against musl libc, as `dlvsym` is a GNU extension.