### PR TITLE
New and improved surface depth layer

### DIFF
--- a/include/core/mir/depth_layer.h
+++ b/include/core/mir/depth_layer.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_DEPTH_LAYER_H_
+#define MIR_DEPTH_LAYER_H_
+
+#include "mir_toolkit/common.h"
+
+namespace mir
+{
+
+/**
+* Returns the height of a MirDepthLayer
+*
+* As the name implies, the returned value is usable as an array index (0 is returned for the bottommost layer and there
+* are no gaps between layers). The values returned for each layer are in no way stable across Mir versions, and are only
+* meaningful relative to each other.
+*/
+auto mir_depth_layer_get_index(MirDepthLayer depth_layer) -> unsigned int;
+
+} // namespace mir
+
+#endif // MIR_DEPTH_LAYER_H_

--- a/include/core/mir_toolkit/common.h
+++ b/include/core/mir_toolkit/common.h
@@ -483,7 +483,10 @@ typedef enum MirOutputGammaSupported
 
 /**
  * Depth layer controls Z ordering of surfaces.
+ *
  * A surface will always appear on top of surfaces with a lower depth layer, and below those with a higher one.
+ * A depth layer can be converted to a number with mir::mir_depth_layer_get_index().
+ * This is useful for creating a list indexed by depth layer, or comparing the height of two layers.
  */
 typedef enum MirDepthLayer
 {

--- a/include/core/mir_toolkit/common.h
+++ b/include/core/mir_toolkit/common.h
@@ -481,6 +481,21 @@ typedef enum MirOutputGammaSupported
     mir_output_gamma_supported
 } MirOutputGammaSupported;
 
+/**
+ * Depth layer controls Z ordering of surfaces.
+ * A surface will always appear on top of surfaces with a lower depth layer, and below those with a higher one.
+ */
+typedef enum MirDepthLayer
+{
+    mir_depth_layer_background,         /**< For desktop backgrounds and alike (lowest layer) */
+    mir_depth_layer_below,              /**< For panels or other controls/decorations below normal windows */
+    mir_depth_layer_application,        /**< For normal application windows */
+    mir_depth_layer_always_on_top,      /**< For always-on-top application windows */
+    mir_depth_layer_above,              /**< For panels or notifications that want to be above normal windows */
+    mir_depth_layer_overlay,            /**< For overlays such as lock screens (heighest layer) */
+} MirDepthLayer;
+
+
 /**@}*/
 
 #endif

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -116,6 +116,9 @@ struct WindowInfo
     void userdata(std::shared_ptr<void> userdata);
 
     void swap(WindowInfo& rhs) { std::swap(self, rhs.self); }
+
+    auto depth_layer() const -> MirDepthLayer;
+    void depth_layer(MirDepthLayer depth_layer);
 private:
     struct Self;
     std::unique_ptr<Self> self;

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -125,6 +125,9 @@ public:
     auto confine_pointer() -> mir::optional_value<MirPointerConfinementState>&;
     auto userdata() -> mir::optional_value<std::shared_ptr<void>>&;
 
+    /**
+     * The depth layer of a child window is updated with the depth layer of its parent, but can be overridden
+     */
     auto depth_layer() const -> mir::optional_value<MirDepthLayer> const&;
     auto depth_layer() -> mir::optional_value<MirDepthLayer>&;
 

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -125,6 +125,9 @@ public:
     auto confine_pointer() -> mir::optional_value<MirPointerConfinementState>&;
     auto userdata() -> mir::optional_value<std::shared_ptr<void>>&;
 
+    auto depth_layer() const -> mir::optional_value<MirDepthLayer> const&;
+    auto depth_layer() -> mir::optional_value<MirDepthLayer>&;
+
 private:
     struct Self;
     std::unique_ptr<Self> self;

--- a/include/server/mir/scene/null_surface_observer.h
+++ b/include/server/mir/scene/null_surface_observer.h
@@ -54,6 +54,7 @@ public:
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
     void input_consumed(Surface const* surf, MirEvent const* event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
+    void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
 
 protected:
     NullSurfaceObserver(NullSurfaceObserver const&) = delete;

--- a/include/server/mir/scene/surface.h
+++ b/include/server/mir/scene/surface.h
@@ -116,6 +116,12 @@ public:
 
     virtual void placed_relative(geometry::Rectangle const& placement) = 0;
     virtual void start_drag_and_drop(std::vector<uint8_t> const& handle) = 0;
+
+    virtual auto depth_layer() const -> MirDepthLayer = 0;
+    /**
+     * When the depth layer is changed, the surface becomes the top surface on that layer
+     */
+    virtual void set_depth_layer(MirDepthLayer depth_layer) = 0;
 };
 }
 }

--- a/include/server/mir/scene/surface_creation_parameters.h
+++ b/include/server/mir/scene/surface_creation_parameters.h
@@ -111,6 +111,8 @@ struct SurfaceCreationParameters
     mir::optional_value<MirShellChrome> shell_chrome;
     mir::optional_value<std::vector<shell::StreamSpecification>> streams;
     mir::optional_value<MirPointerConfinementState> confine_pointer;
+
+    optional_value<MirDepthLayer> depth_layer;
 };
 
 bool operator==(const SurfaceCreationParameters& lhs, const SurfaceCreationParameters& rhs);

--- a/include/server/mir/scene/surface_creation_parameters.h
+++ b/include/server/mir/scene/surface_creation_parameters.h
@@ -112,6 +112,9 @@ struct SurfaceCreationParameters
     mir::optional_value<std::vector<shell::StreamSpecification>> streams;
     mir::optional_value<MirPointerConfinementState> confine_pointer;
 
