### PR TITLE
LTTNG: Generate USDT tracepoints from LTTNG tracepoints.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -58,6 +58,7 @@ Build-Depends: cmake,
                libyaml-cpp-dev,
                libnvidia-egl-wayland-dev [amd64 i386],
                eglexternalplatform-dev [amd64 i386],
+               systemtap-sdt-dev,
                wlcs
 Standards-Version: 3.9.4
 Homepage: https://launchpad.net/mir

--- a/spread/build/fedora/task.yaml
+++ b/spread/build/fedora/task.yaml
@@ -41,7 +41,8 @@ execute: |
         mesa-libwayland-egl-devel\
         libXcursor-devel \
         yaml-cpp-devel\
-        egl-wayland-devel
+        egl-wayland-devel \
+        systemtap-sdt-devel
 
     BUILD_DIR=$(mktemp --directory)
     cmake -H$SPREAD_PATH -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DMIR_USE_LD_GOLD=ON -DMIR_ENABLE_WLCS_TESTS=OFF

--- a/src/server/report/lttng/CMakeLists.txt
+++ b/src/server/report/lttng/CMakeLists.txt
@@ -9,6 +9,16 @@ add_compile_options(
   -Wno-error=unused-parameter
 )
 
+# Add USDT hooks to all LTTNG tracepoints
+#
+# This might be gnarly; this tweaks an LTTNG header to enable its
+# USDT integration. The integration only involves #include-ing a
+# SystemTap header and calling a macro from it in the LTTNG macro,
+# but there aren't guarantees this won't change in future.
+add_compile_definitions(
+  LTTNG_UST_HAVE_SDT_INTEGRATION
+)
+
 # Using LTO on the lttng DSO causes a gcc ICE.
 # Since LTO is reasonably uninteresting for the lttng tracer, disable it.
 string(REPLACE "-flto" "" NO_LTO_FLAGS ${CMAKE_C_FLAGS})

--- a/src/server/report/lttng/CMakeLists.txt
+++ b/src/server/report/lttng/CMakeLists.txt
@@ -15,8 +15,8 @@ add_compile_options(
 # USDT integration. The integration only involves #include-ing a
 # SystemTap header and calling a macro from it in the LTTNG macro,
 # but there aren't guarantees this won't change in future.
-add_compile_definitions(
-  LTTNG_UST_HAVE_SDT_INTEGRATION
+add_definitions(  # Drop in favour of add_compile_definitions when we drop 16.04
+  -DLTTNG_UST_HAVE_SDT_INTEGRATION
 )
 
 # Using LTO on the lttng DSO causes a gcc ICE.

--- a/src/server/report/lttng/CMakeLists.txt
+++ b/src/server/report/lttng/CMakeLists.txt
@@ -19,10 +19,6 @@ add_definitions(  # Drop in favour of add_compile_definitions when we drop 16.04
   -DLTTNG_UST_HAVE_SDT_INTEGRATION
 )
 
-# Using LTO on the lttng DSO causes a gcc ICE.
-# Since LTO is reasonably uninteresting for the lttng tracer, disable it.
-string(REPLACE "-flto" "" NO_LTO_FLAGS ${CMAKE_C_FLAGS})
-set(CMAKE_C_FLAGS ${NO_LTO_FLAGS})
 
 # lttng-ust uses urcu headers which contain code blocks inside expressions 
 # this is a gnu extension.


### PR DESCRIPTION
Userspace Statically Defined Tracepoints are approximately zero-cost (the introduce a single
noop into the codestream + some ELF metadata in the DSO) and can be consumed with various
tracing frameworks, most notably ftrace & bpftrace.

LTTNG has support for generating a USDT for each LTTNG tracepoint, but only if such support is enabled.