### PR TITLE
Support multi-output in Mir-onX

### DIFF
--- a/src/platforms/mesa/server/x11/X11_resources.cpp
+++ b/src/platforms/mesa/server/x11/X11_resources.cpp
@@ -21,6 +21,7 @@
 
 #include "X11_resources.h"
 
+namespace mg=mir::graphics;
 namespace mx = mir::X;
 
 //Force synchronous Xlib operation - for debugging
@@ -56,4 +57,23 @@ std::shared_ptr<::Display> mx::X11Resources::get_conn()
 #endif
     connection = new_conn;
     return new_conn;
+}
+
+void mx::X11Resources::set_output_config_for_win(Window win, mg::DisplayConfigurationOutput* configuration)
+{
+    output_configs[win] = configuration;
+}
+
+void mx::X11Resources::clear_output_config_for_win(Window win)
+{
+    output_configs.erase(win);
+}
+
+std::experimental::optional<mg::DisplayConfigurationOutput*> mx::X11Resources::get_output_config_for_win(Window win)
+{
+    auto configuration = output_configs.find(win);
+    if (configuration != output_configs.end() && configuration->second != nullptr)
+        return {configuration->second};
+    else
+        return std::experimental::nullopt;
 }

--- a/src/platforms/mesa/server/x11/X11_resources.cpp
+++ b/src/platforms/mesa/server/x11/X11_resources.cpp
@@ -26,6 +26,8 @@ namespace mx = mir::X;
 //Force synchronous Xlib operation - for debugging
 //#define FORCE_SYNCHRONOUS
 
+mx::X11Resources mx::X11Resources::instance;
+
 int mx::mir_x11_error_handler(Display* dpy, XErrorEvent* eev)
 {
     char msg[80];

--- a/src/platforms/mesa/server/x11/X11_resources.h
+++ b/src/platforms/mesa/server/x11/X11_resources.h
@@ -20,9 +20,16 @@
 #define MIR_X11_RESOURCES_H_
 
 #include <X11/Xlib.h>
+#include <experimental/optional>
+#include <unordered_map>
 
 namespace mir
 {
+namespace graphics
+{
+struct DisplayConfigurationOutput;
+}
+
 namespace X
 {
 
@@ -32,11 +39,15 @@ class X11Resources
 {
 public:
     std::shared_ptr<::Display> get_conn();
+    void set_output_config_for_win(Window win, graphics::DisplayConfigurationOutput* configuration);
+    void clear_output_config_for_win(Window win);
+    std::experimental::optional<graphics::DisplayConfigurationOutput*> get_output_config_for_win(Window win);
 
     static X11Resources instance;
 
 private:
     std::weak_ptr<::Display> connection;
+    std::unordered_map<Window, graphics::DisplayConfigurationOutput*> output_configs;
 };
 
 }

--- a/src/platforms/mesa/server/x11/X11_resources.h
+++ b/src/platforms/mesa/server/x11/X11_resources.h
@@ -33,6 +33,8 @@ class X11Resources
 public:
     std::shared_ptr<::Display> get_conn();
 
+    static X11Resources instance;
+
 private:
     std::weak_ptr<::Display> connection;
 };

--- a/src/platforms/mesa/server/x11/X11_resources.h
+++ b/src/platforms/mesa/server/x11/X11_resources.h
@@ -38,16 +38,19 @@ int mir_x11_error_handler(Display* dpy, XErrorEvent* eev);
 class X11Resources
 {
 public:
-    std::shared_ptr<::Display> get_conn();
-    void set_output_config_for_win(Window win, graphics::DisplayConfigurationOutput* configuration);
+    auto get_conn() -> std::shared_ptr<::Display>;
+    void set_output_config_for_win(
+        Window win,
+        std::weak_ptr<graphics::DisplayConfigurationOutput const> configuration);
     void clear_output_config_for_win(Window win);
-    std::experimental::optional<graphics::DisplayConfigurationOutput*> get_output_config_for_win(Window win);
+    auto get_output_config_for_win(Window win)
+        -> std::experimental::optional<graphics::DisplayConfigurationOutput const* const>;
 
     static X11Resources instance;
 
 private:
     std::weak_ptr<::Display> connection;
-    std::unordered_map<Window, graphics::DisplayConfigurationOutput*> output_configs;
+    std::unordered_map<Window, std::weak_ptr<graphics::DisplayConfigurationOutput const>> output_configs;
 };
 
 }

