### PR TITLE
Provide a new MinimalWindowManager strategy

### DIFF
--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -341,4 +341,21 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"miral::application_for(wl_client*)@MIRAL_2.5" 2.5.0
  (c++)"miral::application_for(wl_resource*)@MIRAL_2.5" 2.5.0
  (c++)"miral::window_for(wl_resource*)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::advise_focus_gained(miral::WindowInfo const&)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::confirm_inherited_move(miral::WindowInfo const&, mir::geometry::Displacement)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::confirm_placement_on_display(miral::WindowInfo const&, MirWindowState, mir::geometry::Rectangle const&)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::handle_keyboard_event(MirKeyboardEvent const*)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::handle_modify_window(miral::WindowInfo&, miral::WindowSpecification const&)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::handle_pointer_event(MirPointerEvent const*)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::handle_raise_window(miral::WindowInfo&)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::handle_request_drag_and_drop(miral::WindowInfo&)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::handle_request_move(miral::WindowInfo&, MirInputEvent const*)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::handle_request_resize(miral::WindowInfo&, MirInputEvent const*, MirResizeEdge)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::handle_touch_event(MirTouchEvent const*)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::handle_window_ready(miral::WindowInfo&)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::place_new_window(miral::ApplicationInfo const&, miral::WindowSpecification const&)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::~MinimalWindowManager()@MIRAL_2.5" 2.5.0
+ (c++)"typeinfo for miral::MinimalWindowManager@MIRAL_2.5" 2.5.0
+ (c++)"vtable for miral::MinimalWindowManager@MIRAL_2.5" 2.5.0
 

--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -342,6 +342,8 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"miral::application_for(wl_resource*)@MIRAL_2.5" 2.5.0
  (c++)"miral::window_for(wl_resource*)@MIRAL_2.5" 2.5.0
  (c++)"miral::MinimalWindowManager::advise_focus_gained(miral::WindowInfo const&)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::begin_pointer_move(miral::WindowInfo const&, MirInputEvent const*)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::begin_pointer_resize(miral::WindowInfo const&, MirInputEvent const*, MirResizeEdge const&)@MIRAL_2.5" 2.5.0
  (c++)"miral::MinimalWindowManager::confirm_inherited_move(miral::WindowInfo const&, mir::geometry::Displacement)@MIRAL_2.5" 2.5.0
  (c++)"miral::MinimalWindowManager::confirm_placement_on_display(miral::WindowInfo const&, MirWindowState, mir::geometry::Rectangle const&)@MIRAL_2.5" 2.5.0
  (c++)"miral::MinimalWindowManager::handle_keyboard_event(MirKeyboardEvent const*)@MIRAL_2.5" 2.5.0
@@ -358,4 +360,3 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"miral::MinimalWindowManager::~MinimalWindowManager()@MIRAL_2.5" 2.5.0
  (c++)"typeinfo for miral::MinimalWindowManager@MIRAL_2.5" 2.5.0
  (c++)"vtable for miral::MinimalWindowManager@MIRAL_2.5" 2.5.0
-

--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -344,6 +344,8 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"miral::MinimalWindowManager::advise_focus_gained(miral::WindowInfo const&)@MIRAL_2.5" 2.5.0
  (c++)"miral::MinimalWindowManager::begin_pointer_move(miral::WindowInfo const&, MirInputEvent const*)@MIRAL_2.5" 2.5.0
  (c++)"miral::MinimalWindowManager::begin_pointer_resize(miral::WindowInfo const&, MirInputEvent const*, MirResizeEdge const&)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::begin_touch_move(miral::WindowInfo const&, MirInputEvent const*)@MIRAL_2.5" 2.5.0
+ (c++)"miral::MinimalWindowManager::begin_touch_resize(miral::WindowInfo const&, MirInputEvent const*, MirResizeEdge const&)@MIRAL_2.5" 2.5.0
  (c++)"miral::MinimalWindowManager::confirm_inherited_move(miral::WindowInfo const&, mir::geometry::Displacement)@MIRAL_2.5" 2.5.0
  (c++)"miral::MinimalWindowManager::confirm_placement_on_display(miral::WindowInfo const&, MirWindowState, mir::geometry::Rectangle const&)@MIRAL_2.5" 2.5.0
  (c++)"miral::MinimalWindowManager::handle_keyboard_event(MirKeyboardEvent const*)@MIRAL_2.5" 2.5.0

--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -362,3 +362,4 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"miral::MinimalWindowManager::~MinimalWindowManager()@MIRAL_2.5" 2.5.0
  (c++)"typeinfo for miral::MinimalWindowManager@MIRAL_2.5" 2.5.0
  (c++)"vtable for miral::MinimalWindowManager@MIRAL_2.5" 2.5.0
+ (c++)"miral::WindowManagerTools::focus_prev_application()@MIRAL_2.5" 2.5.0

--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -23,12 +23,10 @@
 #include "server_example_custom_compositor.h"
 #include "server_example_test_client.h"
 #include "server_example_input_device_config.h"
-#include "sw_splash.h"
 
 #include <miral/command_line_option.h>
 #include <miral/cursor_theme.h>
 #include <miral/display_configuration_option.h>
-#include <miral/internal_client.h>
 #include <miral/minimal_window_manager.h>
 #include <miral/runner.h>
 #include <miral/set_window_management_policy.h>
@@ -130,8 +128,6 @@ try
     std::function<void()> shutdown_hook{[]{}};
     runner.add_stop_callback([&] { shutdown_hook(); });
 
-    SwSplash spinner;
-
     InputFilters input_filters;
     me::TestClientRunner test_runner;
 
@@ -140,7 +136,6 @@ try
         miral::display_configuration_options,
         me::add_log_host_lifecycle_option_to,
         me::add_glog_options_to,
-        miral::StartupInternalClient{spinner},
         miral::X11Support{},
         miral::WaylandExtensions{miral::WaylandExtensions::recommended_extensions() + ":zwlr_layer_shell_v1"},
         miral::set_window_management_policy<miral::MinimalWindowManager>(),

--- a/examples/mir_demo_server/server_example.cpp
+++ b/examples/mir_demo_server/server_example.cpp
@@ -23,19 +23,17 @@
 #include "server_example_custom_compositor.h"
 #include "server_example_test_client.h"
 #include "server_example_input_device_config.h"
-
-#include "tiling_window_manager.h"
-#include "floating_window_manager.h"
-#include "wallpaper_config.h"
 #include "sw_splash.h"
 
 #include <miral/command_line_option.h>
 #include <miral/cursor_theme.h>
 #include <miral/display_configuration_option.h>
