### PR TITLE
Put the WaylandExtensions(string) constructor back the way it was in 1.1

### DIFF
--- a/include/miral/miral/wayland_extensions.h
+++ b/include/miral/miral/wayland_extensions.h
@@ -48,9 +48,7 @@ public:
 
     /// Initialize "enabled by default" to a custom set of extensions (colon
     /// separated list).
-    /// \note "enabled by default" is validated when the WaylandExtensions
-    /// object is passed to MirRunner::run_with() and can only include
-    /// extensions supported by Mir or added by the server.
+    /// \note This can only be a subset of supported_extensions()
     explicit WaylandExtensions(std::string const& default_value);
 
     void operator()(mir::Server& server) const;

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -33,6 +33,7 @@ struct miral::WaylandExtensions::Self
     Self(std::string const& default_value) : default_value{default_value}
     {
         available_extensions += ":zwlr_layer_shell_v1:";
+        validate(default_value);
     }
 
     void callback(mir::Server& server) const


### PR DESCRIPTION
Put the WaylandExtensions(string) constructor back the way it was in 1.1.

While adding support for "bespoke" Wayland extensions we widened the contract to permit "bespoke" extensions to be specified here. But since #775 that's no longer the way to do it and we should revert this change.