### PR TITLE
LTTNG: Void tracepoints don't need a dummy field.

### DIFF
--- a/src/server/report/lttng/lttng_utils.h
+++ b/src/server/report/lttng/lttng_utils.h
@@ -25,12 +25,12 @@
 #define MIR_LTTNG_VOID_TRACE_CALL(klass, comp, name) \
     void mir::report::lttng::klass::name()           \
     {                                                \
-        mir_tracepoint(comp, name, 0);               \
+        mir_tracepoint(comp, name);               \
     }
 
 #define MIR_LTTNG_VOID_TRACE_CLASS(comp) \
-    TRACEPOINT_EVENT_CLASS(comp, dummy_event, TP_ARGS(int,empty), TP_FIELDS(ctf_integer(int,empty,empty)))
+    TRACEPOINT_EVENT_CLASS(comp, dummy_event, TP_ARGS(), TP_FIELDS())
 #define MIR_LTTNG_VOID_TRACE_POINT(comp, name) \
-    TRACEPOINT_EVENT_INSTANCE(comp, dummy_event, name, TP_ARGS(int,empty))
+    TRACEPOINT_EVENT_INSTANCE(comp, dummy_event, name, TP_ARGS(void))
 
 #endif


### PR DESCRIPTION
We have a bunch of no-context tracepoints - things like compositor::started(), which
have no useful context to add to their bare emission.

LTTNG is quite happy to have tracepoints with no fields, but for some reason we were
creating tracepoints with a dummy integer field and always setting it to 0.

Just use a tracepoint with no fields instead.