+#include <miral/internal_client.h>
+#include <miral/minimal_window_manager.h>
 #include <miral/runner.h>
-#include <miral/window_management_options.h>
-#include <miral/x11_support.h>
+#include <miral/set_window_management_policy.h>
 #include <miral/wayland_extensions.h>
+#include <miral/x11_support.h>
 
 #include "mir/abnormal_exit.h"
 #include "mir/server.h"
@@ -133,12 +131,6 @@ try
     runner.add_stop_callback([&] { shutdown_hook(); });
 
     SwSplash spinner;
-    miral::InternalClientLauncher launcher;
-    miral::WindowManagerOptions window_managers
-        {
-            miral::add_window_manager_policy<FloatingWindowManagerPolicy>("floating", spinner, launcher, shutdown_hook),
-            miral::add_window_manager_policy<TilingWindowManagerPolicy>("tiling", spinner, launcher),
-        };
 
     InputFilters input_filters;
     me::TestClientRunner test_runner;
@@ -151,15 +143,11 @@ try
         miral::StartupInternalClient{spinner},
         miral::X11Support{},
         miral::WaylandExtensions{miral::WaylandExtensions::recommended_extensions() + ":zwlr_layer_shell_v1"},
-        launcher,
-        window_managers,
+        miral::set_window_management_policy<miral::MinimalWindowManager>(),
         me::add_custom_compositor_option_to,
         me::add_input_device_configuration_options_to,
         add_timeout_option_to,
         miral::CursorTheme{"default:DMZ-White"},
-        pre_init(miral::CommandLineOption{
-            [&](std::string const& font) { ::wallpaper::font_file(font); },
-            "wallpaper-font", "font file to use for wallpaper", ::wallpaper::font_file()}),
         input_filters,
         test_runner
     });

--- a/include/miral/miral/minimal_window_manager.h
+++ b/include/miral/miral/minimal_window_manager.h
@@ -76,6 +76,11 @@ public:
 
 protected:
     WindowManagerTools tools;
+
+    bool begin_pointer_move(WindowInfo const& window_info, MirInputEvent const* input_event);
+    bool begin_pointer_resize(WindowInfo const& window_info, MirInputEvent const* input_event, MirResizeEdge const& edge);
+
+private:
     struct Impl* const self;
 };
 }

--- a/include/miral/miral/minimal_window_manager.h
+++ b/include/miral/miral/minimal_window_manager.h
@@ -80,8 +80,12 @@ protected:
     bool begin_pointer_move(WindowInfo const& window_info, MirInputEvent const* input_event);
     bool begin_pointer_resize(WindowInfo const& window_info, MirInputEvent const* input_event, MirResizeEdge const& edge);
 
+    bool begin_touch_move(WindowInfo const& window_info, MirInputEvent const* input_event);
+    bool begin_touch_resize(WindowInfo const& window_info, MirInputEvent const* input_event, MirResizeEdge const& edge);
+
 private:
-    struct Impl* const self;
+    struct Impl;
+    Impl* const self;
 };
 }
 

--- a/include/miral/miral/minimal_window_manager.h
+++ b/include/miral/miral/minimal_window_manager.h
@@ -32,32 +32,47 @@ public:
     explicit MinimalWindowManager(WindowManagerTools const& tools);
     ~MinimalWindowManager();
 
+    /// Honours the requested specification
     auto place_new_window(
         ApplicationInfo const& app_info,
         WindowSpecification const& requested_specification) -> WindowSpecification override;
 
+    /// If the window can have focus it is given focus
     void handle_window_ready(WindowInfo& window_info) override;
 
+    /// Honours the requested modifications
     void handle_modify_window(WindowInfo& window_info, WindowSpecification const& modifications) override;
 
+    /// Gives focus to the requesting window (tree)
     void handle_raise_window(WindowInfo& window_info) override;
 
-    Rectangle confirm_placement_on_display(
-        WindowInfo const& window_info, MirWindowState new_state, Rectangle const& new_placement) override;
+    /// Honours the requested placement
+    auto confirm_placement_on_display(
+        WindowInfo const& window_info, MirWindowState new_state, Rectangle const& new_placement) -> Rectangle override;
 
+    /// Handles Alt-Tab, Alt-Grave and Alt-F4
     bool handle_keyboard_event(MirKeyboardEvent const* event) override;
 
+    /// Handles touch to focus
     bool handle_touch_event(MirTouchEvent const* event) override;
 
+    /// Handles pre-existing move & resize gestures, plus click to focus
     bool handle_pointer_event(MirPointerEvent const* event) override;
 
+    /// Currently unimplemented
     void handle_request_drag_and_drop(WindowInfo& window_info) override;
 
+    /// Initiates a move gesture (only implemented for pointers)
     void handle_request_move(WindowInfo& window_info, MirInputEvent const* input_event) override;
 
+    /// Initiates a resize gesture (only implemented for pointers)
     void handle_request_resize(WindowInfo& window_info, MirInputEvent const* input_event, MirResizeEdge edge) override;
 
-    Rectangle confirm_inherited_move(WindowInfo const& window_info, Displacement movement) override;
+    /// Honours the requested movement
+    auto confirm_inherited_move(WindowInfo const& window_info, Displacement movement) -> Rectangle override;
+
+    /// Raises newly focused window
+    void advise_focus_gained(WindowInfo const& window_info) override;
 
 protected:
     WindowManagerTools tools;

--- a/include/miral/miral/minimal_window_manager.h
+++ b/include/miral/miral/minimal_window_manager.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#ifndef MIRAL_MINIMAL_WINDOW_MANAGER_H
+#define MIRAL_MINIMAL_WINDOW_MANAGER_H
+
+#include <miral/window_management_policy.h>
+#include <miral/window_manager_tools.h>
+
+namespace miral
+{
+/// Minimal implementation of a floating window management policy
+/// \remark Since MirAL 2.5
+class MinimalWindowManager : public WindowManagementPolicy
+{
+public:
+    explicit MinimalWindowManager(WindowManagerTools const& tools);
+    ~MinimalWindowManager();
+
+    auto place_new_window(
+        ApplicationInfo const& app_info,
+        WindowSpecification const& requested_specification) -> WindowSpecification override;
+
+    void handle_window_ready(WindowInfo& window_info) override;
+
+    void handle_modify_window(WindowInfo& window_info, WindowSpecification const& modifications) override;
+
+    void handle_raise_window(WindowInfo& window_info) override;
+
+    Rectangle confirm_placement_on_display(
+        WindowInfo const& window_info, MirWindowState new_state, Rectangle const& new_placement) override;
+
+    bool handle_keyboard_event(MirKeyboardEvent const* event) override;
+
+    bool handle_touch_event(MirTouchEvent const* event) override;
+
+    bool handle_pointer_event(MirPointerEvent const* event) override;
+
+    void handle_request_drag_and_drop(WindowInfo& window_info) override;
+
+    void handle_request_move(WindowInfo& window_info, MirInputEvent const* input_event) override;
+
+    void handle_request_resize(WindowInfo& window_info, MirInputEvent const* input_event, MirResizeEdge edge) override;
+
+    Rectangle confirm_inherited_move(WindowInfo const& window_info, Displacement movement) override;
+
+protected:
+    WindowManagerTools tools;
+    struct Impl* const self;
+};
+}
+
+#endif //MIRAL_MINIMAL_WINDOW_MANAGER_H

