### PR TITLE
Don't lock KeyRepeatDispatcher::repeat_state_mutex unnecessarily

### DIFF
--- a/src/server/input/key_repeat_dispatcher.cpp
+++ b/src/server/input/key_repeat_dispatcher.cpp
@@ -182,9 +182,8 @@ bool mi::KeyRepeatDispatcher::handle_key_input(MirInputDeviceId id, MirKeyboardE
         }
         auto& capture_alarm = device_state.repeat_alarms_by_scancode[scan_code];
         std::shared_ptr<mir::time::Alarm> alarm = alarm_factory->create_alarm(
-            [this, clone_event, &capture_alarm]() mutable
+            [repeat_delay=repeat_delay, clone_event, &capture_alarm]()
             {
-                std::lock_guard<std::mutex> lg(repeat_state_mutex);
                 clone_event();
 
                 capture_alarm->reschedule_in(repeat_delay);

--- a/src/server/input/key_repeat_dispatcher.h
+++ b/src/server/input/key_repeat_dispatcher.h
@@ -70,7 +70,7 @@ private:
     std::shared_ptr<cookie::Authority> const cookie_authority;
     bool const repeat_enabled;
     std::chrono::milliseconds repeat_timeout;
-    std::chrono::milliseconds repeat_delay;
+    std::chrono::milliseconds const repeat_delay;
     bool const disable_repeat_on_touchscreen;
     optional_value<MirInputDeviceId> touch_button_device;
 


### PR DESCRIPTION
Don't lock KeyRepeatDispatcher::repeat_state_mutex unnecessarily in a callback. (Fixes #818)