### PR TITLE
mesa-kms: Switch from deprecated GBM_BO_FORMAT_… enums.

### DIFF
--- a/src/platforms/mesa/server/display_helpers.cpp
+++ b/src/platforms/mesa/server/display_helpers.cpp
@@ -326,7 +326,7 @@ mgm::GBMSurfaceUPtr mgmh::GBMHelper::create_scanout_surface(
     }
 
     auto surface_raw = gbm_surface_create(device, width, height,
-                                          GBM_BO_FORMAT_XRGB8888,
+                                          GBM_FORMAT_XRGB8888,
                                           format_flags);
 
     auto gbm_surface_deleter = [](gbm_surface *p) { if (p) gbm_surface_destroy(p); };

--- a/src/platforms/mesa/server/kms/display_buffer.cpp
+++ b/src/platforms/mesa/server/kms/display_buffer.cpp
@@ -523,7 +523,7 @@ mgm::DisplayBuffer::DisplayBuffer(
                 outputs.front()->drm_fd(),
                 surface.size().width.as_int(),
                 surface.size().height.as_int(),
-                GBM_BO_FORMAT_XRGB8888),
+                GBM_FORMAT_XRGB8888),
             std::placeholders::_1);
     }
     else


### PR DESCRIPTION
`GBM_FORMAT_XRGB8888` is semantically the same, and the Mali gbm only
supports the non-deprecated `GBM_FORMAT_…` enums.

Closes: #606