### PR TITLE
Revert "Try dropping workaround for gcc ICE"

### DIFF
--- a/src/server/report/lttng/CMakeLists.txt
+++ b/src/server/report/lttng/CMakeLists.txt
@@ -19,6 +19,10 @@ add_definitions(  # Drop in favour of add_compile_definitions when we drop 16.04
   -DLTTNG_UST_HAVE_SDT_INTEGRATION
 )
 
+# Using LTO on the lttng DSO causes a gcc ICE.
+# Since LTO is reasonably uninteresting for the lttng tracer, disable it.
+string(REPLACE "-flto" "" NO_LTO_FLAGS ${CMAKE_C_FLAGS})
+set(CMAKE_C_FLAGS ${NO_LTO_FLAGS})
 
 # lttng-ust uses urcu headers which contain code blocks inside expressions 
 # this is a gnu extension.


### PR DESCRIPTION
This reverts commit f50906dcb7842f454b9dd8d01f2dae8f76dd7607.

Turns out that CI doesn't pick up this ICE, as it's only on 16.04 PPA builds,

Fixes: #790