### PR TITLE
Rename zxdg_output_v1 -> zxdg_output_manager_v1

### DIFF
--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -35,7 +35,7 @@ struct miral::WaylandExtensions::Self
 {
     Self(std::string const& default_value) : default_value{default_value}
     {
-        available_extensions += ":zwlr_layer_shell_v1:zxdg_output_v1:";
+        available_extensions += ":zwlr_layer_shell_v1:zxdg_output_manager_v1:";
         validate(default_value);
     }
 

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -41,7 +41,7 @@ auto const wl_shell       = "wl_shell";
 auto const xdg_shell      = "xdg_wm_base";
 auto const xdg_shell_v6   = "zxdg_shell_v6";
 auto const layer_shell_v1 = "zwlr_layer_shell_v1";
-auto const xdg_output_v1  = "zxdg_output_v1";
+auto const xdg_output_v1  = "zxdg_output_manager_v1";
 
 auto configure_wayland_extensions(std::string extensions,
     bool x11_enabled,


### PR DESCRIPTION
I originally incorrectly used `zxdg_output_v1` as the name for the XDG output interface. This is a name of the object in the interface, but not the global object, which is used by everything else.