### PR TITLE
Avoid hanging server used by ClientCredsTestFixture.session_authorizer_receives_pid_of_connecting_clients during TearDown()

### DIFF
--- a/tests/acceptance-tests/test_client_authorization.cpp
+++ b/tests/acceptance-tests/test_client_authorization.cpp
@@ -32,6 +32,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <atomic>
+
 namespace mf = mir::frontend;
 namespace mt = mir::test;
 namespace mtf = mir_test_framework;
@@ -61,11 +63,16 @@ struct ClientCredsTestFixture : mtf::InterprocessClientServerTest
                 MAP_ANONYMOUS | MAP_SHARED, 0, 0));
     }
 
+    ~ClientCredsTestFixture()
+    {
+        munmap(shared_region, sizeof(SharedRegion));
+    }
+
     struct SharedRegion
     {
-        pid_t client_pid = -1;
-        uid_t client_uid = -1;
-        gid_t client_gid = -1;
+        std::atomic<pid_t> client_pid{-1};
+        std::atomic<uid_t> client_uid{0xFFFF};
+        std::atomic<gid_t> client_gid{0xFFFF};
 
         bool matches_client_process_creds(mf::SessionCredentials const& creds)
         {

--- a/tests/acceptance-tests/test_client_authorization.cpp
+++ b/tests/acceptance-tests/test_client_authorization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2013-2014 Canonical Ltd.
+ * Copyright © 2013-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 or 3 as
@@ -128,6 +128,18 @@ TEST_F(ClientCredsTestFixture, session_authorizer_receives_pid_of_connecting_cli
                 .WillOnce(Return(false));
             EXPECT_CALL(mock_authorizer,
                 prompt_session_is_allowed(Truly(matches_creds)))
+                .Times(1)
+                .WillOnce(Return(false));
+            EXPECT_CALL(mock_authorizer,
+                configure_input_is_allowed(Truly(matches_creds)))
+                .Times(1)
+                .WillOnce(Return(false));
+            EXPECT_CALL(mock_authorizer,
+                set_base_input_configuration_is_allowed(Truly(matches_creds)))
+                .Times(1)
+                .WillOnce(Return(false));
+            EXPECT_CALL(mock_authorizer,
+                set_base_display_configuration_is_allowed(Truly(matches_creds)))
                 .Times(1)
                 .WillOnce(Return(false));
         });


### PR DESCRIPTION
Avoid hanging server used by ClientCredsTestFixture.session_authorizer_receives_pid_of_connecting_clients during TearDown(). (Fixes: #852) 