### PR TITLE
Force latest protocol version

### DIFF
--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -36,6 +36,9 @@ struct Version
 class Resource
 {
 public:
+    template<int V>
+    using Version = Version<V>;
+
     Resource();
     virtual ~Resource() = default;
 
@@ -46,6 +49,9 @@ public:
 class Global
 {
 public:
+    template<int V>
+    using Version = Version<V>;
+
     explicit Global(wl_global* global);
     virtual ~Global();
 

--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -28,16 +28,13 @@ namespace mir
 namespace wayland
 {
 
-template<int V>
-struct Version
-{
-};
-
 class Resource
 {
 public:
     template<int V>
-    using Version = Version<V>;
+    struct Version
+    {
+    };
 
     Resource();
     virtual ~Resource() = default;
@@ -50,7 +47,9 @@ class Global
 {
 public:
     template<int V>
-    using Version = Version<V>;
+    struct Version
+    {
+    };
 
     explicit Global(wl_global* global);
     virtual ~Global();

--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -28,6 +28,11 @@ namespace mir
 namespace wayland
 {
 
+template<int V>
+struct Version
+{
+};
+
 class Resource
 {
 public:
@@ -41,7 +46,7 @@ public:
 class Global
 {
 public:
-    explicit Global(wl_global* global, uint32_t max_version);
+    explicit Global(wl_global* global);
     virtual ~Global();
 
     Global(Global const&) = delete;
@@ -51,7 +56,6 @@ public:
     virtual auto interface_name() const -> char const* = 0;
 
     wl_global* const global;
-    uint32_t const max_version;
 };
 
 void internal_error_processing_request(wl_client* client, char const* method_name);

--- a/src/server/frontend_wayland/data_device.cpp
+++ b/src/server/frontend_wayland/data_device.cpp
@@ -70,7 +70,7 @@ struct DataSource : mw::DataSource
 {
 public:
     DataSource(wl_resource* new_resource, DataDeviceManager* manager)
-        : mw::DataSource{new_resource},
+        : mw::DataSource{new_resource, mw::Version<3>()},
           manager{manager}
     {
     }
@@ -205,7 +205,7 @@ DataSource::~DataSource()
 }
 
 DataDeviceManager::DataDeviceManager(struct wl_display* display) :
-    mf::DataDeviceManager(display, mw::Version<3>()),
+    mf::DataDeviceManager(display, mir::wayland::Version<3>()),
     current_data_source{nullptr, [](DataSource* ds) { if(ds) ds->send_cancelled(); }}
 {
 }
@@ -216,7 +216,7 @@ DataDeviceManager::~DataDeviceManager()
 }
 
 DataDeviceManager::Instance::Instance(wl_resource* new_resource, ::DataDeviceManager* manager)
-    : mir::wayland::DataDeviceManager(new_resource),
+    : mir::wayland::DataDeviceManager(new_resource, mir::wayland::Version<3>()),
       manager{manager}
 {
 }
@@ -263,7 +263,7 @@ void DataDeviceManager::bind(wl_resource* new_resource)
 }
 
 DataDevice::DataDevice(wl_resource* new_resource, DataDeviceManager* manager, mf::WlSeat* seat) :
-    mw::DataDevice(new_resource),
+    mw::DataDevice(new_resource, mw::Version<3>()),
     manager{manager},
     seat{seat}
 {
@@ -330,7 +330,7 @@ void DataDevice::focus_on(wl_client* focus)
 }
 
 DataOffer::DataOffer(wl_resource* new_resource, DataSource* source, DataDevice* device) :
-    mw::DataOffer(new_resource),
+    mw::DataOffer(new_resource, mw::Version<3>()),
     source{source}
 {
     source->add_listener(this);

--- a/src/server/frontend_wayland/data_device.cpp
+++ b/src/server/frontend_wayland/data_device.cpp
@@ -70,7 +70,7 @@ struct DataSource : mw::DataSource
 {
 public:
     DataSource(wl_resource* new_resource, DataDeviceManager* manager)
-        : mw::DataSource{new_resource, mw::Version<3>()},
+        : mw::DataSource{new_resource, Version<3>()},
           manager{manager}
     {
     }
@@ -205,7 +205,7 @@ DataSource::~DataSource()
 }
 
 DataDeviceManager::DataDeviceManager(struct wl_display* display) :
-    mf::DataDeviceManager(display, mir::wayland::Version<3>()),
+    mf::DataDeviceManager(display, Version<3>()),
     current_data_source{nullptr, [](DataSource* ds) { if(ds) ds->send_cancelled(); }}
 {
 }
@@ -216,7 +216,7 @@ DataDeviceManager::~DataDeviceManager()
 }
 
 DataDeviceManager::Instance::Instance(wl_resource* new_resource, ::DataDeviceManager* manager)
-    : mir::wayland::DataDeviceManager(new_resource, mir::wayland::Version<3>()),
+    : mir::wayland::DataDeviceManager(new_resource, Version<3>()),
       manager{manager}
 {
 }
@@ -263,7 +263,7 @@ void DataDeviceManager::bind(wl_resource* new_resource)
 }
 
 DataDevice::DataDevice(wl_resource* new_resource, DataDeviceManager* manager, mf::WlSeat* seat) :
-    mw::DataDevice(new_resource, mw::Version<3>()),
+    mw::DataDevice(new_resource, Version<3>()),
     manager{manager},
     seat{seat}
 {
@@ -330,7 +330,7 @@ void DataDevice::focus_on(wl_client* focus)
 }
 
 DataOffer::DataOffer(wl_resource* new_resource, DataSource* source, DataDevice* device) :
-    mw::DataOffer(new_resource, mw::Version<3>()),
+    mw::DataOffer(new_resource, Version<3>()),
     source{source}
 {
     source->add_listener(this);

--- a/src/server/frontend_wayland/data_device.cpp
+++ b/src/server/frontend_wayland/data_device.cpp
@@ -205,7 +205,7 @@ DataSource::~DataSource()
 }
 
 DataDeviceManager::DataDeviceManager(struct wl_display* display) :
-    mf::DataDeviceManager(display, 3),
+    mf::DataDeviceManager(display, mw::Version<3>()),
     current_data_source{nullptr, [](DataSource* ds) { if(ds) ds->send_cancelled(); }}
 {
 }

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -34,7 +34,7 @@ class LayerShellV1::Instance : wayland::LayerShellV1
 {
 public:
     Instance(wl_resource* new_resource, mf::LayerShellV1* shell)
-        : LayerShellV1{new_resource, mw::Version<1>()},
+        : LayerShellV1{new_resource, Version<1>()},
           shell{shell}
     {
     }
@@ -85,7 +85,7 @@ private:
 
 mf::LayerShellV1::LayerShellV1(struct wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat,
                                OutputManager* output_manager)
-    : Global(display, mw::Version<1>()),
+    : Global(display, Version<1>()),
       shell{shell},
       seat{seat},
       output_manager{output_manager}
@@ -113,7 +113,7 @@ void mf::LayerShellV1::Instance::get_layer_surface(
 // LayerSurfaceV1
 
 mf::LayerSurfaceV1::LayerSurfaceV1(wl_resource* new_resource, WlSurface* surface, LayerShellV1 const& layer_shell)
-    : mw::LayerSurfaceV1(new_resource, mw::Version<1>()),
+    : mw::LayerSurfaceV1(new_resource, Version<1>()),
       WindowWlSurfaceRole(
           &layer_shell.seat,
           wayland::LayerSurfaceV1::client,

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -23,6 +23,7 @@
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
+namespace mw = mir::wayland;
 
 namespace mir
 {
@@ -84,7 +85,7 @@ private:
 
 mf::LayerShellV1::LayerShellV1(struct wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat,
                                OutputManager* output_manager)
-    : Global(display, 1),
+    : Global(display, mw::Version<1>()),
       shell{shell},
       seat{seat},
       output_manager{output_manager}

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -34,7 +34,7 @@ class LayerShellV1::Instance : wayland::LayerShellV1
 {
 public:
     Instance(wl_resource* new_resource, mf::LayerShellV1* shell)
-        : LayerShellV1{new_resource},
+        : LayerShellV1{new_resource, mw::Version<1>()},
           shell{shell}
     {
     }
@@ -113,7 +113,7 @@ void mf::LayerShellV1::Instance::get_layer_surface(
 // LayerSurfaceV1
 
 mf::LayerSurfaceV1::LayerSurfaceV1(wl_resource* new_resource, WlSurface* surface, LayerShellV1 const& layer_shell)
-    : wayland::LayerSurfaceV1(new_resource),
+    : mw::LayerSurfaceV1(new_resource, mw::Version<1>()),
       WindowWlSurfaceRole(
           &layer_shell.seat,
           wayland::LayerSurfaceV1::client,

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -95,6 +95,7 @@ namespace ms = mir::scene;
 namespace geom = mir::geometry;
 namespace mcl = mir::client;
 namespace mi = mir::input;
+namespace mw = mir::wayland;
 
 namespace mir
 {
@@ -242,7 +243,7 @@ public:
         struct wl_display* display,
         std::shared_ptr<mir::Executor> const& executor,
         std::shared_ptr<mg::WaylandAllocator> const& allocator)
-        : Global(display, 4),
+        : Global(display, mw::Version<4>()),
           allocator{allocator},
           executor{executor}
     {
@@ -453,7 +454,7 @@ public:
         std::shared_ptr<mf::Shell> const& shell,
         WlSeat& seat,
         OutputManager* const output_manager)
-        : Global(display, 1),
+        : Global(display, mw::Version<1>()),
           shell{shell},
           seat{seat},
           output_manager{output_manager}

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -243,7 +243,7 @@ public:
         struct wl_display* display,
         std::shared_ptr<mir::Executor> const& executor,
         std::shared_ptr<mg::WaylandAllocator> const& allocator)
-        : Global(display, mw::Version<4>()),
+        : Global(display, Version<4>()),
           allocator{allocator},
           executor{executor}
     {
@@ -257,7 +257,7 @@ private:
     {
     public:
         Instance(wl_resource* new_resource, WlCompositor* compositor)
-            : mw::Compositor{new_resource, mw::Version<4>()},
+            : mw::Compositor{new_resource, Version<4>()},
               compositor{compositor}
         {
         }
@@ -293,7 +293,7 @@ public:
         std::shared_ptr<mf::Shell> const& shell,
         WlSeat& seat,
         OutputManager* output_manager)
-        : ShellSurface(new_resource, mw::Version<1>()),
+        : ShellSurface(new_resource, Version<1>()),
           WindowWlSurfaceRole{&seat, wayland::ShellSurface::client, surface, shell, output_manager}
     {
     }
@@ -454,7 +454,7 @@ public:
         std::shared_ptr<mf::Shell> const& shell,
         WlSeat& seat,
         OutputManager* const output_manager)
-        : Global(display, mw::Version<1>()),
+        : Global(display, Version<1>()),
           shell{shell},
           seat{seat},
           output_manager{output_manager}
@@ -472,7 +472,7 @@ private:
     {
     public:
         Instance(wl_resource* new_resource, WlShell* shell)
-            : mw::Shell{new_resource, mw::Version<1>()},
+            : mw::Shell{new_resource, Version<1>()},
               shell{shell}
         {
         }

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -257,7 +257,7 @@ private:
     {
     public:
         Instance(wl_resource* new_resource, WlCompositor* compositor)
-            : wayland::Compositor{new_resource},
+            : mw::Compositor{new_resource, mw::Version<4>()},
               compositor{compositor}
         {
         }
@@ -293,7 +293,7 @@ public:
         std::shared_ptr<mf::Shell> const& shell,
         WlSeat& seat,
         OutputManager* output_manager)
-        : ShellSurface(new_resource),
+        : ShellSurface(new_resource, mw::Version<1>()),
           WindowWlSurfaceRole{&seat, wayland::ShellSurface::client, surface, shell, output_manager}
     {
     }
@@ -472,7 +472,7 @@ private:
     {
     public:
         Instance(wl_resource* new_resource, WlShell* shell)
-            : wayland::Shell{new_resource},
+            : mw::Shell{new_resource, mw::Version<1>()},
               shell{shell}
         {
         }

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -242,7 +242,7 @@ public:
         struct wl_display* display,
         std::shared_ptr<mir::Executor> const& executor,
         std::shared_ptr<mg::WaylandAllocator> const& allocator)
-        : Global(display, 3),
+        : Global(display, 4),
           allocator{allocator},
           executor{executor}
     {

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -32,13 +32,14 @@
 #include <cstring> // memcpy
 
 namespace mf = mir::frontend;
+namespace mw = mir::wayland;
 
 mf::WlKeyboard::WlKeyboard(
     wl_resource* new_resource,
     mir::input::Keymap const& initial_keymap,
     std::function<void(WlKeyboard*)> const& on_destroy,
     std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state)
-    : Keyboard(new_resource),
+    : Keyboard(new_resource, mw::Version<6>()),
       keymap{nullptr, &xkb_keymap_unref},
       state{nullptr, &xkb_state_unref},
       context{xkb_context_new(XKB_CONTEXT_NO_FLAGS), &xkb_context_unref},

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -39,7 +39,7 @@ mf::WlKeyboard::WlKeyboard(
     mir::input::Keymap const& initial_keymap,
     std::function<void(WlKeyboard*)> const& on_destroy,
     std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state)
-    : Keyboard(new_resource, mw::Version<6>()),
+    : Keyboard(new_resource, Version<6>()),
       keymap{nullptr, &xkb_keymap_unref},
       state{nullptr, &xkb_state_unref},
       context{xkb_context_new(XKB_CONTEXT_NO_FLAGS), &xkb_context_unref},

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -55,7 +55,7 @@ struct NullCursor : mf::WlPointer::Cursor
 mf::WlPointer::WlPointer(
     wl_resource* new_resource,
     std::function<void(WlPointer*)> const& on_destroy)
-    : Pointer(new_resource, mw::Version<6>()),
+    : Pointer(new_resource, Version<6>()),
       display{wl_client_get_display(client)},
       on_destroy{on_destroy},
       cursor{std::make_unique<NullCursor>()}

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -32,6 +32,7 @@
 
 namespace mf = mir::frontend;
 using namespace mir::geometry;
+namespace mw = mir::wayland;
 
 struct mf::WlPointer::Cursor
 {
@@ -54,7 +55,7 @@ struct NullCursor : mf::WlPointer::Cursor
 mf::WlPointer::WlPointer(
     wl_resource* new_resource,
     std::function<void(WlPointer*)> const& on_destroy)
-    : Pointer(new_resource),
+    : Pointer(new_resource, mw::Version<6>()),
       display{wl_client_get_display(client)},
       on_destroy{on_destroy},
       cursor{std::make_unique<NullCursor>()}

--- a/src/server/frontend_wayland/wl_region.cpp
+++ b/src/server/frontend_wayland/wl_region.cpp
@@ -26,7 +26,7 @@ namespace geom = mir::geometry;
 namespace mw = mir::wayland;
 
 mf::WlRegion::WlRegion(wl_resource* new_resource)
-    : mw::Region(new_resource, mw::Version<1>())
+    : mw::Region(new_resource, Version<1>())
 {}
 
 mf::WlRegion::~WlRegion()

--- a/src/server/frontend_wayland/wl_region.cpp
+++ b/src/server/frontend_wayland/wl_region.cpp
@@ -23,9 +23,10 @@
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
+namespace mw = mir::wayland;
 
 mf::WlRegion::WlRegion(wl_resource* new_resource)
-    : wayland::Region(new_resource)
+    : mw::Region(new_resource, mw::Version<1>())
 {}
 
 mf::WlRegion::~WlRegion()

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -158,7 +158,7 @@ mf::WlSeat::WlSeat(
     std::shared_ptr<mi::InputDeviceHub> const& input_hub,
     std::shared_ptr<mi::Seat> const& seat,
     std::shared_ptr<mir::Executor> const& executor)
-    :   Global(display, 5),
+    :   Global(display, 6),
         keymap{std::make_unique<input::Keymap>()},
         config_observer{
             std::make_shared<ConfigObserver>(

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -220,7 +220,7 @@ void mf::WlSeat::bind(wl_resource* new_wl_seat)
 }
 
 mf::WlSeat::Instance::Instance(wl_resource* new_resource, mf::WlSeat* seat)
-    : wayland::Seat(new_resource),
+    : mw::Seat(new_resource, mw::Version<6>()),
       seat{seat}
 {
     // TODO: Read the actual capabilities. Do we have a keyboard? Mouse? Touch?

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -42,6 +42,7 @@
 
 namespace mf = mir::frontend;
 namespace mi = mir::input;
+namespace mw = mir::wayland;
 
 namespace mir
 {
@@ -158,7 +159,7 @@ mf::WlSeat::WlSeat(
     std::shared_ptr<mi::InputDeviceHub> const& input_hub,
     std::shared_ptr<mi::Seat> const& seat,
     std::shared_ptr<mir::Executor> const& executor)
-    :   Global(display, 6),
+    :   Global(display, mw::Version<6>()),
         keymap{std::make_unique<input::Keymap>()},
         config_observer{
             std::make_shared<ConfigObserver>(

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -159,7 +159,7 @@ mf::WlSeat::WlSeat(
     std::shared_ptr<mi::InputDeviceHub> const& input_hub,
     std::shared_ptr<mi::Seat> const& seat,
     std::shared_ptr<mir::Executor> const& executor)
-    :   Global(display, mw::Version<6>()),
+    :   Global(display, Version<6>()),
         keymap{std::make_unique<input::Keymap>()},
         config_observer{
             std::make_shared<ConfigObserver>(
@@ -220,7 +220,7 @@ void mf::WlSeat::bind(wl_resource* new_wl_seat)
 }
 
 mf::WlSeat::Instance::Instance(wl_resource* new_resource, mf::WlSeat* seat)
-    : mw::Seat(new_resource, mw::Version<6>()),
+    : mw::Seat(new_resource, Version<6>()),
       seat{seat}
 {
     // TODO: Read the actual capabilities. Do we have a keyboard? Mouse? Touch?

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -44,7 +44,7 @@ private:
 }
 
 mf::WlSubcompositor::WlSubcompositor(wl_display* display)
-    : Global{display, mw::Version<1>()}
+    : Global{display, Version<1>()}
 {
 }
 
@@ -54,7 +54,7 @@ void mf::WlSubcompositor::bind(wl_resource* new_wl_subcompositor)
 }
 
 mf::WlSubcompositorInstance::WlSubcompositorInstance(wl_resource* new_resource)
-    : wayland::Subcompositor(new_resource, mw::Version<1>())
+    : wayland::Subcompositor(new_resource, Version<1>())
 {
 }
 
@@ -72,7 +72,7 @@ void mf::WlSubcompositorInstance::get_subsurface(
 }
 
 mf::WlSubsurface::WlSubsurface(wl_resource* new_subsurface, WlSurface* surface, WlSurface* parent_surface)
-    : wayland::Subsurface(new_subsurface, mw::Version<1>()),
+    : wayland::Subsurface(new_subsurface, Version<1>()),
       surface{surface},
       parent{parent_surface->add_child(this)},
       parent_destroyed{parent_surface->destroyed_flag()},

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -25,6 +25,7 @@
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
+namespace mw = mir::wayland;
 
 namespace mir
 {
@@ -43,7 +44,7 @@ private:
 }
 
 mf::WlSubcompositor::WlSubcompositor(wl_display* display)
-    : Global{display, 1}
+    : Global{display, mw::Version<1>()}
 {
 }
 

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -54,7 +54,7 @@ void mf::WlSubcompositor::bind(wl_resource* new_wl_subcompositor)
 }
 
 mf::WlSubcompositorInstance::WlSubcompositorInstance(wl_resource* new_resource)
-    : wayland::Subcompositor(new_resource)
+    : wayland::Subcompositor(new_resource, mw::Version<1>())
 {
 }
 
@@ -72,7 +72,7 @@ void mf::WlSubcompositorInstance::get_subsurface(
 }
 
 mf::WlSubsurface::WlSubsurface(wl_resource* new_subsurface, WlSurface* surface, WlSurface* parent_surface)
-    : wayland::Subsurface(new_subsurface),
+    : wayland::Subsurface(new_subsurface, mw::Version<1>()),
       surface{surface},
       parent{parent_surface->add_child(this)},
       parent_destroyed{parent_surface->destroyed_flag()},

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -44,7 +44,7 @@ namespace geom = mir::geometry;
 namespace mw = mir::wayland;
 
 mf::WlSurfaceState::Callback::Callback(wl_resource* new_resource)
-    : mw::Callback{new_resource, mw::Version<1>()},
+    : mw::Callback{new_resource, Version<1>()},
       destroyed{deleted_flag_for_resource(resource)}
 {
 }
@@ -79,7 +79,7 @@ mf::WlSurface::WlSurface(
     wl_resource* new_resource,
     std::shared_ptr<Executor> const& executor,
     std::shared_ptr<graphics::WaylandAllocator> const& allocator)
-    : Surface(new_resource, mw::Version<4>()),
+    : Surface(new_resource, Version<4>()),
         session{mf::get_session(client)},
         stream_id{session->create_buffer_stream({{}, mir_pixel_format_invalid, graphics::BufferUsage::undefined})},
         stream{session->get_buffer_stream(stream_id)},

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -41,9 +41,10 @@
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
+namespace mw = mir::wayland;
 
 mf::WlSurfaceState::Callback::Callback(wl_resource* new_resource)
-    : wayland::Callback{new_resource},
+    : mw::Callback{new_resource, mw::Version<1>()},
       destroyed{deleted_flag_for_resource(resource)}
 {
 }
@@ -78,7 +79,7 @@ mf::WlSurface::WlSurface(
     wl_resource* new_resource,
     std::shared_ptr<Executor> const& executor,
     std::shared_ptr<graphics::WaylandAllocator> const& allocator)
-    : Surface(new_resource),
+    : Surface(new_resource, mw::Version<4>()),
         session{mf::get_session(client)},
         stream_id{session->create_buffer_stream({{}, mir_pixel_format_invalid, graphics::BufferUsage::undefined})},
         stream{session->get_buffer_stream(stream_id)},

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -31,7 +31,7 @@ namespace mw = mir::wayland;
 mf::WlTouch::WlTouch(
     wl_resource* new_resource,
     std::function<void(WlTouch*)> const& on_destroy)
-    : Touch(new_resource, mw::Version<6>()),
+    : Touch(new_resource, Version<6>()),
       on_destroy{on_destroy}
 {
 }

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -26,11 +26,12 @@
 #include "mir/log.h"
 
 namespace mf = mir::frontend;
+namespace mw = mir::wayland;
 
 mf::WlTouch::WlTouch(
     wl_resource* new_resource,
     std::function<void(WlTouch*)> const& on_destroy)
-    : Touch(new_resource),
+    : Touch(new_resource, mw::Version<6>()),
       on_destroy{on_destroy}
 {
 }

--- a/src/server/frontend_wayland/xdg_output_v1.cpp
+++ b/src/server/frontend_wayland/xdg_output_v1.cpp
@@ -79,7 +79,7 @@ auto mf::create_xdg_output_manager_v1(struct wl_display* display, OutputManager*
 }
 
 mf::XdgOutputManagerV1::XdgOutputManagerV1(struct wl_display* display, mf::OutputManager* const output_manager)
-    : Global(display, mw::Version<2>()),
+    : Global(display, Version<2>()),
       output_manager{output_manager}
 {
 }
@@ -90,7 +90,7 @@ void mf::XdgOutputManagerV1::bind(wl_resource* new_resource)
 }
 
 mf::XdgOutputManagerV1::Instance::Instance(wl_resource* new_resource, OutputManager* manager)
-    : XdgOutputManagerV1{new_resource, mw::Version<2>()},
+    : XdgOutputManagerV1{new_resource, Version<2>()},
       output_manager{manager}
 {
 }
@@ -129,7 +129,7 @@ void mf::XdgOutputManagerV1::Instance::get_xdg_output(wl_resource* new_output, w
 mf::XdgOutputV1::XdgOutputV1(
     wl_resource* new_resource,
     mg::DisplayConfigurationOutput const& config)
-    : mw::XdgOutputV1(new_resource, mw::Version<2>())
+    : mw::XdgOutputV1(new_resource, Version<2>())
 {
     auto extents = config.extents();
     send_logical_position_event(extents.left().as_int(), extents.top().as_int());

--- a/src/server/frontend_wayland/xdg_output_v1.cpp
+++ b/src/server/frontend_wayland/xdg_output_v1.cpp
@@ -27,6 +27,7 @@
 namespace mf = mir::frontend;
 namespace mg = mir::graphics;
 namespace geom = mir::geometry;
+namespace mw = mir::wayland;
 
 namespace mir
 {
@@ -78,7 +79,7 @@ auto mf::create_xdg_output_manager_v1(struct wl_display* display, OutputManager*
 }
 
 mf::XdgOutputManagerV1::XdgOutputManagerV1(struct wl_display* display, mf::OutputManager* const output_manager)
-    : Global(display, 2),
+    : Global(display, mw::Version<2>()),
       output_manager{output_manager}
 {
 }

--- a/src/server/frontend_wayland/xdg_output_v1.cpp
+++ b/src/server/frontend_wayland/xdg_output_v1.cpp
@@ -90,7 +90,7 @@ void mf::XdgOutputManagerV1::bind(wl_resource* new_resource)
 }
 
 mf::XdgOutputManagerV1::Instance::Instance(wl_resource* new_resource, OutputManager* manager)
-    : XdgOutputManagerV1{new_resource},
+    : XdgOutputManagerV1{new_resource, mw::Version<2>()},
       output_manager{manager}
 {
 }
@@ -129,7 +129,7 @@ void mf::XdgOutputManagerV1::Instance::get_xdg_output(wl_resource* new_output, w
 mf::XdgOutputV1::XdgOutputV1(
     wl_resource* new_resource,
     mg::DisplayConfigurationOutput const& config)
-    : wayland::XdgOutputV1(new_resource)
+    : mw::XdgOutputV1(new_resource, mw::Version<2>())
 {
     auto extents = config.extents();
     send_logical_position_event(extents.left().as_int(), extents.top().as_int());

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -181,7 +181,7 @@ void mf::XdgShellStable::bind(wl_resource* new_resource)
 }
 
 mf::XdgShellStable::Instance::Instance(wl_resource* new_resource, mf::XdgShellStable* shell)
-    : XdgWmBase{new_resource},
+    : XdgWmBase{new_resource, mw::Version<1>()},
       shell{shell}
 {
 }
@@ -216,7 +216,7 @@ mf::XdgSurfaceStable* mf::XdgSurfaceStable::from(wl_resource* surface)
 }
 
 mf::XdgSurfaceStable::XdgSurfaceStable(wl_resource* new_resource, WlSurface* surface, XdgShellStable const& xdg_shell)
-    : wayland::XdgSurface(new_resource),
+    : mw::XdgSurface(new_resource, mw::Version<1>()),
       surface{surface},
       xdg_shell{xdg_shell}
 {
@@ -304,10 +304,10 @@ mf::XdgPopupStable::XdgPopupStable(
     WlSurfaceRole* parent_role,
     wl_resource* positioner,
     WlSurface* surface)
-    : wayland::XdgPopup(new_resource),
+    : mw::XdgPopup(new_resource, mw::Version<1>()),
       WindowWlSurfaceRole(
           &xdg_surface->xdg_shell.seat,
-          wayland::XdgPopup::client,
+          mw::XdgPopup::client,
           surface,
           xdg_surface->xdg_shell.shell,
           xdg_surface->xdg_shell.output_manager),
@@ -359,7 +359,7 @@ void mf::XdgPopupStable::handle_resize(const std::experimental::optional<geometr
 // XdgToplevelStable
 
 mf::XdgToplevelStable::XdgToplevelStable(wl_resource* new_resource, XdgSurfaceStable* xdg_surface, WlSurface* surface)
-    : wayland::XdgToplevel(new_resource),
+    : mw::XdgToplevel(new_resource, mw::Version<1>()),
       WindowWlSurfaceRole(
           &xdg_surface->xdg_shell.seat,
           wayland::XdgToplevel::client,
@@ -562,7 +562,7 @@ mf::XdgToplevelStable* mf::XdgToplevelStable::from(wl_resource* surface)
 // XdgPositionerStable
 
 mf::XdgPositionerStable::XdgPositionerStable(wl_resource* new_resource)
-    : wayland::XdgPositioner(new_resource)
+    : mw::XdgPositioner(new_resource, mw::Version<1>())
 {
     // specifying gravity is not required by the xdg shell protocol, but is by Mir window managers
     surface_placement_gravity = mir_placement_gravity_center;

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -168,7 +168,7 @@ private:
 
 mf::XdgShellStable::XdgShellStable(struct wl_display* display, std::shared_ptr<mf::Shell> const shell, WlSeat& seat,
                                    OutputManager* output_manager)
-    : Global(display, mw::Version<1>()),
+    : Global(display, Version<1>()),
       shell{shell},
       seat{seat},
       output_manager{output_manager}
@@ -181,7 +181,7 @@ void mf::XdgShellStable::bind(wl_resource* new_resource)
 }
 
 mf::XdgShellStable::Instance::Instance(wl_resource* new_resource, mf::XdgShellStable* shell)
-    : XdgWmBase{new_resource, mw::Version<1>()},
+    : XdgWmBase{new_resource, Version<1>()},
       shell{shell}
 {
 }
@@ -216,7 +216,7 @@ mf::XdgSurfaceStable* mf::XdgSurfaceStable::from(wl_resource* surface)
 }
 
 mf::XdgSurfaceStable::XdgSurfaceStable(wl_resource* new_resource, WlSurface* surface, XdgShellStable const& xdg_shell)
-    : mw::XdgSurface(new_resource, mw::Version<1>()),
+    : mw::XdgSurface(new_resource, Version<1>()),
       surface{surface},
       xdg_shell{xdg_shell}
 {
@@ -304,7 +304,7 @@ mf::XdgPopupStable::XdgPopupStable(
     WlSurfaceRole* parent_role,
     wl_resource* positioner,
     WlSurface* surface)
-    : mw::XdgPopup(new_resource, mw::Version<1>()),
+    : mw::XdgPopup(new_resource, Version<1>()),
       WindowWlSurfaceRole(
           &xdg_surface->xdg_shell.seat,
           mw::XdgPopup::client,
@@ -359,7 +359,7 @@ void mf::XdgPopupStable::handle_resize(const std::experimental::optional<geometr
 // XdgToplevelStable
 
 mf::XdgToplevelStable::XdgToplevelStable(wl_resource* new_resource, XdgSurfaceStable* xdg_surface, WlSurface* surface)
-    : mw::XdgToplevel(new_resource, mw::Version<1>()),
+    : mw::XdgToplevel(new_resource, Version<1>()),
       WindowWlSurfaceRole(
           &xdg_surface->xdg_shell.seat,
           wayland::XdgToplevel::client,
@@ -562,7 +562,7 @@ mf::XdgToplevelStable* mf::XdgToplevelStable::from(wl_resource* surface)
 // XdgPositionerStable
 
 mf::XdgPositionerStable::XdgPositionerStable(wl_resource* new_resource)
-    : mw::XdgPositioner(new_resource, mw::Version<1>())
+    : mw::XdgPositioner(new_resource, Version<1>())
 {
     // specifying gravity is not required by the xdg shell protocol, but is by Mir window managers
     surface_placement_gravity = mir_placement_gravity_center;

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -28,6 +28,7 @@
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
+namespace mw = mir::wayland;
 
 namespace mir
 {
@@ -167,7 +168,7 @@ private:
 
 mf::XdgShellStable::XdgShellStable(struct wl_display* display, std::shared_ptr<mf::Shell> const shell, WlSeat& seat,
                                    OutputManager* output_manager)
-    : Global(display, 1),
+    : Global(display, mw::Version<1>()),
       shell{shell},
       seat{seat},
       output_manager{output_manager}

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -28,6 +28,7 @@
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
+namespace mw = mir::wayland;
 
 namespace mir
 {
@@ -191,7 +192,7 @@ mf::XdgShellV6::XdgShellV6(
     std::shared_ptr<mf::Shell> const shell,
     WlSeat& seat,
     OutputManager* output_manager) :
-    Global(display, 1),
+    Global(display, mw::Version<1>()),
     shell{shell},
     seat{seat},
     output_manager{output_manager}

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -159,7 +159,7 @@ private:
 };
 
 mf::XdgShellV6::Instance::Instance(wl_resource* new_resource, mf::XdgShellV6* shell)
-    : wayland::XdgShellV6{new_resource},
+    : mw::XdgShellV6{new_resource, mw::Version<1>()},
       shell{shell}
 {
 }
@@ -214,7 +214,7 @@ mf::XdgSurfaceV6* mf::XdgSurfaceV6::from(wl_resource* surface)
 
 mf::XdgSurfaceV6::XdgSurfaceV6(wl_resource* new_resource, WlSurface* surface,
                                XdgShellV6 const& xdg_shell)
-    : wayland::XdgSurfaceV6(new_resource),
+    : mw::XdgSurfaceV6(new_resource, mw::Version<1>()),
       surface{surface},
       xdg_shell{xdg_shell}
 {
@@ -283,7 +283,7 @@ mf::XdgPopupV6::XdgPopupV6(
     XdgSurfaceV6* parent_surface,
     wl_resource* positioner,
     WlSurface* surface)
-    : wayland::XdgPopupV6(new_resource),
+    : mw::XdgPopupV6(new_resource, mw::Version<1>()),
       WindowWlSurfaceRole(
           &xdg_surface->xdg_shell.seat,
           wayland::XdgPopupV6::client,
@@ -343,7 +343,7 @@ void mf::XdgPopupV6::handle_resize(const std::experimental::optional<geometry::P
 // XdgToplevelV6
 
 mf::XdgToplevelV6::XdgToplevelV6(struct wl_resource* new_resource, XdgSurfaceV6* xdg_surface, WlSurface* surface)
-    : wayland::XdgToplevelV6(new_resource),
+    : mw::XdgToplevelV6(new_resource, mw::Version<1>()),
       WindowWlSurfaceRole(
           &xdg_surface->xdg_shell.seat,
           wayland::XdgToplevelV6::client,
@@ -546,7 +546,7 @@ mf::XdgToplevelV6* mf::XdgToplevelV6::from(wl_resource* surface)
 // XdgPositionerV6
 
 mf::XdgPositionerV6::XdgPositionerV6(wl_resource* new_resource)
-    : wayland::XdgPositionerV6(new_resource)
+    : mw::XdgPositionerV6(new_resource, mw::Version<1>())
 {
     // specifying gravity is not required by the xdg shell protocol, but is by Mir window managers
     surface_placement_gravity = mir_placement_gravity_center;

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -159,7 +159,7 @@ private:
 };
 
 mf::XdgShellV6::Instance::Instance(wl_resource* new_resource, mf::XdgShellV6* shell)
-    : mw::XdgShellV6{new_resource, mw::Version<1>()},
+    : mw::XdgShellV6{new_resource, Version<1>()},
       shell{shell}
 {
 }
@@ -192,7 +192,7 @@ mf::XdgShellV6::XdgShellV6(
     std::shared_ptr<mf::Shell> const shell,
     WlSeat& seat,
     OutputManager* output_manager) :
-    Global(display, mw::Version<1>()),
+    Global(display, Version<1>()),
     shell{shell},
     seat{seat},
     output_manager{output_manager}
@@ -214,7 +214,7 @@ mf::XdgSurfaceV6* mf::XdgSurfaceV6::from(wl_resource* surface)
 
 mf::XdgSurfaceV6::XdgSurfaceV6(wl_resource* new_resource, WlSurface* surface,
                                XdgShellV6 const& xdg_shell)
-    : mw::XdgSurfaceV6(new_resource, mw::Version<1>()),
+    : mw::XdgSurfaceV6(new_resource, Version<1>()),
       surface{surface},
       xdg_shell{xdg_shell}
 {
@@ -283,7 +283,7 @@ mf::XdgPopupV6::XdgPopupV6(
     XdgSurfaceV6* parent_surface,
     wl_resource* positioner,
     WlSurface* surface)
-    : mw::XdgPopupV6(new_resource, mw::Version<1>()),
+    : mw::XdgPopupV6(new_resource, Version<1>()),
       WindowWlSurfaceRole(
           &xdg_surface->xdg_shell.seat,
           wayland::XdgPopupV6::client,
@@ -343,7 +343,7 @@ void mf::XdgPopupV6::handle_resize(const std::experimental::optional<geometry::P
 // XdgToplevelV6
 
 mf::XdgToplevelV6::XdgToplevelV6(struct wl_resource* new_resource, XdgSurfaceV6* xdg_surface, WlSurface* surface)
-    : mw::XdgToplevelV6(new_resource, mw::Version<1>()),
+    : mw::XdgToplevelV6(new_resource, Version<1>()),
       WindowWlSurfaceRole(
           &xdg_surface->xdg_shell.seat,
           wayland::XdgToplevelV6::client,
@@ -546,7 +546,7 @@ mf::XdgToplevelV6* mf::XdgToplevelV6::from(wl_resource* surface)
 // XdgPositionerV6
 
 mf::XdgPositionerV6::XdgPositionerV6(wl_resource* new_resource)
-    : mw::XdgPositionerV6(new_resource, mw::Version<1>())
+    : mw::XdgPositionerV6(new_resource, Version<1>())
 {
     // specifying gravity is not required by the xdg shell protocol, but is by Mir window managers
     surface_placement_gravity = mir_placement_gravity_center;

--- a/src/wayland/generated/wayland_wrapper.cpp
+++ b/src/wayland/generated/wayland_wrapper.cpp
@@ -63,12 +63,14 @@ mw::Callback* mw::Callback::from(struct wl_resource* resource)
 
 struct mw::Callback::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static struct wl_message const event_messages[];
 };
 
-mw::Callback::Callback(struct wl_resource* resource)
+int const mw::Callback::Thunks::supported_version = 1;
+
+mw::Callback::Callback(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -100,7 +102,7 @@ mw::Compositor* mw::Compositor::from(struct wl_resource* resource)
 
 struct mw::Compositor::Thunks
 {
-    static int const supported_version = 4;
+    static int const supported_version;
 
     static void create_surface_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
@@ -153,7 +155,7 @@ struct mw::Compositor::Thunks
         auto resource = wl_resource_create(
             client,
             &wl_compositor_interface_data,
-            std::min(version, me->max_version),
+            std::min((int)version, Thunks::supported_version),
             id);
         if (resource == nullptr)
         {
@@ -176,7 +178,9 @@ struct mw::Compositor::Thunks
     static void const* request_vtable[];
 };
 
-mw::Compositor::Compositor(struct wl_resource* resource)
+int const mw::Compositor::Thunks::supported_version = 4;
+
+mw::Compositor::Compositor(struct wl_resource* resource, Version<4>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -197,15 +201,14 @@ void mw::Compositor::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::Compositor::Global::Global(wl_display* display, uint32_t max_version)
+mw::Compositor::Global::Global(wl_display* display, Version<4>)
     : wayland::Global{
           wl_global_create(
               display,
               &wl_compositor_interface_data,
-              max_version,
+              Thunks::supported_version,
               this,
-              &Thunks::bind_thunk),
-          max_version}
+              &Thunks::bind_thunk)}
 {}
 
 auto mw::Compositor::Global::interface_name() const -> char const*
@@ -236,7 +239,7 @@ mw::ShmPool* mw::ShmPool::from(struct wl_resource* resource)
 
 struct mw::ShmPool::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void create_buffer_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, int32_t offset, int32_t width, int32_t height, int32_t stride, uint32_t format)
     {
@@ -294,7 +297,9 @@ struct mw::ShmPool::Thunks
     static void const* request_vtable[];
 };
 
-mw::ShmPool::ShmPool(struct wl_resource* resource)
+int const mw::ShmPool::Thunks::supported_version = 1;
+
+mw::ShmPool::ShmPool(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -342,7 +347,7 @@ mw::Shm* mw::Shm::from(struct wl_resource* resource)
 
 struct mw::Shm::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void create_pool_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, int32_t fd, int32_t size)
     {
@@ -376,7 +381,7 @@ struct mw::Shm::Thunks
         auto resource = wl_resource_create(
             client,
             &wl_shm_interface_data,
-            std::min(version, me->max_version),
+            std::min((int)version, Thunks::supported_version),
             id);
         if (resource == nullptr)
         {
@@ -399,7 +404,9 @@ struct mw::Shm::Thunks
     static void const* request_vtable[];
 };
 
-mw::Shm::Shm(struct wl_resource* resource)
+int const mw::Shm::Thunks::supported_version = 1;
+
+mw::Shm::Shm(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -425,15 +432,14 @@ void mw::Shm::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::Shm::Global::Global(wl_display* display, uint32_t max_version)
+mw::Shm::Global::Global(wl_display* display, Version<1>)
     : wayland::Global{
           wl_global_create(
               display,
               &wl_shm_interface_data,
-              max_version,
+              Thunks::supported_version,
               this,
-              &Thunks::bind_thunk),
-          max_version}
+              &Thunks::bind_thunk)}
 {}
 
 auto mw::Shm::Global::interface_name() const -> char const*
@@ -464,7 +470,7 @@ mw::Buffer* mw::Buffer::from(struct wl_resource* resource)
 
 struct mw::Buffer::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -489,7 +495,9 @@ struct mw::Buffer::Thunks
     static void const* request_vtable[];
 };
 
-mw::Buffer::Buffer(struct wl_resource* resource)
+int const mw::Buffer::Thunks::supported_version = 1;
+
+mw::Buffer::Buffer(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -533,7 +541,7 @@ mw::DataOffer* mw::DataOffer::from(struct wl_resource* resource)
 
 struct mw::DataOffer::Thunks
 {
-    static int const supported_version = 3;
+    static int const supported_version;
 
     static void accept_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial, char const* mime_type)
     {
@@ -616,7 +624,9 @@ struct mw::DataOffer::Thunks
     static void const* request_vtable[];
 };
 
-mw::DataOffer::DataOffer(struct wl_resource* resource)
+int const mw::DataOffer::Thunks::supported_version = 3;
+
+mw::DataOffer::DataOffer(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -691,7 +701,7 @@ mw::DataSource* mw::DataSource::from(struct wl_resource* resource)
 
 struct mw::DataSource::Thunks
 {
-    static int const supported_version = 3;
+    static int const supported_version;
 
     static void offer_thunk(struct wl_client* client, struct wl_resource* resource, char const* mime_type)
     {
@@ -742,7 +752,9 @@ struct mw::DataSource::Thunks
     static void const* request_vtable[];
 };
 
-mw::DataSource::DataSource(struct wl_resource* resource)
+int const mw::DataSource::Thunks::supported_version = 3;
+
+mw::DataSource::DataSource(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -842,7 +854,7 @@ mw::DataDevice* mw::DataDevice::from(struct wl_resource* resource)
 
 struct mw::DataDevice::Thunks
 {
-    static int const supported_version = 3;
+    static int const supported_version;
 
     static void start_drag_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* source, struct wl_resource* origin, struct wl_resource* icon, uint32_t serial)
     {
@@ -913,7 +925,9 @@ struct mw::DataDevice::Thunks
     static void const* request_vtable[];
 };
 
-mw::DataDevice::DataDevice(struct wl_resource* resource)
+int const mw::DataDevice::Thunks::supported_version = 3;
+
+mw::DataDevice::DataDevice(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -1028,7 +1042,7 @@ mw::DataDeviceManager* mw::DataDeviceManager::from(struct wl_resource* resource)
 
 struct mw::DataDeviceManager::Thunks
 {
-    static int const supported_version = 3;
+    static int const supported_version;
 
     static void create_data_source_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
@@ -1081,7 +1095,7 @@ struct mw::DataDeviceManager::Thunks
         auto resource = wl_resource_create(
             client,
             &wl_data_device_manager_interface_data,
-            std::min(version, me->max_version),
+            std::min((int)version, Thunks::supported_version),
             id);
         if (resource == nullptr)
         {
@@ -1104,7 +1118,9 @@ struct mw::DataDeviceManager::Thunks
     static void const* request_vtable[];
 };
 
-mw::DataDeviceManager::DataDeviceManager(struct wl_resource* resource)
+int const mw::DataDeviceManager::Thunks::supported_version = 3;
+
+mw::DataDeviceManager::DataDeviceManager(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -1125,15 +1141,14 @@ void mw::DataDeviceManager::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::DataDeviceManager::Global::Global(wl_display* display, uint32_t max_version)
+mw::DataDeviceManager::Global::Global(wl_display* display, Version<3>)
     : wayland::Global{
           wl_global_create(
               display,
               &wl_data_device_manager_interface_data,
-              max_version,
+              Thunks::supported_version,
               this,
-              &Thunks::bind_thunk),
-          max_version}
+              &Thunks::bind_thunk)}
 {}
 
 auto mw::DataDeviceManager::Global::interface_name() const -> char const*
@@ -1165,7 +1180,7 @@ mw::Shell* mw::Shell::from(struct wl_resource* resource)
 
 struct mw::Shell::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void get_shell_surface_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface)
     {
@@ -1198,7 +1213,7 @@ struct mw::Shell::Thunks
         auto resource = wl_resource_create(
             client,
             &wl_shell_interface_data,
-            std::min(version, me->max_version),
+            std::min((int)version, Thunks::supported_version),
             id);
         if (resource == nullptr)
         {
@@ -1220,7 +1235,9 @@ struct mw::Shell::Thunks
     static void const* request_vtable[];
 };
 
-mw::Shell::Shell(struct wl_resource* resource)
+int const mw::Shell::Thunks::supported_version = 1;
+
+mw::Shell::Shell(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -1241,15 +1258,14 @@ void mw::Shell::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::Shell::Global::Global(wl_display* display, uint32_t max_version)
+mw::Shell::Global::Global(wl_display* display, Version<1>)
     : wayland::Global{
           wl_global_create(
               display,
               &wl_shell_interface_data,
-              max_version,
+              Thunks::supported_version,
               this,
-              &Thunks::bind_thunk),
-          max_version}
+              &Thunks::bind_thunk)}
 {}
 
 auto mw::Shell::Global::interface_name() const -> char const*
@@ -1276,7 +1292,7 @@ mw::ShellSurface* mw::ShellSurface::from(struct wl_resource* resource)
 
 struct mw::ShellSurface::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void pong_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial)
     {
@@ -1434,7 +1450,9 @@ struct mw::ShellSurface::Thunks
     static void const* request_vtable[];
 };
 
-mw::ShellSurface::ShellSurface(struct wl_resource* resource)
+int const mw::ShellSurface::Thunks::supported_version = 1;
+
+mw::ShellSurface::ShellSurface(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -1539,7 +1557,7 @@ mw::Surface* mw::Surface::from(struct wl_resource* resource)
 
 struct mw::Surface::Thunks
 {
-    static int const supported_version = 4;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -1709,7 +1727,9 @@ struct mw::Surface::Thunks
     static void const* request_vtable[];
 };
 
-mw::Surface::Surface(struct wl_resource* resource)
+int const mw::Surface::Thunks::supported_version = 4;
+
+mw::Surface::Surface(struct wl_resource* resource, Version<4>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -1797,7 +1817,7 @@ mw::Seat* mw::Seat::from(struct wl_resource* resource)
 
 struct mw::Seat::Thunks
 {
-    static int const supported_version = 6;
+    static int const supported_version;
 
     static void get_pointer_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
@@ -1883,7 +1903,7 @@ struct mw::Seat::Thunks
         auto resource = wl_resource_create(
             client,
             &wl_seat_interface_data,
-            std::min(version, me->max_version),
+            std::min((int)version, Thunks::supported_version),
             id);
         if (resource == nullptr)
         {
@@ -1908,7 +1928,9 @@ struct mw::Seat::Thunks
     static void const* request_vtable[];
 };
 
-mw::Seat::Seat(struct wl_resource* resource)
+int const mw::Seat::Thunks::supported_version = 6;
+
+mw::Seat::Seat(struct wl_resource* resource, Version<6>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -1945,15 +1967,14 @@ void mw::Seat::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::Seat::Global::Global(wl_display* display, uint32_t max_version)
+mw::Seat::Global::Global(wl_display* display, Version<6>)
     : wayland::Global{
           wl_global_create(
               display,
               &wl_seat_interface_data,
-              max_version,
+              Thunks::supported_version,
               this,
-              &Thunks::bind_thunk),
-          max_version}
+              &Thunks::bind_thunk)}
 {}
 
 auto mw::Seat::Global::interface_name() const -> char const*
@@ -1995,7 +2016,7 @@ mw::Pointer* mw::Pointer::from(struct wl_resource* resource)
 
 struct mw::Pointer::Thunks
 {
-    static int const supported_version = 6;
+    static int const supported_version;
 
     static void set_cursor_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial, struct wl_resource* surface, int32_t hotspot_x, int32_t hotspot_y)
     {
@@ -2041,7 +2062,9 @@ struct mw::Pointer::Thunks
     static void const* request_vtable[];
 };
 
-mw::Pointer::Pointer(struct wl_resource* resource)
+int const mw::Pointer::Thunks::supported_version = 6;
+
+mw::Pointer::Pointer(struct wl_resource* resource, Version<6>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -2176,7 +2199,7 @@ mw::Keyboard* mw::Keyboard::from(struct wl_resource* resource)
 
 struct mw::Keyboard::Thunks
 {
-    static int const supported_version = 6;
+    static int const supported_version;
 
     static void release_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -2203,7 +2226,9 @@ struct mw::Keyboard::Thunks
     static void const* request_vtable[];
 };
 
-mw::Keyboard::Keyboard(struct wl_resource* resource)
+int const mw::Keyboard::Thunks::supported_version = 6;
+
+mw::Keyboard::Keyboard(struct wl_resource* resource, Version<6>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -2292,7 +2317,7 @@ mw::Touch* mw::Touch::from(struct wl_resource* resource)
 
 struct mw::Touch::Thunks
 {
-    static int const supported_version = 6;
+    static int const supported_version;
 
     static void release_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -2318,7 +2343,9 @@ struct mw::Touch::Thunks
     static void const* request_vtable[];
 };
 
-mw::Touch::Touch(struct wl_resource* resource)
+int const mw::Touch::Thunks::supported_version = 6;
+
+mw::Touch::Touch(struct wl_resource* resource, Version<6>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -2423,7 +2450,7 @@ mw::Output* mw::Output::from(struct wl_resource* resource)
 
 struct mw::Output::Thunks
 {
-    static int const supported_version = 3;
+    static int const supported_version;
 
     static void release_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -2449,7 +2476,7 @@ struct mw::Output::Thunks
         auto resource = wl_resource_create(
             client,
             &wl_output_interface_data,
-            std::min(version, me->max_version),
+            std::min((int)version, Thunks::supported_version),
             id);
         if (resource == nullptr)
         {
@@ -2472,7 +2499,9 @@ struct mw::Output::Thunks
     static void const* request_vtable[];
 };
 
-mw::Output::Output(struct wl_resource* resource)
+int const mw::Output::Thunks::supported_version = 3;
+
+mw::Output::Output(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -2525,15 +2554,14 @@ void mw::Output::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::Output::Global::Global(wl_display* display, uint32_t max_version)
+mw::Output::Global::Global(wl_display* display, Version<3>)
     : wayland::Global{
           wl_global_create(
               display,
               &wl_output_interface_data,
-              max_version,
+              Thunks::supported_version,
               this,
-              &Thunks::bind_thunk),
-          max_version}
+              &Thunks::bind_thunk)}
 {}
 
 auto mw::Output::Global::interface_name() const -> char const*
@@ -2572,7 +2600,7 @@ mw::Region* mw::Region::from(struct wl_resource* resource)
 
 struct mw::Region::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -2622,7 +2650,9 @@ struct mw::Region::Thunks
     static void const* request_vtable[];
 };
 
-mw::Region::Region(struct wl_resource* resource)
+int const mw::Region::Thunks::supported_version = 1;
+
+mw::Region::Region(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -2662,7 +2692,7 @@ mw::Subcompositor* mw::Subcompositor::from(struct wl_resource* resource)
 
 struct mw::Subcompositor::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -2708,7 +2738,7 @@ struct mw::Subcompositor::Thunks
         auto resource = wl_resource_create(
             client,
             &wl_subcompositor_interface_data,
-            std::min(version, me->max_version),
+            std::min((int)version, Thunks::supported_version),
             id);
         if (resource == nullptr)
         {
@@ -2730,7 +2760,9 @@ struct mw::Subcompositor::Thunks
     static void const* request_vtable[];
 };
 
-mw::Subcompositor::Subcompositor(struct wl_resource* resource)
+int const mw::Subcompositor::Thunks::supported_version = 1;
+
+mw::Subcompositor::Subcompositor(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -2751,15 +2783,14 @@ void mw::Subcompositor::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::Subcompositor::Global::Global(wl_display* display, uint32_t max_version)
+mw::Subcompositor::Global::Global(wl_display* display, Version<1>)
     : wayland::Global{
           wl_global_create(
               display,
               &wl_subcompositor_interface_data,
-              max_version,
+              Thunks::supported_version,
               this,
-              &Thunks::bind_thunk),
-          max_version}
+              &Thunks::bind_thunk)}
 {}
 
 auto mw::Subcompositor::Global::interface_name() const -> char const*
@@ -2789,7 +2820,7 @@ mw::Subsurface* mw::Subsurface::from(struct wl_resource* resource)
 
 struct mw::Subsurface::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -2880,7 +2911,9 @@ struct mw::Subsurface::Thunks
     static void const* request_vtable[];
 };
 
-mw::Subsurface::Subsurface(struct wl_resource* resource)
+int const mw::Subsurface::Thunks::supported_version = 1;
+
+mw::Subsurface::Subsurface(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {

--- a/src/wayland/generated/wayland_wrapper.h
+++ b/src/wayland/generated/wayland_wrapper.h
@@ -27,7 +27,7 @@ public:
 
     static Callback* from(struct wl_resource*);
 
-    Callback(struct wl_resource* resource);
+    Callback(struct wl_resource* resource, Version<1>);
     virtual ~Callback() = default;
 
     void send_done_event(uint32_t callback_data) const;
@@ -56,7 +56,7 @@ public:
 
     static Compositor* from(struct wl_resource*);
 
-    Compositor(struct wl_resource* resource);
+    Compositor(struct wl_resource* resource, Version<4>);
     virtual ~Compositor() = default;
 
     void destroy_wayland_object() const;
@@ -71,7 +71,7 @@ public:
     class Global : wayland::Global
     {
     public:
-        Global(wl_display* display, uint32_t max_version);
+        Global(wl_display* display, Version<4>);
 
         auto interface_name() const -> char const* override;
 
@@ -92,7 +92,7 @@ public:
 
     static ShmPool* from(struct wl_resource*);
 
-    ShmPool(struct wl_resource* resource);
+    ShmPool(struct wl_resource* resource, Version<1>);
     virtual ~ShmPool() = default;
 
     void destroy_wayland_object() const;
@@ -117,7 +117,7 @@ public:
 
     static Shm* from(struct wl_resource*);
 
-    Shm(struct wl_resource* resource);
+    Shm(struct wl_resource* resource, Version<1>);
     virtual ~Shm() = default;
 
     void send_format_event(uint32_t format) const;
@@ -208,7 +208,7 @@ public:
     class Global : wayland::Global
     {
     public:
-        Global(wl_display* display, uint32_t max_version);
+        Global(wl_display* display, Version<1>);
 
         auto interface_name() const -> char const* override;
 
@@ -228,7 +228,7 @@ public:
 
     static Buffer* from(struct wl_resource*);
 
-    Buffer(struct wl_resource* resource);
+    Buffer(struct wl_resource* resource, Version<1>);
     virtual ~Buffer() = default;
 
     void send_release_event() const;
@@ -258,7 +258,7 @@ public:
 
     static DataOffer* from(struct wl_resource*);
 
-    DataOffer(struct wl_resource* resource);
+    DataOffer(struct wl_resource* resource, Version<3>);
     virtual ~DataOffer() = default;
 
     void send_offer_event(std::string const& mime_type) const;
@@ -306,7 +306,7 @@ public:
 
     static DataSource* from(struct wl_resource*);
 
-    DataSource(struct wl_resource* resource);
+    DataSource(struct wl_resource* resource, Version<3>);
     virtual ~DataSource() = default;
 
     void send_target_event(std::experimental::optional<std::string> const& mime_type) const;
@@ -357,7 +357,7 @@ public:
 
     static DataDevice* from(struct wl_resource*);
 
-    DataDevice(struct wl_resource* resource);
+    DataDevice(struct wl_resource* resource, Version<3>);
     virtual ~DataDevice() = default;
 
     void send_data_offer_event(struct wl_resource* id) const;
@@ -404,7 +404,7 @@ public:
 
     static DataDeviceManager* from(struct wl_resource*);
 
-    DataDeviceManager(struct wl_resource* resource);
+    DataDeviceManager(struct wl_resource* resource, Version<3>);
     virtual ~DataDeviceManager() = default;
 
     void destroy_wayland_object() const;
@@ -427,7 +427,7 @@ public:
     class Global : wayland::Global
     {
     public:
-        Global(wl_display* display, uint32_t max_version);
+        Global(wl_display* display, Version<3>);
 
         auto interface_name() const -> char const* override;
 
@@ -448,7 +448,7 @@ public:
 
     static Shell* from(struct wl_resource*);
 
-    Shell(struct wl_resource* resource);
+    Shell(struct wl_resource* resource, Version<1>);
     virtual ~Shell() = default;
 
     void destroy_wayland_object() const;
@@ -468,7 +468,7 @@ public:
     class Global : wayland::Global
     {
     public:
-        Global(wl_display* display, uint32_t max_version);
+        Global(wl_display* display, Version<1>);
 
         auto interface_name() const -> char const* override;
 
@@ -488,7 +488,7 @@ public:
 
     static ShellSurface* from(struct wl_resource*);
 
-    ShellSurface(struct wl_resource* resource);
+    ShellSurface(struct wl_resource* resource, Version<1>);
     virtual ~ShellSurface() = default;
 
     void send_ping_event(uint32_t serial) const;
@@ -557,7 +557,7 @@ public:
 
     static Surface* from(struct wl_resource*);
 
-    Surface(struct wl_resource* resource);
+    Surface(struct wl_resource* resource, Version<4>);
     virtual ~Surface() = default;
 
     void send_enter_event(struct wl_resource* output) const;
@@ -604,7 +604,7 @@ public:
 
     static Seat* from(struct wl_resource*);
 
-    Seat(struct wl_resource* resource);
+    Seat(struct wl_resource* resource, Version<6>);
     virtual ~Seat() = default;
 
     void send_capabilities_event(uint32_t capabilities) const;
@@ -636,7 +636,7 @@ public:
     class Global : wayland::Global
     {
     public:
-        Global(wl_display* display, uint32_t max_version);
+        Global(wl_display* display, Version<6>);
 
         auto interface_name() const -> char const* override;
 
@@ -659,7 +659,7 @@ public:
 
     static Pointer* from(struct wl_resource*);
 
-    Pointer(struct wl_resource* resource);
+    Pointer(struct wl_resource* resource, Version<6>);
     virtual ~Pointer() = default;
 
     void send_enter_event(uint32_t serial, struct wl_resource* surface, double surface_x, double surface_y) const;
@@ -735,7 +735,7 @@ public:
 
     static Keyboard* from(struct wl_resource*);
 
-    Keyboard(struct wl_resource* resource);
+    Keyboard(struct wl_resource* resource, Version<6>);
     virtual ~Keyboard() = default;
 
     void send_keymap_event(uint32_t format, mir::Fd fd, uint32_t size) const;
@@ -788,7 +788,7 @@ public:
 
     static Touch* from(struct wl_resource*);
 
-    Touch(struct wl_resource* resource);
+    Touch(struct wl_resource* resource, Version<6>);
     virtual ~Touch() = default;
 
     void send_down_event(uint32_t serial, uint32_t time, struct wl_resource* surface, int32_t id, double x, double y) const;
@@ -832,7 +832,7 @@ public:
 
     static Output* from(struct wl_resource*);
 
-    Output(struct wl_resource* resource);
+    Output(struct wl_resource* resource, Version<3>);
     virtual ~Output() = default;
 
     void send_geometry_event(int32_t x, int32_t y, int32_t physical_width, int32_t physical_height, int32_t subpixel, std::string const& make, std::string const& model, int32_t transform) const;
@@ -890,7 +890,7 @@ public:
     class Global : wayland::Global
     {
     public:
-        Global(wl_display* display, uint32_t max_version);
+        Global(wl_display* display, Version<3>);
 
         auto interface_name() const -> char const* override;
 
@@ -910,7 +910,7 @@ public:
 
     static Region* from(struct wl_resource*);
 
-    Region(struct wl_resource* resource);
+    Region(struct wl_resource* resource, Version<1>);
     virtual ~Region() = default;
 
     void destroy_wayland_object() const;
@@ -935,7 +935,7 @@ public:
 
     static Subcompositor* from(struct wl_resource*);
 
-    Subcompositor(struct wl_resource* resource);
+    Subcompositor(struct wl_resource* resource, Version<1>);
     virtual ~Subcompositor() = default;
 
     void destroy_wayland_object() const;
@@ -955,7 +955,7 @@ public:
     class Global : wayland::Global
     {
     public:
-        Global(wl_display* display, uint32_t max_version);
+        Global(wl_display* display, Version<1>);
 
         auto interface_name() const -> char const* override;
 
@@ -976,7 +976,7 @@ public:
 
     static Subsurface* from(struct wl_resource*);
 
-    Subsurface(struct wl_resource* resource);
+    Subsurface(struct wl_resource* resource, Version<1>);
     virtual ~Subsurface() = default;
 
     void destroy_wayland_object() const;

--- a/src/wayland/generated/wayland_wrapper.h
+++ b/src/wayland/generated/wayland_wrapper.h
@@ -68,7 +68,7 @@ public:
 
     static bool is_instance(wl_resource* resource);
 
-    class Global : wayland::Global
+    class Global : public wayland::Global
     {
     public:
         Global(wl_display* display, Version<4>);
@@ -205,7 +205,7 @@ public:
 
     static bool is_instance(wl_resource* resource);
 
-    class Global : wayland::Global
+    class Global : public wayland::Global
     {
     public:
         Global(wl_display* display, Version<1>);
@@ -424,7 +424,7 @@ public:
 
     static bool is_instance(wl_resource* resource);
 
-    class Global : wayland::Global
+    class Global : public wayland::Global
     {
     public:
         Global(wl_display* display, Version<3>);
@@ -465,7 +465,7 @@ public:
 
     static bool is_instance(wl_resource* resource);
 
-    class Global : wayland::Global
+    class Global : public wayland::Global
     {
     public:
         Global(wl_display* display, Version<1>);
@@ -633,7 +633,7 @@ public:
 
     static bool is_instance(wl_resource* resource);
 
-    class Global : wayland::Global
+    class Global : public wayland::Global
     {
     public:
         Global(wl_display* display, Version<6>);
@@ -887,7 +887,7 @@ public:
 
     static bool is_instance(wl_resource* resource);
 
-    class Global : wayland::Global
+    class Global : public wayland::Global
     {
     public:
         Global(wl_display* display, Version<3>);
@@ -952,7 +952,7 @@ public:
 
     static bool is_instance(wl_resource* resource);
 
-    class Global : wayland::Global
+    class Global : public wayland::Global
     {
     public:
         Global(wl_display* display, Version<1>);

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
@@ -48,7 +48,7 @@ mw::LayerShellV1* mw::LayerShellV1::from(struct wl_resource* resource)
 
 struct mw::LayerShellV1::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void get_layer_surface_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface, struct wl_resource* output, uint32_t layer, char const* namespace_)
     {
@@ -86,7 +86,7 @@ struct mw::LayerShellV1::Thunks
         auto resource = wl_resource_create(
             client,
             &zwlr_layer_shell_v1_interface_data,
-            std::min(version, me->max_version),
+            std::min((int)version, Thunks::supported_version),
             id);
         if (resource == nullptr)
         {
@@ -108,7 +108,9 @@ struct mw::LayerShellV1::Thunks
     static void const* request_vtable[];
 };
 
-mw::LayerShellV1::LayerShellV1(struct wl_resource* resource)
+int const mw::LayerShellV1::Thunks::supported_version = 1;
+
+mw::LayerShellV1::LayerShellV1(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -129,15 +131,14 @@ void mw::LayerShellV1::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::LayerShellV1::Global::Global(wl_display* display, uint32_t max_version)
+mw::LayerShellV1::Global::Global(wl_display* display, Version<1>)
     : wayland::Global{
           wl_global_create(
               display,
               &zwlr_layer_shell_v1_interface_data,
-              max_version,
+              Thunks::supported_version,
               this,
-              &Thunks::bind_thunk),
-          max_version}
+              &Thunks::bind_thunk)}
 {}
 
 auto mw::LayerShellV1::Global::interface_name() const -> char const*
@@ -167,7 +168,7 @@ mw::LayerSurfaceV1* mw::LayerSurfaceV1::from(struct wl_resource* resource)
 
 struct mw::LayerSurfaceV1::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void set_size_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t width, uint32_t height)
     {
@@ -284,7 +285,9 @@ struct mw::LayerSurfaceV1::Thunks
     static void const* request_vtable[];
 };
 
-mw::LayerSurfaceV1::LayerSurfaceV1(struct wl_resource* resource)
+int const mw::LayerSurfaceV1::Thunks::supported_version = 1;
+
+mw::LayerSurfaceV1::LayerSurfaceV1(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
@@ -54,7 +54,7 @@ public:
 
     static bool is_instance(wl_resource* resource);
 
-    class Global : wayland::Global
+    class Global : public wayland::Global
     {
     public:
         Global(wl_display* display, Version<1>);

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
@@ -27,7 +27,7 @@ public:
 
     static LayerShellV1* from(struct wl_resource*);
 
-    LayerShellV1(struct wl_resource* resource);
+    LayerShellV1(struct wl_resource* resource, Version<1>);
     virtual ~LayerShellV1() = default;
 
     void destroy_wayland_object() const;
@@ -57,7 +57,7 @@ public:
     class Global : wayland::Global
     {
     public:
-        Global(wl_display* display, uint32_t max_version);
+        Global(wl_display* display, Version<1>);
 
         auto interface_name() const -> char const* override;
 
@@ -77,7 +77,7 @@ public:
 
     static LayerSurfaceV1* from(struct wl_resource*);
 
-    LayerSurfaceV1(struct wl_resource* resource);
+    LayerSurfaceV1(struct wl_resource* resource, Version<1>);
     virtual ~LayerSurfaceV1() = default;
 
     void send_configure_event(uint32_t serial, uint32_t width, uint32_t height) const;

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
@@ -46,7 +46,7 @@ mw::XdgOutputManagerV1* mw::XdgOutputManagerV1::from(struct wl_resource* resourc
 
 struct mw::XdgOutputManagerV1::Thunks
 {
-    static int const supported_version = 2;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -92,7 +92,7 @@ struct mw::XdgOutputManagerV1::Thunks
         auto resource = wl_resource_create(
             client,
             &zxdg_output_manager_v1_interface_data,
-            std::min(version, me->max_version),
+            std::min((int)version, Thunks::supported_version),
             id);
         if (resource == nullptr)
         {
@@ -114,7 +114,9 @@ struct mw::XdgOutputManagerV1::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgOutputManagerV1::XdgOutputManagerV1(struct wl_resource* resource)
+int const mw::XdgOutputManagerV1::Thunks::supported_version = 2;
+
+mw::XdgOutputManagerV1::XdgOutputManagerV1(struct wl_resource* resource, Version<2>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -135,15 +137,14 @@ void mw::XdgOutputManagerV1::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::XdgOutputManagerV1::Global::Global(wl_display* display, uint32_t max_version)
+mw::XdgOutputManagerV1::Global::Global(wl_display* display, Version<2>)
     : wayland::Global{
           wl_global_create(
               display,
               &zxdg_output_manager_v1_interface_data,
-              max_version,
+              Thunks::supported_version,
               this,
-              &Thunks::bind_thunk),
-          max_version}
+              &Thunks::bind_thunk)}
 {}
 
 auto mw::XdgOutputManagerV1::Global::interface_name() const -> char const*
@@ -172,7 +173,7 @@ mw::XdgOutputV1* mw::XdgOutputV1::from(struct wl_resource* resource)
 
 struct mw::XdgOutputV1::Thunks
 {
-    static int const supported_version = 2;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -197,7 +198,9 @@ struct mw::XdgOutputV1::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgOutputV1::XdgOutputV1(struct wl_resource* resource)
+int const mw::XdgOutputV1::Thunks::supported_version = 2;
+
+mw::XdgOutputV1::XdgOutputV1(struct wl_resource* resource, Version<2>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
@@ -39,7 +39,7 @@ public:
 
     static bool is_instance(wl_resource* resource);
 
-    class Global : wayland::Global
+    class Global : public wayland::Global
     {
     public:
         Global(wl_display* display, Version<2>);

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
@@ -27,7 +27,7 @@ public:
 
     static XdgOutputManagerV1* from(struct wl_resource*);
 
-    XdgOutputManagerV1(struct wl_resource* resource);
+    XdgOutputManagerV1(struct wl_resource* resource, Version<2>);
     virtual ~XdgOutputManagerV1() = default;
 
     void destroy_wayland_object() const;
@@ -42,7 +42,7 @@ public:
     class Global : wayland::Global
     {
     public:
-        Global(wl_display* display, uint32_t max_version);
+        Global(wl_display* display, Version<2>);
 
         auto interface_name() const -> char const* override;
 
@@ -63,7 +63,7 @@ public:
 
     static XdgOutputV1* from(struct wl_resource*);
 
-    XdgOutputV1(struct wl_resource* resource);
+    XdgOutputV1(struct wl_resource* resource, Version<2>);
     virtual ~XdgOutputV1() = default;
 
     void send_logical_position_event(int32_t x, int32_t y) const;

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
@@ -51,7 +51,7 @@ mw::XdgShellV6* mw::XdgShellV6::from(struct wl_resource* resource)
 
 struct mw::XdgShellV6::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -130,7 +130,7 @@ struct mw::XdgShellV6::Thunks
         auto resource = wl_resource_create(
             client,
             &zxdg_shell_v6_interface_data,
-            std::min(version, me->max_version),
+            std::min((int)version, Thunks::supported_version),
             id);
         if (resource == nullptr)
         {
@@ -154,7 +154,9 @@ struct mw::XdgShellV6::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgShellV6::XdgShellV6(struct wl_resource* resource)
+int const mw::XdgShellV6::Thunks::supported_version = 1;
+
+mw::XdgShellV6::XdgShellV6(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -180,15 +182,14 @@ void mw::XdgShellV6::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::XdgShellV6::Global::Global(wl_display* display, uint32_t max_version)
+mw::XdgShellV6::Global::Global(wl_display* display, Version<1>)
     : wayland::Global{
           wl_global_create(
               display,
               &zxdg_shell_v6_interface_data,
-              max_version,
+              Thunks::supported_version,
               this,
-              &Thunks::bind_thunk),
-          max_version}
+              &Thunks::bind_thunk)}
 {}
 
 auto mw::XdgShellV6::Global::interface_name() const -> char const*
@@ -227,7 +228,7 @@ mw::XdgPositionerV6* mw::XdgPositionerV6::from(struct wl_resource* resource)
 
 struct mw::XdgPositionerV6::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -329,7 +330,9 @@ struct mw::XdgPositionerV6::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgPositionerV6::XdgPositionerV6(struct wl_resource* resource)
+int const mw::XdgPositionerV6::Thunks::supported_version = 1;
+
+mw::XdgPositionerV6::XdgPositionerV6(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -377,7 +380,7 @@ mw::XdgSurfaceV6* mw::XdgSurfaceV6::from(struct wl_resource* resource)
 
 struct mw::XdgSurfaceV6::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -470,7 +473,9 @@ struct mw::XdgSurfaceV6::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgSurfaceV6::XdgSurfaceV6(struct wl_resource* resource)
+int const mw::XdgSurfaceV6::Thunks::supported_version = 1;
+
+mw::XdgSurfaceV6::XdgSurfaceV6(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -530,7 +535,7 @@ mw::XdgToplevelV6* mw::XdgToplevelV6::from(struct wl_resource* resource)
 
 struct mw::XdgToplevelV6::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -739,7 +744,9 @@ struct mw::XdgToplevelV6::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgToplevelV6::XdgToplevelV6(struct wl_resource* resource)
+int const mw::XdgToplevelV6::Thunks::supported_version = 1;
+
+mw::XdgToplevelV6::XdgToplevelV6(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -836,7 +843,7 @@ mw::XdgPopupV6* mw::XdgPopupV6::from(struct wl_resource* resource)
 
 struct mw::XdgPopupV6::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -875,7 +882,9 @@ struct mw::XdgPopupV6::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgPopupV6::XdgPopupV6(struct wl_resource* resource)
+int const mw::XdgPopupV6::Thunks::supported_version = 1;
+
+mw::XdgPopupV6::XdgPopupV6(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -27,7 +27,7 @@ public:
 
     static XdgShellV6* from(struct wl_resource*);
 
-    XdgShellV6(struct wl_resource* resource);
+    XdgShellV6(struct wl_resource* resource, Version<1>);
     virtual ~XdgShellV6() = default;
 
     void send_ping_event(uint32_t serial) const;
@@ -59,7 +59,7 @@ public:
     class Global : wayland::Global
     {
     public:
-        Global(wl_display* display, uint32_t max_version);
+        Global(wl_display* display, Version<1>);
 
         auto interface_name() const -> char const* override;
 
@@ -82,7 +82,7 @@ public:
 
     static XdgPositionerV6* from(struct wl_resource*);
 
-    XdgPositionerV6(struct wl_resource* resource);
+    XdgPositionerV6(struct wl_resource* resource, Version<1>);
     virtual ~XdgPositionerV6() = default;
 
     void destroy_wayland_object() const;
@@ -145,7 +145,7 @@ public:
 
     static XdgSurfaceV6* from(struct wl_resource*);
 
-    XdgSurfaceV6(struct wl_resource* resource);
+    XdgSurfaceV6(struct wl_resource* resource, Version<1>);
     virtual ~XdgSurfaceV6() = default;
 
     void send_configure_event(uint32_t serial) const;
@@ -186,7 +186,7 @@ public:
 
     static XdgToplevelV6* from(struct wl_resource*);
 
-    XdgToplevelV6(struct wl_resource* resource);
+    XdgToplevelV6(struct wl_resource* resource, Version<1>);
     virtual ~XdgToplevelV6() = default;
 
     void send_configure_event(int32_t width, int32_t height, struct wl_array* states) const;
@@ -252,7 +252,7 @@ public:
 
     static XdgPopupV6* from(struct wl_resource*);
 
-    XdgPopupV6(struct wl_resource* resource);
+    XdgPopupV6(struct wl_resource* resource, Version<1>);
     virtual ~XdgPopupV6() = default;
 
     void send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const;

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -56,7 +56,7 @@ public:
 
     static bool is_instance(wl_resource* resource);
 
-    class Global : wayland::Global
+    class Global : public wayland::Global
     {
     public:
         Global(wl_display* display, Version<1>);

--- a/src/wayland/generated/xdg-shell_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell_wrapper.cpp
@@ -51,7 +51,7 @@ mw::XdgWmBase* mw::XdgWmBase::from(struct wl_resource* resource)
 
 struct mw::XdgWmBase::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -130,7 +130,7 @@ struct mw::XdgWmBase::Thunks
         auto resource = wl_resource_create(
             client,
             &xdg_wm_base_interface_data,
-            std::min(version, me->max_version),
+            std::min((int)version, Thunks::supported_version),
             id);
         if (resource == nullptr)
         {
@@ -154,7 +154,9 @@ struct mw::XdgWmBase::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgWmBase::XdgWmBase(struct wl_resource* resource)
+int const mw::XdgWmBase::Thunks::supported_version = 1;
+
+mw::XdgWmBase::XdgWmBase(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -180,15 +182,14 @@ void mw::XdgWmBase::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::XdgWmBase::Global::Global(wl_display* display, uint32_t max_version)
+mw::XdgWmBase::Global::Global(wl_display* display, Version<1>)
     : wayland::Global{
           wl_global_create(
               display,
               &xdg_wm_base_interface_data,
-              max_version,
+              Thunks::supported_version,
               this,
-              &Thunks::bind_thunk),
-          max_version}
+              &Thunks::bind_thunk)}
 {}
 
 auto mw::XdgWmBase::Global::interface_name() const -> char const*
@@ -227,7 +228,7 @@ mw::XdgPositioner* mw::XdgPositioner::from(struct wl_resource* resource)
 
 struct mw::XdgPositioner::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -329,7 +330,9 @@ struct mw::XdgPositioner::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgPositioner::XdgPositioner(struct wl_resource* resource)
+int const mw::XdgPositioner::Thunks::supported_version = 1;
+
+mw::XdgPositioner::XdgPositioner(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -377,7 +380,7 @@ mw::XdgSurface* mw::XdgSurface::from(struct wl_resource* resource)
 
 struct mw::XdgSurface::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -475,7 +478,9 @@ struct mw::XdgSurface::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgSurface::XdgSurface(struct wl_resource* resource)
+int const mw::XdgSurface::Thunks::supported_version = 1;
+
+mw::XdgSurface::XdgSurface(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -535,7 +540,7 @@ mw::XdgToplevel* mw::XdgToplevel::from(struct wl_resource* resource)
 
 struct mw::XdgToplevel::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -744,7 +749,9 @@ struct mw::XdgToplevel::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgToplevel::XdgToplevel(struct wl_resource* resource)
+int const mw::XdgToplevel::Thunks::supported_version = 1;
+
+mw::XdgToplevel::XdgToplevel(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -841,7 +848,7 @@ mw::XdgPopup* mw::XdgPopup::from(struct wl_resource* resource)
 
 struct mw::XdgPopup::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -880,7 +887,9 @@ struct mw::XdgPopup::Thunks
     static void const* request_vtable[];
 };
 
-mw::XdgPopup::XdgPopup(struct wl_resource* resource)
+int const mw::XdgPopup::Thunks::supported_version = 1;
+
+mw::XdgPopup::XdgPopup(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {

--- a/src/wayland/generated/xdg-shell_wrapper.h
+++ b/src/wayland/generated/xdg-shell_wrapper.h
@@ -56,7 +56,7 @@ public:
 
     static bool is_instance(wl_resource* resource);
 
-    class Global : wayland::Global
+    class Global : public wayland::Global
     {
     public:
         Global(wl_display* display, Version<1>);

--- a/src/wayland/generated/xdg-shell_wrapper.h
+++ b/src/wayland/generated/xdg-shell_wrapper.h
@@ -27,7 +27,7 @@ public:
 
     static XdgWmBase* from(struct wl_resource*);
 
-    XdgWmBase(struct wl_resource* resource);
+    XdgWmBase(struct wl_resource* resource, Version<1>);
     virtual ~XdgWmBase() = default;
 
     void send_ping_event(uint32_t serial) const;
@@ -59,7 +59,7 @@ public:
     class Global : wayland::Global
     {
     public:
-        Global(wl_display* display, uint32_t max_version);
+        Global(wl_display* display, Version<1>);
 
         auto interface_name() const -> char const* override;
 
@@ -82,7 +82,7 @@ public:
 
     static XdgPositioner* from(struct wl_resource*);
 
-    XdgPositioner(struct wl_resource* resource);
+    XdgPositioner(struct wl_resource* resource, Version<1>);
     virtual ~XdgPositioner() = default;
 
     void destroy_wayland_object() const;
@@ -153,7 +153,7 @@ public:
 
     static XdgSurface* from(struct wl_resource*);
 
-    XdgSurface(struct wl_resource* resource);
+    XdgSurface(struct wl_resource* resource, Version<1>);
     virtual ~XdgSurface() = default;
 
     void send_configure_event(uint32_t serial) const;
@@ -194,7 +194,7 @@ public:
 
     static XdgToplevel* from(struct wl_resource*);
 
-    XdgToplevel(struct wl_resource* resource);
+    XdgToplevel(struct wl_resource* resource, Version<1>);
     virtual ~XdgToplevel() = default;
 
     void send_configure_event(int32_t width, int32_t height, struct wl_array* states) const;
@@ -260,7 +260,7 @@ public:
 
     static XdgPopup* from(struct wl_resource*);
 
-    XdgPopup(struct wl_resource* resource);
+    XdgPopup(struct wl_resource* resource, Version<1>);
     virtual ~XdgPopup() = default;
 
     void send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const;

--- a/src/wayland/generator/global.cpp
+++ b/src/wayland/generator/global.cpp
@@ -31,7 +31,7 @@ Global::Global(std::string const& wl_name, std::string const& generated_name, in
 Emitter Global::declaration() const
 {
     return Lines{
-        {"class Global : wayland::Global"},
+        {"class Global : public wayland::Global"},
         "{",
         "public:",
         Emitter::layout(Lines{

--- a/src/wayland/generator/global.cpp
+++ b/src/wayland/generator/global.cpp
@@ -20,8 +20,9 @@
 
 #include <libxml++/libxml++.h>
 
-Global::Global(std::string const& wl_name, std::string const& generated_name, std::string const& nmspace)
+Global::Global(std::string const& wl_name, std::string const& generated_name, int version, std::string const& nmspace)
     : wl_name{wl_name},
+      version{version},
       generated_name{generated_name},
       nmspace{nmspace}
 {
@@ -57,10 +58,9 @@ Emitter Global::implementation() const
             {"          wl_global_create("},
             {"              display,"},
             {"              &", wl_name, "_interface_data,"},
-            {"              max_version,"},
+            {"              Thunks::supported_version,"},
             {"              this,"},
-            {"              &Thunks::bind_thunk),"},
-            {"          max_version}"},
+            {"              &Thunks::bind_thunk)}"},
             Block{
             }
         },
@@ -83,7 +83,7 @@ Emitter Global::bind_thunk_impl() const
             Emitter::layout(Lines{
                 "client,",
                 {"&", wl_name, "_interface_data,"},
-                "std::min(version, me->max_version),",
+                {"std::min((int)version, Thunks::supported_version),"},
                 "id);",
             }, true, true, Emitter::single_indent),
             "if (resource == nullptr)",
@@ -105,7 +105,7 @@ Emitter Global::bind_thunk_impl() const
 
 Emitter Global::constructor_args() const
 {
-    return {"wl_display* display, uint32_t max_version"};
+    return {"wl_display* display, Version<", std::to_string(version), ">"};
 }
 
 Emitter Global::bind_prototype() const

--- a/src/wayland/generator/global.h
+++ b/src/wayland/generator/global.h
@@ -29,7 +29,7 @@ class Element;
 class Global
 {
 public:
-    Global(std::string const& wl_name, std::string const& generated_name, std::string const& nmspace);
+    Global(std::string const& wl_name, std::string const& generated_name, int version, std::string const& nmspace);
 
     Emitter declaration() const;
     Emitter implementation() const;
@@ -40,6 +40,7 @@ private:
     Emitter bind_prototype() const;
 
     std::string const wl_name;
+    int const version;
     std::string const generated_name;
     std::string const nmspace;
 };

--- a/src/wayland/generator/interface.cpp
+++ b/src/wayland/generator/interface.cpp
@@ -151,7 +151,7 @@ Emitter Interface::constructor_impl() const
 
 Emitter Interface::constructor_args() const
 {
-    return {"struct wl_resource* resource"};
+    return {"struct wl_resource* resource, Version<", std::to_string(version), ">"};
 }
 
 Emitter Interface::destructor_prototype() const

--- a/src/wayland/generator/interface.cpp
+++ b/src/wayland/generator/interface.cpp
@@ -30,7 +30,7 @@ Interface::Interface(xmlpp::Element const& node,
       generated_name{name_transform(wl_name)},
       nmspace{"mw::" + generated_name + "::"},
       global{(constructable_interfaces.count(wl_name) == 0) ?
-          std::experimental::make_optional(Global{wl_name, generated_name, nmspace}) :
+          std::experimental::make_optional(Global{wl_name, generated_name, version, nmspace}) :
           std::experimental::nullopt},
       requests{get_requests(node, generated_name)},
       events{get_events(node, generated_name)},
@@ -258,6 +258,8 @@ Emitter Interface::thunks_impl() const
             {Block{
                 contents
             }, ";"},
+            empty_line,
+            {"int const ", nmspace, "Thunks::supported_version = ", std::to_string(version), ";"},
         };
     }
     else
@@ -270,7 +272,7 @@ Emitter Interface::thunks_impl_contents() const
 {
     std::vector<Emitter> impls;
     impls.push_back(
-        {"static int const supported_version = ", std::to_string(version), ";"});
+        {"static int const supported_version;"});
 
     for (auto const& request : requests)
         impls.push_back(request.thunk_impl());

--- a/src/wayland/wayland_base.cpp
+++ b/src/wayland/wayland_base.cpp
@@ -28,9 +28,8 @@ mw::Resource::Resource()
 {
 }
 
-mw::Global::Global(wl_global* global, uint32_t max_version)
-    : global{global},
-      max_version{max_version}
+mw::Global::Global(wl_global* global)
+    : global{global}
 {
     if (global == nullptr)
     {

--- a/tests/miral/generated/server-decoration_wrapper.cpp
+++ b/tests/miral/generated/server-decoration_wrapper.cpp
@@ -46,7 +46,7 @@ mw::ServerDecorationManager* mw::ServerDecorationManager::from(struct wl_resourc
 
 struct mw::ServerDecorationManager::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void create_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface)
     {
@@ -79,7 +79,7 @@ struct mw::ServerDecorationManager::Thunks
         auto resource = wl_resource_create(
             client,
             &org_kde_kwin_server_decoration_manager_interface_data,
-            std::min(version, me->max_version),
+            std::min((int)version, Thunks::supported_version),
             id);
         if (resource == nullptr)
         {
@@ -102,7 +102,9 @@ struct mw::ServerDecorationManager::Thunks
     static void const* request_vtable[];
 };
 
-mw::ServerDecorationManager::ServerDecorationManager(struct wl_resource* resource)
+int const mw::ServerDecorationManager::Thunks::supported_version = 1;
+
+mw::ServerDecorationManager::ServerDecorationManager(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -128,15 +130,14 @@ void mw::ServerDecorationManager::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::ServerDecorationManager::Global::Global(wl_display* display, uint32_t max_version)
+mw::ServerDecorationManager::Global::Global(wl_display* display, Version<1>)
     : wayland::Global{
           wl_global_create(
               display,
               &org_kde_kwin_server_decoration_manager_interface_data,
-              max_version,
+              Thunks::supported_version,
               this,
-              &Thunks::bind_thunk),
-          max_version}
+              &Thunks::bind_thunk)}
 {}
 
 auto mw::ServerDecorationManager::Global::interface_name() const -> char const*
@@ -166,7 +167,7 @@ mw::ServerDecoration* mw::ServerDecoration::from(struct wl_resource* resource)
 
 struct mw::ServerDecoration::Thunks
 {
-    static int const supported_version = 1;
+    static int const supported_version;
 
     static void release_thunk(struct wl_client* client, struct wl_resource* resource)
     {
@@ -204,7 +205,9 @@ struct mw::ServerDecoration::Thunks
     static void const* request_vtable[];
 };
 
-mw::ServerDecoration::ServerDecoration(struct wl_resource* resource)
+int const mw::ServerDecoration::Thunks::supported_version = 1;
+
+mw::ServerDecoration::ServerDecoration(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {

--- a/tests/miral/generated/server-decoration_wrapper.h
+++ b/tests/miral/generated/server-decoration_wrapper.h
@@ -53,7 +53,7 @@ public:
 
     static bool is_instance(wl_resource* resource);
 
-    class Global : wayland::Global
+    class Global : public wayland::Global
     {
     public:
         Global(wl_display* display, Version<1>);

--- a/tests/miral/generated/server-decoration_wrapper.h
+++ b/tests/miral/generated/server-decoration_wrapper.h
@@ -27,7 +27,7 @@ public:
 
     static ServerDecorationManager* from(struct wl_resource*);
 
-    ServerDecorationManager(struct wl_resource* resource);
+    ServerDecorationManager(struct wl_resource* resource, Version<1>);
     virtual ~ServerDecorationManager() = default;
 
     void send_default_mode_event(uint32_t mode) const;
@@ -56,7 +56,7 @@ public:
     class Global : wayland::Global
     {
     public:
-        Global(wl_display* display, uint32_t max_version);
+        Global(wl_display* display, Version<1>);
 
         auto interface_name() const -> char const* override;
 
@@ -76,7 +76,7 @@ public:
 
     static ServerDecoration* from(struct wl_resource*);
 
-    ServerDecoration(struct wl_resource* resource);
+    ServerDecoration(struct wl_resource* resource, Version<1>);
     virtual ~ServerDecoration() = default;
 
     void send_mode_event(uint32_t mode) const;

--- a/tests/miral/server_example_decoration.cpp
+++ b/tests/miral/server_example_decoration.cpp
@@ -53,12 +53,12 @@ struct ServerDecorationManager : mir::wayland::ServerDecorationManager::Global
     static int const interface_supported = 1;
 
     ServerDecorationManager(struct wl_display* display) :
-        Global(display, interface_supported)
+        Global(display, mir::wayland::Version<interface_supported>())
     {
     };
 
     ServerDecorationManager(struct wl_display* display, ServerDecorationCreateCallback callback) :
-        Global(display, interface_supported),
+        Global(display, mir::wayland::Version<interface_supported>()),
         callback{callback}
     {
     };

--- a/tests/miral/server_example_decoration.cpp
+++ b/tests/miral/server_example_decoration.cpp
@@ -29,7 +29,7 @@ struct ServerDecoration :
     mw::ServerDecoration
 {
     ServerDecoration(wl_resource* new_resource) :
-        mw::ServerDecoration::ServerDecoration(new_resource, mw::Version<1>())
+        mw::ServerDecoration::ServerDecoration(new_resource, Version<1>())
     {
         send_mode_event(decoration_mode);
     }
@@ -55,12 +55,12 @@ struct ServerDecorationManager : mw::ServerDecorationManager::Global
     static int const interface_supported = 1;
 
     ServerDecorationManager(struct wl_display* display) :
-        Global(display, mw::Version<interface_supported>())
+        Global(display, Version<interface_supported>())
     {
     };
 
     ServerDecorationManager(struct wl_display* display, ServerDecorationCreateCallback callback) :
-        Global(display, mw::Version<interface_supported>()),
+        Global(display, Version<interface_supported>()),
         callback{callback}
     {
     };
@@ -69,7 +69,7 @@ struct ServerDecorationManager : mw::ServerDecorationManager::Global
     {
     public:
         Instance(wl_resource* new_resource, ::ServerDecorationManager* manager)
-            : mw::ServerDecorationManager(new_resource, mw::Version<1>()),
+            : mw::ServerDecorationManager(new_resource, Version<1>()),
               manager{manager}
         {
         }

--- a/tests/miral/server_example_decoration.cpp
+++ b/tests/miral/server_example_decoration.cpp
@@ -21,13 +21,15 @@
 
 using mir::examples::ServerDecorationCreateCallback;
 
+namespace mw = mir::wayland;
+
 namespace
 {
 struct ServerDecoration :
-    mir::wayland::ServerDecoration
+    mw::ServerDecoration
 {
     ServerDecoration(wl_resource* new_resource) :
-        mir::wayland::ServerDecoration::ServerDecoration(new_resource)
+        mw::ServerDecoration::ServerDecoration(new_resource, mw::Version<1>())
     {
         send_mode_event(decoration_mode);
     }
@@ -48,26 +50,26 @@ struct ServerDecoration :
     uint32_t decoration_mode = Mode::Server;
 };
 
-struct ServerDecorationManager : mir::wayland::ServerDecorationManager::Global
+struct ServerDecorationManager : mw::ServerDecorationManager::Global
 {
     static int const interface_supported = 1;
 
     ServerDecorationManager(struct wl_display* display) :
-        Global(display, mir::wayland::Version<interface_supported>())
+        Global(display, mw::Version<interface_supported>())
     {
     };
 
     ServerDecorationManager(struct wl_display* display, ServerDecorationCreateCallback callback) :
-        Global(display, mir::wayland::Version<interface_supported>()),
+        Global(display, mw::Version<interface_supported>()),
         callback{callback}
     {
     };
 
-    class Instance : public mir::wayland::ServerDecorationManager
+    class Instance : public mw::ServerDecorationManager
     {
     public:
         Instance(wl_resource* new_resource, ::ServerDecorationManager* manager)
-            : mir::wayland::ServerDecorationManager(new_resource),
+            : mw::ServerDecorationManager(new_resource, mw::Version<1>()),
               manager{manager}
         {
         }


### PR DESCRIPTION
This will cause a compile-time error if XML/generated classes are updated to a new version without also updating the child classes.

(Reopened from #832)