### PR TITLE
Simplify Wayland object construction

### DIFF
--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -32,8 +32,10 @@ namespace frontend
 class LayerSurfaceV1 : public wayland::LayerSurfaceV1, public WindowWlSurfaceRole
 {
 public:
-    LayerSurfaceV1(struct wl_client* client, struct wl_resource* parent_resource, uint32_t id, WlSurface* surface,
-                   LayerShellV1 const& layer_shell);
+    LayerSurfaceV1(
+        wl_resource* new_resource,
+        WlSurface* surface,
+        LayerShellV1 const& layer_shell);
     ~LayerSurfaceV1() = default;
 
 private:
@@ -43,13 +45,14 @@ private:
     void set_exclusive_zone(int32_t zone) override;
     void set_margin(int32_t top, int32_t right, int32_t bottom, int32_t left) override;
     void set_keyboard_interactivity(uint32_t keyboard_interactivity) override;
-    void get_popup(struct wl_resource* popup) override;
+    void get_popup(wl_resource* popup) override;
     void ack_configure(uint32_t serial) override;
     void destroy() override;
 
     // from WindowWlSurfaceRole
-    void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,
-                       geometry::Size const& new_size) override;
+    void handle_resize(
+        std::experimental::optional<geometry::Point> const& new_top_left,
+        geometry::Size const& new_size) override;
 };
 
 }
@@ -66,23 +69,31 @@ mf::LayerShellV1::LayerShellV1(struct wl_display* display, std::shared_ptr<Shell
 {
 }
 
-void mf::LayerShellV1::get_layer_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id,
-                                         struct wl_resource* surface,
-                                         std::experimental::optional<struct wl_resource*> const& output,
-                                         uint32_t layer, std::string const& namespace_)
+void mf::LayerShellV1::get_layer_surface(
+    wl_client* /*client*/,
+    wl_resource* /*resource*/,
+    wl_resource* new_layer_surface,
+    wl_resource* surface,
+    std::experimental::optional<wl_resource*> const& output,
+    uint32_t layer,
+    std::string const& namespace_)
 {
     (void)output;
     (void)layer;
     (void)namespace_;
-    new LayerSurfaceV1(client, resource, id, WlSurface::from(surface), *this);
+    new LayerSurfaceV1(new_layer_surface, WlSurface::from(surface), *this);
 }
 
 // LayerSurfaceV1
 
-mf::LayerSurfaceV1::LayerSurfaceV1(struct wl_client* client, struct wl_resource* parent_resource, uint32_t id,
-                                   WlSurface* surface, LayerShellV1 const& layer_shell)
-    : wayland::LayerSurfaceV1(client, parent_resource, id),
-      WindowWlSurfaceRole(&layer_shell.seat, client, surface, layer_shell.shell, layer_shell.output_manager)
+mf::LayerSurfaceV1::LayerSurfaceV1(wl_resource* new_resource, WlSurface* surface, LayerShellV1 const& layer_shell)
+    : wayland::LayerSurfaceV1(new_resource),
+      WindowWlSurfaceRole(
+          &layer_shell.seat,
+          wayland::LayerSurfaceV1::client,
+          surface,
+          layer_shell.shell,
+          layer_shell.output_manager)
 {
 }
 

