### PR TITLE
mesa-kms: Use EGL_EXT_platform_base.

### DIFF
--- a/include/platform/mir/graphics/egl_extensions.h
+++ b/include/platform/mir/graphics/egl_extensions.h
@@ -87,6 +87,14 @@ struct EGLExtensions
         PFNEGLCREATESTREAMATTRIBNVPROC const eglCreateStreamAttribNV;
         PFNEGLSTREAMCONSUMERACQUIREATTRIBNVPROC const eglStreamConsumerAcquireAttribNV;
     };
+    struct PlatformBaseEXT
+    {
+        PlatformBaseEXT();
+
+        PFNEGLGETPLATFORMDISPLAYEXTPROC const eglGetPlatformDisplay;
+        PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC const eglCreatePlatformWindowSurface;
+    };
+    std::experimental::optional<PlatformBaseEXT> const platform_base;
 };
 
 }

--- a/include/test/mir/test/doubles/mock_egl.h
+++ b/include/test/mir/test/doubles/mock_egl.h
@@ -114,12 +114,15 @@ public:
     MOCK_METHOD1(eglBindApi, EGLBoolean(EGLenum));
     MOCK_METHOD1(eglGetProcAddress,generic_function_pointer_t(const char*));
 
+    MOCK_METHOD3(eglGetPlatformDisplayEXT, EGLDisplay(EGLenum, AnyNativeType, EGLint const*));
+
     // Config management
     MOCK_METHOD4(eglGetConfigs, EGLBoolean(EGLDisplay,EGLConfig*,EGLint,EGLint*));
     MOCK_METHOD5(eglChooseConfig, EGLBoolean(EGLDisplay, const EGLint*,EGLConfig*,EGLint,EGLint*));
     MOCK_METHOD4(eglGetConfigAttrib, EGLBoolean(EGLDisplay,EGLConfig,EGLint,EGLint*));
 
     // Surface management