--- a/include/miral/miral/window_manager_tools.h
+++ b/include/miral/miral/window_manager_tools.h
@@ -151,6 +151,10 @@ public:
     /// make the next application active
     void focus_next_application();
 
+    /// make the previous application active
+    /// \remark Since MirAL 2.5
+    void focus_prev_application();
+
     /// make the next surface active within the active application
     void focus_next_within_application();
 

--- a/include/server/mir/scene/session_coordinator.h
+++ b/include/server/mir/scene/session_coordinator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Canonical Ltd.
+ * Copyright © 2014-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,
@@ -45,14 +45,15 @@ public:
     virtual void set_focus_to(std::shared_ptr<Session> const& focus) = 0;
     virtual void unset_focus() = 0;
 
-    virtual std::shared_ptr<Session> open_session(
+    virtual auto open_session(
         pid_t client_pid,
         std::string const& name,
-        std::shared_ptr<frontend::EventSink> const& sink) = 0;
+        std::shared_ptr<frontend::EventSink> const& sink) -> std::shared_ptr<Session> = 0;
 
     virtual void close_session(std::shared_ptr<Session> const& session)  = 0;
 
-    virtual std::shared_ptr<Session> successor_of(std::shared_ptr<Session> const&) const = 0;
+    virtual auto successor_of(std::shared_ptr<Session> const&) const -> std::shared_ptr<Session> = 0;
+    virtual auto predecessor_of(std::shared_ptr<Session> const&) const -> std::shared_ptr<Session> = 0;
 
     virtual void add_listener(std::shared_ptr<SessionListener> const&) = 0;
     virtual void remove_listener(std::shared_ptr<SessionListener> const&) = 0;

