### PR TITLE
Add Z-index property to Mir surfaces

### DIFF
--- a/include/server/mir/scene/null_surface_observer.h
+++ b/include/server/mir/scene/null_surface_observer.h
@@ -54,6 +54,7 @@ public:
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
     void input_consumed(Surface const* surf, MirEvent const* event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
+    void z_index_set_to(Surface const* surf, int z_index) override;
 
 protected:
     NullSurfaceObserver(NullSurfaceObserver const&) = delete;

--- a/include/server/mir/scene/surface.h
+++ b/include/server/mir/scene/surface.h
@@ -116,6 +116,9 @@ public:
 
     virtual void placed_relative(geometry::Rectangle const& placement) = 0;
     virtual void start_drag_and_drop(std::vector<uint8_t> const& handle) = 0;
+
+    virtual int z_index() = 0;
+    virtual void set_z_index(int z_index) = 0;
 };
 }
 }

--- a/include/server/mir/scene/surface_creation_parameters.h
+++ b/include/server/mir/scene/surface_creation_parameters.h
@@ -111,6 +111,8 @@ struct SurfaceCreationParameters
     mir::optional_value<MirShellChrome> shell_chrome;
     mir::optional_value<std::vector<shell::StreamSpecification>> streams;
     mir::optional_value<MirPointerConfinementState> confine_pointer;
+
+    optional_value<int> z_index;
 };
 
 bool operator==(const SurfaceCreationParameters& lhs, const SurfaceCreationParameters& rhs);

--- a/include/server/mir/scene/surface_observer.h
+++ b/include/server/mir/scene/surface_observer.h
@@ -71,6 +71,7 @@ public:
     virtual void placed_relative(Surface const* surf, geometry::Rectangle const& placement) = 0;
     virtual void input_consumed(Surface const* surf, MirEvent const* event) = 0;
     virtual void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) = 0;
+    virtual void z_index_set_to(Surface const* surf, int z_index) = 0;
 
 protected:
     SurfaceObserver() = default;

--- a/include/server/mir/shell/surface_specification.h
+++ b/include/server/mir/shell/surface_specification.h
@@ -98,7 +98,9 @@ struct SurfaceSpecification
     optional_value<MirShellChrome> shell_chrome;
     optional_value<MirPointerConfinementState> confine_pointer;
     optional_value<std::shared_ptr<graphics::CursorImage>> cursor_image;
-    optional_value<StreamCursor> stream_cursor; 
+    optional_value<StreamCursor> stream_cursor;
+
+    optional_value<int> z_index;
 };
 }
 }

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -70,6 +70,8 @@ struct StubSurface : scene::Surface
     MirPointerConfinementState confine_pointer_state() const override;
     void placed_relative(geometry::Rectangle const& placement) override;
     void start_drag_and_drop(std::vector<uint8_t> const& handle) override;
+    int z_index() override;
+    void set_z_index(int z_index) override;
 };
 }
 }

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -57,6 +57,7 @@ public:
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
     void input_consumed(Surface const* surf, MirEvent const* event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
+    void z_index_set_to(Surface const* surf, int z_index) override;
 };
 
 }

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -158,6 +158,10 @@ struct InputDispatcherSceneObserver :
     {
     }
 
+    void z_index_set_to(ms::Surface const*, int) override
+    {
+    }
+
     std::function<void(ms::Surface*)> const on_removed;
     std::function<void(ms::Surface const*)> const on_surface_moved;
     std::function<void()> const on_surface_resized;

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -162,6 +162,8 @@ mf::SurfaceId ms::ApplicationSession::create_surface(
         surface->configure(mir_window_attrib_preferred_orientation, params.preferred_orientation.value());
     if (params.input_shape.is_set())
         surface->set_input_region(params.input_shape.value());
+    if (params.z_index.is_set())
+        surface->set_z_index(params.z_index.value());
 
     return id;
 }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -153,6 +153,11 @@ void ms::SurfaceObservers::start_drag_and_drop(Surface const* surf, std::vector<
                  { observer->start_drag_and_drop(surf, handle); });
 }
 
+void ms::SurfaceObservers::z_index_set_to(Surface const* surf, int z_index)
+{
+    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
+                 { observer->z_index_set_to(surf, z_index); });
+}
 
 struct ms::CursorStreamImageAdapter
 {
@@ -937,4 +942,5 @@ void mir::scene::BasicSurface::set_z_index(int const z_index)
         std::unique_lock<std::mutex> lg(guard);
         z_index_ = z_index;
     }
