### PR TITLE
Change the behaviour of AbstractShell::focus_next_session() to not notify clients

### DIFF
--- a/include/server/mir/shell/abstract_shell.h
+++ b/include/server/mir/shell/abstract_shell.h
@@ -157,12 +157,18 @@ private:
     std::mutex mutable focus_mutex;
     std::weak_ptr<scene::Surface> focus_surface;
     std::weak_ptr<scene::Session> focus_session;
+    std::weak_ptr<scene::Surface> notified_focus_surface;
     std::shared_ptr<scene::SurfaceObserver> focus_surface_observer;
 
-    void set_focus_to_locked(
+    void notify_focus_locked(
         std::unique_lock<std::mutex> const& lock,
         std::shared_ptr<scene::Session> const& focus_session,
         std::shared_ptr<scene::Surface> const& focus_surface);
+
+    void update_focus_locked(
+        std::unique_lock<std::mutex> const& lock,
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<scene::Surface> const& surface);
 };
 }
 }

--- a/tests/mir_test_framework/basic_window_manager.cpp
+++ b/tests/mir_test_framework/basic_window_manager.cpp
@@ -234,6 +234,7 @@ auto msh::BasicWindowManager::focused_surface() const
 void msh::BasicWindowManager::focus_next_session()
 {
     focus_controller->focus_next_session();
+    focus_controller->set_focus_to(focus_controller->focused_session(), focused_surface());
 }
 
 void msh::BasicWindowManager::set_focus_to(


### PR DESCRIPTION
Change the behaviour of AbstractShell::focus_next_session() to not notify clients. (Fixes: #742)

But preserve the obsolete behaviour in BasicWindowManager::focus_next_session() used in some old tests.

Note that this shouldn't affect Unity8 as that implements its own focus behavior.