+    /**
+     * If the depth layer of a child surface isn't set, it gets the layer of its parent
+     */
     optional_value<MirDepthLayer> depth_layer;
 };
 

--- a/include/server/mir/scene/surface_observer.h
+++ b/include/server/mir/scene/surface_observer.h
@@ -71,6 +71,7 @@ public:
     virtual void placed_relative(Surface const* surf, geometry::Rectangle const& placement) = 0;
     virtual void input_consumed(Surface const* surf, MirEvent const* event) = 0;
     virtual void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) = 0;
+    virtual void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) = 0;
 
 protected:
     SurfaceObserver() = default;

--- a/include/server/mir/shell/surface_specification.h
+++ b/include/server/mir/shell/surface_specification.h
@@ -98,7 +98,9 @@ struct SurfaceSpecification
     optional_value<MirShellChrome> shell_chrome;
     optional_value<MirPointerConfinementState> confine_pointer;
     optional_value<std::shared_ptr<graphics::CursorImage>> cursor_image;
-    optional_value<StreamCursor> stream_cursor; 
+    optional_value<StreamCursor> stream_cursor;
+
+    optional_value<MirDepthLayer> depth_layer;
 };
 }
 }

--- a/include/server/mir/shell/surface_specification.h
+++ b/include/server/mir/shell/surface_specification.h
@@ -100,6 +100,10 @@ struct SurfaceSpecification
     optional_value<std::shared_ptr<graphics::CursorImage>> cursor_image;
     optional_value<StreamCursor> stream_cursor;
 
+    /**
+     * Child surfaces are by default created on the same layer as their parent, and updating the depth layer of a parent
+     * also updates all children.
+     */
     optional_value<MirDepthLayer> depth_layer;
 };
 }

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -70,6 +70,8 @@ struct StubSurface : scene::Surface
     MirPointerConfinementState confine_pointer_state() const override;
     void placed_relative(geometry::Rectangle const& placement) override;
     void start_drag_and_drop(std::vector<uint8_t> const& handle) override;
+    MirDepthLayer depth_layer() const override;
+    void set_depth_layer(MirDepthLayer depth_layer) override;
 };
 }
 }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(mircore SHARED
     anonymous_shm_file.cpp
     fatal.cpp
     fd.cpp
+    depth_layer.cpp
     geometry/rectangle.cpp
     geometry/rectangles.cpp
     geometry/ostream.cpp
@@ -24,6 +25,7 @@ add_library(mircore SHARED
     ${PROJECT_SOURCE_DIR}/include/core/mir/geometry/forward.h
     ${PROJECT_SOURCE_DIR}/include/core/mir/geometry/dimensions.h
     ${PROJECT_SOURCE_DIR}/include/core/mir/shm_file.h
+    ${PROJECT_SOURCE_DIR}/include/core/mir/depth_layer.h
     ${PROJECT_SOURCE_DIR}/include/core/mir_toolkit/common.h
     ${PROJECT_SOURCE_DIR}/include/core/mir_toolkit/mir_version_number.h
 )

--- a/src/core/depth_layer.cpp
+++ b/src/core/depth_layer.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "mir/depth_layer.h"
+
+#include <stdexcept>
+
+auto mir::mir_depth_layer_get_index(MirDepthLayer depth_layer) -> unsigned int
+{
+    switch (depth_layer)
+    {
+    case mir_depth_layer_background:        return 0;
+    case mir_depth_layer_below:             return 1;
+    case mir_depth_layer_application:       return 2;
+    case mir_depth_layer_always_on_top:     return 3;
+    case mir_depth_layer_above:             return 4;
+    case mir_depth_layer_overlay:           return 5;
+    }
+    // GCC and Clang both ensure the switch is exhaustive.
+    // GCC, however, gets a "control reaches end of non-void function" warning without this
+#ifndef __clang__
+    throw std::logic_error("Invalid MirDepthLayer in mir::mir_depth_layer_get_index()");
+#endif
+}

--- a/src/core/symbols.map
+++ b/src/core/symbols.map
@@ -73,3 +73,10 @@ MIR_CORE_1.0 {
   };
   local: *;
 } MIR_CORE_0.25;
+
+MIR_CORE_1.1 {
+ global:
+  extern "C++" {
+    mir::mir_depth_layer_get_index?MirDepthLayer?;
+  };
+} MIR_CORE_1.0;

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -57,6 +57,7 @@ public:
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
     void input_consumed(Surface const* surf, MirEvent const* event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
+    void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
 };
 
 }

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -878,6 +878,7 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
     COPY_IF_SET(confine_pointer);
     COPY_IF_SET(userdata);
     COPY_IF_SET(shell_chrome);
+    COPY_IF_SET(depth_layer);
 
 #undef COPY_IF_SET
 
@@ -919,6 +920,9 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
     std::swap(window_info_tmp, window_info);
 
     auto& window = window_info.window();
+
+    if (modifications.depth_layer().is_set())
+        std::shared_ptr<scene::Surface>(window)->set_depth_layer(modifications.depth_layer().value());
 
     if (window_info.type() != window_info_tmp.type())
         std::shared_ptr<scene::Surface>(window)->configure(mir_window_attrib_type, window_info.type());

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -252,6 +252,7 @@ private:
         -> mir::optional_value<Rectangle>;
 
     void move_tree(miral::WindowInfo& root, mir::geometry::Displacement movement);
+    void set_tree_depth_layer(miral::WindowInfo& root, MirDepthLayer new_layer);
     void erase(miral::WindowInfo const& info);
     void validate_modification_request(WindowSpecification const& modifications, WindowInfo const& window_info) const;
     void place_and_size(WindowInfo& root, Point const& new_pos, Size const& new_size);

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -426,3 +426,11 @@ global:
     vtable?for?miral::WaylandExtensions::Context;
   };
 } MIRAL_2.4;
