### PR TITLE
Remove `BufferStream::resize()`

### DIFF
--- a/include/server/mir/frontend/buffer_stream.h
+++ b/include/server/mir/frontend/buffer_stream.h
@@ -42,7 +42,6 @@ public:
     virtual ~BufferStream() = default;
     
     virtual void submit_buffer(std::shared_ptr<graphics::Buffer> const& buffer) = 0;
-    virtual void resize(geometry::Size const& size) = 0;
 
     virtual void set_frame_posted_callback(
         std::function<void(geometry::Size const&)> const& callback) = 0;

--- a/src/server/compositor/stream.cpp
+++ b/src/server/compositor/stream.cpp
@@ -57,6 +57,7 @@ void mc::Stream::submit_buffer(std::shared_ptr<mg::Buffer> const& buffer)
         std::lock_guard<decltype(mutex)> lk(mutex); 
         first_frame_posted = true;
         pf = buffer->pixel_format();
+        size = buffer->size();
         schedule->schedule(buffer);
     }
     {
@@ -93,13 +94,6 @@ geom::Size mc::Stream::stream_size()
 {
     std::lock_guard<decltype(mutex)> lk(mutex);
     return size;
-}
-
-void mc::Stream::resize(geom::Size const& new_size)
-{
-    //TODO: the client should be resizing itself via the buffer creation/destruction rpc calls
-    std::lock_guard<decltype(mutex)> lk(mutex);
-    size = new_size; 
 }
 
 void mc::Stream::allow_framedropping(bool dropping)

--- a/src/server/compositor/stream.h
+++ b/src/server/compositor/stream.h
@@ -50,7 +50,6 @@ public:
     std::shared_ptr<graphics::Buffer>
         lock_compositor_buffer(void const* user_id) override;
     geometry::Size stream_size() override;
-    void resize(geometry::Size const& size) override;
     void allow_framedropping(bool) override;
     bool framedropping() const override;
     int buffers_ready_for_compositor(void const* user_id) const override;

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -350,15 +350,6 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
                     std::move(release_buffer));
             }
 
-            /*
-             * This is technically incorrect - the resize and submit_buffer *should* be atomic,
-             * but are not, so a client in the process of resizing can have buffers rendered at
-             * an unexpected size.
-             *
-             * It should be good enough for now, though.
-             *
-             * TODO: Provide a mg::Buffer::logical_size() to do this properly.
-             */
             if (!input_shape && (!buffer_size_ || mir_buffer->size() != buffer_size_.value()))
             {
                 state.invalidate_surface_data(); // input shape needs to be recalculated for the new size

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -364,7 +364,6 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
                 state.invalidate_surface_data(); // input shape needs to be recalculated for the new size
             }
             buffer_size_ = mir_buffer->size();
