### PR TITLE
Fix "unused parameter 'type'" warning/error on musl

### DIFF
--- a/src/common/posix_rw_mutex.cpp
+++ b/src/common/posix_rw_mutex.cpp
@@ -100,6 +100,8 @@ mir::PosixRWMutex::PosixRWMutex(Type type)
             std::system_category(),
             "Failed to set preferred rw-lock mode"}));
     }
+#else
+    (void)type;
 #endif
 
     err = pthread_rwlock_init(&mutex, &attr);


### PR DESCRIPTION
Fixes #696