### PR TITLE
Add is_instance() to wrapper types

### DIFF
--- a/src/wayland/generated/wayland_wrapper.cpp
+++ b/src/wayland/generated/wayland_wrapper.cpp
@@ -274,6 +274,11 @@ mw::ShmPool::ShmPool(struct wl_client* client, struct wl_resource* parent, uint3
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+bool mw::ShmPool::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &wl_shm_pool_interface_data, Thunks::request_vtable);
+}
+
 void mw::ShmPool::destroy_wayland_object() const
 {
     wl_resource_destroy(resource);
@@ -444,6 +449,11 @@ void mw::Buffer::send_release_event() const
     wl_resource_post_event(resource, Opcode::release);
 }
 
+bool mw::Buffer::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &wl_buffer_interface_data, Thunks::request_vtable);
+}
+
 void mw::Buffer::destroy_wayland_object() const
 {
     wl_resource_destroy(resource);
@@ -601,6 +611,11 @@ void mw::DataOffer::send_action_event(uint32_t dnd_action) const
     wl_resource_post_event(resource, Opcode::action, dnd_action);
 }
 
+bool mw::DataOffer::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &wl_data_offer_interface_data, Thunks::request_vtable);
+}
+
 void mw::DataOffer::destroy_wayland_object() const
 {
     wl_resource_destroy(resource);
@@ -754,6 +769,11 @@ bool mw::DataSource::version_supports_action()
 void mw::DataSource::send_action_event(uint32_t dnd_action) const
 {
     wl_resource_post_event(resource, Opcode::action, dnd_action);
+}
+
+bool mw::DataSource::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &wl_data_source_interface_data, Thunks::request_vtable);
 }
 
 void mw::DataSource::destroy_wayland_object() const
@@ -920,6 +940,11 @@ void mw::DataDevice::send_selection_event(std::experimental::optional<struct wl_
         id_resolved = id.value();
     }
     wl_resource_post_event(resource, Opcode::selection, id_resolved);
+}
+
+bool mw::DataDevice::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &wl_data_device_interface_data, Thunks::request_vtable);
 }
 
 void mw::DataDevice::destroy_wayland_object() const
@@ -1380,6 +1405,11 @@ void mw::ShellSurface::send_popup_done_event() const
     wl_resource_post_event(resource, Opcode::popup_done);
 }
 
+bool mw::ShellSurface::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &wl_shell_surface_interface_data, Thunks::request_vtable);
+}
+
 void mw::ShellSurface::destroy_wayland_object() const
 {
     wl_resource_destroy(resource);
@@ -1665,6 +1695,11 @@ void mw::Surface::send_enter_event(struct wl_resource* output) const
 void mw::Surface::send_leave_event(struct wl_resource* output) const
 {
     wl_resource_post_event(resource, Opcode::leave, output);
+}
+
+bool mw::Surface::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &wl_surface_interface_data, Thunks::request_vtable);
 }
 
 void mw::Surface::destroy_wayland_object() const
@@ -2027,6 +2062,11 @@ void mw::Pointer::send_axis_discrete_event(uint32_t axis, int32_t discrete) cons
     wl_resource_post_event(resource, Opcode::axis_discrete, axis, discrete);
 }
 
+bool mw::Pointer::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &wl_pointer_interface_data, Thunks::request_vtable);
+}
+
 void mw::Pointer::destroy_wayland_object() const
 {
     wl_resource_destroy(resource);
@@ -2150,6 +2190,11 @@ bool mw::Keyboard::version_supports_repeat_info()
 void mw::Keyboard::send_repeat_info_event(int32_t rate, int32_t delay) const
 {
     wl_resource_post_event(resource, Opcode::repeat_info, rate, delay);
+}
+
+bool mw::Keyboard::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &wl_keyboard_interface_data, Thunks::request_vtable);
 }
 
 void mw::Keyboard::destroy_wayland_object() const
@@ -2278,6 +2323,11 @@ void mw::Touch::send_orientation_event(int32_t id, double orientation) const
 {
     wl_fixed_t orientation_resolved{wl_fixed_from_double(orientation)};
     wl_resource_post_event(resource, Opcode::orientation, id, orientation_resolved);
+}
+
+bool mw::Touch::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &wl_touch_interface_data, Thunks::request_vtable);
 }
 
 void mw::Touch::destroy_wayland_object() const
@@ -2513,6 +2563,11 @@ mw::Region::Region(struct wl_client* client, struct wl_resource* parent, uint32_
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+bool mw::Region::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &wl_region_interface_data, Thunks::request_vtable);
 }
 
 void mw::Region::destroy_wayland_object() const
@@ -2759,6 +2814,11 @@ mw::Subsurface::Subsurface(struct wl_client* client, struct wl_resource* parent,
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+bool mw::Subsurface::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &wl_subsurface_interface_data, Thunks::request_vtable);
 }
 
 void mw::Subsurface::destroy_wayland_object() const

