### PR TITLE
Ensure internal clients don't hang because of queued requests

### DIFF
--- a/src/miral/internal_client.cpp
+++ b/src/miral/internal_client.cpp
@@ -222,6 +222,7 @@ void WlInternalClientRunner<Base>::run(mir::Server& server)
             {
                 auto const deleter = mir::raii::deleter_for(display, &wl_display_disconnect);
                 client_code(display);
+                wl_display_roundtrip(display);
             }
         }};
 }


### PR DESCRIPTION
Ensure internal clients don't hang because of queued requests. (Fixes #753)