+    MOCK_METHOD4(eglCreatePlatformWindowSurfaceEXT, EGLSurface(EGLDisplay,EGLConfig,AnyNativeType, EGLint const*));
     MOCK_METHOD4(eglCreateWindowSurface, EGLSurface(EGLDisplay,EGLConfig,AnyNativeType,const EGLint*));
     MOCK_METHOD4(eglCreatePixmapSurface, EGLSurface(EGLDisplay,EGLConfig,AnyNativeType,const EGLint*));
     MOCK_METHOD3(eglCreatePbufferSurface, EGLSurface(EGLDisplay,EGLConfig,const EGLint*));

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -191,7 +191,6 @@ MIR_PLATFORM_0.33 {
 MIR_PLATFORM_0.32.3 {
  global:
   extern "C++" {
-    mir::graphics::EGLExtensions::PlatformBaseEXT*;
     mir::options::auto_console;
     mir::options::console_provider;
     mir::options::logind_console;
@@ -228,3 +227,10 @@ MIR_PLATFORM_1.1.0 {
     mir::graphics::EGLExtensions::NVStreamAttribExtensions::NVStreamAttribExtensions*;
   };
 } MIR_PLATFORM_0.32.3;
+
+MIR_PLATFORM_1.1.1 {
+ global:
+  extern "C++" {
+    mir::graphics::EGLExtensions::PlatformBaseEXT*;
+  };
+} MIR_PLATFORM_1.1.0;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -191,6 +191,7 @@ MIR_PLATFORM_0.33 {
 MIR_PLATFORM_0.32.3 {
  global:
   extern "C++" {
+    mir::graphics::EGLExtensions::PlatformBaseEXT*;
     mir::options::auto_console;
     mir::options::console_provider;
     mir::options::logind_console;

--- a/src/platforms/mesa/server/buffer_allocator.cpp
+++ b/src/platforms/mesa/server/buffer_allocator.cpp
@@ -456,6 +456,7 @@ public:
 
         const EGLint image_attrs[] =
             {
+                EGL_IMAGE_PRESERVED_KHR, EGL_TRUE,
                 EGL_WAYLAND_PLANE_WL, 0,
                 EGL_NONE
             };

--- a/src/platforms/mesa/server/kms/egl_helper.cpp
+++ b/src/platforms/mesa/server/kms/egl_helper.cpp
@@ -116,7 +116,11 @@ void mgmh::EGLHelper::setup(GBMHelper const& gbm, gbm_surface* surface_gbm,
     // TODO: Take the required format as a parameter, so we can select the framebuffer format.
     setup_internal(gbm, false, GBM_FORMAT_XRGB8888);
 
-    egl_surface = eglCreateWindowSurface(egl_display, egl_config, surface_gbm, nullptr);
+    egl_surface = platform_base.eglCreatePlatformWindowSurface(
+        egl_display,
+        egl_config,
+        surface_gbm,
+        nullptr);
     if(egl_surface == EGL_NO_SURFACE)
         BOOST_THROW_EXCEPTION(mg::egl_error("Failed to create EGL window surface"));
 
@@ -204,7 +208,10 @@ void mgmh::EGLHelper::setup_internal(GBMHelper const& gbm, bool initialize, EGLi
     static const EGLint required_egl_version_major = 1;
     static const EGLint required_egl_version_minor = 4;
 
-    egl_display = eglGetDisplay(static_cast<EGLNativeDisplayType>(gbm.device));
+    egl_display = platform_base.eglGetPlatformDisplay(
+        EGL_PLATFORM_GBM_KHR,      // EGL_PLATFORM_GBM_MESA has the same value.
+        static_cast<EGLNativeDisplayType>(gbm.device),
+        nullptr);
     if (egl_display == EGL_NO_DISPLAY)
         BOOST_THROW_EXCEPTION(mg::egl_error("Failed to get EGL display"));
 

--- a/src/platforms/mesa/server/kms/egl_helper.h
+++ b/src/platforms/mesa/server/kms/egl_helper.h
@@ -20,6 +20,7 @@
 #define MIR_GRAPHICS_MESA_EGL_HELPER_H_
 
 #include "display_helpers.h"
+#include "mir/graphics/egl_extensions.h"
 #include <EGL/egl.h>
 
 namespace mir
@@ -68,6 +69,7 @@ private:
     EGLContext egl_context;
     EGLSurface egl_surface;
     bool should_terminate_egl;
+    EGLExtensions::PlatformBaseEXT platform_base;
 };
 }
 }

--- a/tests/mir_test_doubles/mock_egl.cpp
+++ b/tests/mir_test_doubles/mock_egl.cpp
@@ -61,6 +61,15 @@ EGLBoolean extension_eglQueryWaylandBufferWL(
     EGLDisplay dpy,
     struct wl_resource *buffer,
     EGLint attribute, EGLint *value);
+EGLDisplay extension_eglGetPlatformDisplayEXT(
+    EGLenum platform,
+    void *native_display,
+    const EGLint *attrib_list);
+EGLSurface extension_eglCreatePlatformWindowSurfaceEXT(
+    EGLDisplay dpy,
+    EGLConfig config,
+    void *native_window,
+    const EGLint *attrib_list);
 
 /* EGL{Surface,Display,Config,Context} are all opaque types, so we can put whatever
    we want in them for testing */
@@ -80,6 +89,8 @@ mtd::MockEGL::MockEGL()
 
     ON_CALL(*this, eglGetDisplay(_))
     .WillByDefault(Return(fake_egl_display));
+    ON_CALL(*this, eglGetPlatformDisplayEXT(_,_,_))
+        .WillByDefault(Return(fake_egl_display));
     ON_CALL(*this, eglInitialize(_,_,_))
     .WillByDefault(DoAll(
                        SetArgPointee<1>(1),
@@ -117,6 +128,8 @@ mtd::MockEGL::MockEGL()
         }));
 
     ON_CALL(*this, eglCreateWindowSurface(_,_,_,_))
+        .WillByDefault(Return(fake_egl_surface));
+    ON_CALL(*this, eglCreatePlatformWindowSurfaceEXT(_,_,_,_))
         .WillByDefault(Return(fake_egl_surface));
 
     ON_CALL(*this, eglCreatePbufferSurface(_,_,_))
@@ -173,6 +186,10 @@ mtd::MockEGL::MockEGL()
         .WillByDefault(Return(reinterpret_cast<func_ptr_t>(&extension_eglBindWaylandDisplayWL)));
     ON_CALL(*this, eglGetProcAddress(StrEq("eglUnbindWaylandDisplayWL")))
         .WillByDefault(Return(reinterpret_cast<func_ptr_t>(&extension_eglUnbindWaylandDisplayWL)));
+    ON_CALL(*this, eglGetProcAddress(StrEq("eglGetPlatformDisplayEXT")))
+        .WillByDefault(Return(reinterpret_cast<func_ptr_t>(&extension_eglGetPlatformDisplayEXT)));
+    ON_CALL(*this, eglGetProcAddress(StrEq("eglCreatePlatformWindowSurfaceEXT")))
+        .WillByDefault(Return(reinterpret_cast<func_ptr_t>(&extension_eglCreatePlatformWindowSurfaceEXT)));
 }
 
 void mtd::MockEGL::provide_egl_extensions()
@@ -184,7 +201,8 @@ void mtd::MockEGL::provide_egl_extensions()
         "EGL_KHR_image_base "
         "EGL_KHR_image_pixmap "
         "EGL_EXT_image_dma_buf_import "
-        "EGL_WL_bind_wayland_display";
+        "EGL_WL_bind_wayland_display "
+        "EGL_EXT_platform_base";
     ON_CALL(*this, eglQueryString(_,EGL_EXTENSIONS))
         .WillByDefault(Return(egl_exts));
 }
@@ -483,4 +501,31 @@ EGLBoolean extension_eglQueryWaylandBufferWL(
     CHECK_GLOBAL_MOCK(EGLBoolean);
     return global_mock_egl->eglQueryWaylandBufferWL(
         dpy, buffer, attribute, value);
+}
+
+
+EGLDisplay extension_eglGetPlatformDisplayEXT(
+    EGLenum platform,
+    void *native_display,
+    const EGLint *attrib_list)
+{
+    CHECK_GLOBAL_MOCK(EGLDisplay);
+    return global_mock_egl->eglGetPlatformDisplayEXT(
+        platform,
+        native_display,
+        attrib_list);
+}
+
+EGLSurface extension_eglCreatePlatformWindowSurfaceEXT(
+    EGLDisplay dpy,
+    EGLConfig config,
+    void *native_window,
+    const EGLint *attrib_list)
+{
+    CHECK_GLOBAL_MOCK(EGLSurface);
+    return global_mock_egl->eglCreatePlatformWindowSurfaceEXT(
+        dpy,
+        config,
+        native_window,
+        attrib_list);
 }

--- a/tests/unit-tests/graphics/test_platform_prober.cpp
+++ b/tests/unit-tests/graphics/test_platform_prober.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<void> ensure_mesa_probing_succeeds()
 
     env->udev.add_standard_device("standard-drm-devices");
     ON_CALL(env->egl, eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS))
