### PR TITLE
Provide config option for wallpaper font in mir_demo_shell

### DIFF
--- a/examples/example-server-lib/CMakeLists.txt
+++ b/examples/example-server-lib/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(example-shell-lib STATIC
     tiling_window_manager.cpp   tiling_window_manager.h
     floating_window_manager.cpp floating_window_manager.h
     decoration_provider.cpp     decoration_provider.h
-    titlebar_config.cpp         titlebar_config.h
+    wallpaper_config.cpp        wallpaper_config.h
         splash_session.h
     sw_splash.cpp               sw_splash.h
     wayland_helpers.cpp         wayland_helpers.h

--- a/examples/example-server-lib/decoration_provider.cpp
+++ b/examples/example-server-lib/decoration_provider.cpp
@@ -18,7 +18,7 @@
 
 #include "decoration_provider.h"
 
-#include "titlebar_config.h"
+#include "wallpaper_config.h"
 
 #include "wayland_helpers.h"
 
@@ -70,9 +70,9 @@ Printer::Printer()
     if (FT_Init_FreeType(&lib))
         return;
 
-    if (FT_New_Face(lib, titlebar::font_file().c_str(), 0, &face))
+    if (FT_New_Face(lib, wallpaper::font_file().c_str(), 0, &face))
     {
-        std::cerr << "WARNING: failed to load font: \"" <<  titlebar::font_file() << "\"\n";
+        std::cerr << "WARNING: failed to load font: \"" <<  wallpaper::font_file() << "\"\n";
         FT_Done_FreeType(lib);
         return;
     }

--- a/examples/example-server-lib/wallpaper_config.cpp
+++ b/examples/example-server-lib/wallpaper_config.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2018 Canonical Ltd.
+ * Copyright © 2016-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -16,7 +16,7 @@
  * Authored by: Alan Griffiths <alan@octopull.co.uk>
  */
 
-#include "titlebar_config.h"
+#include "wallpaper_config.h"
 #include <unistd.h>
 #include <mutex>
 
@@ -45,13 +45,13 @@ std::mutex mutex;
 std::string font_file{default_font()};
 }
 
-void titlebar::font_file(std::string const& font_file)
+void wallpaper::font_file(std::string const& font_file)
 {
     std::lock_guard<decltype(mutex)> lock{mutex};
     ::font_file = font_file;
 }
 
-auto titlebar::font_file() -> std::string
+auto wallpaper::font_file() -> std::string
 {
     std::lock_guard<decltype(mutex)> lock{mutex};
     return ::font_file;

--- a/examples/example-server-lib/wallpaper_config.h
+++ b/examples/example-server-lib/wallpaper_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Canonical Ltd.
+ * Copyright © 2016-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -21,7 +21,7 @@
 
 #include <string>
 
-namespace titlebar
+namespace wallpaper
 {
 void font_file(std::string const& font_file);
 auto font_file() -> std::string;

--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2017 Canonical Ltd.
+ * Copyright © 2012-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 or 3 as
@@ -26,9 +26,10 @@
 
 #include "tiling_window_manager.h"
 #include "floating_window_manager.h"
-#include "titlebar_config.h"
+#include "wallpaper_config.h"
 #include "sw_splash.h"
 
+#include <miral/command_line_option.h>
 #include <miral/cursor_theme.h>
 #include <miral/display_configuration_option.h>
 #include <miral/runner.h>
@@ -156,6 +157,9 @@ try
         me::add_input_device_configuration_options_to,
         add_timeout_option_to,
         miral::CursorTheme{"default:DMZ-White"},
+        pre_init(miral::CommandLineOption{
+            [&](std::string const& font) { ::wallpaper::font_file(font); },
+            "wallpaper-font", "font file to use for wallpaper", ::wallpaper::font_file()}),
         input_filters,
         test_runner
     });

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Canonical Ltd.
+ * Copyright © 2016-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -18,7 +18,7 @@
 
 #include "tiling_window_manager.h"
 #include "floating_window_manager.h"
-#include "titlebar_config.h"
+#include "wallpaper_config.h"
 #include "spinner/splash.h"
 
 #include <miral/display_configuration_option.h>
@@ -90,7 +90,7 @@ int main(int argc, char const* argv[])
             debug_extensions,
             AppendEventFilter{quit_on_ctrl_alt_bksp},
             StartupInternalClient{spinner},
-            pre_init(CommandLineOption{[&](std::string const& typeface) { ::titlebar::font_file(typeface); },
-                              "shell-titlebar-font", "font file to use for titlebars", ::titlebar::font_file()})
+            pre_init(CommandLineOption{[&](std::string const& typeface) { ::wallpaper::font_file(typeface); },
+                              "shell-wallpaper-font", "font file to use for wallpaper", ::wallpaper::font_file()})
         });
 }


### PR DESCRIPTION
This will be useful for snapping up the mir-test-tools (as a confined snap cannot access the installed fonts)