### PR TITLE
Don't let help text get too high for the output

### DIFF
--- a/examples/example-server-lib/decoration_provider.cpp
+++ b/examples/example-server-lib/decoration_provider.cpp
@@ -159,7 +159,7 @@ void Printer::printhelp(BackgroundInfo const& region)
 
         auto const line = converter.from_bytes(rawline);
 
-        auto const fwidth = std::min(width / 60, 20);
+        auto const fwidth = std::min({width/60, height/40, 20});
 
         FT_Set_Pixel_Sizes(face, fwidth, 0);
 

--- a/examples/example-server-lib/decoration_provider.cpp
+++ b/examples/example-server-lib/decoration_provider.cpp
@@ -177,6 +177,10 @@ void Printer::printhelp(BackgroundInfo const& region)
         help_height += line_height;
     }
 
+    // Ensure we don't have a crazy font that extends the text beyond the screen
+    if (help_height > static_cast<decltype(help_height)>(height) || help_width > width)
+        return;
+
     int base_y = (height - help_height) / 2;
     auto* const region_address = reinterpret_cast<char unsigned*>(region.content_area);
 


### PR DESCRIPTION
Don't let help text get too high for the output. (Fixes: #799)