### PR TITLE
mesa-kms: Handle failure to detect KMS in platform probe.

### DIFF
--- a/tests/unit-tests/platforms/mesa/kms/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/kms/test_platform.cpp
@@ -271,3 +271,51 @@ TEST_F(MesaGraphicsPlatform, probe_returns_unsupported_when_modesetting_is_not_s
     auto probe = platform_lib.load_function<mg::PlatformProbe>(probe_platform);
     EXPECT_EQ(mg::PlatformPriority::unsupported, probe(stub_vt, options));
 }
+
+TEST_F(MesaGraphicsPlatform, probe_returns_supported_when_cannot_determine_kms_support)
+{
+    using namespace testing;
+
+    boost::program_options::options_description po;
+    mir::options::ProgramOption options;
+    auto const stub_vt = std::make_shared<mtd::StubConsoleServices>();
+
+    ON_CALL(mock_drm, drmCheckModesettingSupported(_)).WillByDefault(Return(-EINVAL));
+
+    mir::SharedLibrary platform_lib{mtf::server_platform("graphics-mesa-kms")};
+    auto probe = platform_lib.load_function<mg::PlatformProbe>(probe_platform);
+    EXPECT_EQ(mg::PlatformPriority::supported, probe(stub_vt, options));
+
+}
+
+TEST_F(MesaGraphicsPlatform, probe_returns_supported_when_unexpected_error_returned)
+{
+    using namespace testing;
+
+    boost::program_options::options_description po;
+    mir::options::ProgramOption options;
+    auto const stub_vt = std::make_shared<mtd::StubConsoleServices>();
+
+    ON_CALL(mock_drm, drmCheckModesettingSupported(_)).WillByDefault(Return(-ENOBUFS));
+
+    mir::SharedLibrary platform_lib{mtf::server_platform("graphics-mesa-kms")};
+    auto probe = platform_lib.load_function<mg::PlatformProbe>(probe_platform);
+    EXPECT_EQ(mg::PlatformPriority::supported, probe(stub_vt, options));
+
+}
+
+TEST_F(MesaGraphicsPlatform, probe_returns_supported_when_cannot_determine_busid)
+{
+    using namespace testing;
+
+    boost::program_options::options_description po;
+    mir::options::ProgramOption options;
+    auto const stub_vt = std::make_shared<mtd::StubConsoleServices>();
+
+    ON_CALL(mock_drm, drmGetBusid(_)).WillByDefault(Return(nullptr));
+
+    mir::SharedLibrary platform_lib{mtf::server_platform("graphics-mesa-kms")};
+    auto probe = platform_lib.load_function<mg::PlatformProbe>(probe_platform);
+    EXPECT_EQ(mg::PlatformPriority::supported, probe(stub_vt, options));
+
+}


### PR DESCRIPTION
`drmCheckModesettingSupported()` requires a (PCI) BusID to query. Some
devices (such as the RPi3) the DRM device isn't actually hooked up to a
PCI bus, so we can't make this check.

Handle this case by making failure in `drmCheckModesettingSupported()`
non-fatal.

Closes: #704