### PR TITLE
mesa-kms: More rigorously detect hybrid GPU setups.

### DIFF
--- a/src/platforms/mesa/server/kms/display_buffer.cpp
+++ b/src/platforms/mesa/server/kms/display_buffer.cpp
@@ -517,6 +517,7 @@ mgm::DisplayBuffer::DisplayBuffer(
 
     if (needs_bounce_buffer(*outputs.front(), temporary_front))
     {
+        mir::log_info("Hybrid GPU setup detected; DisplayBuffer using EGL buffer copies for migration");
         get_front_buffer = std::bind(
             std::mem_fn(&EGLBufferCopier::copy_front_buffer_from),
             std::make_shared<EGLBufferCopier>(


### PR DESCRIPTION
Use the `fstat()` dance to tell whether the drm_fd and the fd returned by
`gbm_device_get_fd()` are *really* the same or not.

On Mali's libgbm the integers returned are not the same, even though
the system is not hybrid.

Closes: #607