+
+MIRAL_2.6 {
+global:
+  extern "C++" {
+    miral::WindowSpecification::depth_layer*;
+    miral::WindowInfo::depth_layer*;
+  };
+} MIRAL_2.5;

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -93,6 +93,7 @@ struct miral::WindowInfo::Self
     AspectRatio max_aspect;
     mir::optional_value<int> output_id;
     MirShellChrome shell_chrome;
+    MirDepthLayer depth_layer;
     std::shared_ptr<void> userdata;
 };
 
@@ -112,7 +113,8 @@ miral::WindowInfo::Self::Self(Window window, WindowSpecification const& params) 
     height_inc{optional_value_or_default(params.height_inc(), default_height_inc)},
     min_aspect(optional_value_or_default(params.min_aspect(), default_min_aspect_ratio)),
     max_aspect(optional_value_or_default(params.max_aspect(), default_max_aspect_ratio)),
-    shell_chrome(optional_value_or_default(params.shell_chrome(), mir_shell_chrome_normal))
+    shell_chrome(optional_value_or_default(params.shell_chrome(), mir_shell_chrome_normal)),
+    depth_layer(optional_value_or_default(params.depth_layer(), mir_depth_layer_application))
 {
     if (params.output_id().is_set())
         output_id = params.output_id().value();
@@ -613,4 +615,14 @@ auto miral::WindowInfo::name() const -> std::string
 void miral::WindowInfo::name(std::string const& name)
 {
     self->name = name;
+}
+
+auto miral::WindowInfo::depth_layer() const -> MirDepthLayer
+{
+    return self->depth_layer;
+}
+
+void miral::WindowInfo::depth_layer(MirDepthLayer depth_layer)
+{
+    self->depth_layer = depth_layer;
 }

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -59,6 +59,7 @@ struct miral::WindowSpecification::Self
     mir::optional_value<InputReceptionMode> input_mode;
     mir::optional_value<MirShellChrome> shell_chrome;
     mir::optional_value<MirPointerConfinementState> confine_pointer;
+    mir::optional_value<MirDepthLayer> depth_layer;
     mir::optional_value<std::shared_ptr<void>> userdata;
 };
 
