### PR TITLE
mesa-kms: More rigorously detect hybrid GPU setups.

### DIFF
--- a/src/platforms/mesa/server/kms/display_buffer.cpp
+++ b/src/platforms/mesa/server/kms/display_buffer.cpp
@@ -517,6 +517,7 @@ mgm::DisplayBuffer::DisplayBuffer(
 
     if (needs_bounce_buffer(*outputs.front(), temporary_front))
     {
+        mir::log_info("Hybrid GPU setup detected; DisplayBuffer using EGL buffer copies for migration");
         get_front_buffer = std::bind(
             std::mem_fn(&EGLBufferCopier::copy_front_buffer_from),
             std::make_shared<EGLBufferCopier>(
@@ -528,6 +529,7 @@ mgm::DisplayBuffer::DisplayBuffer(
     }
     else
     {
+        mir::log_info("Detected single-GPU DisplayBuffer. Rendering will be sent directly to output");
         get_front_buffer = [](auto&& fb) { return std::move(fb); };
     }
 

--- a/tests/include/mir/test/doubles/mock_drm.h
+++ b/tests/include/mir/test/doubles/mock_drm.h
@@ -151,6 +151,7 @@ public:
     MOCK_METHOD1(drmGetBusid, char* (int fd));
     MOCK_METHOD1(drmFreeBusid, void (const char*));
     MOCK_METHOD1(drmGetDeviceNameFromFd, char*(int fd));
+    MOCK_METHOD1(drmGetPrimaryDeviceNameFromFd, char*(int fd));
 
     MOCK_METHOD6(drmModeCrtcGetGamma, int(int fd, uint32_t crtc_id, uint32_t size,
                                           uint16_t* red, uint16_t* green, uint16_t* blue));

--- a/tests/mir_test_doubles/mock_drm.cpp
+++ b/tests/mir_test_doubles/mock_drm.cpp
@@ -338,6 +338,9 @@ mtd::MockDRM::MockDRM()
     ON_CALL(*this, drmFreeBusid(_))
         .WillByDefault(WithArg<0>(Invoke([&](const char* busid) { free(const_cast<char*>(busid)); })));
 
+    ON_CALL(*this, drmGetPrimaryDeviceNameFromFd(_))
+        .WillByDefault(InvokeWithoutArgs([]() { return strdup("/dev/dri/card0"); }));
+
     static drmVersion const version{
         1,
         2,
@@ -724,6 +727,11 @@ void drmFreeBusid(const char* busid)
 char* drmGetDeviceNameFromFd(int fd)
 {
     return global_mock->drmGetDeviceNameFromFd(fd);
+}
+
+char* drmGetPrimaryDeviceNameFromFd(int fd)
+{
+    return global_mock->drmGetPrimaryDeviceNameFromFd(fd);
 }
 
 int drmCheckModesettingSupported(char const* busid)


### PR DESCRIPTION
Use `drmGetPrimaryDeviceNameFromFd()` on both the GBM device and the DRM
device we plan to output to; in the single GPU case these should match,
in the hybrid case they may differ and so we need to migrate the
rendering.

Simply comparing the `drm_fd_` and `gbm_device_get_fd()` return values
is unreliable - there's no guarantee that `gbm_create_device()` won't
internally `dup()` the DRM file descriptor passed in.

Likewise, checking whether both file descriptors point to the same file
is unreliable - `gbm_create_device()` may choose to open a different
file (specifically, the rendernode associated with the DRM node passed
in).

Comparing the primary device nodes for both file descriptors *should* be
reliable.

Closes: #607