### PR TITLE
Check for zero size Windows in WindowWlSurfaceRole

### DIFF
--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -104,7 +104,7 @@ void mf::WindowWlSurfaceRole::apply_spec(mir::shell::SurfaceSpecification const&
 void mf::WindowWlSurfaceRole::set_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
 {
     surface->set_pending_offset({-x, -y});
-    pending_window_size = {width, height};
+    pending_window_size = geom::Size{width, height};
 }
 
 void mf::WindowWlSurfaceRole::set_title(std::string const& title)

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -85,7 +85,7 @@ public:
 protected:
     std::shared_ptr<bool> const destroyed;
 
-    geometry::Size window_size();
+    std::experimental::optional<geometry::Size> window_size();
     MirWindowState window_state();
     bool is_active();
     uint64_t latest_timestamp_ns();
@@ -99,7 +99,7 @@ private:
     OutputManager* output_manager;
     std::shared_ptr<WlSurfaceEventSink> const sink;
     std::unique_ptr<scene::SurfaceCreationParameters> const params;
-    optional_value<geometry::Size> window_size_;
+    std::experimental::optional<geometry::Size> window_size_;
     SurfaceId surface_id_;
     std::unique_ptr<shell::SurfaceSpecification> pending_changes;
 

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -99,7 +99,8 @@ private:
     OutputManager* output_manager;
     std::shared_ptr<WlSurfaceEventSink> const sink;
     std::unique_ptr<scene::SurfaceCreationParameters> const params;
-    std::experimental::optional<geometry::Size> window_size_;
+    std::experimental::optional<geometry::Size> pending_window_size;
+    std::experimental::optional<geometry::Size> committed_window_size;
     SurfaceId surface_id_;
     std::unique_ptr<shell::SurfaceSpecification> pending_changes;
 

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -124,7 +124,7 @@ mf::WlSurface::Position mf::WlSurface::transform_point(geom::Point point)
             return result;
     }
     geom::Rectangle surface_rect = {geom::Point{}, buffer_size_.value_or(geom::Size{})};
-    for (auto& rect : input_shape.value_or(std::vector<geom::Rectangle>{{{}, buffer_size()}}))
+    for (auto& rect : input_shape.value_or(std::vector<geom::Rectangle>{{{}, buffer_size_.value_or(geom::Size{})}}))
     {
         if (rect.intersection_with(surface_rect).contains(point))
             return {point, this, true};

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -125,7 +125,7 @@ public:
     std::shared_ptr<bool> destroyed_flag() const { return destroyed; }
     geometry::Displacement offset() const { return offset_; }
     geometry::Displacement total_offset() const { return offset_ + role->total_offset(); }
-    geometry::Size buffer_size() const { return buffer_size_.value_or(geometry::Size{}); }
+    std::experimental::optional<geometry::Size> buffer_size() const { return buffer_size_; }
     bool synchronized() const;
     Position transform_point(geometry::Point point);
     wl_resource* raw_resource() const { return resource; }


### PR DESCRIPTION
Fixes #674. Check to make sure the window has a non-zero size before modifying the surface.