@@ -88,8 +89,9 @@ miral::WindowSpecification::Self::Self(mir::shell::SurfaceSpecification const& s
     parent(spec.parent),
     input_shape(spec.input_shape),
     input_mode(),
-    shell_chrome(spec.shell_chrome)
-    ,confine_pointer(spec.confine_pointer)
+    shell_chrome(spec.shell_chrome),
+    confine_pointer(spec.confine_pointer),
+    depth_layer(spec.depth_layer)
 {
     if (spec.aux_rect_placement_offset_x.is_set() && spec.aux_rect_placement_offset_y.is_set())
         aux_rect_placement_offset = Displacement{spec.aux_rect_placement_offset_x.value(), spec.aux_rect_placement_offset_y.value()};
@@ -213,8 +215,9 @@ miral::WindowSpecification::Self::Self(mir::scene::SurfaceCreationParameters con
     parent(params.parent),
     input_shape(params.input_shape),
     input_mode(static_cast<InputReceptionMode>(params.input_mode)),
-    shell_chrome(params.shell_chrome)
-    ,confine_pointer(params.confine_pointer)
+    shell_chrome(params.shell_chrome),
+    confine_pointer(params.confine_pointer),
+    depth_layer(params.depth_layer)
 {
     if (params.aux_rect_placement_offset_x.is_set() && params.aux_rect_placement_offset_y.is_set())
         aux_rect_placement_offset = Displacement{params.aux_rect_placement_offset_x.value(), params.aux_rect_placement_offset_y.value()};
@@ -283,6 +286,7 @@ void miral::WindowSpecification::Self::update(mir::scene::SurfaceCreationParamet
     copy_if_set(params.placement_hints, placement_hints);
     copy_if_set(params.surface_placement_gravity, window_placement_gravity);
     copy_if_set(params.aux_rect_placement_gravity, aux_rect_placement_gravity);
+    copy_if_set(params.depth_layer, depth_layer);
 
     if (aux_rect_placement_offset.is_set())
     {
@@ -583,4 +587,14 @@ auto miral::WindowSpecification::confine_pointer() -> mir::optional_value<MirPoi
 auto miral::WindowSpecification::userdata() -> mir::optional_value<std::shared_ptr<void>>&
 {
     return self->userdata;
+}
+
+auto miral::WindowSpecification::depth_layer() const -> mir::optional_value<MirDepthLayer> const&
+{
+    return self->depth_layer;
+}
+
+auto miral::WindowSpecification::depth_layer() -> mir::optional_value<MirDepthLayer>&
+{
+    return self->depth_layer;
 }

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -158,6 +158,10 @@ struct InputDispatcherSceneObserver :
     {
     }
 
+    void depth_layer_set_to(ms::Surface const*, MirDepthLayer) override
+    {
+    }
+
     std::function<void(ms::Surface*)> const on_removed;
     std::function<void(ms::Surface const*)> const on_surface_moved;
     std::function<void()> const on_surface_resized;

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -162,6 +162,8 @@ mf::SurfaceId ms::ApplicationSession::create_surface(
         surface->configure(mir_window_attrib_preferred_orientation, params.preferred_orientation.value());
     if (params.input_shape.is_set())
         surface->set_input_region(params.input_shape.value());
+    if (params.depth_layer.is_set())
+        surface->set_depth_layer(params.depth_layer.value());
 
     return id;
 }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -153,6 +153,11 @@ void ms::SurfaceObservers::start_drag_and_drop(Surface const* surf, std::vector<
                  { observer->start_drag_and_drop(surf, handle); });
 }
 
+void ms::SurfaceObservers::depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer)
+{
+    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
+                 { observer->depth_layer_set_to(surf, depth_layer); });
+}
 
 struct ms::CursorStreamImageAdapter
 {
@@ -937,4 +942,5 @@ void mir::scene::BasicSurface::set_depth_layer(MirDepthLayer depth_layer)
         std::unique_lock<std::mutex> lg(guard);
         depth_layer_ = depth_layer;
     }
+    observers.depth_layer_set_to(this, depth_layer);
 }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -924,3 +924,17 @@ void mir::scene::BasicSurface::start_drag_and_drop(std::vector<uint8_t> const& h
 {
     observers.start_drag_and_drop(this, handle);
 }
+
+auto mir::scene::BasicSurface::depth_layer() const -> MirDepthLayer
+{
+    std::unique_lock<std::mutex> lg(guard);
+    return depth_layer_;
+}
+
+void mir::scene::BasicSurface::set_depth_layer(MirDepthLayer depth_layer)
+{
+    {
+        std::unique_lock<std::mutex> lg(guard);
+        depth_layer_ = depth_layer;
+    }
+}

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -142,6 +142,9 @@ public:
     void placed_relative(geometry::Rectangle const& placement) override;
     void start_drag_and_drop(std::vector<uint8_t> const& handle) override;
 
+    auto depth_layer() const -> MirDepthLayer override;
+    void set_depth_layer(MirDepthLayer depth_layer) override;
+
 private:
     bool visible(std::unique_lock<std::mutex>&) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
@@ -178,6 +181,8 @@ private:
     MirPointerConfinementState confine_pointer_state_ = mir_pointer_unconfined;
 
     std::unique_ptr<CursorStreamImageAdapter> const cursor_stream_adapter;
+
+    MirDepthLayer depth_layer_ = mir_depth_layer_application;
 };
 
 }

--- a/src/server/scene/legacy_surface_change_notification.cpp
+++ b/src/server/scene/legacy_surface_change_notification.cpp
@@ -113,3 +113,7 @@ void ms::LegacySurfaceChangeNotification::input_consumed(Surface const*, MirEven
 void ms::LegacySurfaceChangeNotification::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&)
 {
 }
+
+void ms::LegacySurfaceChangeNotification::depth_layer_set_to(Surface const*, MirDepthLayer)
+{
+}

--- a/src/server/scene/legacy_surface_change_notification.h
+++ b/src/server/scene/legacy_surface_change_notification.h
@@ -57,6 +57,7 @@ public:
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
     void input_consumed(Surface const* surf, MirEvent const* event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
+    void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
 
 private:
     std::function<void()> const notify_scene_change;

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -44,3 +44,4 @@ void ms::NullSurfaceObserver::cursor_image_removed(Surface const*) {}
 void ms::NullSurfaceObserver::placed_relative(Surface const*, geometry::Rectangle const&) {}
 void ms::NullSurfaceObserver::input_consumed(Surface const*, MirEvent const*) {}
 void ms::NullSurfaceObserver::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&) {}
+void ms::NullSurfaceObserver::depth_layer_set_to(Surface const*, MirDepthLayer) {}

--- a/src/server/scene/surface_creation_parameters.cpp
+++ b/src/server/scene/surface_creation_parameters.cpp
@@ -196,6 +196,8 @@ void ms::SurfaceCreationParameters::update_from(msh::SurfaceSpecification const&
         shell_chrome = that.shell_chrome;
     if (that.confine_pointer.is_set())
         confine_pointer = that.confine_pointer;
+    if (that.depth_layer.is_set())
+        depth_layer = that.depth_layer;
     // TODO: should SurfaceCreationParameters support cursors?
 //     if (that.cursor_image.is_set())
 //         cursor_image = that.cursor_image;

--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -25,6 +25,7 @@
 #include "mir/scene/scene_report.h"
 #include "mir/compositor/scene_element.h"
 #include "mir/graphics/renderable.h"
+#include "mir/depth_layer.h"
 
 #include <boost/throw_exception.hpp>
 
@@ -445,24 +446,10 @@ void ms::SurfaceStack::update_rendering_tracker_compositors()
 
 void ms::SurfaceStack::insert_surface_at_top_of_depth_layer(std::shared_ptr<Surface> const& surface)
 {
-    unsigned int depth_index = mir_depth_layer_to_index(surface->depth_layer());
+    unsigned int depth_index = mir_depth_layer_get_index(surface->depth_layer());
     if (surface_layers.size() <= depth_index)
         surface_layers.resize(depth_index + 1);
     surface_layers[depth_index].push_back(surface);
-}
-
-auto ms::SurfaceStack::mir_depth_layer_to_index(MirDepthLayer depth_layer) -> unsigned int
-{
-    switch (depth_layer)
-    {
-    case mir_depth_layer_background:        return 0;
-    case mir_depth_layer_below:             return 1;
-    case mir_depth_layer_application:       return 2;
-    case mir_depth_layer_always_on_top:     return 3;
-    case mir_depth_layer_above:             return 4;
-    case mir_depth_layer_overlay:           return 5;
-    }
-    assert(false);
 }
 
 void ms::SurfaceStack::add_observer(std::shared_ptr<ms::Observer> const& observer)

--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -21,6 +21,7 @@
 #include "surface_stack.h"
 #include "rendering_tracker.h"
 #include "mir/scene/surface.h"
+#include "mir/scene/null_surface_observer.h"
 #include "mir/scene/scene_report.h"
 #include "mir/compositor/scene_element.h"
 #include "mir/graphics/renderable.h"
@@ -106,13 +107,46 @@ private:
     std::shared_ptr<mg::Renderable> const renderable_;
 };
 
+/**
+ * A SurfaceDepthLayerObserver must not outlive the SurfaceStack it was created for
+ */
+struct SurfaceDepthLayerObserver : ms::NullSurfaceObserver
+{
+    SurfaceDepthLayerObserver(ms::SurfaceStack* stack)
+        : stack{stack}
+    {
+    }
+
+    void depth_layer_set_to(ms::Surface const* surface, MirDepthLayer /*z_index*/) override
+    {
+        // move the surface to the top of it's new layer
+        stack->raise(surface);
+    }
+
+private:
+    ms::SurfaceStack* stack;
+};
+
 }
 
 ms::SurfaceStack::SurfaceStack(
     std::shared_ptr<SceneReport> const& report) :
     report{report},
