### PR TITLE
Fix generated globals

### DIFF
--- a/src/server/frontend_wayland/data_device.h
+++ b/src/server/frontend_wayland/data_device.h
@@ -25,10 +25,10 @@ namespace mir
 {
 namespace frontend
 {
-class DataDeviceManager : public wayland::DataDeviceManager
+class DataDeviceManager : public wayland::DataDeviceManager::Global
 {
 public:
-    using wayland::DataDeviceManager::DataDeviceManager;
+    using wayland::DataDeviceManager::Global::Global;
 };
 
 auto create_data_device_manager(struct wl_display* display) -> std::unique_ptr<DataDeviceManager>;

--- a/src/server/frontend_wayland/layer_shell_v1.h
+++ b/src/server/frontend_wayland/layer_shell_v1.h
@@ -30,23 +30,18 @@ class Shell;
 class WlSeat;
 class OutputManager;
 
-class LayerShellV1 : public wayland::LayerShellV1
+class LayerShellV1 : public wayland::LayerShellV1::Global
 {
 public:
     LayerShellV1(wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
 
-    void get_layer_surface(
-        wl_client* client,
-        wl_resource* resource,
-        wl_resource* new_layer_surface,
-        wl_resource* surface,
-        std::experimental::optional<wl_resource*> const& output,
-        uint32_t layer,
-        std::string const& namespace_) override;
-
     std::shared_ptr<Shell> const shell;
     WlSeat& seat;
     OutputManager* const output_manager;
+
+private:
+    class Instance;
+    void bind(wl_resource* new_resource);
 };
 
 }

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -47,7 +47,7 @@ class WlPointer;
 class WlKeyboard;
 class WlTouch;
 
-class WlSeat : public wayland::Seat
+class WlSeat : public wayland::Seat::Global
 {
 public:
     WlSeat(
@@ -88,6 +88,7 @@ private:
     class ListenerList;
 
     class ConfigObserver;
+    class Instance;
 
     std::unique_ptr<mir::input::Keymap> const keymap;
     std::shared_ptr<ConfigObserver> const config_observer;
@@ -102,11 +103,8 @@ private:
 
     std::shared_ptr<mir::Executor> const executor;
 
-    void bind(wl_client* client, wl_resource* resource) override;
-    void get_pointer(wl_client* client, wl_resource* resource, wl_resource* new_pointer) override;
-    void get_keyboard(wl_client* client, wl_resource* resource, wl_resource* new_keyboard) override;
-    void get_touch(wl_client* client, wl_resource* resource, wl_resource* new_touch) override;
-    void release(struct wl_client* /*client*/, struct wl_resource* us) override;
+    void bind(wl_resource* new_wl_seat) override;
+
 };
 }
 }

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -26,18 +26,43 @@
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
 
-mf::WlSubcompositor::WlSubcompositor(struct wl_display* display)
-    : wayland::Subcompositor(display, 1)
-{}
-
-void mf::WlSubcompositor::destroy(struct wl_client* /*client*/, struct wl_resource* resource)
+namespace mir
 {
-    destroy_wayland_object(resource);
+namespace frontend
+{
+class WlSubcompositorInstance: wayland::Subcompositor
+{
+public:
+    WlSubcompositorInstance(wl_resource* new_resource);
+
+private:
+    void destroy() override;
+    void get_subsurface(wl_resource* new_subsurface, wl_resource* surface, wl_resource* parent) override;
+};
+}
 }
 
-void mf::WlSubcompositor::get_subsurface(
-    wl_client* /*client*/,
-    wl_resource* /*resource*/,
+mf::WlSubcompositor::WlSubcompositor(wl_display* display)
+    : Global{display, 1}
+{
+}
+
+void mf::WlSubcompositor::bind(wl_resource* new_wl_subcompositor)
+{
+    new WlSubcompositorInstance(new_wl_subcompositor);
+}
+
+mf::WlSubcompositorInstance::WlSubcompositorInstance(wl_resource* new_resource)
+    : wayland::Subcompositor(new_resource)
+{
+}
+
+void mf::WlSubcompositorInstance::destroy()
+{
+    destroy_wayland_object();
+}
+
+void mf::WlSubcompositorInstance::get_subsurface(
     wl_resource* new_subsurface,
     wl_resource* surface,
     wl_resource* parent)

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -37,16 +37,15 @@ namespace frontend
 {
 
 class WlSurface;
+class WlSubcompositorInstance;
 
-class WlSubcompositor: wayland::Subcompositor
+class WlSubcompositor : wayland::Subcompositor::Global
 {
 public:
-    WlSubcompositor(struct wl_display* display);
+    WlSubcompositor(wl_display* display);
 
 private:
-    void destroy(struct wl_client* client, struct wl_resource* resource) override;
-    void get_subsurface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* new_subsurface,
-                        struct wl_resource* surface, struct wl_resource* parent) override;
+    void bind(wl_resource* new_wl_subcompositor);
 };
 
 class WlSubsurface: public WlSurfaceRole, wayland::Subsurface

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -31,21 +31,19 @@ class Surface;
 class WlSeat;
 class OutputManager;
 
-class XdgShellStable : public wayland::XdgWmBase
+class XdgShellStable : public wayland::XdgWmBase::Global
 {
 public:
-    XdgShellStable(struct wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
-
-    void destroy(struct wl_client* client, struct wl_resource* resource) override;
-    void create_positioner(struct wl_client* client, struct wl_resource* resource, wl_resource* new_positioner) override;
-    void get_xdg_surface(struct wl_client* client, struct wl_resource* resource, wl_resource* new_xdg_surface,
-                         struct wl_resource* surface) override;
-    void pong(struct wl_client* client, struct wl_resource* resource, uint32_t serial) override;
+    XdgShellStable(wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
 
     static auto get_window(wl_resource* surface) -> std::shared_ptr<Surface>;
     std::shared_ptr<Shell> const shell;
     WlSeat& seat;
     OutputManager* const output_manager;
+
+private:
+    class Instance;
+    void bind(wl_resource* new_resource) override;
 };
 
 }

--- a/src/server/frontend_wayland/xdg_shell_v6.h
+++ b/src/server/frontend_wayland/xdg_shell_v6.h
@@ -31,16 +31,10 @@ class Surface;
 class WlSeat;
 class OutputManager;
 
-class XdgShellV6 : public wayland::XdgShellV6
+class XdgShellV6 : public wayland::XdgShellV6::Global
 {
 public:
-    XdgShellV6(struct wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
-
-    void destroy(struct wl_client* client, struct wl_resource* resource) override;
-    void create_positioner(struct wl_client* client, struct wl_resource* resource, wl_resource* new_positioner) override;
-    void get_xdg_surface(struct wl_client* client, struct wl_resource* resource, wl_resource* new_xdg_surface,
-                         struct wl_resource* surface) override;
-    void pong(struct wl_client* client, struct wl_resource* resource, uint32_t serial) override;
+    XdgShellV6(wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
 
     std::shared_ptr<Shell> const shell;
     WlSeat& seat;
@@ -48,6 +42,10 @@ public:
 
     // Returns the Mir surface if the window is recognised by XdgShellV6
     static auto get_window(wl_resource* surface) -> std::shared_ptr<Surface>;
+
+private:
+    class Instance;
+    void bind(wl_resource* new_resource) override;
 };
 
 }

--- a/src/wayland/generated/wayland_wrapper.h
+++ b/src/wayland/generated/wayland_wrapper.h
@@ -43,6 +43,8 @@ public:
 
     struct Thunks;
 
+    static bool is_instance(wl_resource* resource);
+
 private:
 };
 
@@ -54,21 +56,35 @@ public:
 
     static Compositor* from(struct wl_resource*);
 
-    Compositor(struct wl_display* display, uint32_t max_version);
-    virtual ~Compositor();
+    Compositor(struct wl_resource* resource);
+    virtual ~Compositor() = default;
 
-    void destroy_wayland_object(struct wl_resource* resource) const;
+    void destroy_wayland_object() const;
 
-    struct wl_global* const global;
-    uint32_t const max_version;
+    struct wl_client* const client;
+    struct wl_resource* const resource;
 
     struct Thunks;
 
-private:
-    virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
+    static bool is_instance(wl_resource* resource);
 
-    virtual void create_surface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
-    virtual void create_region(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
+    class Global
+    {
+    public:
+        Global(wl_display* display, uint32_t max_version);
+        virtual ~Global();
+
+        wl_global* const global;
+        uint32_t const max_version;
+
+    private:
+        virtual void bind(wl_resource* new_wl_compositor) = 0;
+        friend Compositor::Thunks;
+    };
+
+private:
+    virtual void create_surface(struct wl_resource* id) = 0;
+    virtual void create_region(struct wl_resource* id) = 0;
 };
 
 class ShmPool
@@ -105,15 +121,15 @@ public:
 
     static Shm* from(struct wl_resource*);
 
-    Shm(struct wl_display* display, uint32_t max_version);
-    virtual ~Shm();
+    Shm(struct wl_resource* resource);
+    virtual ~Shm() = default;
 
-    void send_format_event(struct wl_resource* resource, uint32_t format) const;
+    void send_format_event(uint32_t format) const;
 
-    void destroy_wayland_object(struct wl_resource* resource) const;
+    void destroy_wayland_object() const;
 
-    struct wl_global* const global;
-    uint32_t const max_version;
+    struct wl_client* const client;
+    struct wl_resource* const resource;
 
     struct Error
     {
@@ -191,10 +207,24 @@ public:
 
     struct Thunks;
 
-private:
-    virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
+    static bool is_instance(wl_resource* resource);
 
-    virtual void create_pool(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, mir::Fd fd, int32_t size) = 0;
+    class Global
+    {
+    public:
+        Global(wl_display* display, uint32_t max_version);
+        virtual ~Global();
+
+        wl_global* const global;
+        uint32_t const max_version;
+
+    private:
+        virtual void bind(wl_resource* new_wl_shm) = 0;
+        friend Shm::Thunks;
+    };
+
+private:
+    virtual void create_pool(struct wl_resource* id, mir::Fd fd, int32_t size) = 0;
 };
 
 class Buffer
@@ -385,13 +415,13 @@ public:
 
     static DataDeviceManager* from(struct wl_resource*);
 
-    DataDeviceManager(struct wl_display* display, uint32_t max_version);
-    virtual ~DataDeviceManager();
+    DataDeviceManager(struct wl_resource* resource);
+    virtual ~DataDeviceManager() = default;
 
-    void destroy_wayland_object(struct wl_resource* resource) const;
+    void destroy_wayland_object() const;
 
-    struct wl_global* const global;
-    uint32_t const max_version;
+    struct wl_client* const client;
+    struct wl_resource* const resource;
 
     struct DndAction
     {
@@ -403,11 +433,25 @@ public:
 
     struct Thunks;
 
-private:
-    virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
+    static bool is_instance(wl_resource* resource);
 
-    virtual void create_data_source(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
-    virtual void get_data_device(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* seat) = 0;
+    class Global
+    {
+    public:
+        Global(wl_display* display, uint32_t max_version);
+        virtual ~Global();
+
+        wl_global* const global;
+        uint32_t const max_version;
+
+    private:
+        virtual void bind(wl_resource* new_wl_data_device_manager) = 0;
+        friend DataDeviceManager::Thunks;
+    };
+
+private:
+    virtual void create_data_source(struct wl_resource* id) = 0;
+    virtual void get_data_device(struct wl_resource* id, struct wl_resource* seat) = 0;
 };
 
 class Shell
@@ -418,13 +462,13 @@ public:
 
     static Shell* from(struct wl_resource*);
 
-    Shell(struct wl_display* display, uint32_t max_version);
-    virtual ~Shell();
+    Shell(struct wl_resource* resource);
+    virtual ~Shell() = default;
 
-    void destroy_wayland_object(struct wl_resource* resource) const;
+    void destroy_wayland_object() const;
 
-    struct wl_global* const global;
-    uint32_t const max_version;
+    struct wl_client* const client;
+    struct wl_resource* const resource;
 
     struct Error
     {
@@ -433,10 +477,24 @@ public:
 
     struct Thunks;
 
-private:
-    virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
+    static bool is_instance(wl_resource* resource);
 
-    virtual void get_shell_surface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* surface) = 0;
+    class Global
+    {
+    public:
+        Global(wl_display* display, uint32_t max_version);
+        virtual ~Global();
+
+        wl_global* const global;
+        uint32_t const max_version;
+
+    private:
+        virtual void bind(wl_resource* new_wl_shell) = 0;
+        friend Shell::Thunks;
+    };
+
+private:
+    virtual void get_shell_surface(struct wl_resource* id, struct wl_resource* surface) = 0;
 };
 
 class ShellSurface
@@ -565,17 +623,17 @@ public:
 
     static Seat* from(struct wl_resource*);
 
-    Seat(struct wl_display* display, uint32_t max_version);
-    virtual ~Seat();
+    Seat(struct wl_resource* resource);
+    virtual ~Seat() = default;
 
-    void send_capabilities_event(struct wl_resource* resource, uint32_t capabilities) const;
-    bool version_supports_name(struct wl_resource* resource);
-    void send_name_event(struct wl_resource* resource, std::string const& name) const;
+    void send_capabilities_event(uint32_t capabilities) const;
+    bool version_supports_name();
+    void send_name_event(std::string const& name) const;
 
-    void destroy_wayland_object(struct wl_resource* resource) const;
+    void destroy_wayland_object() const;
 
-    struct wl_global* const global;
-    uint32_t const max_version;
+    struct wl_client* const client;
+    struct wl_resource* const resource;
 
     struct Capability
     {
@@ -592,13 +650,27 @@ public:
 
     struct Thunks;
 
-private:
-    virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
+    static bool is_instance(wl_resource* resource);
 
-    virtual void get_pointer(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
-    virtual void get_keyboard(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
-    virtual void get_touch(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
-    virtual void release(struct wl_client* client, struct wl_resource* resource) = 0;
+    class Global
+    {
+    public:
+        Global(wl_display* display, uint32_t max_version);
+        virtual ~Global();
+
+        wl_global* const global;
+        uint32_t const max_version;
+
+    private:
+        virtual void bind(wl_resource* new_wl_seat) = 0;
+        friend Seat::Thunks;
+    };
+
+private:
+    virtual void get_pointer(struct wl_resource* id) = 0;
+    virtual void get_keyboard(struct wl_resource* id) = 0;
+    virtual void get_touch(struct wl_resource* id) = 0;
+    virtual void release() = 0;
 };
 
 class Pointer
@@ -785,20 +857,20 @@ public:
 
     static Output* from(struct wl_resource*);
 
-    Output(struct wl_display* display, uint32_t max_version);
-    virtual ~Output();
+    Output(struct wl_resource* resource);
+    virtual ~Output() = default;
 
-    void send_geometry_event(struct wl_resource* resource, int32_t x, int32_t y, int32_t physical_width, int32_t physical_height, int32_t subpixel, std::string const& make, std::string const& model, int32_t transform) const;
-    void send_mode_event(struct wl_resource* resource, uint32_t flags, int32_t width, int32_t height, int32_t refresh) const;
-    bool version_supports_done(struct wl_resource* resource);
-    void send_done_event(struct wl_resource* resource) const;
-    bool version_supports_scale(struct wl_resource* resource);
-    void send_scale_event(struct wl_resource* resource, int32_t factor) const;
+    void send_geometry_event(int32_t x, int32_t y, int32_t physical_width, int32_t physical_height, int32_t subpixel, std::string const& make, std::string const& model, int32_t transform) const;
+    void send_mode_event(uint32_t flags, int32_t width, int32_t height, int32_t refresh) const;
+    bool version_supports_done();
+    void send_done_event() const;
+    bool version_supports_scale();
+    void send_scale_event(int32_t factor) const;
 
-    void destroy_wayland_object(struct wl_resource* resource) const;
+    void destroy_wayland_object() const;
 
-    struct wl_global* const global;
-    uint32_t const max_version;
+    struct wl_client* const client;
+    struct wl_resource* const resource;
 
     struct Subpixel
     {
@@ -838,10 +910,24 @@ public:
 
     struct Thunks;
 
-private:
-    virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
+    static bool is_instance(wl_resource* resource);
 
-    virtual void release(struct wl_client* client, struct wl_resource* resource) = 0;
+    class Global
+    {
+    public:
+        Global(wl_display* display, uint32_t max_version);
+        virtual ~Global();
+
+        wl_global* const global;
+        uint32_t const max_version;
+
+    private:
+        virtual void bind(wl_resource* new_wl_output) = 0;
+        friend Output::Thunks;
+    };
+
+private:
+    virtual void release() = 0;
 };
 
 class Region
@@ -878,13 +964,13 @@ public:
 
     static Subcompositor* from(struct wl_resource*);
 
-    Subcompositor(struct wl_display* display, uint32_t max_version);
-    virtual ~Subcompositor();
+    Subcompositor(struct wl_resource* resource);
+    virtual ~Subcompositor() = default;
 
-    void destroy_wayland_object(struct wl_resource* resource) const;
+    void destroy_wayland_object() const;
 
-    struct wl_global* const global;
-    uint32_t const max_version;
+    struct wl_client* const client;
+    struct wl_resource* const resource;
 
     struct Error
     {
@@ -893,11 +979,25 @@ public:
 
     struct Thunks;
 
-private:
-    virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
+    static bool is_instance(wl_resource* resource);
 
-    virtual void destroy(struct wl_client* client, struct wl_resource* resource) = 0;
-    virtual void get_subsurface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* surface, struct wl_resource* parent) = 0;
+    class Global
+    {
+    public:
+        Global(wl_display* display, uint32_t max_version);
+        virtual ~Global();
+
+        wl_global* const global;
+        uint32_t const max_version;
+
+    private:
+        virtual void bind(wl_resource* new_wl_subcompositor) = 0;
+        friend Subcompositor::Thunks;
+    };
+
+private:
+    virtual void destroy() = 0;
+    virtual void get_subsurface(struct wl_resource* id, struct wl_resource* surface, struct wl_resource* parent) = 0;
 };
 
 class Subsurface

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
@@ -26,13 +26,13 @@ public:
 
     static LayerShellV1* from(struct wl_resource*);
 
-    LayerShellV1(struct wl_display* display, uint32_t max_version);
-    virtual ~LayerShellV1();
+    LayerShellV1(struct wl_resource* resource);
+    virtual ~LayerShellV1() = default;
 
-    void destroy_wayland_object(struct wl_resource* resource) const;
+    void destroy_wayland_object() const;
 
-    struct wl_global* const global;
-    uint32_t const max_version;
+    struct wl_client* const client;
+    struct wl_resource* const resource;
 
     struct Error
     {
@@ -51,10 +51,24 @@ public:
 
     struct Thunks;
 
-private:
-    virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
+    static bool is_instance(wl_resource* resource);
 
-    virtual void get_layer_surface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* surface, std::experimental::optional<struct wl_resource*> const& output, uint32_t layer, std::string const& namespace_) = 0;
+    class Global
+    {
+    public:
+        Global(wl_display* display, uint32_t max_version);
+        virtual ~Global();
+
+        wl_global* const global;
+        uint32_t const max_version;
+
+    private:
+        virtual void bind(wl_resource* new_zwlr_layer_shell_v1) = 0;
+        friend LayerShellV1::Thunks;
+    };
+
+private:
+    virtual void get_layer_surface(struct wl_resource* id, struct wl_resource* surface, std::experimental::optional<struct wl_resource*> const& output, uint32_t layer, std::string const& namespace_) = 0;
 };
 
 class LayerSurfaceV1

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
@@ -26,21 +26,35 @@ public:
 
     static XdgOutputManagerV1* from(struct wl_resource*);
 
-    XdgOutputManagerV1(struct wl_display* display, uint32_t max_version);
-    virtual ~XdgOutputManagerV1();
+    XdgOutputManagerV1(struct wl_resource* resource);
+    virtual ~XdgOutputManagerV1() = default;
 
-    void destroy_wayland_object(struct wl_resource* resource) const;
+    void destroy_wayland_object() const;
 
-    struct wl_global* const global;
-    uint32_t const max_version;
+    struct wl_client* const client;
+    struct wl_resource* const resource;
 
     struct Thunks;
 
-private:
-    virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
+    static bool is_instance(wl_resource* resource);
 
-    virtual void destroy(struct wl_client* client, struct wl_resource* resource) = 0;
-    virtual void get_xdg_output(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* output) = 0;
+    class Global
+    {
+    public:
+        Global(wl_display* display, uint32_t max_version);
+        virtual ~Global();
+
+        wl_global* const global;
+        uint32_t const max_version;
+
+    private:
+        virtual void bind(wl_resource* new_zxdg_output_manager_v1) = 0;
+        friend XdgOutputManagerV1::Thunks;
+    };
+
+private:
+    virtual void destroy() = 0;
+    virtual void get_xdg_output(struct wl_resource* id, struct wl_resource* output) = 0;
 };
 
 class XdgOutputV1

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -26,15 +26,15 @@ public:
 
     static XdgShellV6* from(struct wl_resource*);
 
-    XdgShellV6(struct wl_display* display, uint32_t max_version);
-    virtual ~XdgShellV6();
+    XdgShellV6(struct wl_resource* resource);
+    virtual ~XdgShellV6() = default;
 
-    void send_ping_event(struct wl_resource* resource, uint32_t serial) const;
+    void send_ping_event(uint32_t serial) const;
 
-    void destroy_wayland_object(struct wl_resource* resource) const;
+    void destroy_wayland_object() const;
 
-    struct wl_global* const global;
-    uint32_t const max_version;
+    struct wl_client* const client;
+    struct wl_resource* const resource;
 
     struct Error
     {
@@ -53,13 +53,27 @@ public:
 
     struct Thunks;
 
-private:
-    virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
+    static bool is_instance(wl_resource* resource);
 
-    virtual void destroy(struct wl_client* client, struct wl_resource* resource) = 0;
-    virtual void create_positioner(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id) = 0;
-    virtual void get_xdg_surface(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* surface) = 0;
-    virtual void pong(struct wl_client* client, struct wl_resource* resource, uint32_t serial) = 0;
+    class Global
+    {
+    public:
+        Global(wl_display* display, uint32_t max_version);
+        virtual ~Global();
+
+        wl_global* const global;
+        uint32_t const max_version;
+
+    private:
+        virtual void bind(wl_resource* new_zxdg_shell_v6) = 0;
+        friend XdgShellV6::Thunks;
+    };
+
+private:
+    virtual void destroy() = 0;
+    virtual void create_positioner(struct wl_resource* id) = 0;
+    virtual void get_xdg_surface(struct wl_resource* id, struct wl_resource* surface) = 0;
+    virtual void pong(uint32_t serial) = 0;
 };
 
 class XdgPositionerV6

--- a/src/wayland/generated/xdg-shell_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell_wrapper.cpp
@@ -76,7 +76,7 @@ struct mw::XdgWmBase::Thunks
         auto me = static_cast<XdgWmBase*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy(client, resource);
+            me->destroy();
         }
         catch(...)
         {
@@ -96,7 +96,7 @@ struct mw::XdgWmBase::Thunks
         }
         try
         {
-            me->create_positioner(client, resource, id_resolved);
+            me->create_positioner(id_resolved);
         }
         catch(...)
         {
@@ -116,7 +116,7 @@ struct mw::XdgWmBase::Thunks
         }
         try
         {
-            me->get_xdg_surface(client, resource, id_resolved, surface);
+            me->get_xdg_surface(id_resolved, surface);
         }
         catch(...)
         {
@@ -129,7 +129,7 @@ struct mw::XdgWmBase::Thunks
         auto me = static_cast<XdgWmBase*>(wl_resource_get_user_data(resource));
         try
         {
-            me->pong(client, resource, serial);
+            me->pong(serial);
         }
         catch(...)
         {
@@ -137,9 +137,14 @@ struct mw::XdgWmBase::Thunks
         }
     }
 
+    static void resource_destroyed_thunk(wl_resource* resource)
+    {
+        delete static_cast<XdgWmBase*>(wl_resource_get_user_data(resource));
+    }
+
     static void bind_thunk(struct wl_client* client, void* data, uint32_t version, uint32_t id)
     {
-        auto me = static_cast<XdgWmBase*>(data);
+        auto me = static_cast<XdgWmBase::Global*>(data);
         auto resource = wl_resource_create(
             client,
             &xdg_wm_base_interface_data,
@@ -150,14 +155,13 @@ struct mw::XdgWmBase::Thunks
             wl_client_post_no_memory(client);
             BOOST_THROW_EXCEPTION((std::bad_alloc{}));
         }
-        wl_resource_set_implementation(resource, Thunks::request_vtable, me, nullptr);
         try
         {
-            me->bind(client, resource);
+            me->bind(resource);
         }
         catch(...)
         {
-            internal_error_processing_request(client, "XdgWmBase::bind()");
+            internal_error_processing_request(client, "XdgWmBase global bind");
         }
     }
 
@@ -168,8 +172,39 @@ struct mw::XdgWmBase::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgWmBase::XdgWmBase(struct wl_display* display, uint32_t max_version)
-    : global{wl_global_create(display, &xdg_wm_base_interface_data, max_version, this, &Thunks::bind_thunk)},
+mw::XdgWmBase::XdgWmBase(struct wl_resource* resource)
+    : client{wl_resource_get_client(resource)},
+      resource{resource}
+{
+    if (resource == nullptr)
+    {
+        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
+    }
+    wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+void mw::XdgWmBase::send_ping_event(uint32_t serial) const
+{
+    wl_resource_post_event(resource, Opcode::ping, serial);
+}
+
+bool mw::XdgWmBase::is_instance(wl_resource* resource)
+{
+    return wl_resource_instance_of(resource, &xdg_wm_base_interface_data, Thunks::request_vtable);
+}
+
+void mw::XdgWmBase::destroy_wayland_object() const
+{
+    wl_resource_destroy(resource);
+}
+
+mw::XdgWmBase::Global::Global(wl_display* display, uint32_t max_version)
+    : global{wl_global_create(
+        display,
+        &xdg_wm_base_interface_data,
+        max_version,
+        this,
+        &Thunks::bind_thunk)},
       max_version{max_version}
 {
     if (global == nullptr)
@@ -178,19 +213,9 @@ mw::XdgWmBase::XdgWmBase(struct wl_display* display, uint32_t max_version)
     }
 }
 
-mw::XdgWmBase::~XdgWmBase()
+mw::XdgWmBase::Global::~Global()
 {
     wl_global_destroy(global);
-}
-
-void mw::XdgWmBase::send_ping_event(struct wl_resource* resource, uint32_t serial) const
-{
-    wl_resource_post_event(resource, Opcode::ping, serial);
-}
-
-void mw::XdgWmBase::destroy_wayland_object(struct wl_resource* resource) const
-{
-    wl_resource_destroy(resource);
 }
 
 struct wl_interface const* mw::XdgWmBase::Thunks::create_positioner_types[] {

--- a/src/wayland/generator/CMakeLists.txt
+++ b/src/wayland/generator/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(mir_wayland_generator
   request.cpp               request.h
   event.cpp                 event.h
   interface.cpp             interface.h
+  global.cpp                global.h
   emitter.cpp               emitter.h
 )
 

--- a/src/wayland/generator/event.cpp
+++ b/src/wayland/generator/event.cpp
@@ -21,8 +21,8 @@
 
 #include <libxml++/libxml++.h>
 
-Event::Event(xmlpp::Element const& node, std::string const& class_name, bool is_global, int opcode)
-    : Method{node, class_name, is_global, true},
+Event::Event(xmlpp::Element const& node, std::string const& class_name, int opcode)
+    : Method{node, class_name, true},
       opcode{opcode}
 {
 }
@@ -37,9 +37,7 @@ Emitter Event::prototype() const
 {
     return Lines{
         (min_version > 0 ? Lines{
-            {"bool version_supports_", name, "(",
-                (is_global ? "struct wl_resource* resource" : Emitter{nullptr}),
-                ");"}
+            {"bool version_supports_", name, "();"}
         } : Emitter{nullptr}),
         {"void send_", name, "_event(", mir_args(), ") const;"}
     };
@@ -50,9 +48,7 @@ Emitter Event::impl() const
 {
     return Lines{
         (min_version > 0 ? Lines{
-            {"bool mw::", class_name, "::version_supports_", name, "(",
-                (is_global ? "struct wl_resource* resource" : Emitter{nullptr}),
-                ")"},
+            {"bool mw::", class_name, "::version_supports_", name, "()"},
             Block{
                 {"return wl_resource_get_version(resource) >= ", std::to_string(min_version), ";"}
             },
@@ -80,10 +76,6 @@ Emitter Event::mir2wl_converters() const
 Emitter Event::mir_args() const
 {
     std::vector<Emitter> mir_args;
-    if (is_global)
-    {
-        mir_args.push_back("struct wl_resource* resource");
-    }
     for (auto& i : arguments)
     {
         mir_args.push_back(i.mir_prototype());

--- a/src/wayland/generator/global.cpp
+++ b/src/wayland/generator/global.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored By: William Wold <william.wold@canonical.com>
+ */
+
+#include "global.h"
+
+#include <libxml++/libxml++.h>
+
+Global::Global(std::string const& wl_name, std::string const& generated_name, std::string const& nmspace)
+    : wl_name{wl_name},
+      generated_name{generated_name},
+      nmspace{nmspace}
+{
+}
+
+Emitter Global::declaration() const
+{
+    return Lines{
+        {"class Global"},
+        "{",
+        "public:",
+        Emitter::layout(Lines{
+            {"Global(", constructor_args(), ");"},
+            "virtual ~Global();",
+            empty_line,
+            member_vars(),
+        }, true, true, Emitter::single_indent),
+        empty_line,
+        "private:",
+        Emitter::layout(Lines{
+            bind_prototype(),
+            {"friend ", generated_name, "::Thunks;"},
+        }, true, true, Emitter::single_indent),
+        "};"
+    };
+}
+
+Emitter Global::implementation() const
+{
+    return EmptyLineList{
+        Lines{
+            {nmspace, "Global::Global(", constructor_args(), ")"},
+            {"    : global{wl_global_create("},
+            {"        display,"},
+            {"        &", wl_name, "_interface_data,"},
+            {"        max_version,"},
+            {"        this,"},
+            {"        &Thunks::bind_thunk)},"},
+            {"      max_version{max_version}"},
+            Block{
+                "if (global == nullptr)",
+                Block{
+                    {"BOOST_THROW_EXCEPTION((std::runtime_error{\"Failed to export ", wl_name, " interface\"}));"}
+                }
+            }
+        },
+        Lines{
+            {nmspace, "Global::~Global()"},
+            Block{
+                "wl_global_destroy(global);"
+            }
+        },
+    };
+}
+
+Emitter Global::bind_thunk_impl() const
+{
+    return Lines{
+        "static void bind_thunk(struct wl_client* client, void* data, uint32_t version, uint32_t id)",
+        Block{
+            {"auto me = static_cast<", generated_name, "::Global*>(data);"},
+            {"auto resource = wl_resource_create("},
+            Emitter::layout(Lines{
+                "client,",
+                {"&", wl_name, "_interface_data,"},
+                "std::min(version, me->max_version),",
+                "id);",
+            }, true, true, Emitter::single_indent),
+            "if (resource == nullptr)",
+            Block{
+                "wl_client_post_no_memory(client);",
+                "BOOST_THROW_EXCEPTION((std::bad_alloc{}));",
+            },
+            "try",
+            Block{
+                "me->bind(resource);"
+            },
+            "catch(...)",
+            Block{{
+                {"internal_error_processing_request(client, \"", generated_name, " global bind\");"},
+            }}
+        }
+    };
+}
+
+Emitter Global::constructor_args() const
+{
+    return {"wl_display* display, uint32_t max_version"};
+}
+
+Emitter Global::bind_prototype() const
+{
+    return {"virtual void bind(wl_resource* new_", wl_name, ") = 0;"};
+}
+
+Emitter Global::member_vars() const
+{
+    return Lines{
+        "wl_global* const global;",
+        "uint32_t const max_version;",
+    };
+}

--- a/src/wayland/generator/global.h
+++ b/src/wayland/generator/global.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Canonical Ltd.
+ * Copyright © 2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,
@@ -16,30 +16,33 @@
  * Authored By: William Wold <william.wold@canonical.com>
  */
 
-#ifndef MIR_WAYLAND_GENERATOR_EVENT_H
-#define MIR_WAYLAND_GENERATOR_EVENT_H
+#ifndef MIR_WAYLAND_GENERATOR_GLOBAL_H
+#define MIR_WAYLAND_GENERATOR_GLOBAL_H
 
-#include "method.h"
+#include "emitter.h"
 
-class Event : public Method
+namespace xmlpp
+{
+class Element;
+}
+
+class Global
 {
 public:
-    Event(xmlpp::Element const& node, std::string const& class_name, int opcode);
+    Global(std::string const& wl_name, std::string const& generated_name, std::string const& nmspace);
 
-    Emitter opcode_declare() const;
-    Emitter prototype() const;
-    Emitter impl() const;
+    Emitter declaration() const;
+    Emitter implementation() const;
+    Emitter bind_thunk_impl() const;
 
-protected:
-    // converts wl input types to mir types
-    Emitter mir2wl_converters() const;
+private:
+    Emitter constructor_args() const;
+    Emitter bind_prototype() const;
+    Emitter member_vars() const;
 
-    Emitter mir_args() const;
-
-    // arguments to call the virtual mir function call (just names, no types)
-    Emitter wl_call_args() const;
-
-    int const opcode;
+    std::string const wl_name;
+    std::string const generated_name;
+    std::string const nmspace;
 };
 
-#endif // MIR_WAYLAND_GENERATOR_EVENT_H
+#endif // MIR_WAYLAND_GENERATOR_GLOBAL_H

--- a/src/wayland/generator/interface.h
+++ b/src/wayland/generator/interface.h
@@ -23,6 +23,7 @@
 #include "request.h"
 #include "event.h"
 #include "enum.h"
+#include "global.h"
 
 #include <experimental/optional>
 #include <functional>
@@ -52,8 +53,6 @@ private:
     Emitter constructor_impl() const;
     Emitter constructor_args() const;
     Emitter destructor_prototype() const;
-    Emitter destructor_impl() const;
-    Emitter bind_prototype() const;
     Emitter virtual_request_prototypes() const;
     Emitter event_prototypes() const;
     Emitter event_impls() const;
@@ -62,21 +61,20 @@ private:
     Emitter event_opcodes() const;
     Emitter thunks_impl() const;
     Emitter thunks_impl_contents() const;
-    Emitter bind_thunk() const;
     Emitter resource_destroyed_thunk() const;
     Emitter types_init() const;
     Emitter is_instance_prototype() const;
     Emitter is_instance_impl() const;
 
-    static std::vector<Request> get_requests(xmlpp::Element const& node, std::string generated_name, bool is_global);
-    static std::vector<Event> get_events(xmlpp::Element const& node, std::string generated_name, bool is_global);
+    static std::vector<Request> get_requests(xmlpp::Element const& node, std::string generated_name);
+    static std::vector<Event> get_events(xmlpp::Element const& node, std::string generated_name);
     static std::vector<Enum> get_enums(xmlpp::Element const& node);
 
     std::string const wl_name;
     int const version;
     std::string const generated_name;
     std::string const nmspace;
-    bool const is_global;
+    std::experimental::optional<Global> const global;
     std::vector<Request> const requests;
     std::vector<Event> const events;
     std::vector<Enum> const enums;

--- a/src/wayland/generator/method.cpp
+++ b/src/wayland/generator/method.cpp
@@ -21,10 +21,9 @@
 
 #include <libxml++/libxml++.h>
 
-Method::Method(xmlpp::Element const& node, std::string const& class_name, bool is_global, bool is_event)
+Method::Method(xmlpp::Element const& node, std::string const& class_name, bool is_event)
     : name{node.get_attribute_value("name")},
       class_name{class_name},
-      is_global{is_global},
       min_version{get_since_version(node)}
 {
     for (auto const& child : node.get_children("arg"))

--- a/src/wayland/generator/method.h
+++ b/src/wayland/generator/method.h
@@ -34,7 +34,7 @@ class Element;
 class Method
 {
 public:
-    Method(xmlpp::Element const& node, std::string const& class_name, bool is_global, bool is_event);
+    Method(xmlpp::Element const& node, std::string const& class_name, bool is_event);
 
     Emitter types_str() const;
     Emitter types_declare() const;
@@ -51,7 +51,6 @@ protected:
 
     std::string const name;
     std::string const class_name;
-    bool const is_global;
     int const min_version;
     std::vector<Argument> arguments;
 };

--- a/src/wayland/generator/request.cpp
+++ b/src/wayland/generator/request.cpp
@@ -18,8 +18,8 @@
 
 #include "request.h"
 
-Request::Request(xmlpp::Element const& node, std::string const& class_name, bool is_global)
-    : Method{node, class_name, is_global, false}
+Request::Request(xmlpp::Element const& node, std::string const& class_name)
+    : Method{node, class_name, false}
 {
 }
 
@@ -65,11 +65,6 @@ Emitter Request::wl_args() const
 Emitter Request::mir_args() const
 {
     std::vector<Emitter> mir_args;
-    if (is_global)
-    {
-        mir_args.push_back("struct wl_client* client");
-        mir_args.push_back("struct wl_resource* resource");
-    }
     for (auto& i : arguments)
     {
         mir_args.push_back(i.mir_prototype());
@@ -91,11 +86,6 @@ Emitter Request::wl2mir_converters() const
 Emitter Request::mir_call_args() const
 {
     std::vector<Emitter> call_args;
-    if (is_global)
-    {
-        call_args.push_back("client");
-        call_args.push_back("resource");
-    }
     for (auto& arg : arguments)
         call_args.push_back(arg.call_fragment());
     return Emitter::seq(call_args, ", ");

--- a/src/wayland/generator/request.h
+++ b/src/wayland/generator/request.h
@@ -24,7 +24,7 @@
 class Request : public Method
 {
 public:
-    Request(xmlpp::Element const& node, std::string const& class_name, bool is_global);
+    Request(xmlpp::Element const& node, std::string const& class_name);
 
     // prototype of virtual function that is overridden in Mir
     Emitter virtual_mir_prototype() const;

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -5,171 +5,239 @@ global:
     non-virtual?thunk?to?mir::wayland::Buffer::*;
     typeinfo?for?mir::wayland::Buffer;
     vtable?for?mir::wayland::Buffer;
+    typeinfo?for?mir::wayland::Buffer::Global;
+    vtable?for?mir::wayland::Buffer::Global;
 
     mir::wayland::Callback::*;
     non-virtual?thunk?to?mir::wayland::Callback::*;
     typeinfo?for?mir::wayland::Callback;
     vtable?for?mir::wayland::Callback;
+    typeinfo?for?mir::wayland::Callback::Global;
+    vtable?for?mir::wayland::Callback::Global;
 
     mir::wayland::Compositor::*;
     non-virtual?thunk?to?mir::wayland::Compositor::*;
     typeinfo?for?mir::wayland::Compositor;
     vtable?for?mir::wayland::Compositor;
+    typeinfo?for?mir::wayland::Compositor::Global;
+    vtable?for?mir::wayland::Compositor::Global;
 
     mir::wayland::DataDevice::*;
     non-virtual?thunk?to?mir::wayland::DataDevice::*;
     typeinfo?for?mir::wayland::DataDevice;
     vtable?for?mir::wayland::DataDevice;
+    typeinfo?for?mir::wayland::DataDevice::Global;
+    vtable?for?mir::wayland::DataDevice::Global;
 
     mir::wayland::DataDeviceManager::*;
     non-virtual?thunk?to?mir::wayland::DataDeviceManager::*;
     typeinfo?for?mir::wayland::DataDeviceManager;
     vtable?for?mir::wayland::DataDeviceManager;
+    typeinfo?for?mir::wayland::DataDeviceManager::Global;
+    vtable?for?mir::wayland::DataDeviceManager::Global;
 
     mir::wayland::DataOffer::*;
     non-virtual?thunk?to?mir::wayland::DataOffer::*;
     typeinfo?for?mir::wayland::DataOffer;
     vtable?for?mir::wayland::DataOffer;
+    typeinfo?for?mir::wayland::DataOffer::Global;
+    vtable?for?mir::wayland::DataOffer::Global;
 
     mir::wayland::DataSource::*;
     non-virtual?thunk?to?mir::wayland::DataSource::*;
     typeinfo?for?mir::wayland::DataSource;
     vtable?for?mir::wayland::DataSource;
+    typeinfo?for?mir::wayland::DataSource::Global;
+    vtable?for?mir::wayland::DataSource::Global;
 
     mir::wayland::Keyboard::*;
     non-virtual?thunk?to?mir::wayland::Keyboard::*;
     typeinfo?for?mir::wayland::Keyboard;
     vtable?for?mir::wayland::Keyboard;
+    typeinfo?for?mir::wayland::Keyboard::Global;
+    vtable?for?mir::wayland::Keyboard::Global;
 
     mir::wayland::LayerShellV1::*;
     non-virtual?thunk?to?mir::wayland::LayerShellV1::*;
     typeinfo?for?mir::wayland::LayerShellV1;
     vtable?for?mir::wayland::LayerShellV1;
+    typeinfo?for?mir::wayland::LayerShellV1::Global;
+    vtable?for?mir::wayland::LayerShellV1::Global;
 
     mir::wayland::LayerSurfaceV1::*;
     non-virtual?thunk?to?mir::wayland::LayerSurfaceV1::*;
     typeinfo?for?mir::wayland::LayerSurfaceV1;
     vtable?for?mir::wayland::LayerSurfaceV1;
+    typeinfo?for?mir::wayland::LayerSurfaceV1::Global;
+    vtable?for?mir::wayland::LayerSurfaceV1::Global;
 
     mir::wayland::Output::*;
     non-virtual?thunk?to?mir::wayland::Output::*;
     typeinfo?for?mir::wayland::Output;
     vtable?for?mir::wayland::Output;
+    typeinfo?for?mir::wayland::Output::Global;
+    vtable?for?mir::wayland::Output::Global;
 
     mir::wayland::Pointer::*;
     non-virtual?thunk?to?mir::wayland::Pointer::*;
     typeinfo?for?mir::wayland::Pointer;
     vtable?for?mir::wayland::Pointer;
+    typeinfo?for?mir::wayland::Pointer::Global;
+    vtable?for?mir::wayland::Pointer::Global;
 
     mir::wayland::Region::*;
     non-virtual?thunk?to?mir::wayland::Region::*;
     typeinfo?for?mir::wayland::Region;
     vtable?for?mir::wayland::Region;
+    typeinfo?for?mir::wayland::Region::Global;
+    vtable?for?mir::wayland::Region::Global;
 
     mir::wayland::Seat::*;
     non-virtual?thunk?to?mir::wayland::Seat::*;
     typeinfo?for?mir::wayland::Seat;
     vtable?for?mir::wayland::Seat;
+    typeinfo?for?mir::wayland::Seat::Global;
+    vtable?for?mir::wayland::Seat::Global;
 
     mir::wayland::Shell::*;
     non-virtual?thunk?to?mir::wayland::Shell::*;
     typeinfo?for?mir::wayland::Shell;
     vtable?for?mir::wayland::Shell;
+    typeinfo?for?mir::wayland::Shell::Global;
+    vtable?for?mir::wayland::Shell::Global;
 
     mir::wayland::ShellSurface::*;
     non-virtual?thunk?to?mir::wayland::ShellSurface::*;
     typeinfo?for?mir::wayland::ShellSurface;
     vtable?for?mir::wayland::ShellSurface;
+    typeinfo?for?mir::wayland::ShellSurface::Global;
+    vtable?for?mir::wayland::ShellSurface::Global;
 
     mir::wayland::Shm::*;
     non-virtual?thunk?to?mir::wayland::Shm::*;
     typeinfo?for?mir::wayland::Shm;
     vtable?for?mir::wayland::Shm;
+    typeinfo?for?mir::wayland::Shm::Global;
+    vtable?for?mir::wayland::Shm::Global;
 
     mir::wayland::ShmPool::*;
     non-virtual?thunk?to?mir::wayland::ShmPool::*;
     typeinfo?for?mir::wayland::ShmPool;
     vtable?for?mir::wayland::ShmPool;
+    typeinfo?for?mir::wayland::ShmPool::Global;
+    vtable?for?mir::wayland::ShmPool::Global;
 
     mir::wayland::Subcompositor::*;
     non-virtual?thunk?to?mir::wayland::Subcompositor::*;
     typeinfo?for?mir::wayland::Subcompositor;
     vtable?for?mir::wayland::Subcompositor;
+    typeinfo?for?mir::wayland::Subcompositor::Global;
+    vtable?for?mir::wayland::Subcompositor::Global;
 
     mir::wayland::Subsurface::*;
     non-virtual?thunk?to?mir::wayland::Subsurface::*;
     typeinfo?for?mir::wayland::Subsurface;
     vtable?for?mir::wayland::Subsurface;
+    typeinfo?for?mir::wayland::Subsurface::Global;
+    vtable?for?mir::wayland::Subsurface::Global;
 
     mir::wayland::Surface::*;
     non-virtual?thunk?to?mir::wayland::Surface::*;
     typeinfo?for?mir::wayland::Surface;
     vtable?for?mir::wayland::Surface;
+    typeinfo?for?mir::wayland::Surface::Global;
+    vtable?for?mir::wayland::Surface::Global;
 
     mir::wayland::Touch::*;
     non-virtual?thunk?to?mir::wayland::Touch::*;
     typeinfo?for?mir::wayland::Touch;
     vtable?for?mir::wayland::Touch;
+    typeinfo?for?mir::wayland::Touch::Global;
+    vtable?for?mir::wayland::Touch::Global;
 
     mir::wayland::XdgPopup::*;
     non-virtual?thunk?to?mir::wayland::XdgPopup::*;
     typeinfo?for?mir::wayland::XdgPopup;
     vtable?for?mir::wayland::XdgPopup;
+    typeinfo?for?mir::wayland::XdgPopup::Global;
+    vtable?for?mir::wayland::XdgPopup::Global;
 
     mir::wayland::XdgPopupV6::*;
     non-virtual?thunk?to?mir::wayland::XdgPopupV6::*;
     typeinfo?for?mir::wayland::XdgPopupV6;
     vtable?for?mir::wayland::XdgPopupV6;
+    typeinfo?for?mir::wayland::XdgPopupV6::Global;
+    vtable?for?mir::wayland::XdgPopupV6::Global;
 
     mir::wayland::XdgPositioner::*;
     non-virtual?thunk?to?mir::wayland::XdgPositioner::*;
     typeinfo?for?mir::wayland::XdgPositioner;
     vtable?for?mir::wayland::XdgPositioner;
+    typeinfo?for?mir::wayland::XdgPositioner::Global;
+    vtable?for?mir::wayland::XdgPositioner::Global;
 
     mir::wayland::XdgPositionerV6::*;
     non-virtual?thunk?to?mir::wayland::XdgPositionerV6::*;
     typeinfo?for?mir::wayland::XdgPositionerV6;
     vtable?for?mir::wayland::XdgPositionerV6;
+    typeinfo?for?mir::wayland::XdgPositionerV6::Global;
+    vtable?for?mir::wayland::XdgPositionerV6::Global;
 
     mir::wayland::XdgShellV6::*;
     non-virtual?thunk?to?mir::wayland::XdgShellV6::*;
     typeinfo?for?mir::wayland::XdgShellV6;
     vtable?for?mir::wayland::XdgShellV6;
+    typeinfo?for?mir::wayland::XdgShellV6::Global;
+    vtable?for?mir::wayland::XdgShellV6::Global;
 
     mir::wayland::XdgSurface::*;
     non-virtual?thunk?to?mir::wayland::XdgSurface::*;
     typeinfo?for?mir::wayland::XdgSurface;
     vtable?for?mir::wayland::XdgSurface;
+    typeinfo?for?mir::wayland::XdgSurface::Global;
+    vtable?for?mir::wayland::XdgSurface::Global;
 
     mir::wayland::XdgSurfaceV6::*;
     non-virtual?thunk?to?mir::wayland::XdgSurfaceV6::*;
     typeinfo?for?mir::wayland::XdgSurfaceV6;
     vtable?for?mir::wayland::XdgSurfaceV6;
+    typeinfo?for?mir::wayland::XdgSurfaceV6::Global;
+    vtable?for?mir::wayland::XdgSurfaceV6::Global;
 
     mir::wayland::XdgToplevel::*;
     non-virtual?thunk?to?mir::wayland::XdgToplevel::*;
     typeinfo?for?mir::wayland::XdgToplevel;
     vtable?for?mir::wayland::XdgToplevel;
+    typeinfo?for?mir::wayland::XdgToplevel::Global;
+    vtable?for?mir::wayland::XdgToplevel::Global;
 
     mir::wayland::XdgToplevelV6::*;
     non-virtual?thunk?to?mir::wayland::XdgToplevelV6::*;
     typeinfo?for?mir::wayland::XdgToplevelV6;
     vtable?for?mir::wayland::XdgToplevelV6;
+    typeinfo?for?mir::wayland::XdgToplevelV6::Global;
+    vtable?for?mir::wayland::XdgToplevelV6::Global;
 
     mir::wayland::XdgWmBase::*;
     non-virtual?thunk?to?mir::wayland::XdgWmBase::*;
     typeinfo?for?mir::wayland::XdgWmBase;
     vtable?for?mir::wayland::XdgWmBase;
+    typeinfo?for?mir::wayland::XdgWmBase::Global;
+    vtable?for?mir::wayland::XdgWmBase::Global;
 
     mir::wayland::XdgOutputManagerV1::*;
     non-virtual?thunk?to?mir::wayland::XdgOutputManagerV1::*;
     typeinfo?for?mir::wayland::XdgOutputManagerV1;
     vtable?for?mir::wayland::XdgOutputManagerV1;
+    typeinfo?for?mir::wayland::XdgOutputManagerV1::Global;
+    vtable?for?mir::wayland::XdgOutputManagerV1::Global;
 
     mir::wayland::XdgOutputV1::*;
     non-virtual?thunk?to?mir::wayland::XdgOutputV1::*;
     typeinfo?for?mir::wayland::XdgOutputV1;
     vtable?for?mir::wayland::XdgOutputV1;
+    typeinfo?for?mir::wayland::XdgOutputV1::Global;
+    vtable?for?mir::wayland::XdgOutputV1::Global;
 
     mir::wayland::wl_buffer_interface_data;
     mir::wayland::wl_callback_interface_data;

--- a/tests/miral/generated/server-decoration_wrapper.h
+++ b/tests/miral/generated/server-decoration_wrapper.h
@@ -26,15 +26,15 @@ public:
 
     static ServerDecorationManager* from(struct wl_resource*);
 
-    ServerDecorationManager(struct wl_display* display, uint32_t max_version);
-    virtual ~ServerDecorationManager();
+    ServerDecorationManager(struct wl_resource* resource);
+    virtual ~ServerDecorationManager() = default;
 
-    void send_default_mode_event(struct wl_resource* resource, uint32_t mode) const;
+    void send_default_mode_event(uint32_t mode) const;
 
-    void destroy_wayland_object(struct wl_resource* resource) const;
+    void destroy_wayland_object() const;
 
-    struct wl_global* const global;
-    uint32_t const max_version;
+    struct wl_client* const client;
+    struct wl_resource* const resource;
 
     struct Mode
     {
@@ -50,10 +50,24 @@ public:
 
     struct Thunks;
 
-private:
-    virtual void bind(struct wl_client* client, struct wl_resource* resource) { (void)client; (void)resource; }
+    static bool is_instance(wl_resource* resource);
 
-    virtual void create(struct wl_client* client, struct wl_resource* resource, struct wl_resource* id, struct wl_resource* surface) = 0;
+    class Global
+    {
+    public:
+        Global(wl_display* display, uint32_t max_version);
+        virtual ~Global();
+
+        wl_global* const global;
+        uint32_t const max_version;
+
+    private:
+        virtual void bind(wl_resource* new_org_kde_kwin_server_decoration_manager) = 0;
+        friend ServerDecorationManager::Thunks;
+    };
+
+private:
+    virtual void create(struct wl_resource* id, struct wl_resource* surface) = 0;
 };
 
 class ServerDecoration


### PR DESCRIPTION
For context, Wayland global's work as follows:
* The compositor notifies a client of the existence of a global
* The client binds one or more Wayland objects to it
* The client can then make requests or get events from those objects just like normal

Unfortunately in Mir we have an odd system where there is only one C++ object to represent the global and all Wayland objects created from a global. Wayland objects created from a global are no different than Wayland objects created from another object, therefor in this PR I split the global and the objects created from them. There will now be a single instance of the `wayland::Type::Global` and each bind creates a new instance of `wayland::Type`

I recommend looking at the individual commits, as they are well organized and less overwhelming.