--- a/include/server/mir/shell/abstract_shell.h
+++ b/include/server/mir/shell/abstract_shell.h
@@ -117,6 +117,7 @@ public:
  * Simply providing them as part of AbstractShell is probably adequate.
  *  @{ */
     void focus_next_session() override;
+    void focus_prev_session() override;
 
     std::shared_ptr<scene::Session> focused_session() const override;
 

--- a/include/server/mir/shell/focus_controller.h
+++ b/include/server/mir/shell/focus_controller.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2013 Canonical Ltd.
+ * Copyright © 2013-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,
@@ -33,16 +33,13 @@ namespace shell
 {
 using SurfaceSet = std::set<std::weak_ptr<scene::Surface>, std::owner_less<std::weak_ptr<scene::Surface>>>;
 
-// TODO I don't think this interface serves a meaningful purpose
-// TODO (It is referenced by a couple of example WindowManagers, and
-// TODO to get the active session in unity-system-compositor.)
-// TODO I think there's a better approach possible.
 class FocusController
 {
 public:
     virtual ~FocusController() = default;
 
     virtual void focus_next_session() = 0;
+    virtual void focus_prev_session() = 0;
 
     virtual auto focused_session() const -> std::shared_ptr<scene::Session> = 0;
 

--- a/include/server/mir/shell/shell_wrapper.h
+++ b/include/server/mir/shell/shell_wrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Canonical Ltd.
+ * Copyright © 2015-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,
@@ -31,6 +31,7 @@ public:
     explicit ShellWrapper(std::shared_ptr<Shell> const& wrapped);
 
     void focus_next_session() override;
+    void focus_prev_session() override;
 
     std::shared_ptr<scene::Session> focused_session() const override;
 

--- a/src/include/server/mir/scene/session_container.h
+++ b/src/include/server/mir/scene/session_container.h
@@ -43,7 +43,8 @@ public:
 
     // For convenience the successor of the null session is defined as the last session
     // which would be passed to the for_each callback
-    std::shared_ptr<Session> successor_of(std::shared_ptr<Session> const&) const;
+    auto successor_of(std::shared_ptr<Session> const&) const -> std::shared_ptr<Session> ;
+    auto predecessor_of(std::shared_ptr<Session> const&) const -> std::shared_ptr<Session> ;
 
     SessionContainer(const SessionContainer&) = delete;
     SessionContainer& operator=(const SessionContainer&) = delete;

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(miral SHARED
     display_configuration.cpp           ${miral_include}/miral/display_configuration.h
     external_client.cpp                 ${miral_include}/miral/external_client.h
     keymap.cpp                          ${miral_include}/miral/keymap.h
+    minimal_window_manager.cpp          ${miral_include}/miral/minimal_window_manager.h
     runner.cpp                          ${miral_include}/miral/runner.h
     display_configuration_option.cpp    ${miral_include}/miral/display_configuration_option.h
     output.cpp                          ${miral_include}/miral/output.h

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -564,6 +564,56 @@ void miral::BasicWindowManager::focus_next_application()
     select_active_window(focussed_surface ? info_for(focussed_surface).window() : Window{});
 }
 
+void miral::BasicWindowManager::focus_prev_application()
+{
+    if (auto const prev = active_window())
+    {
+        auto const workspaces_containing_window = workspaces_containing(prev);
+
+        if (!workspaces_containing_window.empty())
+        {
+            do
+            {
+                focus_controller->focus_prev_session();
+
+                if (can_activate_window_for_session_in_workspace(
+                    focus_controller->focused_session(),
+                    workspaces_containing_window))
+                {
+                    return;
+                }
+            }
+            while (focus_controller->focused_session() != prev.application());
+        }
+        else
+        {
+            do
+            {
+                focus_controller->focus_prev_session();
+
+                if (can_activate_window_for_session(focus_controller->focused_session()))
+                {
+                    return;
+                }
+            }
+            while (focus_controller->focused_session() != prev.application());
+        }
+    }
+    else
+    {
+        focus_controller->focus_prev_session();
+
+        if (can_activate_window_for_session(focus_controller->focused_session()))
+        {
+            return;
+        }
+    }
+
+    // Last resort: accept wherever focus_controller places focus
+    auto const focussed_surface = focus_controller->focused_surface();
+    select_active_window(focussed_surface ? info_for(focussed_surface).window() : Window{});
+}
+
 auto miral::BasicWindowManager::workspaces_containing(Window const& window) const
 -> std::vector<std::shared_ptr<Workspace>>
 {

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2017 Canonical Ltd.
+ * Copyright © 2015-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -174,6 +174,7 @@ public:
     void drag_window(Window const& window, Displacement& movement) override;
 
     void focus_next_application() override;
+    void focus_prev_application() override;
 
     void focus_next_within_application() override;
     void focus_prev_within_application() override;

--- a/src/miral/minimal_window_manager.cpp
+++ b/src/miral/minimal_window_manager.cpp
@@ -18,12 +18,48 @@
 
 #include <miral/minimal_window_manager.h>
 
-struct miral::Impl {};
+namespace
+{
+unsigned int const shift_states =
+    mir_input_event_modifier_alt |
+    mir_input_event_modifier_shift |
+    mir_input_event_modifier_sym |
+    mir_input_event_modifier_ctrl |
+    mir_input_event_modifier_meta;
 
+enum class PointerGesture
+{
+    none,
+    moving,
+    resizing
+};
+}
+
+struct miral::Impl
+{
+    Impl(WindowManagerTools const& tools) : tools{tools} {}
+    WindowManagerTools tools;
+
+    PointerGesture pointer_gesture = PointerGesture::none;
+
+    MirPointerButton pointer_gesture_button;
+    miral::Window pointer_gesture_window;
+    unsigned pointer_gesture_shift_keys = 0;
+    MirResizeEdge resize_edge = mir_resize_edge_none;
+    Point resize_top_left;
+    Size resize_size;
+
+    Point old_cursor{};
+
+    bool begin_pointer_gesture(
+        WindowInfo const& window_info, MirInputEvent const* input_event, PointerGesture gesture, MirResizeEdge edge);
+
+    bool handle_pointer_event(MirPointerEvent const* event);
+};
 
 miral::MinimalWindowManager::MinimalWindowManager(WindowManagerTools const& tools):
     tools{tools},
-    self{new Impl}
+    self{new Impl{tools}}
 {
 }
 
@@ -75,9 +111,9 @@ bool miral::MinimalWindowManager::handle_touch_event(MirTouchEvent const* /*even
     return false;
 }
 
-bool miral::MinimalWindowManager::handle_pointer_event(MirPointerEvent const* /*event*/)
+bool miral::MinimalWindowManager::handle_pointer_event(MirPointerEvent const* event)
 {
-    return false;
+    return self->handle_pointer_event(event);
 }
 
 void miral::MinimalWindowManager::handle_request_drag_and_drop(WindowInfo& /*window_info*/)
@@ -85,19 +121,162 @@ void miral::MinimalWindowManager::handle_request_drag_and_drop(WindowInfo& /*win
     // TODO
 }
 
-void miral::MinimalWindowManager::handle_request_move(WindowInfo& /*window_info*/, MirInputEvent const* /*input_event*/)
+void miral::MinimalWindowManager::handle_request_move(WindowInfo& window_info, MirInputEvent const* input_event)
 {
-    // TODO
+    if (self->begin_pointer_gesture(window_info, input_event, PointerGesture::moving, mir_resize_edge_none))
+    {
+        return;
+    }
+    else
+    {
+        // TODO touch
+    }
 }
 
 void miral::MinimalWindowManager::handle_request_resize(
-    WindowInfo& /*window_info*/, MirInputEvent const* /*input_event*/, MirResizeEdge /*edge*/)
+    WindowInfo& window_info, MirInputEvent const* input_event, MirResizeEdge edge)
 {
-    // TODO
+    if (self->begin_pointer_gesture(window_info, input_event, PointerGesture::resizing, edge))
+    {
+        return;
+    }
+    else
+    {
+        // TODO touch
+    }
 }
 
 auto miral::MinimalWindowManager::confirm_inherited_move(WindowInfo const& window_info, Displacement movement)
 -> Rectangle
 {
     return {window_info.window().top_left()+movement, window_info.window().size()};
+}
+
+bool miral::Impl::begin_pointer_gesture(
+    WindowInfo const& window_info, MirInputEvent const* input_event, PointerGesture gesture, MirResizeEdge edge)
+{
+    if (mir_input_event_get_type(input_event) != mir_input_event_type_pointer)
+        return false;
+
+    if (window_info.state() != mir_window_state_restored)
+        return false;
+
+    MirPointerEvent const* const pointer_event = mir_input_event_get_pointer_event(input_event);
+    pointer_gesture = gesture;
+    pointer_gesture_window = window_info.window();
+    pointer_gesture_shift_keys = mir_pointer_event_modifiers(pointer_event) & shift_states;
+    resize_top_left = pointer_gesture_window.top_left();
+    resize_size = pointer_gesture_window.size();
+    resize_edge = edge;
+
+    for (auto button : {mir_pointer_button_primary, mir_pointer_button_secondary, mir_pointer_button_tertiary})
+    {
+        if (mir_pointer_event_button_state(pointer_event, button))
+        {
+            pointer_gesture_button = button;
+            break;
+        }
+    }
+
+    return true;
+}
+
+bool miral::Impl::handle_pointer_event(MirPointerEvent const* event)
+{
+    auto const action = mir_pointer_event_action(event);
+    auto const shift_keys = mir_pointer_event_modifiers(event) & shift_states;
+    Point const cursor{
+        mir_pointer_event_axis_value(event, mir_pointer_axis_x),
+        mir_pointer_event_axis_value(event, mir_pointer_axis_y)};
+
+    bool consumes_event = false;
+
+    switch (pointer_gesture)
+    {
+    case PointerGesture::resizing:
+        if (action == mir_pointer_action_motion &&
+            shift_keys == pointer_gesture_shift_keys &&
+            mir_pointer_event_button_state(event, pointer_gesture_button))
+        {
+            if (pointer_gesture_window)
+            {
+                if (tools.select_active_window(pointer_gesture_window) == pointer_gesture_window)
+                {
+                    auto const top_left = resize_top_left;
+                    Rectangle const old_pos{top_left, resize_size};
+
+                    auto movement = cursor - old_cursor;
+
+                    auto new_width = old_pos.size.width;
+                    auto new_height = old_pos.size.height;
+
+                    if (resize_edge & mir_resize_edge_east)
+                        new_width = old_pos.size.width + movement.dx;
+
+                    if (resize_edge & mir_resize_edge_west)
+                        new_width = old_pos.size.width - movement.dx;
+
+                    if (resize_edge & mir_resize_edge_north)
+                        new_height = old_pos.size.height - movement.dy;
+
+                    if (resize_edge & mir_resize_edge_south)
+                        new_height = old_pos.size.height + movement.dy;
+
+                    Size new_size{new_width, new_height};
+
+                    Point new_pos = top_left;
+
+                    if (resize_edge & mir_resize_edge_west)
+                        new_pos.x = top_left.x + movement.dx;
+
+                    if (resize_edge & mir_resize_edge_north)
+                        new_pos.y = top_left.y + movement.dy;
+
+                    WindowSpecification modifications;
+                    modifications.top_left() = new_pos;
+                    modifications.size() = new_size;
+                    tools.modify_window(pointer_gesture_window, modifications);
+                    resize_top_left = new_pos;
+                    resize_size = new_size;
+                }
+                else
+                {
+                    pointer_gesture = PointerGesture::none;
+                }
+            }
+            else
+            {
+                pointer_gesture = PointerGesture::none;
+            }
+
+            consumes_event = true;
+        }
+        else
+        {
+            pointer_gesture = PointerGesture::none;
+        }
+        break;
+
+    case PointerGesture::moving:
+        if (action == mir_pointer_action_motion &&
+            shift_keys == pointer_gesture_shift_keys &&
+            mir_pointer_event_button_state(event, pointer_gesture_button))
+        {
+            if (auto const target = tools.window_at(old_cursor))
+            {
+                if (tools.select_active_window(target) == target)
+                    tools.drag_active_window(cursor - old_cursor);
+            }
+            consumes_event = true;
+        }
+        else
+            pointer_gesture = PointerGesture::none;
+        break;
+
+    default:
+        break;
+    }
+
+    old_cursor = cursor;
+    return consumes_event;
 }

--- a/src/miral/minimal_window_manager.cpp
+++ b/src/miral/minimal_window_manager.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include <miral/minimal_window_manager.h>
+
+struct miral::Impl {};
+
+
+miral::MinimalWindowManager::MinimalWindowManager(WindowManagerTools const& tools):
+    tools{tools},
+    self{new Impl}
+{
+}
+
+miral::MinimalWindowManager::~MinimalWindowManager()
+{
+    delete self;
+}
+
+auto miral::MinimalWindowManager::place_new_window(
+    ApplicationInfo const& /*app_info*/, WindowSpecification const& requested_specification)
+    -> WindowSpecification
+{
+    return requested_specification;
+}
+
+void miral::MinimalWindowManager::handle_window_ready(WindowInfo& window_info)
+{
+    if (window_info.can_be_active())
+    {
+        tools.select_active_window(window_info.window());
+    }
+}
+
+void miral::MinimalWindowManager::handle_modify_window(
+    WindowInfo& window_info, miral::WindowSpecification const& modifications)
+{
+    tools.modify_window(window_info, modifications);
+}
+
+void miral::MinimalWindowManager::handle_raise_window(WindowInfo& window_info)
+{
+    tools.select_active_window(window_info.window());
+}
+
+auto miral::MinimalWindowManager::confirm_placement_on_display(
+    WindowInfo const& /*window_info*/, MirWindowState /*new_state*/, Rectangle const& new_placement)
+    -> Rectangle
+{
+    return new_placement;
+}
+
+bool miral::MinimalWindowManager::handle_keyboard_event(MirKeyboardEvent const* /*event*/)
+{
+    return false;
+}
+
+bool miral::MinimalWindowManager::handle_touch_event(MirTouchEvent const* /*event*/)
+{
+    return false;
+}
+
+bool miral::MinimalWindowManager::handle_pointer_event(MirPointerEvent const* /*event*/)
+{
+    return false;
+}
+
+void miral::MinimalWindowManager::handle_request_drag_and_drop(WindowInfo& /*window_info*/)
+{
+    // TODO
+}
+
+void miral::MinimalWindowManager::handle_request_move(WindowInfo& /*window_info*/, MirInputEvent const* /*input_event*/)
+{
+    // TODO
+}
+
+void miral::MinimalWindowManager::handle_request_resize(
+    WindowInfo& /*window_info*/, MirInputEvent const* /*input_event*/, MirResizeEdge /*edge*/)
+{
+    // TODO
+}
+
+auto miral::MinimalWindowManager::confirm_inherited_move(WindowInfo const& window_info, Displacement movement)
+-> Rectangle
+{
+    return {window_info.window().top_left()+movement, window_info.window().size()};
+}

--- a/src/miral/minimal_window_manager.cpp
+++ b/src/miral/minimal_window_manager.cpp
@@ -19,6 +19,7 @@
 #include <miral/minimal_window_manager.h>
 
 #include <linux/input.h>
+#include <gmpxx.h>
 
 namespace
 {
@@ -159,7 +160,7 @@ void miral::MinimalWindowManager::handle_request_drag_and_drop(WindowInfo& /*win
 
 void miral::MinimalWindowManager::handle_request_move(WindowInfo& window_info, MirInputEvent const* input_event)
 {
-    if (self->begin_pointer_gesture(window_info, input_event, PointerGesture::moving, mir_resize_edge_none))
+    if (begin_pointer_move(window_info, input_event))
     {
         return;
     }
@@ -169,10 +170,15 @@ void miral::MinimalWindowManager::handle_request_move(WindowInfo& window_info, M
     }
 }
 
+bool miral::MinimalWindowManager::begin_pointer_move(miral::WindowInfo const& window_info, MirInputEvent const* input_event)
+{
+    return self->begin_pointer_gesture(window_info, input_event, PointerGesture::moving, mir_resize_edge_none);
+}
+
 void miral::MinimalWindowManager::handle_request_resize(
     WindowInfo& window_info, MirInputEvent const* input_event, MirResizeEdge edge)
 {
-    if (self->begin_pointer_gesture(window_info, input_event, PointerGesture::resizing, edge))
+    if (begin_pointer_resize(window_info, input_event, edge))
     {
         return;
     }
@@ -180,6 +186,12 @@ void miral::MinimalWindowManager::handle_request_resize(
     {
         // TODO touch
     }
+}
+
+bool miral::MinimalWindowManager::begin_pointer_resize(
+    WindowInfo const& window_info, MirInputEvent const* input_event, MirResizeEdge const& edge)
+{
+    return self->begin_pointer_gesture(window_info, input_event, PointerGesture::resizing, edge);
 }
 
 auto miral::MinimalWindowManager::confirm_inherited_move(WindowInfo const& window_info, Displacement movement)

--- a/src/miral/minimal_window_manager.cpp
+++ b/src/miral/minimal_window_manager.cpp
@@ -153,6 +153,23 @@ bool miral::MinimalWindowManager::handle_keyboard_event(MirKeyboardEvent const* 
         }
     }
 
+    if (action == mir_keyboard_action_down &&
+        shift_state == (mir_input_event_modifier_alt | mir_input_event_modifier_shift))
+    {
+        switch (mir_keyboard_event_scan_code(event))
+        {
+        case KEY_TAB:
+            tools.focus_prev_application();
+            return true;
+
+        case KEY_GRAVE:
+            tools.focus_prev_within_application();
+            return true;
+
+        default:;
+        }
+    }
+
     return false;
 }
 

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -375,6 +375,21 @@ global:
 MIRAL_2.5 {
 global:
   extern "C++" {
+    miral::MinimalWindowManager::?MinimalWindowManager*;
+    miral::MinimalWindowManager::MinimalWindowManager*;
+    miral::MinimalWindowManager::advise_focus_gained*;
+    miral::MinimalWindowManager::confirm_inherited_move*;
+    miral::MinimalWindowManager::confirm_placement_on_display*;
+    miral::MinimalWindowManager::handle_keyboard_event*;
+    miral::MinimalWindowManager::handle_modify_window*;
+    miral::MinimalWindowManager::handle_pointer_event*;
+    miral::MinimalWindowManager::handle_raise_window*;
+    miral::MinimalWindowManager::handle_request_drag_and_drop*;
+    miral::MinimalWindowManager::handle_request_move*;
+    miral::MinimalWindowManager::handle_request_resize*;
+    miral::MinimalWindowManager::handle_touch_event*;
+    miral::MinimalWindowManager::handle_window_ready*;
+    miral::MinimalWindowManager::place_new_window*;
     miral::WaylandExtensions::Context::?Context*;
     miral::WaylandExtensions::Context::Context*;
     miral::WaylandExtensions::Context::operator*;
@@ -384,9 +399,24 @@ global:
     miral::WaylandExtensions::set_filter*;
     miral::application_for*;
     miral::window_for*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::advise_focus_gained*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::confirm_inherited_move*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::confirm_placement_on_display*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::handle_keyboard_event*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::handle_modify_window*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::handle_pointer_event*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::handle_raise_window*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::handle_request_drag_and_drop*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::handle_request_move*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::handle_request_resize*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::handle_touch_event*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::handle_window_ready*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::place_new_window*;
     non-virtual?thunk?to?miral::WaylandExtensions::Context::?Context*;
+    typeinfo?for?miral::MinimalWindowManager;
     typeinfo?for?miral::WaylandExtensions::Builder;
     typeinfo?for?miral::WaylandExtensions::Context;
+    vtable?for?miral::MinimalWindowManager;
     vtable?for?miral::WaylandExtensions::Builder;
     vtable?for?miral::WaylandExtensions::Context;
   };

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -401,6 +401,7 @@ global:
     miral::WaylandExtensions::add_extension_disabled_by_default*;
     miral::WaylandExtensions::recommended_extensions*;
     miral::WaylandExtensions::set_filter*;
+    miral::WindowManagerTools::focus_prev_application*;
     miral::application_for*;
     miral::window_for*;
     non-virtual?thunk?to?miral::MinimalWindowManager::advise_focus_gained*;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -380,6 +380,8 @@ global:
     miral::MinimalWindowManager::advise_focus_gained*;
     miral::MinimalWindowManager::begin_pointer_move*;
     miral::MinimalWindowManager::begin_pointer_resize*;
+    miral::MinimalWindowManager::begin_touch_move*;
+    miral::MinimalWindowManager::begin_touch_resize*;
     miral::MinimalWindowManager::confirm_inherited_move*;
     miral::MinimalWindowManager::confirm_placement_on_display*;
     miral::MinimalWindowManager::handle_keyboard_event*;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -378,6 +378,8 @@ global:
     miral::MinimalWindowManager::?MinimalWindowManager*;
     miral::MinimalWindowManager::MinimalWindowManager*;
     miral::MinimalWindowManager::advise_focus_gained*;
+    miral::MinimalWindowManager::begin_pointer_move*;
+    miral::MinimalWindowManager::begin_pointer_resize*;
     miral::MinimalWindowManager::confirm_inherited_move*;
     miral::MinimalWindowManager::confirm_placement_on_display*;
     miral::MinimalWindowManager::handle_keyboard_event*;

--- a/src/miral/window_management_trace.cpp
+++ b/src/miral/window_management_trace.cpp
@@ -536,6 +536,15 @@ try {
 }
 MIRAL_TRACE_EXCEPTION
 
+void miral::WindowManagementTrace::focus_prev_application()
+try {
+    log_input();
+    mir::log_info("%s", __func__);
+    trace_count++;
+    wrapped.focus_next_application();
+}
+MIRAL_TRACE_EXCEPTION
+
 void miral::WindowManagementTrace::focus_next_within_application()
 try {
     log_input();

--- a/src/miral/window_management_trace.h
+++ b/src/miral/window_management_trace.h
@@ -65,6 +65,7 @@ private:
     void drag_window(Window const& window, mir::geometry::Displacement& movement) override;
 
     virtual void focus_next_application() override;
+    virtual void focus_prev_application() override;
 
     virtual void focus_next_within_application() override;
     virtual void focus_prev_within_application() override;

--- a/src/miral/window_manager_tools.cpp
+++ b/src/miral/window_manager_tools.cpp
@@ -68,6 +68,9 @@ void miral::WindowManagerTools::drag_window(Window const& window, mir::geometry:
 void miral::WindowManagerTools::focus_next_application()
 { tools->focus_next_application(); }
 
+void miral::WindowManagerTools::focus_prev_application()
+{ tools->focus_prev_application(); }
+
 void miral::WindowManagerTools::focus_next_within_application()
 { tools->focus_next_within_application(); }
 

--- a/src/miral/window_manager_tools_implementation.h
+++ b/src/miral/window_manager_tools_implementation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Canonical Ltd.
+ * Copyright © 2016-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -62,6 +62,7 @@ public:
     virtual void drag_active_window(mir::geometry::Displacement movement) = 0;
     virtual void drag_window(Window const& window, mir::geometry::Displacement& movement) = 0;
     virtual void focus_next_application() = 0;
+    virtual void focus_prev_application() = 0;
     virtual void focus_next_within_application() = 0;
     virtual void focus_prev_within_application() = 0;
     virtual auto window_at(mir::geometry::Point cursor) const -> Window = 0;

--- a/src/server/scene/CMakeLists.txt
+++ b/src/server/scene/CMakeLists.txt
@@ -10,7 +10,7 @@ ADD_LIBRARY(
   basic_surface.cpp
   broadcasting_session_event_sink.cpp
   default_configuration.cpp
-  default_session_container.cpp
+        session_container.cpp
   gl_pixel_buffer.cpp
   mediating_display_changer.cpp
   session_manager.cpp

--- a/src/server/scene/session_container.cpp
+++ b/src/server/scene/session_container.cpp
@@ -60,7 +60,8 @@ void ms::SessionContainer::for_each(std::function<void(std::shared_ptr<Session> 
     }
 }
 
-std::shared_ptr<ms::Session> ms::SessionContainer::successor_of(std::shared_ptr<Session> const& session) const
+auto ms::SessionContainer::successor_of(std::shared_ptr<Session> const& session) const
+    -> std::shared_ptr<ms::Session>
 {
     std::shared_ptr<Session> result, first;
 
@@ -76,6 +77,30 @@ std::shared_ptr<ms::Session> ms::SessionContainer::successor_of(std::shared_ptr<
             auto successor = ++it;
             if (successor == apps.end())
                 return *apps.begin();
+            else return *successor;
+        }
+    }
+
+    BOOST_THROW_EXCEPTION(std::logic_error("Invalid session"));
+}
+
+auto mir::scene::SessionContainer::predecessor_of(std::shared_ptr<Session> const& session) const
+    -> std::shared_ptr<Session>
+{
+    std::shared_ptr<Session> result, first;
+
+    if (!session && apps.size())
+        return apps.front();
+    else if(!session)
+        return std::shared_ptr<Session>();
+
+    for (auto it = apps.rbegin(); it != apps.rend(); it++)
+    {
+        if (*it == session)
+        {
+            auto successor = ++it;
+            if (successor == apps.rend())
+                return *apps.rbegin();
             else return *successor;
         }
     }

--- a/src/server/scene/session_manager.cpp
+++ b/src/server/scene/session_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2015 Canonical Ltd.
+ * Copyright © 2012-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,
@@ -189,10 +189,16 @@ void ms::SessionManager::close_session(std::shared_ptr<Session> const& session)
 }
 
 
-std::shared_ptr<ms::Session> ms::SessionManager::successor_of(
-    std::shared_ptr<Session> const& session) const
+auto ms::SessionManager::successor_of(std::shared_ptr<Session> const& session) const
+    -> std::shared_ptr<ms::Session>
 {
     return app_container->successor_of(session);
+}
+
+auto ms::SessionManager::predecessor_of(std::shared_ptr<Session> const& session) const
+    -> std::shared_ptr<mir::scene::Session>
+{
+    return app_container->predecessor_of(session);
 }
 
 void ms::SessionManager::add_listener(std::shared_ptr<SessionListener> const& listener)

--- a/src/server/scene/session_manager.h
+++ b/src/server/scene/session_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Canonical Ltd.
+ * Copyright © 2012-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,
@@ -65,14 +65,15 @@ public:
 
     virtual ~SessionManager() noexcept;
 
-    std::shared_ptr<Session> open_session(
+    auto open_session(
         pid_t client_pid,
         std::string const& name,
-        std::shared_ptr<frontend::EventSink> const& sink) override;
+        std::shared_ptr<frontend::EventSink> const& sink) -> std::shared_ptr<Session> override;
 
     void close_session(std::shared_ptr<Session> const& session) override;
 
-    std::shared_ptr<Session> successor_of(std::shared_ptr<Session> const&) const override;
+    auto successor_of(std::shared_ptr<Session> const&) const -> std::shared_ptr<Session> override;
+    auto predecessor_of(std::shared_ptr<Session> const&) const -> std::shared_ptr<Session> override;
 
     void set_focus_to(std::shared_ptr<Session> const& focus) override;
     void unset_focus() override;

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -309,6 +309,29 @@ void msh::AbstractShell::focus_next_session()
     update_focus_locked(lock, successor, surface);
 }
 
+void msh::AbstractShell::focus_prev_session()
+{
+    std::unique_lock<std::mutex> lock(focus_mutex);
+    auto const focused_session = focus_session.lock();
+    auto predecessor = session_coordinator->predecessor_of(focused_session);
+    auto const sentinel = predecessor;
+
+    while (predecessor != nullptr &&
+           predecessor->default_surface() == nullptr)
+    {
+        predecessor = session_coordinator->predecessor_of(predecessor);
+        if (predecessor == sentinel)
+            break;
+    }
+
+    auto const surface = predecessor ? predecessor->default_surface() : nullptr;
+
+    if (!surface)
+        predecessor = nullptr;
+
+    update_focus_locked(lock, predecessor, surface);
+}
+
 std::shared_ptr<ms::Session> msh::AbstractShell::focused_session() const
 {
     std::unique_lock<std::mutex> lg(focus_mutex);

--- a/src/server/shell/shell_wrapper.cpp
+++ b/src/server/shell/shell_wrapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Canonical Ltd.
+ * Copyright © 2015-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,
@@ -44,6 +44,11 @@ void msh::ShellWrapper::close_session(std::shared_ptr<ms::Session> const& sessio
 void msh::ShellWrapper::focus_next_session()
 {
     wrapped->focus_next_session();
+}
+
+void msh::ShellWrapper::focus_prev_session()
+{
+    wrapped->focus_prev_session();
 }
 
 std::shared_ptr<ms::Session> msh::ShellWrapper::focused_session() const

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -958,5 +958,6 @@ MIR_SERVER_1.2 {
     mir::DefaultServerConfiguration::set_wayland_extension_filter*;
     mir::frontend::get_session*;
     mir::frontend::get_window*;
+    mir::shell::ShellWrapper::focus_prev_session*;
   };
 } MIR_SERVER_0.32;

--- a/tests/acceptance-tests/wayland/miral_integration.cpp
+++ b/tests/acceptance-tests/wayland/miral_integration.cpp
@@ -545,6 +545,9 @@ struct MirWlcsDisplayServer : miral::TestDisplayServer, public WlcsDisplayServer
 {
     MirWlcsDisplayServer();
 
+    auto build_window_manager_policy(miral::WindowManagerTools const& tools)
+    -> std::unique_ptr<TestWindowManagerPolicy> override;
+
     testing::NiceMock<mir::test::doubles::MockGL> mockgl;
     std::shared_ptr<ResourceMapper> const resource_mapper{std::make_shared<ResourceMapper>()};
     std::shared_ptr<InputEventListener> event_listener;
@@ -1077,5 +1080,11 @@ MirWlcsDisplayServer::MirWlcsDisplayServer()
     create_pointer = &wlcs_server_create_pointer;
     create_touch = &wlcs_server_create_touch;
     get_descriptor = &::get_descriptor;
+}
+
+auto MirWlcsDisplayServer::build_window_manager_policy(miral::WindowManagerTools const& tools)
+->std::unique_ptr<TestWindowManagerPolicy>
+{
+    return std::make_unique<TestWindowManagerPolicy>(tools, *this);
 }
 }

--- a/tests/include/miral/test_server.h
+++ b/tests/include/miral/test_server.h
@@ -21,7 +21,7 @@
 
 #include <mir/client/connection.h>
 
-#include <miral/canonical_window_manager.h>
+#include <miral/minimal_window_manager.h>
 #include <miral/runner.h>
 #include <miral/window_manager_tools.h>
 
@@ -86,23 +86,9 @@ struct TestServer : TestDisplayServer, testing::Test
     void TearDown() override;
 };
 
-struct TestDisplayServer::TestWindowManagerPolicy : CanonicalWindowManagerPolicy
+struct TestDisplayServer::TestWindowManagerPolicy : MinimalWindowManager
 {
     TestWindowManagerPolicy(WindowManagerTools const& tools, TestDisplayServer& test_fixture);
-
-    bool handle_keyboard_event(MirKeyboardEvent const*) override { return false; }
-    bool handle_pointer_event(MirPointerEvent const*) override;
-    bool handle_touch_event(MirTouchEvent const*) override { return false; }
-    void handle_request_drag_and_drop(miral::WindowInfo&) override {}
-    void handle_request_move(miral::WindowInfo&, MirInputEvent const*) override {}
-    void handle_request_resize(miral::WindowInfo&, MirInputEvent const*, MirResizeEdge) override {}
-    mir::geometry::Rectangle confirm_placement_on_display(
-        const miral::WindowInfo&,
-        MirWindowState,
-        mir::geometry::Rectangle const& new_placement) override
-    {
-        return new_placement;
-    }
 };
 
 }

--- a/tests/miral/drag_and_drop.cpp
+++ b/tests/miral/drag_and_drop.cpp
@@ -537,7 +537,8 @@ auto DragAndDrop::count_of_handles_when_moving_mouse() -> int
     move_mouse({1,1});
     release_mouse();
 
-    EXPECT_TRUE(have_3_events.wait_for(receive_event_timeout));
+    EXPECT_TRUE(have_3_events.wait_for(receive_event_timeout))
+        << "events=" << events.load();
 
     reset_window_event_handler(window);
     reset_window_event_handler(target_window);
@@ -557,6 +558,22 @@ auto DragAndDrop::build_window_manager_policy(miral::WindowManagerTools const& t
             std::vector<uint8_t> const handle{std::begin(uuid), std::end(uuid)};
 
             tools.start_drag_and_drop(window_info, handle);
+        }
+
+        bool handle_pointer_event(MirPointerEvent const* event) override
+        {
+            auto const action = mir_pointer_event_action(event);
+
+            Point const cursor{
+                mir_pointer_event_axis_value(event, mir_pointer_axis_x),
+                mir_pointer_event_axis_value(event, mir_pointer_axis_y)};
+
+            if (action == mir_pointer_action_button_down)
+            {
+                tools.select_active_window(tools.window_at(cursor));
+            }
+
+            return false;
         }
 
         void handle_request_move(miral::WindowInfo&, MirInputEvent const*) override {}

--- a/tests/miral/test_server.cpp
+++ b/tests/miral/test_server.cpp
@@ -71,7 +71,18 @@ miral::TestDisplayServer::~TestDisplayServer() = default;
 auto miral::TestDisplayServer::build_window_manager_policy(WindowManagerTools const& tools)
 -> std::unique_ptr<TestWindowManagerPolicy>
 {
-    return std::make_unique<TestWindowManagerPolicy>(tools, *this);
+    // TODO: Fix the acceptance tests that rely on this
+    // (And then remove MirWlcsDisplayServer::build_window_manager_policy()
+    // which reinstates the correct behaviour.)
+    struct XX : TestWindowManagerPolicy
+    {
+        using TestWindowManagerPolicy::TestWindowManagerPolicy;
+        bool handle_pointer_event(MirPointerEvent const*) override
+        {
+            return false;
+        }
+    };
+    return std::make_unique<XX>(tools, *this);
 }
 
 void miral::TestDisplayServer::start_server()

--- a/tests/miral/test_server.cpp
+++ b/tests/miral/test_server.cpp
@@ -52,25 +52,9 @@ char const* const trace_option = "window-management-trace";
 
 miral::TestDisplayServer::TestWindowManagerPolicy::TestWindowManagerPolicy(
     WindowManagerTools const& tools, TestDisplayServer& test_fixture) :
-    CanonicalWindowManagerPolicy{tools}
+    MinimalWindowManager{tools}
 {
     test_fixture.tools = tools;
-}
-
-bool TestDisplayServer::TestWindowManagerPolicy::handle_pointer_event(MirPointerEvent const* event)
-{
-    auto const action = mir_pointer_event_action(event);
-
-    Point const cursor{
-        mir_pointer_event_axis_value(event, mir_pointer_axis_x),
-        mir_pointer_event_axis_value(event, mir_pointer_axis_y)};
-
-    if (action == mir_pointer_action_button_down)
-    {
-        tools.select_active_window(tools.window_at(cursor));
-    }
-
-    return false;
 }
 
 miral::TestDisplayServer::TestDisplayServer() :

--- a/tests/miral/test_window_manager_tools.h
+++ b/tests/miral/test_window_manager_tools.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Canonical Ltd.
+ * Copyright © 2016-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -40,6 +40,7 @@
 struct StubFocusController : mir::shell::FocusController
 {
     void focus_next_session() override {}
+    void focus_prev_session() override {}
 
     auto focused_session() const -> std::shared_ptr<mir::scene::Session> override { return {}; }
 

--- a/tests/miral/workspaces.cpp
+++ b/tests/miral/workspaces.cpp
@@ -255,7 +255,7 @@ void WorkspacesWindowManagerPolicy::advise_new_window(miral::WindowInfo const& w
 
 void WorkspacesWindowManagerPolicy::handle_window_ready(miral::WindowInfo& window_info)
 {
-    miral::CanonicalWindowManagerPolicy::handle_window_ready(window_info);
+    miral::TestServer::TestWindowManagerPolicy::handle_window_ready(window_info);
     advise_window_ready(window_info);
 }
 }


### PR DESCRIPTION
Provide a new MinimalWindowManager strategy. (Fixes #761, #816)

With this the MinimalWindowManager is only used by `mir_demo_server` and tests. Will follow up by integrating with the example shells.