-    scene_changed{false}
+    scene_changed{false},
+    surface_observer{std::make_shared<SurfaceDepthLayerObserver>(this)}
 {
+}
+
+ms::SurfaceStack::~SurfaceStack() noexcept(true)
+{
+    RecursiveWriteLock lg(guard);
+    for (auto const& layer : surface_layers)
+    {
+        for (auto const& surface : layer)
+        {
+            surface->remove_observer(surface_observer);
+        }
+    }
 }
 
 mc::SceneElementSequence ms::SurfaceStack::scene_elements_for(mc::CompositorID id)
@@ -121,18 +155,21 @@ mc::SceneElementSequence ms::SurfaceStack::scene_elements_for(mc::CompositorID i
 
     scene_changed = false;
     mc::SceneElementSequence elements;
-    for (auto const& surface : surfaces)
+    for (auto const& layer : surface_layers)
     {
-        if (surface->visible())
+        for (auto const& surface : layer)
         {
-            for (auto& renderable : surface->generate_renderables(id))
+            if (surface->visible())
             {
-                elements.emplace_back(
-                    std::make_shared<SurfaceSceneElement>(
-                        surface->name(),
-                        renderable,
-                        rendering_trackers[surface.get()],
-                        id));
+                for (auto& renderable : surface->generate_renderables(id))
+                {
+                    elements.emplace_back(
+                        std::make_shared<SurfaceSceneElement>(
+                            surface->name(),
+                            renderable,
+                            rendering_trackers[surface.get()],
+                            id));
+                }
             }
         }
     }
@@ -148,19 +185,22 @@ int ms::SurfaceStack::frames_pending(mc::CompositorID id) const
     RecursiveReadLock lg(guard);
 
     int result = scene_changed ? 1 : 0;
-    for (auto const& surface : surfaces)
+    for (auto const& layer : surface_layers)
     {
-        if (surface->visible())
+        for (auto const& surface : layer)
         {
-            auto const tracker = rendering_trackers.find(surface.get());
-            if (tracker != rendering_trackers.end() && tracker->second->is_exposed_in(id))
+            if (surface->visible())
             {
-                // Note that we ask the surface and not a Renderable.
-                // This is because we don't want to waste time and resources
-                // on a snapshot till we're sure we need it...
-                int ready = surface->buffers_ready_for_compositor(id);
-                if (ready > result)
-                    result = ready;
+                auto const tracker = rendering_trackers.find(surface.get());
+                if (tracker != rendering_trackers.end() && tracker->second->is_exposed_in(id))
+                {
+                    // Note that we ask the surface and not a Renderable.
+                    // This is because we don't want to waste time and resources
+                    // on a snapshot till we're sure we need it...
+                    int ready = surface->buffers_ready_for_compositor(id);
+                    if (ready > result)
+                        result = ready;
+                }
             }
         }
     }
@@ -227,8 +267,9 @@ void ms::SurfaceStack::add_surface(
 {
     {
         RecursiveWriteLock lg(guard);
-        surfaces.push_back(surface);
+        insert_surface_at_top_of_depth_layer(surface);
         create_rendering_tracker_for(surface);
+        surface->add_observer(surface_observer);
     }
     surface->set_reception_mode(input_mode);
     observers.surface_added(surface.get());
@@ -244,20 +285,24 @@ void ms::SurfaceStack::remove_surface(std::weak_ptr<Surface> const& surface)
     {
         RecursiveWriteLock lg(guard);
 
-        auto const surface = std::find(surfaces.begin(), surfaces.end(), keep_alive);
-
-        if (surface != surfaces.end())
+        for (auto& layer : surface_layers)
         {
-            surfaces.erase(surface);
-            rendering_trackers.erase(keep_alive.get());
-            found_surface = true;
+            auto const surface = std::find(layer.begin(), layer.end(), keep_alive);
+
+            if (surface != layer.end())
+            {
+                layer.erase(surface);
+                rendering_trackers.erase(keep_alive.get());
+                keep_alive->remove_observer(surface_observer);
+                found_surface = true;
+                break;
+            }
         }
     }
 
     if (found_surface)
     {
         observers.surface_removed(keep_alive.get());
-
         report->surface_removed(keep_alive.get(), keep_alive.get()->name());
     }
     // TODO: error logging when surface not found
@@ -280,14 +325,17 @@ auto ms::SurfaceStack::surface_at(geometry::Point cursor) const
 -> std::shared_ptr<Surface>
 {
     RecursiveReadLock lg(guard);
-    for (auto const& surface : in_reverse(surfaces))
+    for (auto const& layer : in_reverse(surface_layers))
     {
-        // TODO There's a lack of clarity about how the input area will
-        // TODO be maintained and whether this test will detect clicks on
-        // TODO decorations (it should) as these may be outside the area
-        // TODO known to the client.  But it works for now.
-        if (surface->input_area_contains(cursor))
-                return surface;
+        for (auto const& surface : in_reverse(layer))
+        {
+            // TODO There's a lack of clarity about how the input area will
+            // TODO be maintained and whether this test will detect clicks on
+            // TODO decorations (it should) as these may be outside the area
+            // TODO known to the client.  But it works for now.
+            if (surface->input_area_contains(cursor))
+                    return surface;
+        }
     }
 
     return {};
@@ -296,27 +344,39 @@ auto ms::SurfaceStack::surface_at(geometry::Point cursor) const
 void ms::SurfaceStack::for_each(std::function<void(std::shared_ptr<mi::Surface> const&)> const& callback)
 {
     RecursiveReadLock lg(guard);
-    for (auto &surface : surfaces)
+    for (auto const& layer : surface_layers)
     {
-        callback(surface);
+        for (auto const& surface : layer)
+        {
+            callback(surface);
+        }
     }
 }
 
-void ms::SurfaceStack::raise(std::weak_ptr<Surface> const& s)
+void ms::SurfaceStack::raise(Surface const* surface)
 {
     bool surfaces_reordered{false};
 
     {
-        auto const surface = s.lock();
-
         RecursiveWriteLock ul(guard);
-        auto const p = std::find(surfaces.begin(), surfaces.end(), surface);
-
-        if (p != surfaces.end())
+        for (auto& layer : surface_layers)
         {
-            surfaces.erase(p);
-            surfaces.push_back(surface);
-            surfaces_reordered = true;
+            auto const p = std::find_if(
+                layer.begin(),
+                layer.end(),
+                [surface](auto const& i)
+                    {
+                        return surface == i.get();
+                    });
+
+            if (p != layer.end())
+            {
+                std::shared_ptr<Surface> surface_shared = *p;
+                layer.erase(p);
+                insert_surface_at_top_of_depth_layer(surface_shared);
+                surfaces_reordered = true;
+                break;
+            }
         }
     }
 
@@ -324,7 +384,11 @@ void ms::SurfaceStack::raise(std::weak_ptr<Surface> const& s)
         BOOST_THROW_EXCEPTION(std::runtime_error("Invalid surface"));
 
     observers.surfaces_reordered();
-    return;
+}
+
+void ms::SurfaceStack::raise(std::weak_ptr<Surface> const& s)
+{
+    raise(s.lock().get());
 }
 
 void ms::SurfaceStack::raise(SurfaceSet const& ss)
@@ -332,14 +396,30 @@ void ms::SurfaceStack::raise(SurfaceSet const& ss)
     bool surfaces_reordered{false};
     {
         RecursiveWriteLock ul(guard);
+        for (auto& layer : surface_layers)
+        {
+            auto const old_layer = layer;
 
-        auto const old_surfaces = surfaces;
-        std::stable_partition(
-            begin(surfaces), end(surfaces),
-            [&](std::weak_ptr<Surface> const& s) { return !ss.count(s); });
+            // Put all the surfaces to raise at the end of the list (preserving order)
+            auto split = std::stable_partition(
+                begin(layer), end(layer),
+                [&](std::weak_ptr<Surface> const& s) { return !ss.count(s); });
 
-        if (old_surfaces != surfaces)
-            surfaces_reordered = true;
+            // Make a new vector with only the surfaces to raise
+            auto to_raise = std::vector<std::shared_ptr<Surface>>{split, layer.end()};
+
+            // Chop off the surfaces we are moving from the old vector (they are now only in to_raise)
+            layer.erase(split, layer.end());
+
+            // One by one insert to_raise surfaces into the surfaces vector at the correct position
+            // It is important that to_raise is still in the original order
+            for (auto const& surface : to_raise)
+                insert_surface_at_top_of_depth_layer(surface);
+
+            // Only set surfaces_reordered if the end result is different than before
+            if (old_layer != layer)
+                surfaces_reordered = true;
+        }
     }
 
     if (surfaces_reordered)
@@ -363,15 +443,40 @@ void ms::SurfaceStack::update_rendering_tracker_compositors()
         pair.second->active_compositors(registered_compositors);
 }
 
+void ms::SurfaceStack::insert_surface_at_top_of_depth_layer(std::shared_ptr<Surface> const& surface)
+{
+    unsigned int depth_index = mir_depth_layer_to_index(surface->depth_layer());
+    if (surface_layers.size() <= depth_index)
+        surface_layers.resize(depth_index + 1);
+    surface_layers[depth_index].push_back(surface);
+}
+
+auto ms::SurfaceStack::mir_depth_layer_to_index(MirDepthLayer depth_layer) -> unsigned int
+{
+    switch (depth_layer)
+    {
+    case mir_depth_layer_background:        return 0;
+    case mir_depth_layer_below:             return 1;
+    case mir_depth_layer_application:       return 2;
+    case mir_depth_layer_always_on_top:     return 3;
+    case mir_depth_layer_above:             return 4;
+    case mir_depth_layer_overlay:           return 5;
+    }
+    assert(false);
+}
+
 void ms::SurfaceStack::add_observer(std::shared_ptr<ms::Observer> const& observer)
 {
     observers.add(observer);
 
     // Notify observer of existing surfaces
     RecursiveReadLock lk(guard);
-    for (auto &surface : surfaces)
+    for (auto const& layer : surface_layers)
     {
-        observer->surface_exists(surface.get());
+        for (auto const& surface : layer)
+        {
+            observer->surface_exists(surface.get());
+        }
     }
 }
 

--- a/src/server/scene/surface_stack.h
+++ b/src/server/scene/surface_stack.h
@@ -109,11 +109,6 @@ private:
     void update_rendering_tracker_compositors();
     void insert_surface_at_top_of_depth_layer(std::shared_ptr<Surface> const& surface);
 
-    /**
-     * Converts a MirDepthLayer into an index for a list of layers (0 is bottom-most layer)
-     */
-    static auto mir_depth_layer_to_index(MirDepthLayer depth_layer) -> unsigned int;
-
     RecursiveReadWriteMutex mutable guard;
 
     std::shared_ptr<SceneReport> const report;

--- a/src/server/scene/surface_stack.h
+++ b/src/server/scene/surface_stack.h
@@ -27,6 +27,7 @@
 #include "mir/recursive_read_write_mutex.h"
 
 #include "mir/basic_observers.h"
+#include "mir/scene/surface_observer.h"
 
 #include <atomic>
 #include <map>
@@ -69,7 +70,7 @@ class SurfaceStack : public compositor::Scene, public input::Scene, public shell
 public:
     explicit SurfaceStack(
         std::shared_ptr<SceneReport> const& report);
-    virtual ~SurfaceStack() noexcept(true) {}
+    virtual ~SurfaceStack() noexcept(true);
 
     // From Scene
     compositor::SceneElementSequence scene_elements_for(compositor::CompositorID id) override;
@@ -82,23 +83,23 @@ public:
 
     virtual void remove_surface(std::weak_ptr<Surface> const& surface) override;
 
+    void raise(Surface const* surface);
     virtual void raise(std::weak_ptr<Surface> const& surface) override;
-
     void raise(SurfaceSet const& surfaces) override;
 
     void add_surface(
         std::shared_ptr<Surface> const& surface,
         input::InputReceptionMode input_mode) override;
-    
+
     auto surface_at(geometry::Point) const -> std::shared_ptr<Surface> override;
 
     void add_observer(std::shared_ptr<Observer> const& observer) override;
     void remove_observer(std::weak_ptr<Observer> const& observer) override;
-    
+
     // Intended for input overlays, as described in mir::input::Scene documentation.
     void add_input_visualization(std::shared_ptr<graphics::Renderable> const& overlay) override;
     void remove_input_visualization(std::weak_ptr<graphics::Renderable> const& overlay) override;
-    
+
     void emit_scene_changed() override;
 
 private:
@@ -106,12 +107,25 @@ private:
     SurfaceStack& operator=(const SurfaceStack&) = delete;
     void create_rendering_tracker_for(std::shared_ptr<Surface> const&);
     void update_rendering_tracker_compositors();
+    void insert_surface_at_top_of_depth_layer(std::shared_ptr<Surface> const& surface);
+
+    /**
+     * Converts a MirDepthLayer into an index for a list of layers (0 is bottom-most layer)
+     */
+    static auto mir_depth_layer_to_index(MirDepthLayer depth_layer) -> unsigned int;
 
     RecursiveReadWriteMutex mutable guard;
 
     std::shared_ptr<SceneReport> const report;
 
-    std::vector<std::shared_ptr<Surface>> surfaces;
+    /**
+     * All surfaces managed by this class
+     *
+     * Each depth layer is mapped to an index of the outer vector by mir_depth_layer_to_index()
+     * The outer vector starts out empty, and is expanded as needed to contain the highest layer encountered
+     * The inner vectors contain the list of surfaces on each layer (bottom to top)
+     */
+    std::vector<std::vector<std::shared_ptr<Surface>>> surface_layers;
     std::map<Surface*,std::shared_ptr<RenderingTracker>> rendering_trackers;
     std::set<compositor::CompositorID> registered_compositors;
     
@@ -119,6 +133,7 @@ private:
 
     Observers observers;
     std::atomic<bool> scene_changed;
+    std::shared_ptr<SurfaceObserver> surface_observer;
 };
 
 }

--- a/src/server/shell/surface_specification.cpp
+++ b/src/server/shell/surface_specification.cpp
@@ -47,7 +47,8 @@ bool msh::SurfaceSpecification::is_empty() const
         !streams.is_set() &&
         !parent.is_set() &&
         !input_shape.is_set() &&
-        !shell_chrome.is_set();
+        !shell_chrome.is_set() &&
+        !depth_layer.is_set();
 }
 
 void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