--- a/src/wayland/generated/wayland_wrapper.h
+++ b/src/wayland/generated/wayland_wrapper.h
@@ -89,6 +89,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
     virtual void create_buffer(uint32_t id, int32_t offset, int32_t width, int32_t height, int32_t stride, uint32_t format) = 0;
     virtual void destroy() = 0;
@@ -220,6 +222,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
     virtual void destroy() = 0;
 };
@@ -262,6 +266,8 @@ public:
     };
 
     struct Thunks;
+
+    static bool is_instance(wl_resource* resource);
 
 private:
     virtual void accept(uint32_t serial, std::experimental::optional<std::string> const& mime_type) = 0;
@@ -315,6 +321,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
     virtual void offer(std::string const& mime_type) = 0;
     virtual void destroy() = 0;
@@ -360,6 +368,8 @@ public:
     };
 
     struct Thunks;
+
+    static bool is_instance(wl_resource* resource);
 
 private:
     virtual void start_drag(std::experimental::optional<struct wl_resource*> const& source, struct wl_resource* origin, std::experimental::optional<struct wl_resource*> const& icon, uint32_t serial) = 0;
@@ -484,6 +494,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
     virtual void pong(uint32_t serial) = 0;
     virtual void move(struct wl_resource* seat, uint32_t serial) = 0;
@@ -529,6 +541,8 @@ public:
     };
 
     struct Thunks;
+
+    static bool is_instance(wl_resource* resource);
 
 private:
     virtual void destroy() = 0;
@@ -657,6 +671,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
     virtual void set_cursor(uint32_t serial, std::experimental::optional<struct wl_resource*> const& surface, int32_t hotspot_x, int32_t hotspot_y) = 0;
     virtual void release() = 0;
@@ -710,6 +726,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
     virtual void release() = 0;
 };
@@ -752,6 +770,8 @@ public:
     };
 
     struct Thunks;
+
+    static bool is_instance(wl_resource* resource);
 
 private:
     virtual void release() = 0;
@@ -842,6 +862,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
     virtual void destroy() = 0;
     virtual void add(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
@@ -900,6 +922,8 @@ public:
     };
 
     struct Thunks;
+
+    static bool is_instance(wl_resource* resource);
 
 private:
     virtual void destroy() = 0;

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
@@ -301,6 +301,11 @@ void mw::LayerSurfaceV1::send_closed_event() const
     wl_resource_post_event(resource, Opcode::closed);
 }
 
+bool mw::LayerSurfaceV1::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &zwlr_layer_surface_v1_interface_data, Thunks::request_vtable);
+}
+
 void mw::LayerSurfaceV1::destroy_wayland_object() const
 {
     wl_resource_destroy(resource);

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
@@ -99,6 +99,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
     virtual void set_size(uint32_t width, uint32_t height) = 0;
     virtual void set_anchor(uint32_t anchor) = 0;

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
@@ -335,6 +335,11 @@ mw::XdgPositionerV6::XdgPositionerV6(struct wl_client* client, struct wl_resourc
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+bool mw::XdgPositionerV6::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &zxdg_positioner_v6_interface_data, Thunks::request_vtable);
+}
+
 void mw::XdgPositionerV6::destroy_wayland_object() const
 {
     wl_resource_destroy(resource);
@@ -474,6 +479,11 @@ mw::XdgSurfaceV6::XdgSurfaceV6(struct wl_client* client, struct wl_resource* par
 void mw::XdgSurfaceV6::send_configure_event(uint32_t serial) const
 {
     wl_resource_post_event(resource, Opcode::configure, serial);
+}
+
+bool mw::XdgSurfaceV6::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &zxdg_surface_v6_interface_data, Thunks::request_vtable);
 }
 
 void mw::XdgSurfaceV6::destroy_wayland_object() const
@@ -786,6 +796,11 @@ void mw::XdgToplevelV6::send_close_event() const
     wl_resource_post_event(resource, Opcode::close);
 }
 
+bool mw::XdgToplevelV6::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &zxdg_toplevel_v6_interface_data, Thunks::request_vtable);
+}
+
 void mw::XdgToplevelV6::destroy_wayland_object() const
 {
     wl_resource_destroy(resource);
@@ -920,6 +935,11 @@ void mw::XdgPopupV6::send_configure_event(int32_t x, int32_t y, int32_t width, i
 void mw::XdgPopupV6::send_popup_done_event() const
 {
     wl_resource_post_event(resource, Opcode::popup_done);
+}
+
+bool mw::XdgPopupV6::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &zxdg_popup_v6_interface_data, Thunks::request_vtable);
 }
 
 void mw::XdgPopupV6::destroy_wayland_object() const

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -114,6 +114,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
     virtual void destroy() = 0;
     virtual void set_size(int32_t width, int32_t height) = 0;
@@ -155,6 +157,8 @@ public:
     };
 
     struct Thunks;
+
+    static bool is_instance(wl_resource* resource);
 
 private:
     virtual void destroy() = 0;
@@ -212,6 +216,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
     virtual void destroy() = 0;
     virtual void set_parent(std::experimental::optional<struct wl_resource*> const& parent) = 0;
