### PR TITLE
Use LTTng best practices

### DIFF
--- a/src/server/report/lttng/compositor_report_tp.h
+++ b/src/server/report/lttng/compositor_report_tp.h
@@ -50,31 +50,34 @@ TRACEPOINT_EVENT(
     )
 )
 
-TRACEPOINT_EVENT(
+TRACEPOINT_EVENT_CLASS(
     mir_server_compositor,
+    subcompositor_event,
+    TP_ARGS(void const*, id),
+    TP_FIELDS(
+        ctf_integer_hex(uintptr_t, id, (uintptr_t)(id))
+    )
+)
+
+TRACEPOINT_EVENT_INSTANCE(
+    mir_server_compositor,
+    subcompositor_event,
     began_frame,
-    TP_ARGS(void const*, id),
-    TP_FIELDS(
-        ctf_integer_hex(uintptr_t, id, (uintptr_t)(id))
-    )
+    TP_ARGS(void const*, id)
 )
 
-TRACEPOINT_EVENT(
+TRACEPOINT_EVENT_INSTANCE(
     mir_server_compositor,
+    subcompositor_event,
     rendered_frame,
-    TP_ARGS(void const*, id),
-    TP_FIELDS(
-        ctf_integer_hex(uintptr_t, id, (uintptr_t)(id))
-    )
+    TP_ARGS(void const*, id)
 )
 
-TRACEPOINT_EVENT(
+TRACEPOINT_EVENT_INSTANCE(
     mir_server_compositor,
+    subcompositor_event,
     finished_frame,
-    TP_ARGS(void const*, id),
-    TP_FIELDS(
-        ctf_integer_hex(uintptr_t, id, (uintptr_t)(id))
-    )
+    TP_ARGS(void const*, id)
 )
 
 TRACEPOINT_EVENT(

--- a/src/server/report/lttng/input_report_tp.h
+++ b/src/server/report/lttng/input_report_tp.h
@@ -39,46 +39,53 @@ TRACEPOINT_EVENT(
      )
 )
 
-TRACEPOINT_EVENT(
+TRACEPOINT_EVENT_CLASS(
     mir_server_input,
+    published_event,
+    TP_ARGS(int, dest_fd, uint32_t, seq_id, int64_t, event_time),
+    TP_FIELDS(
+        ctf_integer(int, dest_fd, dest_fd)
+        ctf_integer(uint32_t, seq_id, seq_id)
+        ctf_integer(int64_t, event_time, event_time)
+    )
+)
+
+TRACEPOINT_EVENT_INSTANCE(
+    mir_server_input,
+    published_event,
     published_key_event,
-    TP_ARGS(int, dest_fd, uint32_t, seq_id, int64_t, event_time),
-    TP_FIELDS(
-        ctf_integer(int, dest_fd, dest_fd)
-        ctf_integer(uint32_t, seq_id, seq_id)
-        ctf_integer(int64_t, event_time, event_time)
-     )
+    TP_ARGS(int, dest_fd, uint32_t, seq_id, int64_t, event_time)
 )
 
-TRACEPOINT_EVENT(
+TRACEPOINT_EVENT_INSTANCE(
     mir_server_input,
+    published_event,
     published_motion_event,
-    TP_ARGS(int, dest_fd, uint32_t, seq_id, int64_t, event_time),
-    TP_FIELDS(
-        ctf_integer(int, dest_fd, dest_fd)
-        ctf_integer(uint32_t, seq_id, seq_id)
-        ctf_integer(int64_t, event_time, event_time)
-     )
+    TP_ARGS(int, dest_fd, uint32_t, seq_id, int64_t, event_time)
 )
 
-TRACEPOINT_EVENT(
+TRACEPOINT_EVENT_CLASS(
     mir_server_input,
+    device_event,
+    TP_ARGS(const char*, device, const char*, platform),
+    TP_FIELDS(
+        ctf_string(device, device)
+        ctf_string(platform, platform)
+    )
+)
+
+TRACEPOINT_EVENT_INSTANCE(
+    mir_server_input,
+    device_event,
     opened_input_device,
-    TP_ARGS(const char*, device, const char*, platform),
-    TP_FIELDS(
-        ctf_string(device, device)
-        ctf_string(platform, platform)
-    )
+    TP_ARGS(const char*, device, const char*, platform)
 )
 
-TRACEPOINT_EVENT(
+TRACEPOINT_EVENT_INSTANCE(
     mir_server_input,
+    device_event,
     failed_to_open_input_device,
-    TP_ARGS(const char*, device, const char*, platform),
-    TP_FIELDS(
-        ctf_string(device, device)
-        ctf_string(platform, platform)
-    )
+    TP_ARGS(const char*, device, const char*, platform)
 )
 
 #endif /* MIR_LTTNG_DISPLAY_REPORT_TP_H_ */

--- a/src/server/report/lttng/scene_report_tp.h
+++ b/src/server/report/lttng/scene_report_tp.h
@@ -32,25 +32,40 @@
 
 #undef SCENE_TRACE_POINT
 
-TRACEPOINT_EVENT(TRACEPOINT_PROVIDER,
-                 surface_created,
-                 TP_ARGS(char const*, name),
-                 TP_FIELDS(ctf_string(name, name)))
+TRACEPOINT_EVENT_CLASS(
+    mir_server_scene,
+    surface_event,
+    TP_ARGS(char const*, name),
+    TP_FIELDS(ctf_string(name, name))
+)
 
-TRACEPOINT_EVENT(TRACEPOINT_PROVIDER,
-                 surface_added,
-                 TP_ARGS(char const*, name),
-                 TP_FIELDS(ctf_string(name, name)))
+TRACEPOINT_EVENT_INSTANCE(
+    mir_server_scene,
+    surface_event,
+    surface_created,
+    TP_ARGS(char const*, name)
+)
 
-TRACEPOINT_EVENT(TRACEPOINT_PROVIDER,
-                 surface_removed,
-                 TP_ARGS(char const*, name),
-                 TP_FIELDS(ctf_string(name, name)))
+TRACEPOINT_EVENT_INSTANCE(
+    mir_server_scene,
+    surface_event,
+    surface_added,
+    TP_ARGS(char const*, name)
+)
 
-TRACEPOINT_EVENT(TRACEPOINT_PROVIDER,
-                 surface_deleted,
-                 TP_ARGS(char const*, name),
-                 TP_FIELDS(ctf_string(name, name)))
+TRACEPOINT_EVENT_INSTANCE(
+    mir_server_scene,
+    surface_event,
+    surface_removed,
+    TP_ARGS(char const*, name)
+)
+
+TRACEPOINT_EVENT_INSTANCE(
+    mir_server_scene,
+    surface_event,
+    surface_deleted,
+    TP_ARGS(char const*, name)
+)
 
 #endif /* MIR_LTTNG_SCENE_REPORT_TP_H_ */
 


### PR DESCRIPTION
Another tiny one; LTTng recommend combining events with the same fields into a tracepoint-class and then instantiating tracepoint-instances.