--- a/src/platforms/mesa/server/x11/graphics/display.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display.cpp
@@ -257,14 +257,13 @@ mgx::Display::Display(::Display* x_dpy,
         auto pf = (red_mask == 0xFF0000 ?
             mir_pixel_format_argb_8888 :
             mir_pixel_format_abgr_8888);
-        auto configuration = static_cast<std::unique_ptr<graphics::DisplayConfigurationOutput>>(
-            std::make_unique<DisplayConfigurationOutput>(
-                pf,
-                actual_size,
-                top_left,
-                geom::Size{actual_size.width * pixel_width, actual_size.height * pixel_height},
-                1.0f,
-                mir_orientation_normal));
+        auto configuration = DisplayConfiguration::build_output(
+            pf,
+            actual_size,
+            top_left,
+            geom::Size{actual_size.width * pixel_width, actual_size.height * pixel_height},
+            1.0f,
+            mir_orientation_normal);
         auto display_buffer = std::make_unique<mgx::DisplayBuffer>(
             x_dpy,
             configuration->id,
@@ -298,7 +297,7 @@ void mgx::Display::for_each_display_sync_group(std::function<void(mg::DisplaySyn
 
 std::unique_ptr<mg::DisplayConfiguration> mgx::Display::configuration() const
 {
-    std::vector<mg::DisplayConfigurationOutput> output_configurations;
+    std::vector<DisplayConfigurationOutput> output_configurations;
     for (auto const& output : outputs)
     {
         output_configurations.push_back(*output->configuration);
@@ -314,7 +313,7 @@ void mgx::Display::configure(mg::DisplayConfiguration const& new_configuration)
             std::logic_error("Invalid or inconsistent display configuration"));
     }
 
-    new_configuration.for_each_output([&](graphics::DisplayConfigurationOutput const& conf_output)
+    new_configuration.for_each_output([&](DisplayConfigurationOutput const& conf_output)
     {
         bool found_info = false;
 
@@ -392,7 +391,7 @@ mg::Frame mgx::Display::last_frame_on(unsigned) const
 mgx::Display::OutputInfo::OutputInfo(
     std::unique_ptr<X11Window> window,
     std::unique_ptr<DisplayBuffer> display_buffer,
-    std::unique_ptr<graphics::DisplayConfigurationOutput> configuration)
+    std::unique_ptr<DisplayConfigurationOutput> configuration)
     : window{move(window)},
       display_buffer{move(display_buffer)},
       configuration{move(configuration)}

--- a/src/platforms/mesa/server/x11/graphics/display.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display.cpp
@@ -274,7 +274,7 @@ mgx::Display::Display(::Display* x_dpy,
             report,
             *gl_config);
         display_buffer->set_view_area(configuration->extents());
-        outputs.push_back(std::make_unique<OutputInfo>(move(window), move(display_buffer), move(configuration)));
+        outputs.push_back(std::make_unique<OutputInfo>(move(window), move(display_buffer), configuration));
         top_left.x = geom::X{top_left.x.as_int() + actual_size.width.as_int()};
     }
 
@@ -391,12 +391,12 @@ mg::Frame mgx::Display::last_frame_on(unsigned) const
 mgx::Display::OutputInfo::OutputInfo(
     std::unique_ptr<X11Window> window,
     std::unique_ptr<DisplayBuffer> display_buffer,
-    std::unique_ptr<DisplayConfigurationOutput> configuration)
+    std::shared_ptr<DisplayConfigurationOutput> configuration)
     : window{move(window)},
       display_buffer{move(display_buffer)},
-      configuration{move(configuration)}
+      configuration{configuration}
 {
-    mx::X11Resources::instance.set_output_config_for_win(*this->window, this->configuration.get());
+    mx::X11Resources::instance.set_output_config_for_win(*this->window, this->configuration);
 }
 
 mgx::Display::OutputInfo::~OutputInfo()

--- a/src/platforms/mesa/server/x11/graphics/display.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display.cpp
@@ -28,6 +28,7 @@
 #include "display_configuration.h"
 #include "display.h"
 #include "display_buffer.h"
+#include "../X11_resources.h"
 
 #include <boost/throw_exception.hpp>
 
@@ -37,6 +38,7 @@
 #define MIR_LOG_COMPONENT "display"
 #include "mir/log.h"
 
+namespace mx=mir::X;
 namespace mg=mir::graphics;
 namespace mgx=mg::X;
 namespace geom=mir::geometry;
@@ -390,4 +392,10 @@ mgx::Display::OutputInfo::OutputInfo(
       display_buffer{move(display_buffer)},
       configuration{move(configuration)}
 {
+    mx::X11Resources::instance.set_output_config_for_win(*this->window, this->configuration.get());
+}
+
+mgx::Display::OutputInfo::~OutputInfo()
+{
+    mx::X11Resources::instance.clear_output_config_for_win(*this->window);
 }

--- a/src/platforms/mesa/server/x11/graphics/display.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display.cpp
@@ -247,6 +247,8 @@ mgx::Display::Display(::Display* x_dpy,
 {
     shared_egl.setup(x_dpy);
 
+    geom::Point top_left{0, 0};
+
     for (auto const& requested_size : requested_sizes)
     {
         auto actual_size = clip_to_display(x_dpy, requested_size);
@@ -259,6 +261,7 @@ mgx::Display::Display(::Display* x_dpy,
             std::make_unique<DisplayConfigurationOutput>(
                 pf,
                 actual_size,
+                top_left,
                 geom::Size{actual_size.width * pixel_width, actual_size.height * pixel_height},
                 1.0f,
                 mir_orientation_normal));
@@ -271,7 +274,9 @@ mgx::Display::Display(::Display* x_dpy,
             last_frame,
             report,
             *gl_config);
+        display_buffer->set_view_area(configuration->extents());
         outputs.push_back(std::make_unique<OutputInfo>(move(window), move(display_buffer), move(configuration)));
+        top_left.x = geom::X{top_left.x.as_int() + actual_size.width.as_int()};
     }
 
     shared_egl.make_current();

--- a/src/platforms/mesa/server/x11/graphics/display.h
+++ b/src/platforms/mesa/server/x11/graphics/display.h
@@ -111,6 +111,7 @@ private:
             std::unique_ptr<X11Window> window,
             std::unique_ptr<DisplayBuffer> display_buffer,
             std::unique_ptr<graphics::DisplayConfigurationOutput> configuration);
+        ~OutputInfo();
 
         std::unique_ptr<X11Window> window;
         std::unique_ptr<DisplayBuffer> display_buffer;

--- a/src/platforms/mesa/server/x11/graphics/display.h
+++ b/src/platforms/mesa/server/x11/graphics/display.h
@@ -39,6 +39,7 @@ namespace graphics
 class AtomicFrame;
 class GLConfig;
 class DisplayReport;
+struct DisplayConfigurationOutput;
 
 namespace X
 {
@@ -69,7 +70,7 @@ class Display : public graphics::Display,
 {
 public:
     explicit Display(::Display* x_dpy,
-                     geometry::Size const requested_size,
+                     std::vector<geometry::Size> const& requested_size,
                      std::shared_ptr<GLConfig> const& gl_config,
                      std::shared_ptr<DisplayReport> const& report);
     ~Display() noexcept;
@@ -104,19 +105,26 @@ public:
     Frame last_frame_on(unsigned output_id) const override;
 
 private:
+    struct OutputInfo
+    {
+        OutputInfo(
+            std::unique_ptr<X11Window> window,
+            std::unique_ptr<DisplayBuffer> display_buffer,
+            std::unique_ptr<graphics::DisplayConfigurationOutput> configuration);
+
+        std::unique_ptr<X11Window> window;
+        std::unique_ptr<DisplayBuffer> display_buffer;
+        std::unique_ptr<graphics::DisplayConfigurationOutput> configuration;
+    };
+
+    std::vector<std::unique_ptr<OutputInfo>> outputs;
     helpers::EGLHelper shared_egl;
     ::Display* const x_dpy;
-    mir::geometry::Size const actual_size;
     std::shared_ptr<GLConfig> const gl_config;
     float pixel_width;
     float pixel_height;
-    float scale;
-    std::unique_ptr<X11Window> win;
-    MirPixelFormat pf;
     std::shared_ptr<DisplayReport> const report;
-    MirOrientation orientation; //TODO: keep entire current display configuration
     std::shared_ptr<AtomicFrame> last_frame;
-    std::unique_ptr<DisplayBuffer> display_buffer;
 };
 
 }

--- a/src/platforms/mesa/server/x11/graphics/display.h
+++ b/src/platforms/mesa/server/x11/graphics/display.h
@@ -110,12 +110,12 @@ private:
         OutputInfo(
             std::unique_ptr<X11Window> window,
             std::unique_ptr<DisplayBuffer> display_buffer,
-            std::unique_ptr<graphics::DisplayConfigurationOutput> configuration);
+            std::unique_ptr<DisplayConfigurationOutput> configuration);
         ~OutputInfo();
 
         std::unique_ptr<X11Window> window;
         std::unique_ptr<DisplayBuffer> display_buffer;
-        std::unique_ptr<graphics::DisplayConfigurationOutput> configuration;
+        std::unique_ptr<DisplayConfigurationOutput> configuration;
     };
 
     std::vector<std::unique_ptr<OutputInfo>> outputs;

--- a/src/platforms/mesa/server/x11/graphics/display.h
+++ b/src/platforms/mesa/server/x11/graphics/display.h
@@ -110,12 +110,12 @@ private:
         OutputInfo(
             std::unique_ptr<X11Window> window,
             std::unique_ptr<DisplayBuffer> display_buffer,
-            std::unique_ptr<DisplayConfigurationOutput> configuration);
+            std::shared_ptr<DisplayConfigurationOutput> configuration);
         ~OutputInfo();
 
         std::unique_ptr<X11Window> window;
         std::unique_ptr<DisplayBuffer> display_buffer;
-        std::unique_ptr<DisplayConfigurationOutput> configuration;
+        std::shared_ptr<DisplayConfigurationOutput> configuration;
     };
 
     std::vector<std::unique_ptr<OutputInfo>> outputs;

--- a/src/platforms/mesa/server/x11/graphics/display_buffer.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display_buffer.cpp
@@ -30,6 +30,7 @@ namespace mgx=mg::X;
 namespace geom=mir::geometry;
 
 mgx::DisplayBuffer::DisplayBuffer(::Display* const x_dpy,
+                                  DisplayConfigurationOutputId output_id,
                                   Window const win,
                                   geometry::Size const& view_area_size,
                                   EGLContext const shared_context,
@@ -41,6 +42,7 @@ mgx::DisplayBuffer::DisplayBuffer(::Display* const x_dpy,
                                     transform(1),
                                     egl{gl_config},
                                     last_frame{f},
+                                    output_id{output_id},
                                     eglGetSyncValues{nullptr}
 {
     egl.setup(x_dpy, win, shared_context);
@@ -137,8 +139,7 @@ void mgx::DisplayBuffer::swap_buffers()
      * but this is best-effort. And besides, we don't want Mir reporting all
      * real vsyncs because that would mean the compositor never sleeps.
      */
-    report->report_vsync(mgx::DisplayConfiguration::the_output_id.as_value(),
-                         last_frame->load());
+    report->report_vsync(output_id.as_value(), last_frame->load());
 }
 
 void mgx::DisplayBuffer::bind()

--- a/src/platforms/mesa/server/x11/graphics/display_buffer.h
+++ b/src/platforms/mesa/server/x11/graphics/display_buffer.h
@@ -21,6 +21,7 @@
 #define MIR_GRAPHICS_X_DISPLAY_BUFFER_H_
 
 #include "mir/graphics/display_buffer.h"
+#include "mir/graphics/display_configuration.h"
 #include "mir/graphics/display.h"
 #include "mir/renderer/gl/render_target.h"
 #include "egl_helper.h"
@@ -48,6 +49,7 @@ class DisplayBuffer : public graphics::DisplayBuffer,
 public:
     DisplayBuffer(
             ::Display* const x_dpy,
+            DisplayConfigurationOutputId output_id,
             Window const win,
             geometry::Size const& view_area_size,
             EGLContext const shared_context,
@@ -78,6 +80,7 @@ private:
     glm::mat2 transform;
     helpers::EGLHelper egl;
     std::shared_ptr<AtomicFrame> const last_frame;
+    DisplayConfigurationOutputId output_id;
 
     typedef EGLBoolean (EGLAPIENTRY EglGetSyncValuesCHROMIUM)
         (EGLDisplay dpy, EGLSurface surface, int64_t *ust,

--- a/src/platforms/mesa/server/x11/graphics/display_configuration.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display_configuration.cpp
@@ -24,11 +24,16 @@ namespace mg = mir::graphics;
 namespace mgx = mg::X;
 namespace geom = mir::geometry;
 
-mg::DisplayConfigurationOutputId const mgx::DisplayConfiguration::the_output_id{1};
+int mgx::DisplayConfigurationOutput::next_output_id{1};
 
-mgx::DisplayConfiguration::DisplayConfiguration(MirPixelFormat pf, geom::Size const pixels, geom::Size const size, const float scale, MirOrientation orientation) :
-    configuration{
-            the_output_id,
+mgx::DisplayConfigurationOutput::DisplayConfigurationOutput(
+    MirPixelFormat pf,
+    geom::Size const pixels,
+    geom::Size const size,
+    const float scale,
+    MirOrientation orientation)
+    : graphics::DisplayConfigurationOutput{
+            mg::DisplayConfigurationOutputId{next_output_id++},
             mg::DisplayConfigurationCardId{0},
             mg::DisplayConfigurationOutputType::unknown,
             {pf},
@@ -49,8 +54,13 @@ mgx::DisplayConfiguration::DisplayConfiguration(MirPixelFormat pf, geom::Size co
             {},
             mir_output_gamma_unsupported,
             {},
-            {}},
-    card{mg::DisplayConfigurationCardId{0}, 1}
+            {}}
+{
+}
+
+mgx::DisplayConfiguration::DisplayConfiguration(std::vector<mg::DisplayConfigurationOutput> const& configuration)
+    : configuration{configuration},
+      card{mg::DisplayConfigurationCardId{0}, 1}
 {
 }
 
@@ -68,13 +78,19 @@ void mgx::DisplayConfiguration::for_each_card(std::function<void(mg::DisplayConf
 
 void mgx::DisplayConfiguration::for_each_output(std::function<void(mg::DisplayConfigurationOutput const&)> f) const
 {
-    f(configuration);
+    for (auto const& output : configuration)
+    {
+        f(output);
+    }
 }
 
 void mgx::DisplayConfiguration::for_each_output(std::function<void(mg::UserDisplayConfigurationOutput&)> f)
 {
-    mg::UserDisplayConfigurationOutput user(configuration);
-    f(user);
+    for (auto& output : configuration)
+    {
+        mg::UserDisplayConfigurationOutput user(output);
+        f(user);
+    }
 }
 
 std::unique_ptr<mg::DisplayConfiguration> mgx::DisplayConfiguration::clone() const

--- a/src/platforms/mesa/server/x11/graphics/display_configuration.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display_configuration.cpp
@@ -26,7 +26,7 @@ namespace geom = mir::geometry;
 
 int mgx::DisplayConfiguration::last_output_id{0};
 
-std::unique_ptr<mg::DisplayConfigurationOutput> mgx::DisplayConfiguration::build_output(
+std::shared_ptr<mg::DisplayConfigurationOutput> mgx::DisplayConfiguration::build_output(
     MirPixelFormat pf,
     geom::Size const pixels,
     geom::Point const top_left,
@@ -35,7 +35,7 @@ std::unique_ptr<mg::DisplayConfigurationOutput> mgx::DisplayConfiguration::build
     MirOrientation orientation)
 {
     last_output_id++;
-    return std::unique_ptr<DisplayConfigurationOutput>(
+    return std::shared_ptr<DisplayConfigurationOutput>(
         new DisplayConfigurationOutput{
             mg::DisplayConfigurationOutputId{last_output_id},
             mg::DisplayConfigurationCardId{0},

--- a/src/platforms/mesa/server/x11/graphics/display_configuration.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display_configuration.cpp
@@ -29,6 +29,7 @@ int mgx::DisplayConfigurationOutput::next_output_id{1};
 mgx::DisplayConfigurationOutput::DisplayConfigurationOutput(
     MirPixelFormat pf,
     geom::Size const pixels,
+    geom::Point const top_left,
     geom::Size const size,
     const float scale,
     MirOrientation orientation)
@@ -43,7 +44,7 @@ mgx::DisplayConfigurationOutput::DisplayConfigurationOutput(
             size,
             true,
             true,
-            geom::Point{0, 0},
+            top_left,
             0,
             pf,
             mir_power_mode_on,
@@ -60,7 +61,7 @@ mgx::DisplayConfigurationOutput::DisplayConfigurationOutput(
 
 mgx::DisplayConfiguration::DisplayConfiguration(std::vector<mg::DisplayConfigurationOutput> const& configuration)
     : configuration{configuration},
-      card{mg::DisplayConfigurationCardId{0}, 1}
+      card{mg::DisplayConfigurationCardId{0}, configuration.size()}
 {
 }
 

--- a/src/platforms/mesa/server/x11/graphics/display_configuration.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display_configuration.cpp
@@ -24,17 +24,20 @@ namespace mg = mir::graphics;
 namespace mgx = mg::X;
 namespace geom = mir::geometry;
 
-int mgx::DisplayConfigurationOutput::next_output_id{1};
+int mgx::DisplayConfiguration::last_output_id{0};
 
-mgx::DisplayConfigurationOutput::DisplayConfigurationOutput(
+std::unique_ptr<mg::DisplayConfigurationOutput> mgx::DisplayConfiguration::build_output(
     MirPixelFormat pf,
     geom::Size const pixels,
     geom::Point const top_left,
     geom::Size const size,
     const float scale,
     MirOrientation orientation)
-    : graphics::DisplayConfigurationOutput{
-            mg::DisplayConfigurationOutputId{next_output_id++},
+{
+    last_output_id++;
+    return std::unique_ptr<DisplayConfigurationOutput>(
+        new DisplayConfigurationOutput{
+            mg::DisplayConfigurationOutputId{last_output_id},
             mg::DisplayConfigurationCardId{0},
             mg::DisplayConfigurationOutputType::unknown,
             {pf},
@@ -55,8 +58,7 @@ mgx::DisplayConfigurationOutput::DisplayConfigurationOutput(
             {},
             mir_output_gamma_unsupported,
             {},
-            {}}
-{
+            {}});
 }
 
 mgx::DisplayConfiguration::DisplayConfiguration(std::vector<mg::DisplayConfigurationOutput> const& configuration)

--- a/src/platforms/mesa/server/x11/graphics/display_configuration.h
+++ b/src/platforms/mesa/server/x11/graphics/display_configuration.h
@@ -33,7 +33,7 @@ namespace X
 class DisplayConfiguration : public graphics::DisplayConfiguration
 {
 public:
-    static std::unique_ptr<DisplayConfigurationOutput> build_output(
+    static std::shared_ptr<DisplayConfigurationOutput> build_output(
         MirPixelFormat pf,
         geometry::Size const pixels,
         geometry::Point const top_left,

--- a/src/platforms/mesa/server/x11/graphics/display_configuration.h
+++ b/src/platforms/mesa/server/x11/graphics/display_configuration.h
@@ -30,27 +30,33 @@ namespace graphics
 namespace X
 {
 
+struct DisplayConfigurationOutput : graphics::DisplayConfigurationOutput
+{
+    DisplayConfigurationOutput(
+        MirPixelFormat pf,
+        mir::geometry::Size const pixels,
+        mir::geometry::Size const size_mm,
+        float const scale,
+        MirOrientation orientation);
+
+    static int next_output_id;
+};
+
 class DisplayConfiguration : public graphics::DisplayConfiguration
 {
 public:
-    DisplayConfiguration(MirPixelFormat pf,
-                         mir::geometry::Size const pixels,
-                         mir::geometry::Size const size_mm,
-                         float const scale,
-                         MirOrientation orientation);
+    DisplayConfiguration(std::vector<graphics::DisplayConfigurationOutput> const& outputs);
     DisplayConfiguration(DisplayConfiguration const&);
 
     virtual ~DisplayConfiguration() = default;
 
     void for_each_card(std::function<void(DisplayConfigurationCard const&)> f) const override;
-    void for_each_output(std::function<void(DisplayConfigurationOutput const&)> f) const override;
+    void for_each_output(std::function<void(graphics::DisplayConfigurationOutput const&)> f) const override;
     void for_each_output(std::function<void(UserDisplayConfigurationOutput&)> f) override;
     std::unique_ptr<graphics::DisplayConfiguration> clone() const override;
 
-    static DisplayConfigurationOutputId const the_output_id;
-
 private:
-    DisplayConfigurationOutput configuration;
+    std::vector<graphics::DisplayConfigurationOutput> configuration;
     DisplayConfigurationCard card;
 };
 

--- a/src/platforms/mesa/server/x11/graphics/display_configuration.h
+++ b/src/platforms/mesa/server/x11/graphics/display_configuration.h
@@ -34,8 +34,9 @@ struct DisplayConfigurationOutput : graphics::DisplayConfigurationOutput
 {
     DisplayConfigurationOutput(
         MirPixelFormat pf,
-        mir::geometry::Size const pixels,
-        mir::geometry::Size const size_mm,
+        geometry::Size const pixels,
+        geometry::Point const top_left,
+        geometry::Size const size_mm,
         float const scale,
         MirOrientation orientation);
 

--- a/src/platforms/mesa/server/x11/graphics/display_configuration.h
+++ b/src/platforms/mesa/server/x11/graphics/display_configuration.h
@@ -30,9 +30,10 @@ namespace graphics
 namespace X
 {
 
-struct DisplayConfigurationOutput : graphics::DisplayConfigurationOutput
+class DisplayConfiguration : public graphics::DisplayConfiguration
 {
-    DisplayConfigurationOutput(
+public:
+    static std::unique_ptr<DisplayConfigurationOutput> build_output(
         MirPixelFormat pf,
         geometry::Size const pixels,
         geometry::Point const top_left,
@@ -40,24 +41,20 @@ struct DisplayConfigurationOutput : graphics::DisplayConfigurationOutput
         float const scale,
         MirOrientation orientation);
 
-    static int next_output_id;
-};
-
-class DisplayConfiguration : public graphics::DisplayConfiguration
-{
-public:
-    DisplayConfiguration(std::vector<graphics::DisplayConfigurationOutput> const& outputs);
+    DisplayConfiguration(std::vector<DisplayConfigurationOutput> const& outputs);
     DisplayConfiguration(DisplayConfiguration const&);
 
     virtual ~DisplayConfiguration() = default;
 
     void for_each_card(std::function<void(DisplayConfigurationCard const&)> f) const override;
-    void for_each_output(std::function<void(graphics::DisplayConfigurationOutput const&)> f) const override;
+    void for_each_output(std::function<void(DisplayConfigurationOutput const&)> f) const override;
     void for_each_output(std::function<void(UserDisplayConfigurationOutput&)> f) override;
     std::unique_ptr<graphics::DisplayConfiguration> clone() const override;
 
 private:
-    std::vector<graphics::DisplayConfigurationOutput> configuration;
+    static int last_output_id;
+
+    std::vector<DisplayConfigurationOutput> configuration;
     DisplayConfigurationCard card;
 };
 

--- a/src/platforms/mesa/server/x11/graphics/graphics.cpp
+++ b/src/platforms/mesa/server/x11/graphics/graphics.cpp
@@ -66,7 +66,7 @@ void add_graphics_platform_options(boost::program_options::options_description& 
     config.add_options()
         (x11_displays_option_name,
          boost::program_options::value<std::string>()->default_value("1280x1024"),
-         "[mir-on-X specific] Comma separated list of WIDTHxHEIGHT for \"output\" windows.");
+         "[mir-on-X specific] Colon separated list of WIDTHxHEIGHT sizes for \"output\" windows.");
 }
 
 mg::PlatformPriority probe_graphics_platform(

--- a/src/platforms/mesa/server/x11/graphics/graphics.cpp
+++ b/src/platforms/mesa/server/x11/graphics/graphics.cpp
@@ -60,9 +60,9 @@ mir::UniqueModulePtr<mg::Platform> create_host_platform(
 
     return mir::make_module_ptr<mgx::Platform>(
         x11_resources.get_conn(),
-        geom::Size{
+        std::vector<geom::Size>{{
             std::stoi(display_dims_str.substr(0, pos)),
-            std::stoi(display_dims_str.substr(pos+1, display_dims_str.find(':')))},
+            std::stoi(display_dims_str.substr(pos+1, display_dims_str.find(':')))}},
         report
     );
 }
@@ -134,11 +134,11 @@ mir::UniqueModulePtr<mir::graphics::DisplayPlatform> create_display_platform(
         BOOST_THROW_EXCEPTION(std::runtime_error("Malformed output size option"));
 
     return mir::make_module_ptr<mgx::Platform>(
-               x11_resources.get_conn(),
-               geom::Size{std::stoi(display_dims_str.substr(0, pos)),
-                          std::stoi(display_dims_str.substr(pos+1, display_dims_str.find(':')))},
-               report
-           );
+        x11_resources.get_conn(),
+        std::vector<geom::Size>{{
+            std::stoi(display_dims_str.substr(0, pos)),
+            std::stoi(display_dims_str.substr(pos+1, display_dims_str.find(':')))}},
+        report);
 }
 
 mir::UniqueModulePtr<mir::graphics::RenderingPlatform> create_rendering_platform(

--- a/src/platforms/mesa/server/x11/graphics/graphics.cpp
+++ b/src/platforms/mesa/server/x11/graphics/graphics.cpp
@@ -35,8 +35,6 @@ namespace mx = mir::X;
 namespace mgx = mg::X;
 namespace geom = mir::geometry;
 
-mx::X11Resources x11_resources;
-
 namespace
 {
 char const* x11_displays_option_name{"x11-output"};
@@ -50,7 +48,7 @@ mir::UniqueModulePtr<mg::Platform> create_host_platform(
     std::shared_ptr<mir::logging::Logger> const& /*logger*/)
 {
     mir::assert_entry_point_signature<mg::CreateHostPlatform>(&create_host_platform);
-    if (!x11_resources.get_conn())
+    if (!mx::X11Resources::instance.get_conn())
         BOOST_THROW_EXCEPTION(std::runtime_error("Need valid x11 output"));
 
     auto display_dims_str = options->get<std::string>(x11_displays_option_name);
@@ -59,7 +57,7 @@ mir::UniqueModulePtr<mg::Platform> create_host_platform(
         BOOST_THROW_EXCEPTION(std::runtime_error("Malformed output size option"));
 
     return mir::make_module_ptr<mgx::Platform>(
-        x11_resources.get_conn(),
+        mx::X11Resources::instance.get_conn(),
         std::vector<geom::Size>{{
             std::stoi(display_dims_str.substr(0, pos)),
             std::stoi(display_dims_str.substr(pos+1, display_dims_str.find(':')))}},
@@ -125,7 +123,7 @@ mir::UniqueModulePtr<mir::graphics::DisplayPlatform> create_display_platform(
 {
     mir::assert_entry_point_signature<mg::CreateDisplayPlatform>(&create_display_platform);
 
-    if (!x11_resources.get_conn())
+    if (!mx::X11Resources::instance.get_conn())
         BOOST_THROW_EXCEPTION(std::runtime_error("Need valid x11 output"));
 
     auto display_dims_str = options->get<std::string>(x11_displays_option_name);
@@ -134,7 +132,7 @@ mir::UniqueModulePtr<mir::graphics::DisplayPlatform> create_display_platform(
         BOOST_THROW_EXCEPTION(std::runtime_error("Malformed output size option"));
 
     return mir::make_module_ptr<mgx::Platform>(
-        x11_resources.get_conn(),
+        mx::X11Resources::instance.get_conn(),
         std::vector<geom::Size>{{
             std::stoi(display_dims_str.substr(0, pos)),
             std::stoi(display_dims_str.substr(pos+1, display_dims_str.find(':')))}},

--- a/src/platforms/mesa/server/x11/graphics/graphics.cpp
+++ b/src/platforms/mesa/server/x11/graphics/graphics.cpp
@@ -38,49 +38,6 @@ namespace geom = mir::geometry;
 namespace
 {
 char const* x11_displays_option_name{"x11-output"};
-
-auto parse_size_dimension(std::string const& str) -> int
-{
-    try
-    {
-        size_t num_end = 0;
-        int const value = std::stoi(str, &num_end);
-        if (num_end != str.size())
-            BOOST_THROW_EXCEPTION(std::runtime_error("Output dimension \"" + str + "\" is not a valid number"));
-        if (value <= 0)
-            BOOST_THROW_EXCEPTION(std::runtime_error("Output dimensions must be greater than zero"));
-        return value;
-    }
-    catch (std::invalid_argument const &e)
-    {
-        BOOST_THROW_EXCEPTION(std::runtime_error("Output dimension \"" + str + "\" is not a valid number"));
-    }
-}
-
-auto parse_size(std::string const& str) -> geom::Size
-{
-    size_t x = str.find('x');
-    if (x == std::string::npos || x <= 0 || x >= str.size() - 1)
-        BOOST_THROW_EXCEPTION(std::runtime_error("Output size \"" + str + "\" does not have two dimensions"));
-    return geom::Size{
-        parse_size_dimension(str.substr(0, x)),
-        parse_size_dimension(str.substr(x + 1, std::string::npos))};
-
-}
-
-auto parse_output_options(std::shared_ptr<mo::Option> const& options) -> std::vector<geom::Size>
-{
-    auto output_dims = options->get<std::string>(x11_displays_option_name);
-    std::vector<geom::Size> sizes;
-    for (size_t start = 0, end; start < output_dims.size(); start = end + 1)
-    {
-        end = output_dims.find(',', start);
-        if (end == std::string::npos)
-            end = output_dims.size();
-        sizes.push_back(parse_size(output_dims.substr(start, end - start)));
-    }
-    return sizes;
-}
 }
 
 mir::UniqueModulePtr<mg::Platform> create_host_platform(
@@ -94,9 +51,11 @@ mir::UniqueModulePtr<mg::Platform> create_host_platform(
     if (!mx::X11Resources::instance.get_conn())
         BOOST_THROW_EXCEPTION(std::runtime_error("Need valid x11 output"));
 
+    auto output_sizes = mgx::Platform::parse_output_sizes(options->get<std::string>(x11_displays_option_name));
+
     return mir::make_module_ptr<mgx::Platform>(
         mx::X11Resources::instance.get_conn(),
-        parse_output_options(options),
+        output_sizes,
         report
     );
 }
@@ -162,9 +121,11 @@ mir::UniqueModulePtr<mir::graphics::DisplayPlatform> create_display_platform(
     if (!mx::X11Resources::instance.get_conn())
         BOOST_THROW_EXCEPTION(std::runtime_error("Need valid x11 output"));
 
+    auto output_sizes = mgx::Platform::parse_output_sizes(options->get<std::string>(x11_displays_option_name));
+
     return mir::make_module_ptr<mgx::Platform>(
         mx::X11Resources::instance.get_conn(),
-        parse_output_options(options),
+        output_sizes,
         report);
 }
 

--- a/src/platforms/mesa/server/x11/graphics/platform.cpp
+++ b/src/platforms/mesa/server/x11/graphics/platform.cpp
@@ -64,10 +64,10 @@ auto parse_size(std::string const& str) -> geom::Size
 std::vector<geom::Size> mgx::Platform::parse_output_sizes(std::string output_sizes)
 {
     std::vector<geom::Size> sizes;
-    for (size_t start = 0, end; start < output_sizes.size(); start = end + 1)
+    for (int start = 0, end; start - 1 < (int)output_sizes.size(); start = end + 1)
     {
         end = output_sizes.find(',', start);
-        if (end == std::string::npos)
+        if (end == (int)std::string::npos)
             end = output_sizes.size();
         sizes.push_back(parse_size(output_sizes.substr(start, end - start)));
     }

--- a/src/platforms/mesa/server/x11/graphics/platform.cpp
+++ b/src/platforms/mesa/server/x11/graphics/platform.cpp
@@ -28,14 +28,14 @@ namespace mgx = mg::X;
 namespace geom = mir::geometry;
 
 mgx::Platform::Platform(std::shared_ptr<::Display> const& conn,
-                        geom::Size const size,
+                        std::vector<geom::Size> const output_sizes,
                         std::shared_ptr<mg::DisplayReport> const& report)
     : x11_connection{conn},
       udev{std::make_shared<mir::udev::Context>()},
       drm{mgm::helpers::DRMHelper::open_any_render_node(udev)},
       report{report},
       gbm{drm->fd},
-      size{size}
+      output_sizes{output_sizes}
 {
     if (!x11_connection)
         BOOST_THROW_EXCEPTION(std::runtime_error("Need valid x11 display"));
@@ -53,8 +53,7 @@ mir::UniqueModulePtr<mg::Display> mgx::Platform::create_display(
     std::shared_ptr<DisplayConfigurationPolicy> const& /*initial_conf_policy*/,
     std::shared_ptr<GLConfig> const& gl_config)
 {
-    return make_module_ptr<mgx::Display>(x11_connection.get(), size, gl_config,
-                                         report);
+    return make_module_ptr<mgx::Display>(x11_connection.get(), output_sizes, gl_config, report);
 }
 
 mg::NativeDisplayPlatform* mgx::Platform::native_display_platform()

--- a/src/platforms/mesa/server/x11/graphics/platform.cpp
+++ b/src/platforms/mesa/server/x11/graphics/platform.cpp
@@ -21,11 +21,58 @@
 #include "buffer_allocator.h"
 #include "ipc_operations.h"
 #include "mesa_extensions.h"
+#include "mir/options/option.h"
 
+namespace mo = mir::options;
 namespace mg = mir::graphics;
 namespace mgm = mg::mesa;
 namespace mgx = mg::X;
 namespace geom = mir::geometry;
+
+namespace
+{
+auto parse_size_dimension(std::string const& str) -> int
+{
+    try
+    {
+        size_t num_end = 0;
+        int const value = std::stoi(str, &num_end);
+        if (num_end != str.size())
+            BOOST_THROW_EXCEPTION(std::runtime_error("Output dimension \"" + str + "\" is not a valid number"));
+        if (value <= 0)
+            BOOST_THROW_EXCEPTION(std::runtime_error("Output dimensions must be greater than zero"));
+        return value;
+    }
+    catch (std::invalid_argument const &e)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("Output dimension \"" + str + "\" is not a valid number"));
+    }
+}
+
+auto parse_size(std::string const& str) -> geom::Size
+{
+    size_t x = str.find('x');
+    if (x == std::string::npos || x <= 0 || x >= str.size() - 1)
+        BOOST_THROW_EXCEPTION(std::runtime_error("Output size \"" + str + "\" does not have two dimensions"));
+    return geom::Size{
+        parse_size_dimension(str.substr(0, x)),
+        parse_size_dimension(str.substr(x + 1, std::string::npos))};
+
+}
+}
+
+std::vector<geom::Size> mgx::Platform::parse_output_sizes(std::string output_sizes)
+{
+    std::vector<geom::Size> sizes;
+    for (size_t start = 0, end; start < output_sizes.size(); start = end + 1)
+    {
+        end = output_sizes.find(',', start);
+        if (end == std::string::npos)
+            end = output_sizes.size();
+        sizes.push_back(parse_size(output_sizes.substr(start, end - start)));
+    }
+    return sizes;
+}
 
 mgx::Platform::Platform(std::shared_ptr<::Display> const& conn,
                         std::vector<geom::Size> const output_sizes,

--- a/src/platforms/mesa/server/x11/graphics/platform.cpp
+++ b/src/platforms/mesa/server/x11/graphics/platform.cpp
@@ -66,7 +66,7 @@ std::vector<geom::Size> mgx::Platform::parse_output_sizes(std::string output_siz
     std::vector<geom::Size> sizes;
     for (int start = 0, end; start - 1 < (int)output_sizes.size(); start = end + 1)
     {
-        end = output_sizes.find(',', start);
+        end = output_sizes.find(':', start);
         if (end == (int)std::string::npos)
             end = output_sizes.size();
         sizes.push_back(parse_size(output_sizes.substr(start, end - start)));

--- a/src/platforms/mesa/server/x11/graphics/platform.h
+++ b/src/platforms/mesa/server/x11/graphics/platform.h
@@ -41,6 +41,9 @@ class Platform : public graphics::Platform,
                  public mir::renderer::gl::EGLPlatform
 {
 public:
+    // Parses comma separated list of WIDTHxHEIGHT
+    static std::vector<geometry::Size> parse_output_sizes(std::string output_sizes);
+
     explicit Platform(std::shared_ptr<::Display> const& conn,
                       std::vector<mir::geometry::Size> const output_sizes,
                       std::shared_ptr<DisplayReport> const& report);

--- a/src/platforms/mesa/server/x11/graphics/platform.h
+++ b/src/platforms/mesa/server/x11/graphics/platform.h
@@ -42,7 +42,7 @@ class Platform : public graphics::Platform,
 {
 public:
     explicit Platform(std::shared_ptr<::Display> const& conn,
-                      mir::geometry::Size const size,
+                      std::vector<mir::geometry::Size> const output_sizes,
                       std::shared_ptr<DisplayReport> const& report);
     ~Platform() = default;
 
@@ -66,7 +66,7 @@ private:
     std::shared_ptr<mesa::helpers::DRMHelper> const drm;
     std::shared_ptr<DisplayReport> const report;
     mesa::helpers::GBMHelper gbm;
-    mir::geometry::Size const size;
+    std::vector<mir::geometry::Size> const output_sizes;
     std::unique_ptr<mesa::DRMNativePlatformAuthFactory> auth_factory;
 };
 

--- a/src/platforms/mesa/server/x11/graphics/platform.h
+++ b/src/platforms/mesa/server/x11/graphics/platform.h
@@ -41,7 +41,7 @@ class Platform : public graphics::Platform,
                  public mir::renderer::gl::EGLPlatform
 {
 public:
-    // Parses comma separated list of WIDTHxHEIGHT
+    // Parses colon separated list of sizes in the form WIDTHxHEIGHT
     static std::vector<geometry::Size> parse_output_sizes(std::string output_sizes);
 
     explicit Platform(std::shared_ptr<::Display> const& conn,

--- a/src/platforms/mesa/server/x11/input/input.cpp
+++ b/src/platforms/mesa/server/x11/input/input.cpp
@@ -27,8 +27,6 @@ namespace mi = mir::input;
 namespace mx = mir::X;
 namespace mix = mi::X;
 
-extern mx::X11Resources x11_resources;
-
 mir::UniqueModulePtr<mi::Platform> create_input_platform(
     mo::Option const& /*options*/,
     std::shared_ptr<mir::EmergencyCleanupRegistry> const& /*emergency_cleanup_registry*/,
@@ -37,7 +35,7 @@ mir::UniqueModulePtr<mi::Platform> create_input_platform(
     std::shared_ptr<mi::InputReport> const& /*report*/)
 {
     mir::assert_entry_point_signature<mi::CreatePlatform>(&create_input_platform);
-    return mir::make_module_ptr<mix::XInputPlatform>(input_device_registry, x11_resources.get_conn());
+    return mir::make_module_ptr<mix::XInputPlatform>(input_device_registry, mx::X11Resources::instance.get_conn());
 }
 
 void add_input_platform_options(
@@ -54,7 +52,7 @@ mi::PlatformPriority probe_input_platform(
     if (options.is_set("host-socket") || options.is_set("vt"))
         return mi::PlatformPriority::unsupported;
 
-    auto display_available = x11_resources.get_conn() != nullptr;
+    auto display_available = mx::X11Resources::instance.get_conn() != nullptr;
     if (display_available)
         return mi::PlatformPriority::best;
     else

--- a/tests/unit-tests/platforms/mesa/x11/test_display.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_display.cpp
@@ -106,7 +106,7 @@ public:
     {
         return std::make_shared<mgx::Display>(
                    mock_x11.fake_x11.display,
-                   size,
+                   std::vector<geom::Size>{size},
                    mt::fake_shared(mock_gl_config),
                    std::make_shared<mir::report::null::DisplayReport>());
     }

--- a/tests/unit-tests/platforms/mesa/x11/test_display_generic.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_display_generic.cpp
@@ -97,13 +97,15 @@ public:
 
     std::shared_ptr<mg::Display> create_display()
     {
-        auto const platform = std::make_shared<mg::X::Platform>(std::shared_ptr<::Display>(
+        auto const platform = std::make_shared<mg::X::Platform>(
+            std::shared_ptr<::Display>(
                 XOpenDisplay(nullptr),
                 [](::Display* display)
                 {
                     XCloseDisplay(display);
-                }), mir::geometry::Size{1280,1024},
-                std::make_shared<mir::report::null::DisplayReport>());
+                }),
+            std::vector<mir::geometry::Size>{{1280, 1024}},
+            std::make_shared<mir::report::null::DisplayReport>());
         return platform->create_display(
             std::make_shared<mg::CloneDisplayConfigurationPolicy>(),
             std::make_shared<mtd::StubGLConfig>());

--- a/tests/unit-tests/platforms/mesa/x11/test_graphics_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_graphics_platform.cpp
@@ -80,13 +80,15 @@ public:
 
     std::shared_ptr<mg::Platform> create_platform()
     {
-      return std::make_shared<mg::X::Platform>(std::shared_ptr<::Display>(
-              XOpenDisplay(nullptr),
-              [](::Display* display)
-              {
-                  XCloseDisplay(display);
-              }), mir::geometry::Size{1280,1024},
-              std::make_shared<mir::report::null::DisplayReport>());
+        return std::make_shared<mg::X::Platform>(
+            std::shared_ptr<::Display>(
+                XOpenDisplay(nullptr),
+                [](::Display* display)
+                {
+                    XCloseDisplay(display);
+                }),
+            std::vector<mir::geometry::Size>{{1280, 1024}},
+            std::make_shared<mir::report::null::DisplayReport>());
     }
 
     std::shared_ptr<ml::Logger> logger;

--- a/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
@@ -146,7 +146,7 @@ TEST_F(X11GraphicsPlatformTest, parses_multiple_output_size)
 {
     using namespace ::testing;
 
-    auto str = "1280x1024,600x600,30x750";
+    auto str = "1280x1024:600x600:30x750";
     auto parsed = mg::X::Platform::parse_output_sizes(str);
 
     EXPECT_THAT(parsed, Eq(std::vector<mir::geometry::Size>{{1280, 1024}, {600, 600}, {30, 750}}));
@@ -155,13 +155,17 @@ TEST_F(X11GraphicsPlatformTest, parses_multiple_output_size)
 TEST_F(X11GraphicsPlatformTest, output_size_parsing_throws_on_bad_input)
 {
     using namespace ::testing;
-    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280"), std::runtime_error);
-    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x"), std::runtime_error);
-    EXPECT_THROW(mg::X::Platform::parse_output_sizes("x1280"), std::runtime_error);
-    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x720,"), std::runtime_error);
-    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x720,500"), std::runtime_error);
-    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x1024:1280x1024"), std::runtime_error);
-    EXPECT_THROW(mg::X::Platform::parse_output_sizes("0x0"), std::runtime_error);
-    EXPECT_THROW(mg::X::Platform::parse_output_sizes("0x200"), std::runtime_error);
-    EXPECT_THROW(mg::X::Platform::parse_output_sizes("50x50,20,50x50"), std::runtime_error);
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280"), std::runtime_error) << "No height or 'x'";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x"), std::runtime_error) << "No height";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("x1280"), std::runtime_error) << "No width";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("=20x40"), std::runtime_error) << "Random equals";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("20x30x40"), std::runtime_error) << "Too many dimensions";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x720:"), std::runtime_error) << "Ends with delim";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes(":1280x720"), std::runtime_error) << "Starts with delim";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x720:500"), std::runtime_error) << "No height or x on 2nd size";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("50x50:x20:50x50"), std::runtime_error) << "No width on 2nd size";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x1024,1280x1024"), std::runtime_error) << "Uses comma delim";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("0x0"), std::runtime_error) << "Zero size";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("0x200"), std::runtime_error) << "Zero width";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("200x-300"), std::runtime_error) << "Negative height";
 }

--- a/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
@@ -131,3 +131,37 @@ TEST_F(X11GraphicsPlatformTest, probe_returns_supported_when_drm_render_nodes_ex
     auto probe = platform_lib.load_function<mg::PlatformProbe>(probe_platform);
     EXPECT_EQ(mg::PlatformPriority::supported, probe(nullptr, options));
 }
+
+TEST_F(X11GraphicsPlatformTest, parses_simple_output_size)
+{
+    using namespace ::testing;
+
+    auto str = "1280x720";
+    auto parsed = mg::X::Platform::parse_output_sizes(str);
+
+    EXPECT_THAT(parsed, Eq(std::vector<mir::geometry::Size>{{1280, 720}}));
+}
+
+TEST_F(X11GraphicsPlatformTest, parses_multiple_output_size)
+{
+    using namespace ::testing;
+
+    auto str = "1280x1024,600x600,30x750";
+    auto parsed = mg::X::Platform::parse_output_sizes(str);
+
+    EXPECT_THAT(parsed, Eq(std::vector<mir::geometry::Size>{{1280, 1024}, {600, 600}, {30, 750}}));
+}
+
+TEST_F(X11GraphicsPlatformTest, output_size_parsing_throws_on_bad_input)
+{
+    using namespace ::testing;
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280"), std::runtime_error);
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x"), std::runtime_error);
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("x1280"), std::runtime_error);
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x720,"), std::runtime_error);
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x720,500"), std::runtime_error);
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x1024:1280x1024"), std::runtime_error);
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("0x0"), std::runtime_error);
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("0x200"), std::runtime_error);
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("50x50,20,50x50"), std::runtime_error);
+}

--- a/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
@@ -49,13 +49,15 @@ public:
 
     std::shared_ptr<mg::Platform> create_platform()
     {
-        return std::make_shared<mg::X::Platform>(std::shared_ptr<::Display>(
+        return std::make_shared<mg::X::Platform>(
+            std::shared_ptr<::Display>(
                 XOpenDisplay(nullptr),
                 [](::Display* display)
                 {
                     XCloseDisplay(display);
-                }), mir::geometry::Size{1280,1024},
-                std::make_shared<mir::report::null::DisplayReport>());
+                }),
+            std::vector<mir::geometry::Size>{{1280, 1024}},
+            std::make_shared<mir::report::null::DisplayReport>());
     }
 
     ::testing::NiceMock<mtd::MockDRM> mock_drm;


### PR DESCRIPTION
Enhance the `--x11-output` option to support a colon separated list of output sizes. Outputs are lined up horizontally from Mir's perspective, and are each shown in a different X11 window. Useful if you need to test multi-output code paths and do not have auxiliary physical display handy.