### PR TITLE
William enters the dlvsym fray

### DIFF
--- a/src/common/sharedlibrary/CMakeLists.txt
+++ b/src/common/sharedlibrary/CMakeLists.txt
@@ -22,7 +22,10 @@ list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 check_cxx_symbol_exists("dlvsym" "dlfcn.h" HAS_DLVSYM)
 
 if (NOT HAS_DLVSYM)
-  add_compile_definitions(DONT_USE_DLVSYM)
+  set_source_files_properties (
+    "shared_library.cpp"
+    PROPERTIES COMPILE_DEFINITIONS DONT_USE_DLVSYM="1"
+  )
   message(
     WARNING
     "dlvsym() not supported by libc. Mir may attempt to load ABI-incompatible platform modules"

--- a/src/common/sharedlibrary/CMakeLists.txt
+++ b/src/common/sharedlibrary/CMakeLists.txt
@@ -14,15 +14,12 @@
 #
 # Authored by: Alexandros Frantzis <alexandros.frantzis@canonical.com>
 
-include(CheckFunctionExists)
+include(CheckCXXSymbolExists)
 
 list(APPEND CMAKE_REQUIRED_LIBRARIES dl)
 list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 
-# CMake docs suggests that we should, instead, be using check_symbol_exists.
-# The only problem there is that check_symbol_exists("dlvsym", "dlfcn.h", HAS_DLVSYM) never finds
-# the dlvsym symbol ☹.
-check_function_exists("dlvsym" HAS_DLVSYM)
+check_cxx_symbol_exists("dlvsym" "dlfcn.h" HAS_DLVSYM)
 
 if (NOT HAS_DLVSYM)
   add_compile_definitions(DONT_USE_DLVSYM)

--- a/src/common/sharedlibrary/CMakeLists.txt
+++ b/src/common/sharedlibrary/CMakeLists.txt
@@ -20,12 +20,21 @@ list(APPEND CMAKE_REQUIRED_LIBRARIES dl)
 list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 
 check_cxx_symbol_exists("dlvsym" "dlfcn.h" HAS_DLVSYM)
+check_cxx_symbol_exists("dlsym" "dlfcn.h" HAS_DLSYM)
 
 if (NOT HAS_DLVSYM)
+  if (NOT HAS_DLSYM)
+    message(
+      FATAL_ERROR
+      "Could not detect dlvsym or dlsym"
+    )
+  endif()
+
   set_source_files_properties (
     "shared_library.cpp"
     PROPERTIES COMPILE_DEFINITIONS MIR_DONT_USE_DLVSYM="1"
   )
+
   message(
     WARNING
     "dlvsym() not supported by libc. Mir may attempt to load ABI-incompatible platform modules"

--- a/src/common/sharedlibrary/CMakeLists.txt
+++ b/src/common/sharedlibrary/CMakeLists.txt
@@ -24,7 +24,7 @@ check_cxx_symbol_exists("dlvsym" "dlfcn.h" HAS_DLVSYM)
 if (NOT HAS_DLVSYM)
   set_source_files_properties (
     "shared_library.cpp"
-    PROPERTIES COMPILE_DEFINITIONS DONT_USE_DLVSYM="1"
+    PROPERTIES COMPILE_DEFINITIONS MIR_DONT_USE_DLVSYM="1"
   )
   message(
     WARNING

--- a/src/common/sharedlibrary/CMakeLists.txt
+++ b/src/common/sharedlibrary/CMakeLists.txt
@@ -14,6 +14,24 @@
 #
 # Authored by: Alexandros Frantzis <alexandros.frantzis@canonical.com>
 
+include(CheckFunctionExists)
+
+list(APPEND CMAKE_REQUIRED_LIBRARIES dl)
+list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+
+# CMake docs suggests that we should, instead, be using check_symbol_exists.
+# The only problem there is that check_symbol_exists("dlvsym", "dlfcn.h", HAS_DLVSYM) never finds
+# the dlvsym symbol ☹.
+check_function_exists("dlvsym" HAS_DLVSYM)
+
+if (NOT HAS_DLVSYM)
+  add_compile_definitions(NEEDS_STUB_DLVSYM)
+  message(
+    WARNING
+    "dlvsym() not supported by libc. Mir may attempt to load ABI-incompatible platform modules"
+  )
+endif()
+
 add_library(mirsharedsharedlibrary OBJECT
   module_deleter.cpp
   shared_library.cpp

--- a/src/common/sharedlibrary/CMakeLists.txt
+++ b/src/common/sharedlibrary/CMakeLists.txt
@@ -25,7 +25,7 @@ list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 check_function_exists("dlvsym" HAS_DLVSYM)
 
 if (NOT HAS_DLVSYM)
-  add_compile_definitions(NEEDS_STUB_DLVSYM)
+  add_compile_definitions(DONT_USE_DLVSYM)
   message(
     WARNING
     "dlvsym() not supported by libc. Mir may attempt to load ABI-incompatible platform modules"

--- a/src/common/sharedlibrary/shared_library.cpp
+++ b/src/common/sharedlibrary/shared_library.cpp
@@ -59,7 +59,7 @@ void* mir::SharedLibrary::load_symbol(char const* function_name, char const* ver
 {
     // Some libc implementations (such as musl) do not support dlvsym
 
-#ifdef DONT_USE_DLVSYM
+#ifdef MIR_DONT_USE_DLVSYM
     // Load the function without checking the version
     log_debug("Cannot check %s symbol version is %d: dlvsym() is unavailable", function_name, version);
     return load_symbol(function_name);

--- a/src/common/sharedlibrary/shared_library.cpp
+++ b/src/common/sharedlibrary/shared_library.cpp
@@ -61,7 +61,7 @@ void* mir::SharedLibrary::load_symbol(char const* function_name, char const* ver
 
 #ifdef MIR_DONT_USE_DLVSYM
     // Load the function without checking the version
-    log_debug("Cannot check %s symbol version is %d: dlvsym() is unavailable", function_name, version);
+    log_debug("Cannot check \"%s\" symbol version is \"%s\": dlvsym() is unavailable", function_name, version);
     return load_symbol(function_name);
 #else
     if (void* result = dlvsym(so, function_name, version))

--- a/src/common/sharedlibrary/shared_library.cpp
+++ b/src/common/sharedlibrary/shared_library.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "mir/shared_library.h"
+#include <mir/log.h>
 
 #include <boost/throw_exception.hpp>
 #include <boost/exception/info.hpp>
@@ -60,9 +61,8 @@ void* mir::SharedLibrary::load_symbol(char const* function_name, char const* ver
 
 #ifdef DONT_USE_DLVSYM
     // Load the function without checking the version
+    log_debug("Cannot check %s symbol version is %d: dlvsym() is unavailable", function_name, version);
     return load_symbol(function_name);
-    // Suppress unused argument warning
-    (void)version;
 #else
     if (void* result = dlvsym(so, function_name, version))
     {

--- a/src/common/sharedlibrary/shared_library.cpp
+++ b/src/common/sharedlibrary/shared_library.cpp
@@ -54,6 +54,13 @@ void* mir::SharedLibrary::load_symbol(char const* function_name) const
     }
 }
 
+#ifdef NEEDS_STUB_DLVSYM
+static void* dlvsym(void* handle, char const* function_name, char const* /*version*/)
+{
+    return dlsym(handle, function_name);
+}
+#endif
+
 void* mir::SharedLibrary::load_symbol(char const* function_name, char const* version) const
 {
     if (void* result = dlvsym(so, function_name, version))


### PR DESCRIPTION
Yet another fix for the musl dlvsym problem, alternative to #683, #687 and #698

* Uses cmake and an #ifdef to remove dlvsym
* Defaults to using dlvsym if anything goes wrong in the build system
* Puts the ifdef right where the function is called
* Uses the `load_symbol(function_name)` method for minimal redundancy