-        .WillByDefault(Return("EGL_MESA_platform_gbm"));
+        .WillByDefault(Return("EGL_MESA_platform_gbm EGL_EXT_platform_base"));
     ON_CALL(env->gbm, gbm_create_device(_))
         .WillByDefault(Return(fake_gbm_device));
     ON_CALL(env->egl, eglGetDisplay(fake_gbm_device))

--- a/tests/unit-tests/platforms/mesa/kms/test_display.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_display.cpp
@@ -252,9 +252,10 @@ TEST_F(MesaDisplayTest, create_display)
         .Times(Exactly(1));
 
     /* Create an EGL window surface backed by the gbm surface */
-    EXPECT_CALL(mock_egl, eglCreateWindowSurface(mock_egl.fake_egl_display,
-                                                 mock_egl.fake_configs[0],
-                                                 mock_gbm.fake_gbm.surface, _))
+    EXPECT_CALL(mock_egl, eglCreatePlatformWindowSurfaceEXT(
+        mock_egl.fake_egl_display,
+        mock_egl.fake_configs[0],
+        mock_gbm.fake_gbm.surface, _))
         .Times(Exactly(1));
 
     /* Swap the EGL window surface to bring the back buffer to the front */

--- a/tests/unit-tests/platforms/mesa/kms/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_platform.cpp
@@ -231,7 +231,7 @@ TEST_F(MesaGraphicsPlatform, probe_returns_supported_when_old_egl_mesa_gbm_platf
     udev_environment.add_standard_device("standard-drm-devices");
 
     ON_CALL(mock_egl, eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS))
-        .WillByDefault(Return("EGL_KHR_not_really_an_extension EGL_MESA_platform_gbm EGL_EXT_master_of_the_house"));
+        .WillByDefault(Return("EGL_KHR_not_really_an_extension EGL_MESA_platform_gbm EGL_EXT_master_of_the_house EGL_EXT_platform_base"));
 
     mir::SharedLibrary platform_lib{mtf::server_platform("graphics-mesa-kms")};
     auto probe = platform_lib.load_function<mg::PlatformProbe>(probe_platform);

--- a/tests/unit-tests/platforms/mesa/kms/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_platform.cpp
@@ -71,7 +71,7 @@ public:
         Mock::VerifyAndClearExpectations(&mock_drm);
         Mock::VerifyAndClearExpectations(&mock_gbm);
         ON_CALL(mock_egl, eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS))
-            .WillByDefault(Return("EGL_AN_extension_string EGL_KHR_platform_gbm"));
+            .WillByDefault(Return("EGL_AN_extension_string EGL_EXT_platform_base EGL_KHR_platform_gbm"));
         ON_CALL(mock_egl, eglGetDisplay(_))
             .WillByDefault(Return(fake_display));
         ON_CALL(mock_gl, glGetString(GL_RENDERER))
@@ -250,7 +250,7 @@ TEST_F(MesaGraphicsPlatform, probe_returns_unsupported_when_gbm_platform_not_sup
     udev_environment.add_standard_device("standard-drm-devices");
 
     ON_CALL(mock_egl, eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS))
-        .WillByDefault(Return("EGL_KHR_not_really_an_extension EGL_EXT_master_of_the_house"));
+        .WillByDefault(Return("EGL_KHR_not_really_an_extension EGL_EXT_platform_base"));
 
     mir::SharedLibrary platform_lib{mtf::server_platform("graphics-mesa-kms")};
     auto probe = platform_lib.load_function<mg::PlatformProbe>(probe_platform);


### PR DESCRIPTION
This lets us explicitly ask for a GBM-backed EGL platform, rather than just hoping
the libEGL can correctly guess what we've handed in is a pointer to a `gbm_device`.

This is necessary for Mali support, as Mali's libEGL will *not* guess that what
you've passed in to `eglGetDisplay()` is a `gbm_device*`.