@@ -116,4 +117,6 @@ void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
         cursor_image = that.cursor_image;
     if (that.stream_cursor.is_set())
         stream_cursor = that.stream_cursor;
+    if (that.depth_layer.is_set())
+        depth_layer = that.depth_layer;
 }

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -961,3 +961,11 @@ MIR_SERVER_1.2 {
     mir::shell::ShellWrapper::focus_prev_session*;
   };
 } MIR_SERVER_0.32;
+
+MIR_SERVER_1.3 {
+ global:
+  extern "C++" {
+    mir::scene::NullSurfaceObserver::depth_layer_set_to*;
+    non-virtual?thunk?to?mir::scene::NullSurfaceObserver::depth_layer_set_to*;
+  };
+} MIR_SERVER_1.2;

--- a/tests/acceptance-tests/test_client_cursor_api.cpp
+++ b/tests/acceptance-tests/test_client_cursor_api.cpp
@@ -87,6 +87,7 @@ public:
     MOCK_METHOD2(placed_relative, void(msc::Surface const*, geom::Rectangle const& placement));
     MOCK_METHOD2(input_consumed, void(msc::Surface const*, MirEvent const*));
     MOCK_METHOD2(start_drag_and_drop, void(msc::Surface const*, std::vector<uint8_t> const& handle));