+    observers.z_index_set_to(this, z_index);
 }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -924,3 +924,17 @@ void mir::scene::BasicSurface::start_drag_and_drop(std::vector<uint8_t> const& h
 {
     observers.start_drag_and_drop(this, handle);
 }
+
+int mir::scene::BasicSurface::z_index()
+{
+    std::unique_lock<std::mutex> lg(guard);
+    return z_index_;
+}
+
+void mir::scene::BasicSurface::set_z_index(int const z_index)
+{
+    {
+        std::unique_lock<std::mutex> lg(guard);
+        z_index_ = z_index;
+    }
+}

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -142,6 +142,9 @@ public:
     void placed_relative(geometry::Rectangle const& placement) override;
     void start_drag_and_drop(std::vector<uint8_t> const& handle) override;
 
+    int z_index() override;
+    void set_z_index(int z_index) override;
+
 private:
     bool visible(std::unique_lock<std::mutex>&) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
@@ -178,6 +181,8 @@ private:
     MirPointerConfinementState confine_pointer_state_ = mir_pointer_unconfined;
 
     std::unique_ptr<CursorStreamImageAdapter> const cursor_stream_adapter;
+
+    int z_index_ = 0;
 };
 
 }

--- a/src/server/scene/legacy_surface_change_notification.cpp
+++ b/src/server/scene/legacy_surface_change_notification.cpp
@@ -113,3 +113,7 @@ void ms::LegacySurfaceChangeNotification::input_consumed(Surface const*, MirEven
 void ms::LegacySurfaceChangeNotification::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&)
 {
 }
+
+void ms::LegacySurfaceChangeNotification::z_index_set_to(Surface const*, int)
+{
+}

--- a/src/server/scene/legacy_surface_change_notification.h
+++ b/src/server/scene/legacy_surface_change_notification.h
@@ -57,6 +57,7 @@ public:
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
     void input_consumed(Surface const* surf, MirEvent const* event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
+    void z_index_set_to(Surface const* surf, int z_index) override;
 
 private:
     std::function<void()> const notify_scene_change;

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -44,3 +44,4 @@ void ms::NullSurfaceObserver::cursor_image_removed(Surface const*) {}
 void ms::NullSurfaceObserver::placed_relative(Surface const*, geometry::Rectangle const&) {}
 void ms::NullSurfaceObserver::input_consumed(Surface const*, MirEvent const*) {}
 void ms::NullSurfaceObserver::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&) {}
+void ms::NullSurfaceObserver::z_index_set_to(Surface const*, int) {}

--- a/src/server/scene/surface_creation_parameters.cpp
+++ b/src/server/scene/surface_creation_parameters.cpp
@@ -196,6 +196,8 @@ void ms::SurfaceCreationParameters::update_from(msh::SurfaceSpecification const&
         shell_chrome = that.shell_chrome;
     if (that.confine_pointer.is_set())
         confine_pointer = that.confine_pointer;
+    if (that.z_index.is_set())
+        z_index = that.z_index;
     // TODO: should SurfaceCreationParameters support cursors?
 //     if (that.cursor_image.is_set())
 //         cursor_image = that.cursor_image;

--- a/src/server/scene/surface_stack.h
+++ b/src/server/scene/surface_stack.h
@@ -27,6 +27,7 @@
 #include "mir/recursive_read_write_mutex.h"
 
 #include "mir/basic_observers.h"
+#include "mir/scene/surface_observer.h"
 
 #include <atomic>
 #include <map>
@@ -69,7 +70,7 @@ class SurfaceStack : public compositor::Scene, public input::Scene, public shell
 public:
     explicit SurfaceStack(
         std::shared_ptr<SceneReport> const& report);
-    virtual ~SurfaceStack() noexcept(true) {}
+    virtual ~SurfaceStack() noexcept(true);
 
     // From Scene
     compositor::SceneElementSequence scene_elements_for(compositor::CompositorID id) override;
@@ -82,23 +83,23 @@ public:
 
     virtual void remove_surface(std::weak_ptr<Surface> const& surface) override;
 
+    void raise(Surface const* surface);
     virtual void raise(std::weak_ptr<Surface> const& surface) override;
-
     void raise(SurfaceSet const& surfaces) override;
 
     void add_surface(
         std::shared_ptr<Surface> const& surface,
         input::InputReceptionMode input_mode) override;
-    
+
     auto surface_at(geometry::Point) const -> std::shared_ptr<Surface> override;
 
     void add_observer(std::shared_ptr<Observer> const& observer) override;
     void remove_observer(std::weak_ptr<Observer> const& observer) override;
-    
+
     // Intended for input overlays, as described in mir::input::Scene documentation.
     void add_input_visualization(std::shared_ptr<graphics::Renderable> const& overlay) override;
     void remove_input_visualization(std::weak_ptr<graphics::Renderable> const& overlay) override;
-    
+
     void emit_scene_changed() override;
 
 private:
@@ -106,6 +107,7 @@ private:
     SurfaceStack& operator=(const SurfaceStack&) = delete;
     void create_rendering_tracker_for(std::shared_ptr<Surface> const&);
     void update_rendering_tracker_compositors();
+    void insert_surface_at_top_of_z_layer(std::shared_ptr<Surface> const& surface);
 
     RecursiveReadWriteMutex mutable guard;
 
@@ -119,6 +121,7 @@ private:
 
     Observers observers;
     std::atomic<bool> scene_changed;
+    std::shared_ptr<SurfaceObserver> surface_observer;
 };
 
 }

