### PR TITLE
Check that the buffer stream has a buffer before setting cursor

### DIFF
--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -201,7 +201,10 @@ struct ms::CursorStreamImageAdapter
 private:
     void post_cursor_image_from_current_buffer() const
     {
-        surface.set_cursor_from_buffer(*stream->lock_compositor_buffer(this), hotspot);
+        if (stream->has_submitted_buffer())
+        {
+            surface.set_cursor_from_buffer(*stream->lock_compositor_buffer(this), hotspot);
+        }
     }
 
     ms::BasicSurface& surface;

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -205,6 +205,10 @@ private:
         {
             surface.set_cursor_from_buffer(*stream->lock_compositor_buffer(this), hotspot);
         }
+        else
+        {
+            surface.set_cursor_image(nullptr);
+        }
     }
 
     ms::BasicSurface& surface;

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -207,7 +207,7 @@ private:
         }
         else
         {
-            surface.set_cursor_image(nullptr);
+            surface.remove_cursor_image();
         }
     }
 
@@ -623,6 +623,12 @@ void ms::BasicSurface::set_cursor_image(std::shared_ptr<mg::CursorImage> const& 
         observers.cursor_image_set_to(this, *image);
     else
         observers.cursor_image_removed(this);
+}
+
+void ms::BasicSurface::remove_cursor_image()
+{
+    cursor_image_ = nullptr;
+    observers.cursor_image_removed(this);
 }
 
 std::shared_ptr<mg::CursorImage> ms::BasicSurface::cursor_image() const

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -115,6 +115,7 @@ public:
     void show() override;
     
     void set_cursor_image(std::shared_ptr<graphics::CursorImage> const& image) override;
+    void remove_cursor_image(); // Removes the cursor image without resetting the stream
     std::shared_ptr<graphics::CursorImage> cursor_image() const override;
 
     void set_cursor_stream(std::shared_ptr<frontend::BufferStream> const& stream,

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -653,6 +653,38 @@ TEST_F(BasicSurfaceTest, notifies_about_cursor_image_removal)
     surface.set_cursor_image({});
 }
 
+TEST_F(BasicSurfaceTest, notifies_when_cursor_stream_set)
+{
+    using namespace testing;
+
+    NiceMock<MockSurfaceObserver> mock_surface_observer;
+    auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
+    auto stub_buffer = std::make_shared<mtd::StubBuffer>();
+
+    ON_CALL(*buffer_stream, lock_compositor_buffer(_))
+        .WillByDefault(Return(stub_buffer));
+    EXPECT_CALL(mock_surface_observer, cursor_image_set_to(_, _));
+
+    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.set_cursor_stream(buffer_stream, {});
+}
+
+TEST_F(BasicSurfaceTest, notifies_about_cursor_removal_when_empty_stream_set)
+{
+    using namespace testing;
+
+    NiceMock<MockSurfaceObserver> mock_surface_observer;
+    auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
+
+    ON_CALL(*buffer_stream, has_submitted_buffer())
+        .WillByDefault(Return(false));
+    EXPECT_CALL(mock_surface_observer, cursor_image_set_to(_, _)).Times(0);
+    EXPECT_CALL(mock_surface_observer, cursor_image_removed(_));
+
+    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.set_cursor_stream(buffer_stream, {});
+}
+
 TEST_F(BasicSurfaceTest, observer_can_trigger_state_change_within_notification)
 {
     using namespace testing;

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -693,7 +693,7 @@ TEST_F(BasicSurfaceTest, cursor_can_be_set_from_stream_that_started_empty)
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
     std::shared_ptr<mtd::StubBuffer> stub_buffer;
     // Must be a shared pointer, because it is set by CursorStreamImageAdapter::reset() in the destructor
-    auto frame_posted_callback = std::make_shared<std::function<void(mir::geometry::Size const&)>>([this](auto)
+    auto frame_posted_callback = std::make_shared<std::function<void(mir::geometry::Size const&)>>([](auto)
         {
             FAIL() << "frame_posted_callback should have been set by the surface";
         });

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -685,6 +685,43 @@ TEST_F(BasicSurfaceTest, notifies_about_cursor_removal_when_empty_stream_set)
     surface.set_cursor_stream(buffer_stream, {});
 }
 
+TEST_F(BasicSurfaceTest, cursor_can_be_set_from_stream_that_started_empty)
+{
+    using namespace testing;
+
+    NiceMock<MockSurfaceObserver> mock_surface_observer;
+    auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
+    std::shared_ptr<mtd::StubBuffer> stub_buffer;
+    // Must be a shared pointer, because it is set by CursorStreamImageAdapter::reset() in the destructor
+    auto frame_posted_callback = std::make_shared<std::function<void(mir::geometry::Size const&)>>([this](auto)
+        {
+            FAIL() << "frame_posted_callback should have been set by the surface";
+        });
+
+    ON_CALL(*buffer_stream, has_submitted_buffer())
+        .WillByDefault(Invoke([&]
+            {
+                return stub_buffer != nullptr;
+            }));
+    ON_CALL(*buffer_stream, lock_compositor_buffer(_))
+        .WillByDefault(Invoke([&](auto)
+            {
+                return stub_buffer;
+            }));
+    ON_CALL(*buffer_stream, set_frame_posted_callback(_))
+        .WillByDefault(Invoke([=](auto const& callback)
+            {
+                *frame_posted_callback = callback;
+            }));
+    EXPECT_CALL(mock_surface_observer, cursor_image_removed(_)).Times(1);
+    EXPECT_CALL(mock_surface_observer, cursor_image_set_to(_, _)).Times(1);
+
+    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.set_cursor_stream(buffer_stream, {});
+    stub_buffer = std::make_shared<mtd::StubBuffer>();
+    (*frame_posted_callback)({});
+}
+
 TEST_F(BasicSurfaceTest, observer_can_trigger_state_change_within_notification)
 {
     using namespace testing;


### PR DESCRIPTION
Fixes #735. Not the direction we discussed, but real easy and it looks to me like it's somewhat correct