@@ -260,6 +266,8 @@ public:
     };
 
     struct Thunks;
+
+    static bool is_instance(wl_resource* resource);
 
 private:
     virtual void destroy() = 0;

--- a/src/wayland/generated/xdg-shell_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell_wrapper.cpp
@@ -335,6 +335,11 @@ mw::XdgPositioner::XdgPositioner(struct wl_client* client, struct wl_resource* p
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+bool mw::XdgPositioner::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &xdg_positioner_interface_data, Thunks::request_vtable);
+}
+
 void mw::XdgPositioner::destroy_wayland_object() const
 {
     wl_resource_destroy(resource);
@@ -479,6 +484,11 @@ mw::XdgSurface::XdgSurface(struct wl_client* client, struct wl_resource* parent,
 void mw::XdgSurface::send_configure_event(uint32_t serial) const
 {
     wl_resource_post_event(resource, Opcode::configure, serial);
+}
+
+bool mw::XdgSurface::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &xdg_surface_interface_data, Thunks::request_vtable);
 }
 
 void mw::XdgSurface::destroy_wayland_object() const
@@ -791,6 +801,11 @@ void mw::XdgToplevel::send_close_event() const
     wl_resource_post_event(resource, Opcode::close);
 }
 
+bool mw::XdgToplevel::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &xdg_toplevel_interface_data, Thunks::request_vtable);
+}
+
 void mw::XdgToplevel::destroy_wayland_object() const
 {
     wl_resource_destroy(resource);
@@ -925,6 +940,11 @@ void mw::XdgPopup::send_configure_event(int32_t x, int32_t y, int32_t width, int
 void mw::XdgPopup::send_popup_done_event() const
 {
     wl_resource_post_event(resource, Opcode::popup_done);
+}
+
+bool mw::XdgPopup::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &xdg_popup_interface_data, Thunks::request_vtable);
 }
 
 void mw::XdgPopup::destroy_wayland_object() const

--- a/src/wayland/generated/xdg-shell_wrapper.h
+++ b/src/wayland/generated/xdg-shell_wrapper.h
@@ -122,6 +122,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
     virtual void destroy() = 0;
     virtual void set_size(int32_t width, int32_t height) = 0;
@@ -163,6 +165,8 @@ public:
     };
 
     struct Thunks;
+
+    static bool is_instance(wl_resource* resource);
 
 private:
     virtual void destroy() = 0;
@@ -220,6 +224,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
     virtual void destroy() = 0;
     virtual void set_parent(std::experimental::optional<struct wl_resource*> const& parent) = 0;
@@ -268,6 +274,8 @@ public:
     };
 
     struct Thunks;
+
+    static bool is_instance(wl_resource* resource);
 
 private:
     virtual void destroy() = 0;

--- a/src/wayland/generator/interface.cpp
+++ b/src/wayland/generator/interface.cpp
@@ -59,6 +59,7 @@ Emitter Interface::declaration() const
             enum_declarations(),
             event_opcodes(),
             (thunks_impl_contents().is_valid() ? "struct Thunks;" : nullptr),
+            is_instance_prototype(),
         }, true, true, Emitter::single_indent),
         empty_line,
         "private:",
@@ -86,6 +87,7 @@ Emitter Interface::implementation() const
             constructor_impl(),
             destructor_impl(),
             event_impls(),
+            is_instance_impl(),
             Lines{
                 {"void ", nmspace, "destroy_wayland_object(", is_global ? "struct wl_resource* resource" : nullptr, ") const"},
                 Block{
@@ -251,6 +253,26 @@ Emitter Interface::member_vars() const
             {"struct wl_resource* const resource;"}
         };
     }
+}
+
+
+Emitter Interface::is_instance_prototype() const
+{
+    if (is_global || !has_vtable)
+        return Lines{};
+
+    return "static bool is_instance(wl_resource* resource);";
+}
+
+Emitter Interface::is_instance_impl() const
+{
+    if (is_global || !has_vtable)
+        return Lines{};
+
+    return Lines{
+        {"bool ", nmspace, "is_instance(wl_resource* resource)"},
+        Block{"return wl_resource_instance_of(resource, &" + wl_name + "_interface_data, Thunks::request_vtable);"}
+    };
 }
 
 Emitter Interface::enum_declarations() const

--- a/src/wayland/generator/interface.h
+++ b/src/wayland/generator/interface.h
@@ -65,6 +65,8 @@ private:
     Emitter bind_thunk() const;
     Emitter resource_destroyed_thunk() const;
     Emitter types_init() const;
+    Emitter is_instance_prototype() const;
+    Emitter is_instance_impl() const;
 
     static std::vector<Request> get_requests(xmlpp::Element const& node, std::string generated_name, bool is_global);
     static std::vector<Event> get_events(xmlpp::Element const& node, std::string generated_name, bool is_global);


### PR DESCRIPTION
Provide a way to identify the type of a wl_resource.

This is one small piece of providing `convert(resource) -> Window`