### PR TITLE
Wayland: Eagerly send buffer release events.

### DIFF
--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -346,7 +346,7 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
                     {
                         executor->spawn(run_unless(
                             destroyed,
-                            [buffer](){ wl_resource_queue_event(buffer, wayland::Buffer::Opcode::release); }));
+                            [buffer](){ wl_resource_post_event(buffer, wayland::Buffer::Opcode::release); }));
                     };
 
                 mir_buffer = allocator->buffer_from_resource(


### PR DESCRIPTION
We want to use `wl_resource_post_event()` (which is what is generated for
`wl_buffer_send_release()` by wayland-scanner), as this marks the connection
as flushable (ie: we want the client to receive this event now).

We want the release events to make it to the client ASAP, so they can act
on it.