### PR TITLE
Allow unfocused windows to receive mouse down events

### DIFF
--- a/src/miral/minimal_window_manager.cpp
+++ b/src/miral/minimal_window_manager.cpp
@@ -434,8 +434,7 @@ bool miral::MinimalWindowManager::Impl::handle_touch_event(MirTouchEvent const* 
     {
         if (auto const window = tools.window_at(new_touch))
         {
-            if (tools.active_window() != tools.select_active_window(window))
-                consumes_event = true;
+            tools.select_active_window(window);
         }
     }
 

--- a/src/miral/minimal_window_manager.cpp
+++ b/src/miral/minimal_window_manager.cpp
@@ -355,8 +355,7 @@ bool miral::MinimalWindowManager::Impl::handle_pointer_event(MirPointerEvent con
     {
         if (auto const window = tools.window_at(new_cursor))
         {
-            if (tools.active_window() != tools.select_active_window(window))
-                consumes_event = true;
+            tools.select_active_window(window);
         }
     }
 


### PR DESCRIPTION
When the user clicks on an unfocused window, the window gets focus. We were not also sending that click event through to the client, and with this PR we are. I believe this is a better UX, and it fixes a layer-shell bug where unforeseeable windows could not be clicked. Most importantly, it is the standard behavior in other desktops (tested on Gnome Wayland and MacOS).

EDIT: to test:
* Open two windows next to each other
* Click in the unfocused one
* Note that it becomes focused, and also the click action happens (menu opens, icon is selected, whatever)