### PR TITLE
Make it possible to disable probing for KMS on platforms where drmCheckModesettingSupported() is unreliable.

### DIFF
--- a/src/platforms/mesa/server/kms/platform_symbols.cpp
+++ b/src/platforms/mesa/server/kms/platform_symbols.cpp
@@ -179,12 +179,16 @@ mg::PlatformPriority probe_graphics_platform(
                     drmGetBusid(tmp_fd),
                     &drmFreeBusid
                 };
-                if (auto err = -drmCheckModesettingSupported(busid.get()))
+
+                if (getenv("MIR_MESA_KMS_DISABLE_MODESET_PROBE") == nullptr)
                 {
-                    throw std::system_error{
-                        err,
-                        std::system_category(),
-                        std::string("Device ") + device.devnode() + " does not support KMS"};
+                    if (auto err = -drmCheckModesettingSupported(busid.get()))
+                    {
+                        throw std::system_error{
+                            err,
+                            std::system_category(),
+                            std::string("Device ") + device.devnode() + " does not support KMS"};
+                    }
                 }
 
                 mgm::helpers::GBMHelper gbm_device{tmp_fd};


### PR DESCRIPTION
Make it possible to disable probing for KMS on platforms where drmCheckModesettingSupported() is unreliable. (Workaround for #704)