--- a/src/server/frontend_wayland/layer_shell_v1.h
+++ b/src/server/frontend_wayland/layer_shell_v1.h
@@ -33,11 +33,16 @@ class OutputManager;
 class LayerShellV1 : public wayland::LayerShellV1
 {
 public:
-    LayerShellV1(struct wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
+    LayerShellV1(wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
 
-    void get_layer_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id,
-                           struct wl_resource* surface, std::experimental::optional<struct wl_resource*> const& output,
-                           uint32_t layer, std::string const& namespace_) override;
+    void get_layer_surface(
+        wl_client* client,
+        wl_resource* resource,
+        wl_resource* new_layer_surface,
+        wl_resource* surface,
+        std::experimental::optional<wl_resource*> const& output,
+        uint32_t layer,
+        std::string const& namespace_) override;
 
     std::shared_ptr<Shell> const shell;
     WlSeat& seat;

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -252,33 +252,31 @@ private:
     std::shared_ptr<mg::WaylandAllocator> const allocator;
     std::shared_ptr<mir::Executor> const executor;
 
-    void create_surface(wl_client* client, wl_resource* resource, uint32_t id) override;
-    void create_region(wl_client* client, wl_resource* resource, uint32_t id) override;
+    void create_surface(wl_client* client, wl_resource* resource, wl_resource* new_surface) override;
+    void create_region(wl_client* client, wl_resource* resource, wl_resource* new_region) override;
 };
 
-void WlCompositor::create_surface(wl_client* client, wl_resource* resource, uint32_t id)
+void WlCompositor::create_surface(wl_client* /*client*/, wl_resource* /*resource*/, wl_resource* new_surface)
 {
-    new WlSurface{client, resource, id, executor, allocator};
+    new WlSurface{new_surface, executor, allocator};
 }
 
-void WlCompositor::create_region(wl_client* client, wl_resource* resource, uint32_t id)
+void WlCompositor::create_region(wl_client* /*client*/, wl_resource* /*resource*/, wl_resource* new_region)
 {
-    new WlRegion{client, resource, id};
+    new WlRegion{new_region};
 }
 
 class WlShellSurface  : public wayland::ShellSurface, public WindowWlSurfaceRole
 {
 public:
     WlShellSurface(
-        wl_client* client,
-        wl_resource* parent,
-        uint32_t id,
+        wl_resource* new_resource,
         WlSurface* surface,
         std::shared_ptr<mf::Shell> const& shell,
         WlSeat& seat,
         OutputManager* output_manager)
-        : ShellSurface(client, parent, id),
-          WindowWlSurfaceRole{&seat, client, surface, shell, output_manager}
+        : ShellSurface(new_resource),
+          WindowWlSurfaceRole{&seat, wayland::ShellSurface::client, surface, shell, output_manager}
     {
     }
 
@@ -442,12 +440,12 @@ public:
     }
 
     void get_shell_surface(
-        wl_client* client,
-        wl_resource* resource,
-        uint32_t id,
+        wl_client* /*client*/,
+        wl_resource* /*resource*/,
+        wl_resource* new_shell_surface,
         wl_resource* surface) override
     {
-        new WlShellSurface(client, resource, id, WlSurface::from(surface), shell, seat, output_manager);
+        new WlShellSurface(new_shell_surface, WlSurface::from(surface), shell, seat, output_manager);
     }
 
     static auto get_window(wl_resource* window) -> std::shared_ptr<Surface>;

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -34,13 +34,11 @@
 namespace mf = mir::frontend;
 
 mf::WlKeyboard::WlKeyboard(
-    wl_client* client,
-    wl_resource* parent,
-    uint32_t id,
+    wl_resource* new_resource,
     mir::input::Keymap const& initial_keymap,
     std::function<void(WlKeyboard*)> const& on_destroy,
     std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state)
-    : Keyboard(client, parent, id),
+    : Keyboard(new_resource),
       keymap{nullptr, &xkb_keymap_unref},
       state{nullptr, &xkb_state_unref},
       context{xkb_context_new(XKB_CONTEXT_NO_FLAGS), &xkb_context_unref},

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -53,9 +53,7 @@ class WlKeyboard : public wayland::Keyboard
 {
 public:
     WlKeyboard(
-        wl_client* client,
-        wl_resource* parent,
-        uint32_t id,
+        wl_resource* new_resource,
         mir::input::Keymap const& initial_keymap,
         std::function<void(WlKeyboard*)> const& on_destroy,
         std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state);

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -52,11 +52,9 @@ struct NullCursor : mf::WlPointer::Cursor
 }
 
 mf::WlPointer::WlPointer(
-    wl_client* client,
-    wl_resource* parent,
-    uint32_t id,
+    wl_resource* new_resource,
     std::function<void(WlPointer*)> const& on_destroy)
-    : Pointer(client, parent, id),
+    : Pointer(new_resource),
       display{wl_client_get_display(client)},
       on_destroy{on_destroy},
       cursor{std::make_unique<NullCursor>()}

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -44,9 +44,7 @@ class WlPointer : public wayland::Pointer
 public:
 
     WlPointer(
-        wl_client* client,
-        wl_resource* parent,
-        uint32_t id,
+        wl_resource* new_resource,
         std::function<void(WlPointer*)> const& on_destroy);
 
     ~WlPointer();

--- a/src/server/frontend_wayland/wl_region.cpp
+++ b/src/server/frontend_wayland/wl_region.cpp
@@ -24,8 +24,8 @@
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
 
-mf::WlRegion::WlRegion(struct wl_client* client, struct wl_resource* parent, uint32_t id)
-    : wayland::Region(client, parent, id)
+mf::WlRegion::WlRegion(wl_resource* new_resource)
+    : wayland::Region(new_resource)
 {}
 
 mf::WlRegion::~WlRegion()

--- a/src/server/frontend_wayland/wl_region.h
+++ b/src/server/frontend_wayland/wl_region.h
@@ -34,7 +34,7 @@ namespace frontend
 class WlRegion: wayland::Region
 {
 public:
-    WlRegion(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    WlRegion(wl_resource* new_resource);
     ~WlRegion();
 
     std::vector<geometry::Rectangle> rectangle_vector();

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -208,28 +208,24 @@ void mf::WlSeat::bind(wl_client* /*client*/, wl_resource* resource)
         send_name_event(resource, "seat0");
 }
 
-void mf::WlSeat::get_pointer(wl_client* client, wl_resource* resource, uint32_t id)
+void mf::WlSeat::get_pointer(wl_client* client, wl_resource* /*resource*/, wl_resource* new_pointer)
 {
     pointer_listeners->register_listener(
         client,
         new WlPointer{
-            client,
-            resource,
-            id,
+            new_pointer,
             [listeners = pointer_listeners, client](WlPointer* listener)
             {
                 listeners->unregister_listener(client, listener);
             }});
 }
 
-void mf::WlSeat::get_keyboard(wl_client* client, wl_resource* resource, uint32_t id)
+void mf::WlSeat::get_keyboard(wl_client* client, wl_resource* /*resource*/, wl_resource* new_keyboard)
 {
     keyboard_listeners->register_listener(
         client,
         new WlKeyboard{
-            client,
-            resource,
-            id,
+            new_keyboard,
             *keymap,
             [listeners = keyboard_listeners, client](WlKeyboard* listener)
             {
@@ -263,14 +259,12 @@ void mf::WlSeat::get_keyboard(wl_client* client, wl_resource* resource, uint32_t
             }});
 }
 
-void mf::WlSeat::get_touch(wl_client* client, wl_resource* resource, uint32_t id)
+void mf::WlSeat::get_touch(wl_client* client, wl_resource* /*resource*/, wl_resource* new_touch)
 {
     touch_listeners->register_listener(
         client,
         new WlTouch{
-            client,
-            resource,
-            id,
+            new_touch,
             [listeners = touch_listeners, client](WlTouch* listener)
             {
                 listeners->unregister_listener(client, listener);

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -103,9 +103,9 @@ private:
     std::shared_ptr<mir::Executor> const executor;
 
     void bind(wl_client* client, wl_resource* resource) override;
-    void get_pointer(wl_client* client, wl_resource* resource, uint32_t id) override;
-    void get_keyboard(wl_client* client, wl_resource* resource, uint32_t id) override;
-    void get_touch(wl_client* client, wl_resource* resource, uint32_t id) override;
+    void get_pointer(wl_client* client, wl_resource* resource, wl_resource* new_pointer) override;
+    void get_keyboard(wl_client* client, wl_resource* resource, wl_resource* new_keyboard) override;
+    void get_touch(wl_client* client, wl_resource* resource, wl_resource* new_touch) override;
     void release(struct wl_client* /*client*/, struct wl_resource* us) override;
 };
 }

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -35,15 +35,18 @@ void mf::WlSubcompositor::destroy(struct wl_client* /*client*/, struct wl_resour
     destroy_wayland_object(resource);
 }
 
-void mf::WlSubcompositor::get_subsurface(struct wl_client* client, struct wl_resource* resource, uint32_t id,
-                                         struct wl_resource* surface, struct wl_resource* parent)
+void mf::WlSubcompositor::get_subsurface(
+    wl_client* /*client*/,
+    wl_resource* /*resource*/,
+    wl_resource* new_subsurface,
+    wl_resource* surface,
+    wl_resource* parent)
 {
-    new WlSubsurface(client, resource, id, WlSurface::from(surface), WlSurface::from(parent));
+    new WlSubsurface(new_subsurface, WlSurface::from(surface), WlSurface::from(parent));
 }
 
-mf::WlSubsurface::WlSubsurface(struct wl_client* client, struct wl_resource* object_parent, uint32_t id,
-                               WlSurface* surface, WlSurface* parent_surface)
-    : wayland::Subsurface(client, object_parent, id),
+mf::WlSubsurface::WlSubsurface(wl_resource* new_subsurface, WlSurface* surface, WlSurface* parent_surface)
+    : wayland::Subsurface(new_subsurface),
       surface{surface},
       parent{parent_surface->add_child(this)},
       parent_destroyed{parent_surface->destroyed_flag()},

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -45,15 +45,14 @@ public:
 
 private:
     void destroy(struct wl_client* client, struct wl_resource* resource) override;
-    void get_subsurface(struct wl_client* client, struct wl_resource* resource, uint32_t id,
+    void get_subsurface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* new_subsurface,
                         struct wl_resource* surface, struct wl_resource* parent) override;
 };
 
 class WlSubsurface: public WlSurfaceRole, wayland::Subsurface
 {
 public:
-    WlSubsurface(struct wl_client* client, struct wl_resource* object_parent, uint32_t id, WlSurface* surface,
-                 WlSurface* parent_surface);
+    WlSubsurface(wl_resource* new_subsurface, WlSurface* surface, WlSurface* parent_surface);
     ~WlSubsurface();
 
     void populate_surface_data(std::vector<shell::StreamSpecification>& buffer_streams,

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -42,8 +42,8 @@
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
 
-mf::WlSurfaceState::Callback::Callback(struct wl_client* client, struct wl_resource* parent, uint32_t id)
-    : wayland::Callback{client, parent, id},
+mf::WlSurfaceState::Callback::Callback(wl_resource* new_resource)
+    : wayland::Callback{new_resource},
       destroyed{deleted_flag_for_resource(resource)}
 {
 }
@@ -75,12 +75,10 @@ bool mf::WlSurfaceState::surface_data_needs_refresh() const
 }
 
 mf::WlSurface::WlSurface(
-    wl_client* client,
-    wl_resource* parent,
-    uint32_t id,
+    wl_resource* new_resource,
     std::shared_ptr<Executor> const& executor,
     std::shared_ptr<graphics::WaylandAllocator> const& allocator)
-    : Surface(client, parent, id),
+    : Surface(new_resource),
         session{mf::get_session(client)},
         stream_id{session->create_buffer_stream({{}, mir_pixel_format_invalid, graphics::BufferUsage::undefined})},
         stream{session->get_buffer_stream(stream_id)},
@@ -266,9 +264,9 @@ void mf::WlSurface::damage_buffer(int32_t x, int32_t y, int32_t width, int32_t h
     // This isn't essential, but could enable optimizations
 }
 
-void mf::WlSurface::frame(uint32_t callback)
+void mf::WlSurface::frame(wl_resource* new_callback)
 {
-    pending.frame_callbacks.push_back(std::make_shared<WlSurfaceState::Callback>(client, resource, callback));
+    pending.frame_callbacks.push_back(std::make_shared<WlSurfaceState::Callback>(new_callback));
 }
 
 void mf::WlSurface::set_opaque_region(std::experimental::optional<wl_resource*> const& region)

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -62,7 +62,7 @@ struct WlSurfaceState
     class Callback : public wayland::Callback
     {
     public:
-        Callback(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+        Callback(wl_resource* new_resource);
         std::shared_ptr<bool> destroyed;
     };
 
@@ -114,9 +114,7 @@ public:
         bool is_in_input_region;
     };
 
-    WlSurface(wl_client* client,
-              wl_resource* parent,
-              uint32_t id,
+    WlSurface(wl_resource* new_resource,
               std::shared_ptr<mir::Executor> const& executor,
               std::shared_ptr<mir::graphics::WaylandAllocator> const& allocator);
 
@@ -171,7 +169,7 @@ private:
     void destroy() override;
     void attach(std::experimental::optional<wl_resource*> const& buffer, int32_t x, int32_t y) override;
     void damage(int32_t x, int32_t y, int32_t width, int32_t height) override;
-    void frame(uint32_t callback) override;
+    void frame(wl_resource* callback) override;
     void set_opaque_region(std::experimental::optional<wl_resource*> const& region) override;
     void set_input_region(std::experimental::optional<wl_resource*> const& region) override;
     void commit() override;

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -28,11 +28,9 @@
 namespace mf = mir::frontend;
 
 mf::WlTouch::WlTouch(
-    wl_client* client,
-    wl_resource* parent,
-    uint32_t id,
+    wl_resource* new_resource,
     std::function<void(WlTouch*)> const& on_destroy)
-    : Touch(client, parent, id),
+    : Touch(new_resource),
       on_destroy{on_destroy}
 {
 }

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -41,9 +41,7 @@ class WlTouch : public wayland::Touch
 {
 public:
     WlTouch(
-        wl_client* client,
-        wl_resource* parent,
-        uint32_t id,
+        wl_resource* new_resource,
         std::function<void(WlTouch*)> const& on_destroy);
 
     ~WlTouch();

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -39,14 +39,15 @@ class XdgSurfaceStable : wayland::XdgSurface
 public:
     static XdgSurfaceStable* from(wl_resource* surface);
 
-    XdgSurfaceStable(wl_client* client, wl_resource* resource_parent, uint32_t id, WlSurface* surface,
-                     XdgShellStable const& xdg_shell);
+    XdgSurfaceStable(wl_resource* new_resource, WlSurface* surface, XdgShellStable const& xdg_shell);
     ~XdgSurfaceStable() = default;
 
     void destroy() override;
-    void get_toplevel(uint32_t id) override;
-    void get_popup(uint32_t id, std::experimental::optional<struct wl_resource*> const& parent_surface,
-                   struct wl_resource* positioner) override;
+    void get_toplevel(wl_resource* new_toplevel) override;
+    void get_popup(
+        wl_resource* new_popup,
+        std::experimental::optional<wl_resource*> const& parent_surface,
+        wl_resource* positioner) override;
     void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) override;
     void ack_configure(uint32_t serial) override;
 
@@ -71,15 +72,19 @@ public:
 class XdgPopupStable : wayland::XdgPopup, public WindowWlSurfaceRole
 {
 public:
-    XdgPopupStable(struct wl_client* client, struct wl_resource* resource_parent, uint32_t id,
-                   XdgSurfaceStable* xdg_surface, WlSurfaceRole* parent_role, struct wl_resource* positioner,
-                   WlSurface* surface);
+    XdgPopupStable(
+        wl_resource* new_resource,
+        XdgSurfaceStable* xdg_surface,
+        WlSurfaceRole* parent_role,
+        wl_resource* positioner,
+        WlSurface* surface);
 
     void grab(struct wl_resource* seat, uint32_t serial) override;
     void destroy() override;
 
-    void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,
-                       geometry::Size const& new_size) override;
+    void handle_resize(
+        std::experimental::optional<geometry::Point> const& new_top_left,
+        geometry::Size const& new_size) override;
 
 private:
     std::experimental::optional<geom::Point> cached_top_left;
@@ -91,8 +96,10 @@ private:
 class XdgToplevelStable : wayland::XdgToplevel, public WindowWlSurfaceRole
 {
 public:
-    XdgToplevelStable(struct wl_client* client, struct wl_resource* resource_parent, uint32_t id, XdgSurfaceStable* xdg_surface,
-                      WlSurface* surface);
+    XdgToplevelStable(
+        wl_resource* new_resource,
+        XdgSurfaceStable* xdg_surface,
+        WlSurface* surface);
 
     void destroy() override;
     void set_parent(std::experimental::optional<struct wl_resource*> const& parent) override;
@@ -121,7 +128,7 @@ private:
 class XdgPositionerStable : public wayland::XdgPositioner, public shell::SurfaceSpecification
 {
 public:
-    XdgPositionerStable(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    XdgPositionerStable(wl_resource* new_resource);
 
 private:
     void destroy() override;
@@ -153,15 +160,18 @@ void mf::XdgShellStable::destroy(struct wl_client* client, struct wl_resource* r
     // TODO
 }
 
-void mf::XdgShellStable::create_positioner(struct wl_client* client, struct wl_resource* resource, uint32_t id)
+void mf::XdgShellStable::create_positioner(wl_client* /*client*/, wl_resource* /*resource*/, wl_resource* new_positioner)
 {
-    new XdgPositionerStable{client, resource, id};
+    new XdgPositionerStable{new_positioner};
 }
 
-void mf::XdgShellStable::get_xdg_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id,
-                                         struct wl_resource* surface)
+void mf::XdgShellStable::get_xdg_surface(
+    wl_client* /*client*/,
+    wl_resource* /*resource*/,
+    wl_resource* new_shell_surface,
+    wl_resource* surface)
 {
-    new XdgSurfaceStable{client, resource, id, WlSurface::from(surface), *this};
+    new XdgSurfaceStable{new_shell_surface, WlSurface::from(surface), *this};
 }
 
 void mf::XdgShellStable::pong(struct wl_client* client, struct wl_resource* resource, uint32_t serial)
@@ -178,9 +188,8 @@ mf::XdgSurfaceStable* mf::XdgSurfaceStable::from(wl_resource* surface)
     return static_cast<XdgSurfaceStable*>(static_cast<wayland::XdgSurface*>(tmp));
 }
 
-mf::XdgSurfaceStable::XdgSurfaceStable(wl_client* client, wl_resource* resource_parent, uint32_t id, WlSurface* surface,
-                                       XdgShellStable const& xdg_shell)
-    : wayland::XdgSurface(client, resource_parent, id),
+mf::XdgSurfaceStable::XdgSurfaceStable(wl_resource* new_resource, WlSurface* surface, XdgShellStable const& xdg_shell)
+    : wayland::XdgSurface(new_resource),
       surface{surface},
       xdg_shell{xdg_shell}
 {
@@ -191,15 +200,16 @@ void mf::XdgSurfaceStable::destroy()
     destroy_wayland_object();
 }
 
-void mf::XdgSurfaceStable::get_toplevel(uint32_t id)
+void mf::XdgSurfaceStable::get_toplevel(wl_resource* new_toplevel)
 {
-    auto toplevel = new XdgToplevelStable{wayland::XdgSurface::client, resource, id, this, surface};
+    auto toplevel = new XdgToplevelStable{new_toplevel, this, surface};
     set_window_role(toplevel);
 }
 
-void mf::XdgSurfaceStable::get_popup(uint32_t id,
-                                     std::experimental::optional<struct wl_resource*> const& parent_surface,
-                                     struct wl_resource* positioner)
+void mf::XdgSurfaceStable::get_popup(
+    wl_resource* new_popup,
+    std::experimental::optional<struct wl_resource*> const& parent_surface,
+    wl_resource* positioner)
 {
     auto parent_xdg_surface = parent_surface ?
                                   std::experimental::make_optional(XdgSurfaceStable::from(parent_surface.value()))
@@ -209,7 +219,6 @@ void mf::XdgSurfaceStable::get_popup(uint32_t id,
                                   parent_xdg_surface.value()->window_role()
                                   : std::experimental::nullopt;
 
-
     if  (!parent_window_role)
     {
         // When we implement layer shell, it will be more clear why this function might be called with a null parent,
@@ -218,8 +227,7 @@ void mf::XdgSurfaceStable::get_popup(uint32_t id,
         return;
     }
 
-    auto popup = new XdgPopupStable{wayland::XdgSurface::client, resource, id, this, parent_window_role.value(), positioner,
-                                    surface};
+    auto popup = new XdgPopupStable{new_popup, this, parent_window_role.value(), positioner, surface};
     set_window_role(popup);
 }
 
@@ -263,13 +271,19 @@ void mf::XdgSurfaceStable::set_window_role(WindowWlSurfaceRole* role)
 
 // XdgPopupStable
 
-mf::XdgPopupStable::XdgPopupStable(struct wl_client* client, struct wl_resource* resource_parent, uint32_t id,
-                                   XdgSurfaceStable* xdg_surface,
-                                   WlSurfaceRole* parent_role,
-                                   struct wl_resource* positioner, WlSurface* surface)
-    : wayland::XdgPopup(client, resource_parent, id),
-      WindowWlSurfaceRole(&xdg_surface->xdg_shell.seat, client, surface, xdg_surface->xdg_shell.shell,
-                          xdg_surface->xdg_shell.output_manager),
+mf::XdgPopupStable::XdgPopupStable(
+    wl_resource* new_resource,
+    XdgSurfaceStable* xdg_surface,
+    WlSurfaceRole* parent_role,
+    wl_resource* positioner,
+    WlSurface* surface)
+    : wayland::XdgPopup(new_resource),
+      WindowWlSurfaceRole(
+          &xdg_surface->xdg_shell.seat,
+          wayland::XdgPopup::client,
+          surface,
+          xdg_surface->xdg_shell.shell,
+          xdg_surface->xdg_shell.output_manager),
       xdg_surface{xdg_surface}
 {
     auto specification = static_cast<mir::shell::SurfaceSpecification*>(
@@ -317,11 +331,14 @@ void mf::XdgPopupStable::handle_resize(const std::experimental::optional<geometr
 
 // XdgToplevelStable
 
-mf::XdgToplevelStable::XdgToplevelStable(struct wl_client* client, struct wl_resource* resource_parent, uint32_t id,
-                                         XdgSurfaceStable* xdg_surface, WlSurface* surface)
-    : wayland::XdgToplevel(client, resource_parent, id),
-      WindowWlSurfaceRole(&xdg_surface->xdg_shell.seat, client, surface, xdg_surface->xdg_shell.shell,
-                          xdg_surface->xdg_shell.output_manager),
+mf::XdgToplevelStable::XdgToplevelStable(wl_resource* new_resource, XdgSurfaceStable* xdg_surface, WlSurface* surface)
+    : wayland::XdgToplevel(new_resource),
+      WindowWlSurfaceRole(
+          &xdg_surface->xdg_shell.seat,
+          wayland::XdgToplevel::client,
+          surface,
+          xdg_surface->xdg_shell.shell,
+          xdg_surface->xdg_shell.output_manager),
       xdg_surface{xdg_surface}
 {
     wl_array states;
@@ -498,8 +515,8 @@ mf::XdgToplevelStable* mf::XdgToplevelStable::from(wl_resource* surface)
 
 // XdgPositionerStable
 
-mf::XdgPositionerStable::XdgPositionerStable(struct wl_client* client, struct wl_resource* parent, uint32_t id)
-    : wayland::XdgPositioner(client, parent, id)
+mf::XdgPositionerStable::XdgPositionerStable(wl_resource* new_resource)
+    : wayland::XdgPositioner(new_resource)
 {
     // specifying gravity is not required by the xdg shell protocol, but is by Mir window managers
     surface_placement_gravity = mir_placement_gravity_center;

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -37,8 +37,8 @@ public:
     XdgShellStable(struct wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
 
     void destroy(struct wl_client* client, struct wl_resource* resource) override;
-    void create_positioner(struct wl_client* client, struct wl_resource* resource, uint32_t id) override;
-    void get_xdg_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id,
+    void create_positioner(struct wl_client* client, struct wl_resource* resource, wl_resource* new_positioner) override;
+    void get_xdg_surface(struct wl_client* client, struct wl_resource* resource, wl_resource* new_xdg_surface,
                          struct wl_resource* surface) override;
     void pong(struct wl_client* client, struct wl_resource* resource, uint32_t serial) override;
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -39,13 +39,12 @@ class XdgSurfaceV6 : wayland::XdgSurfaceV6
 public:
     static XdgSurfaceV6* from(wl_resource* surface);
 
-    XdgSurfaceV6(wl_client* client, wl_resource* resource_parent, uint32_t id, WlSurface* surface,
-                 XdgShellV6 const& xdg_shell);
+    XdgSurfaceV6(wl_resource* new_resource, WlSurface* surface, XdgShellV6 const& xdg_shell);
     ~XdgSurfaceV6() = default;
 
     void destroy() override;
-    void get_toplevel(uint32_t id) override;
-    void get_popup(uint32_t id, struct wl_resource* parent_surface, struct wl_resource* positioner) override;
+    void get_toplevel(wl_resource* new_toplevel) override;
+    void get_popup(wl_resource* new_popup, wl_resource* parent_surface, wl_resource* positioner) override;
     void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) override;
     void ack_configure(uint32_t serial) override;
 
@@ -70,14 +69,19 @@ public:
 class XdgPopupV6 : wayland::XdgPopupV6, public WindowWlSurfaceRole
 {
 public:
-    XdgPopupV6(struct wl_client* client, struct wl_resource* resource_parent, uint32_t id, XdgSurfaceV6* xdg_surface,
-               XdgSurfaceV6* parent_surface, struct wl_resource* positioner, WlSurface* surface);
+    XdgPopupV6(
+        wl_resource* new_resource,
+        XdgSurfaceV6* xdg_surface,
+        XdgSurfaceV6* parent_surface,
+        wl_resource* positioner,
+        WlSurface* surface);
 
     void grab(struct wl_resource* seat, uint32_t serial) override;
     void destroy() override;
 
-    void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,
-                       geometry::Size const& new_size) override;
+    void handle_resize(
+        std::experimental::optional<geometry::Point> const& new_top_left,
+        geometry::Size const& new_size) override;
 
 private:
     std::experimental::optional<geom::Point> cached_top_left;
@@ -89,8 +93,7 @@ private:
 class XdgToplevelV6 : wayland::XdgToplevelV6, public WindowWlSurfaceRole
 {
 public:
-    XdgToplevelV6(struct wl_client* client, struct wl_resource* resource_parent, uint32_t id, XdgSurfaceV6* xdg_surface,
-                  WlSurface* surface);
+    XdgToplevelV6(wl_resource* new_resource, XdgSurfaceV6* xdg_surface, WlSurface* surface);
 
     void destroy() override;
     void set_parent(std::experimental::optional<struct wl_resource*> const& parent) override;
@@ -119,7 +122,7 @@ private:
 class XdgPositionerV6 : public wayland::XdgPositionerV6, public shell::SurfaceSpecification
 {
 public:
-    XdgPositionerV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    XdgPositionerV6(wl_resource* new_resource);
 
 private:
     void destroy() override;
@@ -154,15 +157,18 @@ void mf::XdgShellV6::destroy(struct wl_client* client, struct wl_resource* resou
     // TODO
 }
 
-void mf::XdgShellV6::create_positioner(struct wl_client* client, struct wl_resource* resource, uint32_t id)
+void mf::XdgShellV6::create_positioner(wl_client* /*client*/, wl_resource* /*resource*/, wl_resource* new_positioner)
 {
-    new XdgPositionerV6{client, resource, id};
+    new XdgPositionerV6{new_positioner};
 }
 
-void mf::XdgShellV6::get_xdg_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id,
-                                     struct wl_resource* surface)
+void mf::XdgShellV6::get_xdg_surface(
+    wl_client* /*client*/,
+    wl_resource* /*resource*/,
+    wl_resource* new_xdg_surface,
+    wl_resource* surface)
 {
-    new XdgSurfaceV6{client, resource, id, WlSurface::from(surface), *this};
+    new XdgSurfaceV6{new_xdg_surface, WlSurface::from(surface), *this};
 }
 
 void mf::XdgShellV6::pong(struct wl_client* client, struct wl_resource* resource, uint32_t serial)
@@ -179,9 +185,9 @@ mf::XdgSurfaceV6* mf::XdgSurfaceV6::from(wl_resource* surface)
     return static_cast<XdgSurfaceV6*>(static_cast<wayland::XdgSurfaceV6*>(tmp));
 }
 
-mf::XdgSurfaceV6::XdgSurfaceV6(wl_client* client, wl_resource* resource_parent, uint32_t id, WlSurface* surface,
+mf::XdgSurfaceV6::XdgSurfaceV6(wl_resource* new_resource, WlSurface* surface,
                                XdgShellV6 const& xdg_shell)
-    : wayland::XdgSurfaceV6(client, resource_parent, id),
+    : wayland::XdgSurfaceV6(new_resource),
       surface{surface},
       xdg_shell{xdg_shell}
 {
@@ -192,16 +198,15 @@ void mf::XdgSurfaceV6::destroy()
     wl_resource_destroy(resource);
 }
 
-void mf::XdgSurfaceV6::get_toplevel(uint32_t id)
+void mf::XdgSurfaceV6::get_toplevel(wl_resource* new_toplevel)
 {
-    auto toplevel = new XdgToplevelV6{wayland::XdgSurfaceV6::client, resource, id, this, surface};
+    auto toplevel = new XdgToplevelV6{new_toplevel, this, surface};
     set_window_role(toplevel);
 }
 
-void mf::XdgSurfaceV6::get_popup(uint32_t id, struct wl_resource* parent_surface, struct wl_resource* positioner)
+void mf::XdgSurfaceV6::get_popup(wl_resource* new_popup, struct wl_resource* parent_surface, struct wl_resource* positioner)
 {
-    auto popup = new XdgPopupV6{wayland::XdgSurfaceV6::client, resource, id, this, XdgSurfaceV6::from(parent_surface),
-                                positioner, surface};
+    auto popup = new XdgPopupV6{new_popup, this, XdgSurfaceV6::from(parent_surface), positioner, surface};
     set_window_role(popup);
 }
 
@@ -245,12 +250,19 @@ void mf::XdgSurfaceV6::set_window_role(WindowWlSurfaceRole* role)
 
 // XdgPopupV6
 
-mf::XdgPopupV6::XdgPopupV6(struct wl_client* client, struct wl_resource* resource_parent, uint32_t id,
-                           XdgSurfaceV6* xdg_surface, XdgSurfaceV6* parent_surface, struct wl_resource* positioner,
-                           WlSurface* surface)
-    : wayland::XdgPopupV6(client, resource_parent, id),
-      WindowWlSurfaceRole(&xdg_surface->xdg_shell.seat, client, surface, xdg_surface->xdg_shell.shell,
-                          xdg_surface->xdg_shell.output_manager),
+mf::XdgPopupV6::XdgPopupV6(
+    wl_resource* new_resource,
+    XdgSurfaceV6* xdg_surface,
+    XdgSurfaceV6* parent_surface,
+    wl_resource* positioner,
+    WlSurface* surface)
+    : wayland::XdgPopupV6(new_resource),
+      WindowWlSurfaceRole(
+          &xdg_surface->xdg_shell.seat,
+          wayland::XdgPopupV6::client,
+          surface,
+          xdg_surface->xdg_shell.shell,
+          xdg_surface->xdg_shell.output_manager),
       xdg_surface{xdg_surface}
 {
     auto specification = static_cast<mir::shell::SurfaceSpecification*>(
@@ -303,11 +315,14 @@ void mf::XdgPopupV6::handle_resize(const std::experimental::optional<geometry::P
 
 // XdgToplevelV6
 
-mf::XdgToplevelV6::XdgToplevelV6(struct wl_client* client, struct wl_resource* resource_parent, uint32_t id,
-                                 XdgSurfaceV6* xdg_surface, WlSurface* surface)
-    : wayland::XdgToplevelV6(client, resource_parent, id),
-      WindowWlSurfaceRole(&xdg_surface->xdg_shell.seat, client, surface, xdg_surface->xdg_shell.shell,
-                          xdg_surface->xdg_shell.output_manager),
+mf::XdgToplevelV6::XdgToplevelV6(struct wl_resource* new_resource, XdgSurfaceV6* xdg_surface, WlSurface* surface)
+    : wayland::XdgToplevelV6(new_resource),
+      WindowWlSurfaceRole(
+          &xdg_surface->xdg_shell.seat,
+          wayland::XdgToplevelV6::client,
+          surface,
+          xdg_surface->xdg_shell.shell,
+          xdg_surface->xdg_shell.output_manager),
       xdg_surface{xdg_surface}
 {
     wl_array states;
@@ -484,8 +499,8 @@ mf::XdgToplevelV6* mf::XdgToplevelV6::from(wl_resource* surface)
 
 // XdgPositionerV6
 
-mf::XdgPositionerV6::XdgPositionerV6(struct wl_client* client, struct wl_resource* parent, uint32_t id)
-    : wayland::XdgPositionerV6(client, parent, id)
+mf::XdgPositionerV6::XdgPositionerV6(wl_resource* new_resource)
+    : wayland::XdgPositionerV6(new_resource)
 {
     // specifying gravity is not required by the xdg shell protocol, but is by Mir window managers
     surface_placement_gravity = mir_placement_gravity_center;

--- a/src/server/frontend_wayland/xdg_shell_v6.h
+++ b/src/server/frontend_wayland/xdg_shell_v6.h
@@ -37,8 +37,8 @@ public:
     XdgShellV6(struct wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
 
     void destroy(struct wl_client* client, struct wl_resource* resource) override;
-    void create_positioner(struct wl_client* client, struct wl_resource* resource, uint32_t id) override;
-    void get_xdg_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id,
+    void create_positioner(struct wl_client* client, struct wl_resource* resource, wl_resource* new_positioner) override;
+    void get_xdg_surface(struct wl_client* client, struct wl_resource* resource, wl_resource* new_xdg_surface,
                          struct wl_resource* surface) override;
     void pong(struct wl_client* client, struct wl_resource* resource, uint32_t serial) override;
 

--- a/src/wayland/generated/wayland_wrapper.h
+++ b/src/wayland/generated/wayland_wrapper.h
@@ -26,7 +26,7 @@ public:
 
     static Callback* from(struct wl_resource*);
 
-    Callback(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    Callback(struct wl_resource* resource);
     virtual ~Callback() = default;
 
     void send_done_event(uint32_t callback_data) const;
@@ -67,8 +67,8 @@ public:
 private:
     virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
 
-    virtual void create_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id) = 0;
-    virtual void create_region(struct wl_client* client, struct wl_resource* resource, uint32_t id) = 0;
+    virtual void create_surface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
+    virtual void create_region(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
 };
 
 class ShmPool
@@ -79,7 +79,7 @@ public:
 
     static ShmPool* from(struct wl_resource*);
 
-    ShmPool(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    ShmPool(struct wl_resource* resource);
     virtual ~ShmPool() = default;
 
     void destroy_wayland_object() const;
@@ -92,7 +92,7 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void create_buffer(uint32_t id, int32_t offset, int32_t width, int32_t height, int32_t stride, uint32_t format) = 0;
+    virtual void create_buffer(struct wl_resource* id, int32_t offset, int32_t width, int32_t height, int32_t stride, uint32_t format) = 0;
     virtual void destroy() = 0;
     virtual void resize(int32_t size) = 0;
 };
@@ -194,7 +194,7 @@ public:
 private:
     virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
 
-    virtual void create_pool(struct wl_client* client, struct wl_resource* resource, uint32_t id, mir::Fd fd, int32_t size) = 0;
+    virtual void create_pool(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, mir::Fd fd, int32_t size) = 0;
 };
 
 class Buffer
@@ -205,7 +205,7 @@ public:
 
     static Buffer* from(struct wl_resource*);
 
-    Buffer(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    Buffer(struct wl_resource* resource);
     virtual ~Buffer() = default;
 
     void send_release_event() const;
@@ -236,7 +236,7 @@ public:
 
     static DataOffer* from(struct wl_resource*);
 
-    DataOffer(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    DataOffer(struct wl_resource* resource);
     virtual ~DataOffer() = default;
 
     void send_offer_event(std::string const& mime_type) const;
@@ -285,7 +285,7 @@ public:
 
     static DataSource* from(struct wl_resource*);
 
-    DataSource(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    DataSource(struct wl_resource* resource);
     virtual ~DataSource() = default;
 
     void send_target_event(std::experimental::optional<std::string> const& mime_type) const;
@@ -337,7 +337,7 @@ public:
 
     static DataDevice* from(struct wl_resource*);
 
-    DataDevice(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    DataDevice(struct wl_resource* resource);
     virtual ~DataDevice() = default;
 
     void send_data_offer_event(struct wl_resource* id) const;
@@ -406,8 +406,8 @@ public:
 private:
     virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
 
-    virtual void create_data_source(struct wl_client* client, struct wl_resource* resource, uint32_t id) = 0;
-    virtual void get_data_device(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* seat) = 0;
+    virtual void create_data_source(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
+    virtual void get_data_device(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* seat) = 0;
 };
 
 class Shell
@@ -436,7 +436,7 @@ public:
 private:
     virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
 
-    virtual void get_shell_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface) = 0;
+    virtual void get_shell_surface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* surface) = 0;
 };
 
 class ShellSurface
@@ -447,7 +447,7 @@ public:
 
     static ShellSurface* from(struct wl_resource*);
 
-    ShellSurface(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    ShellSurface(struct wl_resource* resource);
     virtual ~ShellSurface() = default;
 
     void send_ping_event(uint32_t serial) const;
@@ -517,7 +517,7 @@ public:
 
     static Surface* from(struct wl_resource*);
 
-    Surface(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    Surface(struct wl_resource* resource);
     virtual ~Surface() = default;
 
     void send_enter_event(struct wl_resource* output) const;
@@ -548,7 +548,7 @@ private:
     virtual void destroy() = 0;
     virtual void attach(std::experimental::optional<struct wl_resource*> const& buffer, int32_t x, int32_t y) = 0;
     virtual void damage(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
-    virtual void frame(uint32_t callback) = 0;
+    virtual void frame(struct wl_resource* callback) = 0;
     virtual void set_opaque_region(std::experimental::optional<struct wl_resource*> const& region) = 0;
     virtual void set_input_region(std::experimental::optional<struct wl_resource*> const& region) = 0;
     virtual void commit() = 0;
@@ -595,9 +595,9 @@ public:
 private:
     virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
 
-    virtual void get_pointer(struct wl_client* client, struct wl_resource* resource, uint32_t id) = 0;
-    virtual void get_keyboard(struct wl_client* client, struct wl_resource* resource, uint32_t id) = 0;
-    virtual void get_touch(struct wl_client* client, struct wl_resource* resource, uint32_t id) = 0;
+    virtual void get_pointer(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
+    virtual void get_keyboard(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
+    virtual void get_touch(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
     virtual void release(struct wl_client* client, struct wl_resource* resource) = 0;
 };
 
@@ -609,7 +609,7 @@ public:
 
     static Pointer* from(struct wl_resource*);
 
-    Pointer(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    Pointer(struct wl_resource* resource);
     virtual ~Pointer() = default;
 
     void send_enter_event(uint32_t serial, struct wl_resource* surface, double surface_x, double surface_y) const;
@@ -686,7 +686,7 @@ public:
 
     static Keyboard* from(struct wl_resource*);
 
-    Keyboard(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    Keyboard(struct wl_resource* resource);
     virtual ~Keyboard() = default;
 
     void send_keymap_event(uint32_t format, mir::Fd fd, uint32_t size) const;
@@ -740,7 +740,7 @@ public:
 
     static Touch* from(struct wl_resource*);
 
-    Touch(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    Touch(struct wl_resource* resource);
     virtual ~Touch() = default;
 
     void send_down_event(uint32_t serial, uint32_t time, struct wl_resource* surface, int32_t id, double x, double y) const;
@@ -852,7 +852,7 @@ public:
 
     static Region* from(struct wl_resource*);
 
-    Region(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    Region(struct wl_resource* resource);
     virtual ~Region() = default;
 
     void destroy_wayland_object() const;
@@ -897,7 +897,7 @@ private:
     virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
 
     virtual void destroy(struct wl_client* client, struct wl_resource* resource) = 0;
-    virtual void get_subsurface(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface, struct wl_resource* parent) = 0;
+    virtual void get_subsurface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* surface, struct wl_resource* parent) = 0;
 };
 
 class Subsurface
@@ -908,7 +908,7 @@ public:
 
     static Subsurface* from(struct wl_resource*);
 
-    Subsurface(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    Subsurface(struct wl_resource* resource);
     virtual ~Subsurface() = default;
 
     void destroy_wayland_object() const;

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
@@ -54,7 +54,7 @@ public:
 private:
     virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
 
-    virtual void get_layer_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface, std::experimental::optional<struct wl_resource*> const& output, uint32_t layer, std::string const& namespace_) = 0;
+    virtual void get_layer_surface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* surface, std::experimental::optional<struct wl_resource*> const& output, uint32_t layer, std::string const& namespace_) = 0;
 };
 
 class LayerSurfaceV1
@@ -65,7 +65,7 @@ public:
 
     static LayerSurfaceV1* from(struct wl_resource*);
 
-    LayerSurfaceV1(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    LayerSurfaceV1(struct wl_resource* resource);
     virtual ~LayerSurfaceV1() = default;
 
     void send_configure_event(uint32_t serial, uint32_t width, uint32_t height) const;

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
@@ -40,7 +40,7 @@ private:
     virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
 
     virtual void destroy(struct wl_client* client, struct wl_resource* resource) = 0;
-    virtual void get_xdg_output(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* output) = 0;
+    virtual void get_xdg_output(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* output) = 0;
 };
 
 class XdgOutputV1
@@ -51,7 +51,7 @@ public:
 
     static XdgOutputV1* from(struct wl_resource*);
 
-    XdgOutputV1(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    XdgOutputV1(struct wl_resource* resource);
     virtual ~XdgOutputV1() = default;
 
     void send_logical_position_event(int32_t x, int32_t y) const;

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
@@ -87,9 +87,16 @@ struct mw::XdgShellV6::Thunks
     static void create_positioner_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
         auto me = static_cast<XdgShellV6*>(wl_resource_get_user_data(resource));
+        wl_resource* id_resolved{
+            wl_resource_create(client, &zxdg_positioner_v6_interface_data, wl_resource_get_version(resource), id)};
+        if (id_resolved == nullptr)
+        {
+            wl_client_post_no_memory(client);
+            BOOST_THROW_EXCEPTION((std::bad_alloc{}));
+        }
         try
         {
-            me->create_positioner(client, resource, id);
+            me->create_positioner(client, resource, id_resolved);
         }
         catch(...)
         {
@@ -100,9 +107,16 @@ struct mw::XdgShellV6::Thunks
     static void get_xdg_surface_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface)
     {
         auto me = static_cast<XdgShellV6*>(wl_resource_get_user_data(resource));
+        wl_resource* id_resolved{
+            wl_resource_create(client, &zxdg_surface_v6_interface_data, wl_resource_get_version(resource), id)};
+        if (id_resolved == nullptr)
+        {
+            wl_client_post_no_memory(client);
+            BOOST_THROW_EXCEPTION((std::bad_alloc{}));
+        }
         try
         {
-            me->get_xdg_surface(client, resource, id, surface);
+            me->get_xdg_surface(client, resource, id_resolved, surface);
         }
         catch(...)
         {
@@ -126,8 +140,11 @@ struct mw::XdgShellV6::Thunks
     static void bind_thunk(struct wl_client* client, void* data, uint32_t version, uint32_t id)
     {
         auto me = static_cast<XdgShellV6*>(data);
-        auto resource = wl_resource_create(client, &zxdg_shell_v6_interface_data,
-                                           std::min(version, me->max_version), id);
+        auto resource = wl_resource_create(
+            client,
+            &zxdg_shell_v6_interface_data,
+            std::min(version, me->max_version),
+            id);
         if (resource == nullptr)
         {
             wl_client_post_no_memory(client);
@@ -307,13 +324,12 @@ struct mw::XdgPositionerV6::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgPositionerV6::XdgPositionerV6(struct wl_client* client, struct wl_resource* parent, uint32_t id)
-    : client{client},
-      resource{wl_resource_create(client, &zxdg_positioner_v6_interface_data, wl_resource_get_version(parent), id)}
+mw::XdgPositionerV6::XdgPositionerV6(struct wl_resource* resource)
+    : client{wl_resource_get_client(resource)},
+      resource{resource}
 {
     if (resource == nullptr)
     {
-        wl_resource_post_no_memory(parent);
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
@@ -372,9 +388,16 @@ struct mw::XdgSurfaceV6::Thunks
     static void get_toplevel_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
         auto me = static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
+        wl_resource* id_resolved{
+            wl_resource_create(client, &zxdg_toplevel_v6_interface_data, wl_resource_get_version(resource), id)};
+        if (id_resolved == nullptr)
+        {
+            wl_client_post_no_memory(client);
+            BOOST_THROW_EXCEPTION((std::bad_alloc{}));
+        }
         try
         {
-            me->get_toplevel(id);
+            me->get_toplevel(id_resolved);
         }
         catch(...)
         {
@@ -385,9 +408,16 @@ struct mw::XdgSurfaceV6::Thunks
     static void get_popup_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* parent, struct wl_resource* positioner)
     {
         auto me = static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
+        wl_resource* id_resolved{
+            wl_resource_create(client, &zxdg_popup_v6_interface_data, wl_resource_get_version(resource), id)};
+        if (id_resolved == nullptr)
+        {
+            wl_client_post_no_memory(client);
+            BOOST_THROW_EXCEPTION((std::bad_alloc{}));
+        }
         try
         {
-            me->get_popup(id, parent, positioner);
+            me->get_popup(id_resolved, parent, positioner);
         }
         catch(...)
         {
@@ -433,13 +463,12 @@ struct mw::XdgSurfaceV6::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgSurfaceV6::XdgSurfaceV6(struct wl_client* client, struct wl_resource* parent, uint32_t id)
-    : client{client},
-      resource{wl_resource_create(client, &zxdg_surface_v6_interface_data, wl_resource_get_version(parent), id)}
+mw::XdgSurfaceV6::XdgSurfaceV6(struct wl_resource* resource)
+    : client{wl_resource_get_client(resource)},
+      resource{resource}
 {
     if (resource == nullptr)
     {
-        wl_resource_post_no_memory(parent);
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
@@ -701,13 +730,12 @@ struct mw::XdgToplevelV6::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgToplevelV6::XdgToplevelV6(struct wl_client* client, struct wl_resource* parent, uint32_t id)
-    : client{client},
-      resource{wl_resource_create(client, &zxdg_toplevel_v6_interface_data, wl_resource_get_version(parent), id)}
+mw::XdgToplevelV6::XdgToplevelV6(struct wl_resource* resource)
+    : client{wl_resource_get_client(resource)},
+      resource{resource}
 {
     if (resource == nullptr)
     {
-        wl_resource_post_no_memory(parent);
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
@@ -836,13 +864,12 @@ struct mw::XdgPopupV6::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgPopupV6::XdgPopupV6(struct wl_client* client, struct wl_resource* parent, uint32_t id)
-    : client{client},
-      resource{wl_resource_create(client, &zxdg_popup_v6_interface_data, wl_resource_get_version(parent), id)}
+mw::XdgPopupV6::XdgPopupV6(struct wl_resource* resource)
+    : client{wl_resource_get_client(resource)},
+      resource{resource}
 {
     if (resource == nullptr)
     {
-        wl_resource_post_no_memory(parent);
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -57,8 +57,8 @@ private:
     virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
 
     virtual void destroy(struct wl_client* client, struct wl_resource* resource) = 0;
-    virtual void create_positioner(struct wl_client* client, struct wl_resource* resource, uint32_t id) = 0;
-    virtual void get_xdg_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface) = 0;
+    virtual void create_positioner(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
+    virtual void get_xdg_surface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* surface) = 0;
     virtual void pong(struct wl_client* client, struct wl_resource* resource, uint32_t serial) = 0;
 };
 
@@ -70,7 +70,7 @@ public:
 
     static XdgPositionerV6* from(struct wl_resource*);
 
-    XdgPositionerV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    XdgPositionerV6(struct wl_resource* resource);
     virtual ~XdgPositionerV6() = default;
 
     void destroy_wayland_object() const;
@@ -134,7 +134,7 @@ public:
 
     static XdgSurfaceV6* from(struct wl_resource*);
 
-    XdgSurfaceV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    XdgSurfaceV6(struct wl_resource* resource);
     virtual ~XdgSurfaceV6() = default;
 
     void send_configure_event(uint32_t serial) const;
@@ -162,8 +162,8 @@ public:
 
 private:
     virtual void destroy() = 0;
-    virtual void get_toplevel(uint32_t id) = 0;
-    virtual void get_popup(uint32_t id, struct wl_resource* parent, struct wl_resource* positioner) = 0;
+    virtual void get_toplevel(struct wl_resource* id) = 0;
+    virtual void get_popup(struct wl_resource* id, struct wl_resource* parent, struct wl_resource* positioner) = 0;
     virtual void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
     virtual void ack_configure(uint32_t serial) = 0;
 };
@@ -176,7 +176,7 @@ public:
 
     static XdgToplevelV6* from(struct wl_resource*);
 
-    XdgToplevelV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    XdgToplevelV6(struct wl_resource* resource);
     virtual ~XdgToplevelV6() = default;
 
     void send_configure_event(int32_t width, int32_t height, struct wl_array* states) const;
@@ -243,7 +243,7 @@ public:
 
     static XdgPopupV6* from(struct wl_resource*);
 
-    XdgPopupV6(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    XdgPopupV6(struct wl_resource* resource);
     virtual ~XdgPopupV6() = default;
 
     void send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const;

--- a/src/wayland/generated/xdg-shell_wrapper.h
+++ b/src/wayland/generated/xdg-shell_wrapper.h
@@ -57,8 +57,8 @@ private:
     virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
 
     virtual void destroy(struct wl_client* client, struct wl_resource* resource) = 0;
-    virtual void create_positioner(struct wl_client* client, struct wl_resource* resource, uint32_t id) = 0;
-    virtual void get_xdg_surface(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface) = 0;
+    virtual void create_positioner(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
+    virtual void get_xdg_surface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* surface) = 0;
     virtual void pong(struct wl_client* client, struct wl_resource* resource, uint32_t serial) = 0;
 };
 
@@ -70,7 +70,7 @@ public:
 
     static XdgPositioner* from(struct wl_resource*);
 
-    XdgPositioner(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    XdgPositioner(struct wl_resource* resource);
     virtual ~XdgPositioner() = default;
 
     void destroy_wayland_object() const;
@@ -142,7 +142,7 @@ public:
 
     static XdgSurface* from(struct wl_resource*);
 
-    XdgSurface(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    XdgSurface(struct wl_resource* resource);
     virtual ~XdgSurface() = default;
 
     void send_configure_event(uint32_t serial) const;
@@ -170,8 +170,8 @@ public:
 
 private:
     virtual void destroy() = 0;
-    virtual void get_toplevel(uint32_t id) = 0;
-    virtual void get_popup(uint32_t id, std::experimental::optional<struct wl_resource*> const& parent, struct wl_resource* positioner) = 0;
+    virtual void get_toplevel(struct wl_resource* id) = 0;
+    virtual void get_popup(struct wl_resource* id, std::experimental::optional<struct wl_resource*> const& parent, struct wl_resource* positioner) = 0;
     virtual void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
     virtual void ack_configure(uint32_t serial) = 0;
 };
@@ -184,7 +184,7 @@ public:
 
     static XdgToplevel* from(struct wl_resource*);
 
-    XdgToplevel(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    XdgToplevel(struct wl_resource* resource);
     virtual ~XdgToplevel() = default;
 
     void send_configure_event(int32_t width, int32_t height, struct wl_array* states) const;
@@ -251,7 +251,7 @@ public:
 
     static XdgPopup* from(struct wl_resource*);
 
-    XdgPopup(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    XdgPopup(struct wl_resource* resource);
     virtual ~XdgPopup() = default;
 
     void send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const;

--- a/src/wayland/generator/argument.cpp
+++ b/src/wayland/generator/argument.cpp
@@ -36,6 +36,21 @@ Emitter fd_mir2wl(Argument const* me)
     return Line{"int32_t ", me->name, "_resolved{", me->name, "};"};
 }
 
+Emitter new_id_wl2mir(Argument const* me)
+{
+    return Lines{
+        {"wl_resource* ", me->name, "_resolved{"},
+        {Emitter::layout({
+            "wl_resource_create(client, ", me->object_type_fragment(), ", wl_resource_get_version(resource), ", me->name, ")"
+        }, true, false, Emitter::single_indent), "};"},
+        {"if (", me->name, "_resolved == nullptr)"},
+        Block{
+            "wl_client_post_no_memory(client);",
+            "BOOST_THROW_EXCEPTION((std::bad_alloc{}));",
+        }
+    };
+}
+
 Emitter fixed_wl2mir(Argument const* me)
 {
     return Line{"double ", me->name, "_resolved{wl_fixed_to_double(", me->name, ")};"};
@@ -103,7 +118,7 @@ std::unordered_map<std::string, Argument::TypeDescriptor const> const request_ty
     { "fd", { "mir::Fd", "int32_t", "h", { fd_wl2mir } }},
     { "object", { "struct wl_resource*", "struct wl_resource*", "o", {} }},
     { "string", { "std::string const&", "char const*", "s", {} }},
-    { "new_id", { "uint32_t", "uint32_t", "n", {} }},
+    { "new_id", { "struct wl_resource*", "uint32_t", "n", {new_id_wl2mir} }},
     { "fixed", { "double", "wl_fixed_t", "f", { fixed_wl2mir } }},
     { "array", { "struct wl_array*", "struct wl_array*", "a", {} }}
 };

--- a/src/wayland/generator/argument.h
+++ b/src/wayland/generator/argument.h
@@ -39,7 +39,7 @@ public:
         std::string mir_type;
         std::string wl_type;
         std::string wl_type_abbr; // abbreviated type (i for int, etc), used by libwayland
-        std::experimental::optional<std::function<Emitter(std::string)>> converter;
+        std::experimental::optional<std::function<Emitter(Argument const*)>> converter;
     };
 
     Argument(xmlpp::Element const& node, bool is_event);
@@ -53,13 +53,13 @@ public:
 
     void populate_required_interfaces(std::set<std::string>& interfaces) const; // fills the set with interfaces used
 
+    std::string const name;
+    std::experimental::optional<std::string> const interface;
 private:
     static TypeDescriptor get_type(xmlpp::Element const& node, bool is_event);
     static std::experimental::optional<std::string> get_interface(xmlpp::Element const& node);
 
-    std::string const name;
     TypeDescriptor descriptor;
-    std::experimental::optional<std::string> const interface;
 };
 
 #endif // MIR_WAYLAND_GENERATOR_ARGUMENT_H

--- a/tests/miral/generated/server-decoration_wrapper.h
+++ b/tests/miral/generated/server-decoration_wrapper.h
@@ -53,7 +53,7 @@ public:
 private:
     virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
 
-    virtual void create(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface) = 0;
+    virtual void create(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* surface) = 0;
 };
 
 class ServerDecoration
@@ -64,7 +64,7 @@ public:
 
     static ServerDecoration* from(struct wl_resource*);
 
-    ServerDecoration(struct wl_client* client, struct wl_resource* parent, uint32_t id);
+    ServerDecoration(struct wl_resource* resource);
     virtual ~ServerDecoration() = default;
 
     void send_mode_event(uint32_t mode) const;

--- a/tests/miral/server_example_decoration.cpp
+++ b/tests/miral/server_example_decoration.cpp
@@ -26,8 +26,8 @@ namespace
 struct ServerDecoration :
     mir::wayland::ServerDecoration
 {
-    ServerDecoration(struct wl_client *client, struct wl_resource *parent, uint32_t id) :
-        mir::wayland::ServerDecoration::ServerDecoration(client, parent, id)
+    ServerDecoration(wl_resource* new_resource) :
+        mir::wayland::ServerDecoration::ServerDecoration(new_resource)
     {
         send_mode_event(decoration_mode);
     }
@@ -63,9 +63,9 @@ struct ServerDecorationManager : mir::wayland::ServerDecorationManager
     {
     };
 
-    void create(wl_client* client, wl_resource* resource, uint32_t id, wl_resource* surface) override
+    void create(wl_client* client, wl_resource* /*resource*/, wl_resource* new_resource, wl_resource* surface) override
     {
-        new ServerDecoration{client, resource, id};
+        new ServerDecoration{new_resource};
         callback(client, surface);
     }
 


### PR DESCRIPTION
On top of #739 and #804

Instead of passing a client, a parent resource and an ID, create the `wl_resource` in the thunk that first gets the new ID, and then just pass around that `wl_resource*`.

The first step to dealing with #801. Next up: fix globals