--- a/src/server/shell/surface_specification.cpp
+++ b/src/server/shell/surface_specification.cpp
@@ -47,7 +47,8 @@ bool msh::SurfaceSpecification::is_empty() const
         !streams.is_set() &&
         !parent.is_set() &&
         !input_shape.is_set() &&
-        !shell_chrome.is_set();
+        !shell_chrome.is_set() &&
+        !z_index.is_set();
 }
 
 void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
@@ -116,4 +117,6 @@ void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
         cursor_image = that.cursor_image;
     if (that.stream_cursor.is_set())
         stream_cursor = that.stream_cursor;
+    if (that.z_index.is_set())
+        z_index = that.z_index;
 }

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -958,5 +958,7 @@ MIR_SERVER_1.2 {
     mir::DefaultServerConfiguration::set_wayland_extension_filter*;
     mir::frontend::get_session*;
     mir::frontend::get_window*;
+    mir::scene::NullSurfaceObserver::z_index_set_to*;
+    non-virtual?thunk?to?mir::scene::NullSurfaceObserver::z_index_set_to*;
   };
 } MIR_SERVER_0.32;

--- a/tests/acceptance-tests/test_client_cursor_api.cpp
+++ b/tests/acceptance-tests/test_client_cursor_api.cpp
@@ -87,6 +87,7 @@ public:
     MOCK_METHOD2(placed_relative, void(msc::Surface const*, geom::Rectangle const& placement));
     MOCK_METHOD2(input_consumed, void(msc::Surface const*, MirEvent const*));
     MOCK_METHOD2(start_drag_and_drop, void(msc::Surface const*, std::vector<uint8_t> const& handle));
+    MOCK_METHOD2(z_index_set_to, void(msc::Surface const*, int z_index));
 };
 
 

--- a/tests/include/mir/test/doubles/stub_scene_surface.h
+++ b/tests/include/mir/test/doubles/stub_scene_surface.h
@@ -94,6 +94,9 @@ public:
     MirPointerConfinementState confine_pointer_state() const override { return {}; }
     void placed_relative(geometry::Rectangle const& /*placement*/) override {}
     void start_drag_and_drop(std::vector<uint8_t> const& /*handle*/) override {}
+
+    int z_index() override { return 0; }
+    void set_z_index(int /*z_index*/) override {}
 };
 
 }

--- a/tests/mir_test_framework/stub_surface.cpp
+++ b/tests/mir_test_framework/stub_surface.cpp
@@ -197,6 +197,15 @@ void mtd::StubSurface::start_drag_and_drop(std::vector<uint8_t> const& /*handle*
 {
 }
 
+int mtd::StubSurface::z_index()
+{
+    return 0;
+}
+
+void mtd::StubSurface::set_z_index(int /*z_index*/)
+{
+}
+
 namespace
 {
 // Ensure we don't accidentally have an abstract class


### PR DESCRIPTION
Surfaces with higher Z-indices will always appear above surfaces with lower ones. This is useful in implementing Layer Shell, but may have other applications as well. All the interesting logic changes are in `surface_stack.cpp`.