### PR TITLE
Add Wayland support for `mir_demo_server --test-client`

### DIFF
--- a/examples/mir_demo_server/server_example_test_client.cpp
+++ b/examples/mir_demo_server/server_example_test_client.cpp
@@ -130,6 +130,14 @@ void me::TestClientRunner::operator()(mir::Server& server)
 
                 setenv("MIR_SOCKET", connect_string, 1);
 
+                // Enable tests with toolkits supporting Wayland
+                auto const wayland_display = server.wayland_display();
+                setenv("WAYLAND_DISPLAY", wayland_display.value().c_str(),  true);   // configure Wayland socket
+                setenv("GDK_BACKEND", "wayland,mir", true);         // configure GTK to use Wayland (or Mir)
+                setenv("QT_QPA_PLATFORM", "wayland", true);         // configure Qt to use Wayland
+                unsetenv("QT_QPA_PLATFORMTHEME");                   // Discourage Qt from unsupported theme
+                setenv("SDL_VIDEODRIVER", "wayland", true);         // configure SDL to use Wayland
+
                 auto const client = options1->get<std::string>(test_client_opt);
                 execlp(client.c_str(), client.c_str(), static_cast<char const*>(nullptr));
                 // If execl() returns then something is badly wrong


### PR DESCRIPTION
Add Wayland support for `mir_demo_server --test-client`.

Enable automated testing against toolkits that support Wayland.