### PR TITLE
mesa-kms: Check for EGL_KHR_platform_gbm extension.

### DIFF
--- a/src/platforms/mesa/server/kms/platform_symbols.cpp
+++ b/src/platforms/mesa/server/kms/platform_symbols.cpp
@@ -125,11 +125,17 @@ mg::PlatformPriority probe_graphics_platform(
         mir::log_info("Unsupported: EGL platform does not support client extensions.");
         return mg::PlatformPriority::unsupported;
     }
-    if (strstr(client_extensions, "EGL_MESA_platform_gbm") == nullptr)
+    if (strstr(client_extensions, "EGL_KHR_platform_gbm") == nullptr)
     {
-        // No platform_gbm support, so we can't work.
-        mir::log_info("Unsupported: EGL platform does not support EGL_MESA_platform_gbm extension");
-        return mg::PlatformPriority::unsupported;
+        // Doesn't support the Khronos-standardised GBM platform…
+        mir::log_info("EGL platform does not support EGL_KHR_platform_gbm extension");
+        // …maybe we support the old pre-standardised Mesa GBM platform?
+        if (strstr(client_extensions, "EGL_MESA_platform_gbm") == nullptr)
+        {
+            mir::log_info(
+                "Unsupported: EGL platform supports neither EGL_KHR_platform_gbm nor EGL_MESA_platform_gbm");
+            return mg::PlatformPriority::unsupported;
+        }
     }
 
     // Check for suitability

--- a/tests/unit-tests/platforms/mesa/kms/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_platform.cpp
@@ -71,7 +71,7 @@ public:
         Mock::VerifyAndClearExpectations(&mock_drm);
         Mock::VerifyAndClearExpectations(&mock_gbm);
         ON_CALL(mock_egl, eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS))
-            .WillByDefault(Return("EGL_AN_extension_string EGL_MESA_platform_gbm"));
+            .WillByDefault(Return("EGL_AN_extension_string EGL_KHR_platform_gbm"));
         ON_CALL(mock_egl, eglGetDisplay(_))
             .WillByDefault(Return(fake_display));
         ON_CALL(mock_gl, glGetString(GL_RENDERER))
@@ -217,6 +217,25 @@ TEST_F(MesaGraphicsPlatform, probe_returns_unsupported_when_egl_client_extension
     mir::SharedLibrary platform_lib{mtf::server_platform("graphics-mesa-kms")};
     auto probe = platform_lib.load_function<mg::PlatformProbe>(probe_platform);
     EXPECT_EQ(mg::PlatformPriority::unsupported, probe(stub_vt, options));
+}
+
+TEST_F(MesaGraphicsPlatform, probe_returns_supported_when_old_egl_mesa_gbm_platform_supported)
+{
+    using namespace testing;
+
+    mtf::UdevEnvironment udev_environment;
+    boost::program_options::options_description po;
+    mir::options::ProgramOption options;
+    auto const stub_vt = std::make_shared<mtd::StubConsoleServices>();
+
+    udev_environment.add_standard_device("standard-drm-devices");
+
+    ON_CALL(mock_egl, eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS))
+        .WillByDefault(Return("EGL_KHR_not_really_an_extension EGL_MESA_platform_gbm EGL_EXT_master_of_the_house"));
+
+    mir::SharedLibrary platform_lib{mtf::server_platform("graphics-mesa-kms")};
+    auto probe = platform_lib.load_function<mg::PlatformProbe>(probe_platform);
+    EXPECT_EQ(mg::PlatformPriority::best, probe(stub_vt, options));
 }
 
 TEST_F(MesaGraphicsPlatform, probe_returns_unsupported_when_gbm_platform_not_supported)


### PR DESCRIPTION
We were checking for the EGL_MESA_platform_gbm extension, an old pre-standardisation version of
the GBM platform extension. Some drivers (hello, Mali!) support EGL_KHR_platform_gbm but not
the Mesa-namespaced version, so preferentially check for the KHR standard extension.

Fixes: #600