-            stream->resize(buffer_size_.value());
             stream->submit_buffer(mir_buffer);
         }
     }

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -112,8 +112,6 @@ mf::SurfaceId ms::ApplicationSession::create_surface(
     {
         stream_id = params.content_id.value();
         buffer_stream = checked_find(stream_id)->second;
-        if (params.size != buffer_stream->stream_size())
-            buffer_stream->resize(params.size);
     }
     else
     {

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -125,7 +125,7 @@ mf::SurfaceId ms::ApplicationSession::create_surface(
     std::list<StreamInfo> streams;
     if (the_params.content_id.is_set())
     {
-        streams.push_back({checked_find(the_params.content_id.value())->second, {0,0}, {}});
+        streams.push_back({checked_find(the_params.content_id.value())->second, {0,0}, the_params.size});
     }
     else
     {

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -335,15 +335,6 @@ void ms::BasicSurface::resize(geom::Size const& desired_size)
     if (new_size == size())
         return;
 
-    /*
-     * Other combinations may still be invalid (like dimensions too big or
-     * insufficient resources), but those are runtime and platform-specific, so
-     * not predictable here. Such critical exceptions would arise from
-     * the platform buffer allocator as a runtime_error via:
-     */
-    surface_buffer_stream->resize(new_size);
-
-    // Now the buffer stream has successfully resized, update the state second;
     {
         std::unique_lock<std::mutex> lock(guard);
         surface_rect.size = new_size;

--- a/tests/include/mir/test/doubles/mock_buffer_stream.h
+++ b/tests/include/mir/test/doubles/mock_buffer_stream.h
@@ -63,7 +63,6 @@ struct MockBufferStream : public compositor::BufferStream
 
     MOCK_METHOD0(get_stream_pixel_format, MirPixelFormat());
     MOCK_METHOD0(stream_size, geometry::Size());
-    MOCK_METHOD1(resize, void(geometry::Size const&));
     MOCK_METHOD0(force_client_completion, void());
     MOCK_METHOD1(allow_framedropping, void(bool));
     MOCK_CONST_METHOD0(framedropping, bool());

--- a/tests/include/mir/test/doubles/stub_buffer_stream.h
+++ b/tests/include/mir/test/doubles/stub_buffer_stream.h
@@ -51,10 +51,6 @@ public:
         return geometry::Size();
     }
 
-    void resize(geometry::Size const&) override
-    {
-    }
-
     void allow_framedropping(bool) override
     {
     }

--- a/tests/unit-tests/compositor/test_stream.cpp
+++ b/tests/unit-tests/compositor/test_stream.cpp
@@ -197,8 +197,9 @@ TEST_F(Stream, throws_on_nullptr_submissions)
 TEST_F(Stream, reports_size)
 {
     geom::Size new_size{333,139};
+    auto new_size_buffer = std::make_shared<mtd::StubBuffer>(new_size);
     EXPECT_THAT(stream.stream_size(), Eq(initial_size));
-    stream.resize(new_size);
+    stream.submit_buffer(new_size_buffer);
     EXPECT_THAT(stream.stream_size(), Eq(new_size));
 }
 

--- a/tests/unit-tests/scene/test_surface.cpp
+++ b/tests/unit-tests/scene/test_surface.cpp
@@ -242,9 +242,6 @@ TEST_F(SurfaceCreation, resize_updates_stream_and_state)
     using namespace testing;
     geom::Size const new_size{123, 456};
 
-    EXPECT_CALL(*mock_buffer_stream, resize(new_size))
-        .Times(1);
-
     auto const mock_event_sink = std::make_shared<mt::doubles::MockEventSink>();
     ms::OutputPropertiesCache cache;
     auto const observer = std::make_shared<ms::SurfaceEventSource>(mf::SurfaceId(), surface, cache, mock_event_sink);
@@ -270,7 +267,6 @@ TEST_F(SurfaceCreation, duplicate_resize_ignored)
 
     ASSERT_THAT(surface.size(), Ne(new_size));
 
-    EXPECT_CALL(*mock_buffer_stream, resize(new_size)).Times(1);
     EXPECT_CALL(*mock_event_sink, handle_event(_)).Times(1);
     surface.resize(new_size);
     EXPECT_THAT(surface.size(), Eq(new_size));
@@ -278,26 +274,9 @@ TEST_F(SurfaceCreation, duplicate_resize_ignored)
     Mock::VerifyAndClearExpectations(mock_buffer_stream.get());
     Mock::VerifyAndClearExpectations(mock_event_sink.get());
 
-    EXPECT_CALL(*mock_buffer_stream, resize(_)).Times(0);
     EXPECT_CALL(*mock_event_sink, handle_event(_)).Times(0);
     surface.resize(new_size);
     EXPECT_THAT(surface.size(), Eq(new_size));
-}
-
-TEST_F(SurfaceCreation, unsuccessful_resize_does_not_update_state)
-{
-    using namespace testing;
-    geom::Size const new_size{123, 456};
-
-    EXPECT_CALL(*mock_buffer_stream, resize(new_size))
-        .Times(1)
-        .WillOnce(Throw(std::runtime_error("bad resize")));
-
-    EXPECT_THROW({
-        surface.resize(new_size);
-    }, std::runtime_error);
-
-    EXPECT_EQ(size, surface.size());
 }
 
 TEST_F(SurfaceCreation, impossible_resize_clamps)
@@ -321,7 +300,6 @@ TEST_F(SurfaceCreation, impossible_resize_clamps)
         if (expect_size.height <= geom::Height{0})
             expect_size.height = geom::Height{1};
 
-        EXPECT_CALL(*mock_buffer_stream, resize(expect_size)).Times(1);
         EXPECT_NO_THROW({ surface.resize(size); });
         EXPECT_EQ(expect_size, surface.size());
     }


### PR DESCRIPTION
A `BufferStream`'s size is now just the size of the most recent buffer (or the initial size sent to the constructor, if there is no buffer yet). This simplifies the code, fixes #604, and the non-atomic resize problem noted in a TODO in wl_surface.cpp.