+    MOCK_METHOD2(depth_layer_set_to, void(msc::Surface const*, MirDepthLayer depth_layer));
 };
 
 

--- a/tests/include/mir/test/doubles/stub_scene_surface.h
+++ b/tests/include/mir/test/doubles/stub_scene_surface.h
@@ -94,6 +94,9 @@ public:
     MirPointerConfinementState confine_pointer_state() const override { return {}; }
     void placed_relative(geometry::Rectangle const& /*placement*/) override {}
     void start_drag_and_drop(std::vector<uint8_t> const& /*handle*/) override {}
+
+    auto depth_layer() const -> MirDepthLayer override { return mir_depth_layer_application; }
+    void set_depth_layer(MirDepthLayer /*depth_layer*/) override {}
 };
 
 }

--- a/tests/mir_test_framework/stub_surface.cpp
+++ b/tests/mir_test_framework/stub_surface.cpp
@@ -197,6 +197,15 @@ void mtd::StubSurface::start_drag_and_drop(std::vector<uint8_t> const& /*handle*
 {
 }
 
+auto mtd::StubSurface::depth_layer() const -> MirDepthLayer
+{
+    return mir_depth_layer_application;
+}
+
+void mtd::StubSurface::set_depth_layer(MirDepthLayer /*depth_layer*/)
+{
+}
+
 namespace
 {
 // Ensure we don't accidentally have an abstract class

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -51,6 +51,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     client_mediated_gestures.cpp
     window_info.cpp
     test_window_manager_tools.h
+    depth_layer.cpp
 )
 
 set_source_files_properties(static_display_config.cpp PROPERTIES COMPILE_FLAGS

--- a/tests/miral/depth_layer.cpp
+++ b/tests/miral/depth_layer.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "test_window_manager_tools.h"
+
+using namespace miral;
+using namespace testing;
+namespace mt = mir::test;
+
+namespace
+{
+X const display_left{0};
+Y const display_top{0};
+Width const display_width{1280};
+Height const display_height{720};
+
+Rectangle const display_area{{display_left,  display_top},
+                             {display_width, display_height}};
+
+struct DepthLayer : TestWindowManagerTools, WithParamInterface<MirDepthLayer>
+{
+    void SetUp() override
+    {
+        basic_window_manager.add_display_for_testing(display_area);
+        basic_window_manager.add_session(session);
+    }
+
+    auto create_window(mir::scene::SurfaceCreationParameters creation_parameters) -> Window
+    {
+        Window result;
+
+        EXPECT_CALL(*window_manager_policy, advise_new_window(_))
+            .WillOnce(
+                Invoke(
+                    [&result](WindowInfo const& window_info)
+                        { result = window_info.window(); }));
+
+        basic_window_manager.add_surface(session, creation_parameters, &create_surface);
+        basic_window_manager.select_active_window(result);
+
+        // Clear the expectations used to capture parent & child
+        Mock::VerifyAndClearExpectations(window_manager_policy);
+
+        return result;
+    }
+};
+}
+
+TEST_P(DepthLayer, creation_depth_layer_is_applied)
+{
+    MirDepthLayer layer = GetParam();
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.depth_layer = layer;
+        window = create_window(params);
+    }
+    auto const& info = basic_window_manager.info_for(window);
+    std::shared_ptr<mir::scene::Surface> surface = window;
+    ASSERT_THAT(surface, NotNull());
+
+    EXPECT_THAT(info.depth_layer(), Eq(layer));
+    EXPECT_THAT(surface->depth_layer(), Eq(layer));
+}
+
+TEST_P(DepthLayer, modify_surface_updates_depth_layer)
+{
+    MirDepthLayer layer = GetParam();
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        window = create_window(params);
+    }
+    auto const& info = basic_window_manager.info_for(window);
+    std::shared_ptr<mir::scene::Surface> surface = window;
+    ASSERT_THAT(surface, NotNull());
+
+    EXPECT_THAT(surface->depth_layer(), Eq(mir_depth_layer_application));
+
+    mir::shell::SurfaceSpecification modifications;
+    modifications.depth_layer = layer;
+    basic_window_manager.modify_surface(session, surface, modifications);
+
+    EXPECT_THAT(info.depth_layer(), Eq(layer));
+    EXPECT_THAT(surface->depth_layer(), Eq(layer));
+}
+
+TEST_P(DepthLayer, modify_window_updates_depth_layer)
+{
+    MirDepthLayer layer = GetParam();
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.type = mir_window_type_normal;
+        window = create_window(params);
+    }
+    auto& info = basic_window_manager.info_for(window);
+    std::shared_ptr<mir::scene::Surface> surface = window;
+    ASSERT_THAT(surface, NotNull());
+
+    EXPECT_THAT(surface->depth_layer(), Eq(mir_depth_layer_application));
+
+    WindowSpecification mods;
+    mods.depth_layer() = layer;
+    basic_window_manager.modify_window(info, mods);
+
+    EXPECT_THAT(info.depth_layer(), Eq(layer));
+    EXPECT_THAT(surface->depth_layer(), Eq(layer));
+}
+
+INSTANTIATE_TEST_CASE_P(DepthLayer, DepthLayer, ::testing::Values(
+    mir_depth_layer_background,
+    mir_depth_layer_below,
+    mir_depth_layer_application,
+    mir_depth_layer_always_on_top,
+    mir_depth_layer_above,
+    mir_depth_layer_overlay
+));


### PR DESCRIPTION
Based on feedback from #815, I've changed the property name from `z_index` to `depth_layer` and changed the type from an int to an enum. I've also documented things a bit better and added more tests.

The `MirDepthLayer` does not map to ABI-stable ints. Instead it is left to the doc comments to explain the order of the layers, and up to `SurfaceStack` to properly implement that (of course, for now they are all in order, and hopefully we won't need to add any layers for a while).