### PR TITLE
Refactor TestWindowManagerTools and add output tests

### DIFF
--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -52,6 +52,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     window_info.cpp
     test_window_manager_tools.cpp           test_window_manager_tools.h
     depth_layer.cpp
+    output_updates.cpp
 )
 
 set_source_files_properties(static_display_config.cpp PROPERTIES COMPILE_FLAGS

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -50,7 +50,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     static_display_config.cpp
     client_mediated_gestures.cpp
     window_info.cpp
-    test_window_manager_tools.h
+    test_window_manager_tools.cpp           test_window_manager_tools.h
     depth_layer.cpp
 )
 

--- a/tests/miral/depth_layer.cpp
+++ b/tests/miral/depth_layer.cpp
@@ -32,7 +32,7 @@ Height const display_height{720};
 Rectangle const display_area{{display_left,  display_top},
                              {display_width, display_height}};
 
-struct DepthLayer : TestWindowManagerTools, WithParamInterface<MirDepthLayer>
+struct DepthLayer : mt::TestWindowManagerTools, WithParamInterface<MirDepthLayer>
 {
     void SetUp() override
     {

--- a/tests/miral/display_reconfiguration.cpp
+++ b/tests/miral/display_reconfiguration.cpp
@@ -34,7 +34,7 @@ Height const display_height{480};
 Rectangle const display_area{{display_left,  display_top},
                              {display_width, display_height}};
 
-struct DisplayConfiguration : TestWindowManagerTools
+struct DisplayConfiguration : mt::TestWindowManagerTools
 {
     Size const initial_window_size{600, 400};
 

--- a/tests/miral/drag_active_window.cpp
+++ b/tests/miral/drag_active_window.cpp
@@ -34,7 +34,7 @@ Height const display_height{480};
 Rectangle const display_area{{display_left,  display_top},
                              {display_width, display_height}};
 
-struct DragActiveWindow : TestWindowManagerTools, WithParamInterface<MirWindowType>
+struct DragActiveWindow : mt::TestWindowManagerTools, WithParamInterface<MirWindowType>
 {
     Size const initial_parent_size{600, 400};
 

--- a/tests/miral/modify_window_specification.cpp
+++ b/tests/miral/modify_window_specification.cpp
@@ -34,7 +34,7 @@ Height const display_height{480};
 Rectangle const display_area{{display_left,  display_top},
                              {display_width, display_height}};
 
-struct ModifyWindowState : TestWindowManagerTools, WithParamInterface<MirWindowType>
+struct ModifyWindowState : mt::TestWindowManagerTools, WithParamInterface<MirWindowType>
 {
     Size const initial_parent_size{600, 400};
 

--- a/tests/miral/modify_window_state.cpp
+++ b/tests/miral/modify_window_state.cpp
@@ -34,7 +34,7 @@ Height const display_height{480};
 Rectangle const display_area{{display_left,  display_top},
                              {display_width, display_height}};
 
-struct ModifyWindowState : TestWindowManagerTools, WithParamInterface<MirWindowType>
+struct ModifyWindowState : mt::TestWindowManagerTools, WithParamInterface<MirWindowType>
 {
     Size const initial_parent_size{600, 400};
 

--- a/tests/miral/output_updates.cpp
+++ b/tests/miral/output_updates.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2017 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "test_window_manager_tools.h"
+#include "miral/output.h"
+
+#include <experimental/optional>
+
+using namespace miral;
+using namespace testing;
+namespace mt = mir::test;
+
+namespace
+{
+Rectangle const display_area_a{{20, 30}, {600, 400}};
+Rectangle const display_area_b{{620, 0}, {800, 500}};
+
+struct OutputUpdates : mt::TestWindowManagerTools
+{
+    void SetUp() override
+    {
+        basic_window_manager.add_session(session);
+    }
+};
+}
+
+TEST_F(OutputUpdates, policy_notified_of_output_creation)
+{
+    std::experimental::optional<Output> output_a;
+
+    EXPECT_CALL(*window_manager_policy, advise_output_create(_))
+        .WillOnce(Invoke([&](Output const& output){ output_a = output; }));
+
+    set_outputs({display_area_a});
+
+    Mock::VerifyAndClearExpectations(window_manager_policy);
+    EXPECT_THAT(output_a.value().extents(), Eq(display_area_a));
+}
+
+TEST_F(OutputUpdates, policy_notified_of_multiple_outputs)
+{
+    std::experimental::optional<Output> output_a;
+    std::experimental::optional<Output> output_b;
+
+    EXPECT_CALL(*window_manager_policy, advise_output_create(_))
+        .WillOnce(Invoke([&](Output const& output){ output_a = output; }))
+        .WillOnce(Invoke([&](Output const& output){ output_b = output; }));
+
+    set_outputs({display_area_a, display_area_b});
+
+    Mock::VerifyAndClearExpectations(window_manager_policy);
+    EXPECT_THAT(output_a.value().extents(), Eq(display_area_a));
+    EXPECT_THAT(output_b.value().extents(), Eq(display_area_b));
+    EXPECT_FALSE(output_a.value().is_same_output(output_b.value()));
+}
+
+TEST_F(OutputUpdates, policy_notified_of_output_update)
+{
+    std::experimental::optional<Output> output_initial;
+    std::experimental::optional<Output> output_original;
+    std::experimental::optional<Output> output_updated;
+
+    EXPECT_CALL(*window_manager_policy, advise_output_create(_))
+        .WillOnce(Invoke([&](Output const& output){ output_initial = output; }));
+
+    set_outputs({display_area_a});
+
+    Mock::VerifyAndClearExpectations(window_manager_policy);
+
+    EXPECT_CALL(*window_manager_policy, advise_output_update(_, _))
+        .WillOnce(Invoke([&](Output const& updated, Output const& original){
+            output_original = original;
+            output_updated = updated;
+        }));
+
+    set_outputs({display_area_b});
+
+    Mock::VerifyAndClearExpectations(window_manager_policy);
+    EXPECT_TRUE(output_initial.value().is_same_output(output_original.value()));
+    EXPECT_TRUE(output_original.value().is_same_output(output_updated.value()));
+
+    EXPECT_THAT(output_initial.value().extents(), Eq(display_area_a));
+    EXPECT_THAT(output_original.value().extents(), Eq(display_area_a));
+    EXPECT_THAT(output_updated.value().extents(), Eq(display_area_b));
+}
+
+TEST_F(OutputUpdates, policy_notified_of_output_delete)
+{
+    std::experimental::optional<Output> output_a;
+    std::experimental::optional<Output> output_b;
+    std::experimental::optional<Output> output_b_deleted;
+
+    EXPECT_CALL(*window_manager_policy, advise_output_create(_))
+        .WillOnce(Invoke([&](Output const& output){ output_a = output; }))
+        .WillOnce(Invoke([&](Output const& output){ output_b = output; }));
+
+    set_outputs({display_area_a, display_area_b});
+
+    Mock::VerifyAndClearExpectations(window_manager_policy);
+
+    EXPECT_CALL(*window_manager_policy, advise_output_delete(_))
+        .WillOnce(Invoke([&](Output const& output){ output_b_deleted = output; }));
+
+    set_outputs({display_area_a});
+
+    Mock::VerifyAndClearExpectations(window_manager_policy);
+
+    EXPECT_TRUE(output_b_deleted.value().is_same_output(output_b.value()));
+    EXPECT_THAT(output_b_deleted.value().extents(), Eq(output_b.value().extents()));
+}

--- a/tests/miral/output_updates.cpp
+++ b/tests/miral/output_updates.cpp
@@ -42,11 +42,12 @@ struct OutputUpdates : mt::TestWindowManagerTools
 TEST_F(OutputUpdates, policy_notified_of_output_creation)
 {
     std::experimental::optional<Output> output_a;
+    auto display_config_a = create_mock_display_configuration({display_area_a});
 
     EXPECT_CALL(*window_manager_policy, advise_output_create(_))
         .WillOnce(Invoke([&](Output const& output){ output_a = output; }));
 
-    set_outputs({display_area_a});
+    notify_configuration_applied(display_config_a);
 
     Mock::VerifyAndClearExpectations(window_manager_policy);
     EXPECT_THAT(output_a.value().extents(), Eq(display_area_a));
@@ -56,12 +57,13 @@ TEST_F(OutputUpdates, policy_notified_of_multiple_outputs)
 {
     std::experimental::optional<Output> output_a;
     std::experimental::optional<Output> output_b;
+    auto display_config_a_b = create_mock_display_configuration({display_area_a, display_area_b});
 
     EXPECT_CALL(*window_manager_policy, advise_output_create(_))
         .WillOnce(Invoke([&](Output const& output){ output_a = output; }))
         .WillOnce(Invoke([&](Output const& output){ output_b = output; }));
 
-    set_outputs({display_area_a, display_area_b});
+    notify_configuration_applied(display_config_a_b);
 
     Mock::VerifyAndClearExpectations(window_manager_policy);
     EXPECT_THAT(output_a.value().extents(), Eq(display_area_a));
@@ -74,11 +76,13 @@ TEST_F(OutputUpdates, policy_notified_of_output_update)
     std::experimental::optional<Output> output_initial;
     std::experimental::optional<Output> output_original;
     std::experimental::optional<Output> output_updated;
+    auto display_config_a = create_mock_display_configuration({display_area_a});
+    auto display_config_b = create_mock_display_configuration({display_area_b});
 
     EXPECT_CALL(*window_manager_policy, advise_output_create(_))
         .WillOnce(Invoke([&](Output const& output){ output_initial = output; }));
 
-    set_outputs({display_area_a});
+    notify_configuration_applied(display_config_a);
 
     // Before continuing with the test, we must insure output_initial has been set
     Mock::VerifyAndClearExpectations(window_manager_policy);
@@ -89,7 +93,7 @@ TEST_F(OutputUpdates, policy_notified_of_output_update)
             output_updated = updated;
         }));
 
-    set_outputs({display_area_b});
+    notify_configuration_applied(display_config_b);
 
     Mock::VerifyAndClearExpectations(window_manager_policy);
     EXPECT_TRUE(output_initial.value().is_same_output(output_original.value()));
@@ -105,12 +109,14 @@ TEST_F(OutputUpdates, policy_notified_of_output_delete)
     std::experimental::optional<Output> output_a;
     std::experimental::optional<Output> output_b;
     std::experimental::optional<Output> output_b_deleted;
+    auto display_config_a_b = create_mock_display_configuration({display_area_a, display_area_b});
+    auto display_config_a = create_mock_display_configuration({display_area_a});
 
     EXPECT_CALL(*window_manager_policy, advise_output_create(_))
         .WillOnce(Invoke([&](Output const& output){ output_a = output; }))
         .WillOnce(Invoke([&](Output const& output){ output_b = output; }));
 
-    set_outputs({display_area_a, display_area_b});
+    notify_configuration_applied(display_config_a_b);
 
     // Before continuing with the test, we must insure output_a and output_b have been set
     Mock::VerifyAndClearExpectations(window_manager_policy);
@@ -118,7 +124,7 @@ TEST_F(OutputUpdates, policy_notified_of_output_delete)
     EXPECT_CALL(*window_manager_policy, advise_output_delete(_))
         .WillOnce(Invoke([&](Output const& output){ output_b_deleted = output; }));
 
-    set_outputs({display_area_a});
+    notify_configuration_applied(display_config_a);
 
     Mock::VerifyAndClearExpectations(window_manager_policy);
 

--- a/tests/miral/output_updates.cpp
+++ b/tests/miral/output_updates.cpp
@@ -42,7 +42,7 @@ struct OutputUpdates : mt::TestWindowManagerTools
 TEST_F(OutputUpdates, policy_notified_of_output_creation)
 {
     std::experimental::optional<Output> output_a;
-    auto display_config_a = create_mock_display_configuration({display_area_a});
+    auto display_config_a = create_fake_display_configuration({display_area_a});
 
     EXPECT_CALL(*window_manager_policy, advise_output_create(_))
         .WillOnce(Invoke([&](Output const& output){ output_a = output; }));
@@ -57,7 +57,7 @@ TEST_F(OutputUpdates, policy_notified_of_multiple_outputs)
 {
     std::experimental::optional<Output> output_a;
     std::experimental::optional<Output> output_b;
-    auto display_config_a_b = create_mock_display_configuration({display_area_a, display_area_b});
+    auto display_config_a_b = create_fake_display_configuration({display_area_a, display_area_b});
 
     EXPECT_CALL(*window_manager_policy, advise_output_create(_))
         .WillOnce(Invoke([&](Output const& output){ output_a = output; }))
@@ -76,8 +76,8 @@ TEST_F(OutputUpdates, policy_notified_of_output_update)
     std::experimental::optional<Output> output_initial;
     std::experimental::optional<Output> output_original;
     std::experimental::optional<Output> output_updated;
-    auto display_config_a = create_mock_display_configuration({display_area_a});
-    auto display_config_b = create_mock_display_configuration({display_area_b});
+    auto display_config_a = create_fake_display_configuration({display_area_a});
+    auto display_config_b = create_fake_display_configuration({display_area_b});
 
     EXPECT_CALL(*window_manager_policy, advise_output_create(_))
         .WillOnce(Invoke([&](Output const& output){ output_initial = output; }));
@@ -109,8 +109,8 @@ TEST_F(OutputUpdates, policy_notified_of_output_delete)
     std::experimental::optional<Output> output_a;
     std::experimental::optional<Output> output_b;
     std::experimental::optional<Output> output_b_deleted;
-    auto display_config_a_b = create_mock_display_configuration({display_area_a, display_area_b});
-    auto display_config_a = create_mock_display_configuration({display_area_a});
+    auto display_config_a_b = create_fake_display_configuration({display_area_a, display_area_b});
+    auto display_config_a = create_fake_display_configuration({display_area_a});
 
     EXPECT_CALL(*window_manager_policy, advise_output_create(_))
         .WillOnce(Invoke([&](Output const& output){ output_a = output; }))

--- a/tests/miral/output_updates.cpp
+++ b/tests/miral/output_updates.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Canonical Ltd.
+ * Copyright © 2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ * Authored by: William Wold <william.wold@canonical.com>
  */
 
 #include "test_window_manager_tools.h"

--- a/tests/miral/output_updates.cpp
+++ b/tests/miral/output_updates.cpp
@@ -80,6 +80,7 @@ TEST_F(OutputUpdates, policy_notified_of_output_update)
 
     set_outputs({display_area_a});
 
+    // Before continuing with the test, we must insure output_initial has been set
     Mock::VerifyAndClearExpectations(window_manager_policy);
 
     EXPECT_CALL(*window_manager_policy, advise_output_update(_, _))
@@ -111,6 +112,7 @@ TEST_F(OutputUpdates, policy_notified_of_output_delete)
 
     set_outputs({display_area_a, display_area_b});
 
+    // Before continuing with the test, we must insure output_a and output_b have been set
     Mock::VerifyAndClearExpectations(window_manager_policy);
 
     EXPECT_CALL(*window_manager_policy, advise_output_delete(_))

--- a/tests/miral/raise_tree.cpp
+++ b/tests/miral/raise_tree.cpp
@@ -31,7 +31,7 @@ Height const display_height{480};
 
 Rectangle const display_area{{display_left, display_top}, {display_width, display_height}};
 
-struct RaiseTree : TestWindowManagerTools
+struct RaiseTree : mt::TestWindowManagerTools
 {
     Size const initial_parent_size{600, 400};
     Size const initial_child_size{300, 300};

--- a/tests/miral/select_active_window.cpp
+++ b/tests/miral/select_active_window.cpp
@@ -32,7 +32,7 @@ Height const display_height{720};
 Rectangle const display_area{{display_left,  display_top},
                              {display_width, display_height}};
 
-struct SelectActiveWindow : TestWindowManagerTools
+struct SelectActiveWindow : mt::TestWindowManagerTools
 {
 
     void SetUp() override

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -250,7 +250,8 @@ auto mt::TestWindowManagerTools::create_surface(
     return session->create_surface(params, sink);
 }
 
-void mt::TestWindowManagerTools::set_outputs(std::vector<miral::Rectangle> outputs)
+auto mt::TestWindowManagerTools::create_mock_display_configuration(std::vector<miral::Rectangle> outputs)
+    -> std::shared_ptr<graphics::DisplayConfiguration const>
 {
     auto const display_config = std::make_shared<const mir::test::doubles::MockDisplayConfiguration>();
     EXPECT_CALL(*display_config, for_each_output(testing::_))
@@ -284,6 +285,12 @@ void mt::TestWindowManagerTools::set_outputs(std::vector<miral::Rectangle> outpu
                 func(display_config_output);
             }
         }));
+    return display_config;
+}
+
+void mt::TestWindowManagerTools::notify_configuration_applied(
+    std::shared_ptr<graphics::DisplayConfiguration const> display_config)
+{
     auto config_observer = self->display_configuration_observer.observer.lock();
     ASSERT_THAT(config_observer, testing::NotNull());
     config_observer->configuration_applied(display_config);

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -182,12 +182,12 @@ struct MockWindowManagerPolicy : miral::CanonicalWindowManagerPolicy
     }
 };
 
-struct TestDisplayConfigurationObserver : mir::ObserverRegistrar<mir::graphics::DisplayConfigurationObserver>
+struct FakeDisplayConfigurationObserverRegistrar : mir::ObserverRegistrar<mir::graphics::DisplayConfigurationObserver>
 {
     void register_interest(std::weak_ptr<mir::graphics::DisplayConfigurationObserver> const& o) override
     {
         ASSERT_THAT(observer.lock(), testing::IsNull())
-            << "TestDisplayConfigurationObserver does not support multiple observers";
+            << "FakeDisplayConfigurationObserverRegistrar does not support multiple observers";
         observer = o;
     }
 
@@ -214,7 +214,7 @@ struct mt::TestWindowManagerTools::Self
     StubFocusController focus_controller;
     StubDisplayLayout display_layout;
     StubPersistentSurfaceStore persistent_surface_store;
-    TestDisplayConfigurationObserver display_configuration_observer;
+    FakeDisplayConfigurationObserverRegistrar display_configuration_observer;
 
 };
 

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -202,6 +202,14 @@ struct FakeDisplayConfigurationObserverRegistrar : mir::ObserverRegistrar<mir::g
         observer = std::weak_ptr<mir::graphics::DisplayConfigurationObserver>(); // set to null
     }
 
+    void notify_configuration_applied(
+        std::shared_ptr<mir::graphics::DisplayConfiguration const> display_config)
+    {
+        auto config_observer = observer.lock();
+        EXPECT_THAT(config_observer, testing::NotNull());
+        config_observer->configuration_applied(display_config);
+    }
+
     std::weak_ptr<mir::graphics::DisplayConfigurationObserver> observer;
 };
 
@@ -291,7 +299,5 @@ auto mt::TestWindowManagerTools::create_mock_display_configuration(std::vector<m
 void mt::TestWindowManagerTools::notify_configuration_applied(
     std::shared_ptr<graphics::DisplayConfiguration const> display_config)
 {
-    auto config_observer = self->display_configuration_observer.observer.lock();
-    ASSERT_THAT(config_observer, testing::NotNull());
-    config_observer->configuration_applied(display_config);
+    self->display_configuration_observer.notify_configuration_applied(display_config);
 }

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -255,7 +255,7 @@ auto mt::TestWindowManagerTools::create_mock_display_configuration(std::vector<m
 {
     auto const display_config = std::make_shared<const mir::test::doubles::MockDisplayConfiguration>();
     EXPECT_CALL(*display_config, for_each_output(testing::_))
-        .WillOnce(testing::Invoke([outputs](std::function<void(mir::graphics::DisplayConfigurationOutput const&)> func){
+        .WillRepeatedly(testing::Invoke([outputs](std::function<void(mir::graphics::DisplayConfigurationOutput const&)> func){
             for (auto i = 0u; i < outputs.size(); i++)
             {
                 auto const& rect = outputs[i];

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -1,0 +1,290 @@
+/*
+ * Copyright © 2016-2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "test_window_manager_tools.h"
+
+#include "basic_window_manager.h"
+
+#include <miral/canonical_window_manager.h>
+#include <miral/output.h>
+
+#include <mir/scene/surface_creation_parameters.h>
+#include <mir/shell/display_layout.h>
+#include <mir/shell/focus_controller.h>
+#include <mir/shell/persistent_surface_store.h>
+#include "mir/graphics/display_configuration_observer.h"
+
+#include <mir/test/doubles/stub_session.h>
+#include <mir/test/doubles/stub_surface.h>
+#include "mir/test/doubles/mock_display_configuration.h"
+#include <mir/test/fake_shared.h>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <atomic>
+
+namespace
+{
+
+struct StubFocusController : mir::shell::FocusController
+{
+    void focus_next_session() override {}
+    void focus_prev_session() override {}
+
+    auto focused_session() const -> std::shared_ptr<mir::scene::Session> override { return {}; }
+
+    void set_focus_to(
+        std::shared_ptr<mir::scene::Session> const& /*focus_session*/,
+        std::shared_ptr<mir::scene::Surface> const& /*focus_surface*/) override {}
+
+    auto focused_surface() const -> std::shared_ptr<mir::scene::Surface> override { return {}; }
+
+    void raise(mir::shell::SurfaceSet const& /*windows*/) override {}
+
+    virtual auto surface_at(mir::geometry::Point /*cursor*/) const -> std::shared_ptr<mir::scene::Surface> override
+        { return {}; }
+
+    void set_drag_and_drop_handle(std::vector<uint8_t> const& /*handle*/) override {}
+
+    void clear_drag_and_drop_handle() override {}
+};
+
+struct StubDisplayLayout : mir::shell::DisplayLayout
+{
+    void clip_to_output(mir::geometry::Rectangle& /*rect*/) override {}
+
+    void size_to_output(mir::geometry::Rectangle& /*rect*/) override {}
+
+    bool place_in_output(mir::graphics::DisplayConfigurationOutputId /*id*/, mir::geometry::Rectangle& /*rect*/) override
+        { return false; }
+};
+
+struct StubPersistentSurfaceStore : mir::shell::PersistentSurfaceStore
+{
+    Id id_for_surface(std::shared_ptr<mir::scene::Surface> const& /*surface*/) override { return {}; }
+
+    auto surface_for_id(Id const& /*id*/) const -> std::shared_ptr<mir::scene::Surface> override { return {}; }
+};
+
+struct StubSurface : mir::test::doubles::StubSurface
+{
+    StubSurface(
+        std::string name,
+        MirWindowType type,
+        mir::geometry::Point top_left,
+        mir::geometry::Size size,
+        MirDepthLayer depth_layer)
+        : name_{name}, type_{type}, top_left_{top_left}, size_{size}, depth_layer_{depth_layer}
+    {
+    }
+
+    std::string name() const override { return name_; };
+    MirWindowType type() const override { return type_; }
+
+    mir::geometry::Point top_left() const override { return top_left_; }
+    void move_to(mir::geometry::Point const& top_left) override { top_left_ = top_left; }
+
+    mir::geometry::Size size() const override { return  size_; }
+    void resize(mir::geometry::Size const& size) override { size_ = size; }
+
+    auto state() const -> MirWindowState override { return state_; }
+    auto configure(MirWindowAttrib attrib, int value) -> int override {
+        switch (attrib)
+        {
+        case mir_window_attrib_state:
+            state_ = MirWindowState(value);
+            return state_;
+        default:
+            return value;
+        }
+    }
+
+    bool visible() const override { return  state() != mir_window_state_hidden; }
+
+    auto depth_layer() const -> MirDepthLayer override { return depth_layer_; }
+    void set_depth_layer(MirDepthLayer depth_layer) override { depth_layer_ = depth_layer; }
+
+    std::string name_;
+    MirWindowType type_;
+    mir::geometry::Point top_left_;
+    mir::geometry::Size size_;
+    MirWindowState state_ = mir_window_state_restored;
+    MirDepthLayer depth_layer_;
+};
+
+struct StubStubSession : mir::test::doubles::StubSession
+{
+    mir::frontend::SurfaceId create_surface(
+        mir::scene::SurfaceCreationParameters const& params,
+        std::shared_ptr<mir::frontend::EventSink> const& /*sink*/) override
+    {
+        auto id = mir::frontend::SurfaceId{next_surface_id.fetch_add(1)};
+        auto surface = std::make_shared<StubSurface>(
+            params.name,
+            params.type.value(),
+            params.top_left,
+            params.size,
+            params.depth_layer.is_set() ?
+                params.depth_layer.value()
+                : mir_depth_layer_application);
+        surfaces[id] = surface;
+        return id;
+    }
+
+    std::shared_ptr<mir::scene::Surface> surface(mir::frontend::SurfaceId surface) const override
+    {
+        return surfaces.at(surface);
+    }
+
+private:
+    std::atomic<int> next_surface_id;
+    std::map<mir::frontend::SurfaceId, std::shared_ptr<mir::scene::Surface>> surfaces;
+};
+
+struct MockWindowManagerPolicy : miral::CanonicalWindowManagerPolicy
+{
+    using miral::CanonicalWindowManagerPolicy::CanonicalWindowManagerPolicy;
+
+    bool handle_touch_event(MirTouchEvent const* /*event*/) { return false; }
+    bool handle_pointer_event(MirPointerEvent const* /*event*/) { return false; }
+    bool handle_keyboard_event(MirKeyboardEvent const* /*event*/) { return false; }
+
+    MOCK_METHOD1(advise_new_window, void (miral::WindowInfo const& window_info));
+    MOCK_METHOD2(advise_move_to, void(miral::WindowInfo const& window_info, mir::geometry::Point top_left));
+    MOCK_METHOD2(advise_resize, void(miral::WindowInfo const& window_info, mir::geometry::Size const& new_size));
+    MOCK_METHOD1(advise_raise, void(std::vector<miral::Window> const&));
+    MOCK_METHOD1(advise_output_create, void(miral::Output const&));
+    MOCK_METHOD2(advise_output_update, void(miral::Output const&, miral::Output const&));
+    MOCK_METHOD1(advise_output_delete, void(miral::Output const&));
+
+    void handle_request_drag_and_drop(miral::WindowInfo& /*window_info*/) {}
+    void handle_request_move(miral::WindowInfo& /*window_info*/, MirInputEvent const* /*input_event*/) {}
+    void handle_request_resize(miral::WindowInfo& /*window_info*/, MirInputEvent const* /*input_event*/, MirResizeEdge /*edge*/) {}
+    mir::geometry::Rectangle confirm_placement_on_display(const miral::WindowInfo&, MirWindowState, mir::geometry::Rectangle const& new_placement)
+    {
+        return new_placement;
+    }
+};
+
+struct TestDisplayConfigurationObserver : mir::ObserverRegistrar<mir::graphics::DisplayConfigurationObserver>
+{
+    void register_interest(std::weak_ptr<mir::graphics::DisplayConfigurationObserver> const& o) override
+    {
+        ASSERT_THAT(observer.lock(), testing::IsNull())
+            << "TestDisplayConfigurationObserver does not support multiple observers";
+        observer = o;
+    }
+
+    void register_interest(std::weak_ptr<mir::graphics::DisplayConfigurationObserver> const& o, mir::Executor&) override
+    {
+        register_interest(o);
+    }
+
+    void unregister_interest(mir::graphics::DisplayConfigurationObserver const& o) override
+    {
+        ASSERT_THAT(observer.lock().get(), testing::Eq(&o));
+        observer = std::weak_ptr<mir::graphics::DisplayConfigurationObserver>(); // set to null
+    }
+
+    std::weak_ptr<mir::graphics::DisplayConfigurationObserver> observer;
+};
+
+}
+
+namespace mt = mir::test;
+
+struct mt::TestWindowManagerTools::Self
+{
+    StubFocusController focus_controller;
+    StubDisplayLayout display_layout;
+    StubPersistentSurfaceStore persistent_surface_store;
+    TestDisplayConfigurationObserver display_configuration_observer;
+
+};
+
+mt::TestWindowManagerTools::TestWindowManagerTools()
+    : self{std::make_unique<Self>()},
+      session{std::make_shared<StubStubSession>()},
+      window_manager_policy{nullptr},
+      window_manager_tools{nullptr},
+      basic_window_manager{
+        &self->focus_controller,
+        mir::test::fake_shared(self->display_layout),
+        mir::test::fake_shared(self->persistent_surface_store),
+        self->display_configuration_observer,
+        [this](miral::WindowManagerTools const& tools) -> std::unique_ptr<miral::WindowManagementPolicy>
+            {
+                auto policy = std::make_unique<testing::NiceMock<MockWindowManagerPolicy>>(tools);
+                window_manager_policy = policy.get();
+                window_manager_tools = tools;
+                return policy;
+            }
+    }
+{
+}
+
+mt::TestWindowManagerTools::~TestWindowManagerTools() = default;
+
+auto mt::TestWindowManagerTools::create_surface(
+    std::shared_ptr<mir::scene::Session> const& session,
+    mir::scene::SurfaceCreationParameters const& params) -> mir::frontend::SurfaceId
+{
+    // This type is Mir-internal, I hope we don't need to create it here
+    std::shared_ptr<mir::frontend::EventSink> const sink;
+    return session->create_surface(params, sink);
+}
+
+void mt::TestWindowManagerTools::set_outputs(std::vector<miral::Rectangle> outputs)
+{
+    auto const display_config = std::make_shared<const mir::test::doubles::MockDisplayConfiguration>();
+    EXPECT_CALL(*display_config, for_each_output(testing::_))
+        .WillOnce(testing::Invoke([outputs](std::function<void(mir::graphics::DisplayConfigurationOutput const&)> func){
+            for (auto i = 0u; i < outputs.size(); i++)
+            {
+                auto const& rect = outputs[i];
+                mir::graphics::DisplayConfigurationOutput display_config_output{
+                    mir::graphics::DisplayConfigurationOutputId{(int)i}, // id
+                    mir::graphics::DisplayConfigurationCardId{1}, // card_id
+                    mir::graphics::DisplayConfigurationOutputType::unknown, // type
+                    {mir_pixel_format_abgr_8888}, // pixel_formats
+                    {{rect.size, 60}}, // modes
+                    0, // prefered_mode_index
+                    {rect.size}, // physical_size_mm
+                    true, // connected
+                    true, // used
+                    rect.top_left, // top_left
+                    0, // current_mode_index
+                    mir_pixel_format_abgr_8888, // current_format
+                    mir_power_mode_on, // power_mode
+                    mir_orientation_normal, // orientation
+                    1.0, // scale
+                    mir_form_factor_unknown, // form_factor
+                    mir_subpixel_arrangement_unknown, // subpixel_arrangement
+                    {}, // gamma
+                    mir_output_gamma_unsupported, // gamma_supported
+                    {}, // edid
+                    {}, // custom_logical_size
+                };
+                func(display_config_output);
+            }
+        }));
+    auto config_observer = self->display_configuration_observer.observer.lock();
+    ASSERT_THAT(config_observer, testing::NotNull());
+    config_observer->configuration_applied(display_config);
+}

--- a/tests/miral/test_window_manager_tools.h
+++ b/tests/miral/test_window_manager_tools.h
@@ -22,6 +22,7 @@
 #include "basic_window_manager.h"
 
 #include <miral/canonical_window_manager.h>
+#include <miral/output.h>
 
 #include <mir/scene/surface_creation_parameters.h>
 #include <mir/shell/display_layout.h>

--- a/tests/miral/test_window_manager_tools.h
+++ b/tests/miral/test_window_manager_tools.h
@@ -32,6 +32,11 @@
 
 namespace mir
 {
+namespace graphics
+{
+class DisplayConfiguration;
+}
+
 namespace test
 {
 
@@ -79,7 +84,10 @@ public:
         std::shared_ptr<mir::scene::Session> const& session,
         mir::scene::SurfaceCreationParameters const& params) -> mir::frontend::SurfaceId;
 
-    void set_outputs(std::vector<miral::Rectangle> outputs);
+    auto static create_mock_display_configuration(std::vector<miral::Rectangle> outputs)
+        -> std::shared_ptr<graphics::DisplayConfiguration const>;
+    void notify_configuration_applied(
+        std::shared_ptr<graphics::DisplayConfiguration const> display_config);
 };
 
 }

--- a/tests/miral/test_window_manager_tools.h
+++ b/tests/miral/test_window_manager_tools.h
@@ -84,7 +84,7 @@ public:
         std::shared_ptr<mir::scene::Session> const& session,
         mir::scene::SurfaceCreationParameters const& params) -> mir::frontend::SurfaceId;
 
-    auto static create_mock_display_configuration(std::vector<miral::Rectangle> outputs)
+    auto static create_fake_display_configuration(std::vector<miral::Rectangle> outputs)
         -> std::shared_ptr<graphics::DisplayConfiguration const>;
     void notify_configuration_applied(
         std::shared_ptr<graphics::DisplayConfiguration const> display_config);

--- a/tests/miral/window_placement.cpp
+++ b/tests/miral/window_placement.cpp
@@ -41,7 +41,7 @@ mir::shell::SurfaceSpecification edge_attachment(Rectangle const& aux_rect, MirE
     return result;
 }
 
-struct WindowPlacement : TestWindowManagerTools
+struct WindowPlacement : mt::TestWindowManagerTools
 {
     Size const initial_parent_size{600, 400};
     Size const initial_child_size{300, 300};

--- a/tests/miral/window_placement_anchors_to_parent.cpp
+++ b/tests/miral/window_placement_anchors_to_parent.cpp
@@ -44,7 +44,7 @@ auto placement(
     return modification;
 }
 
-struct WindowPlacementAnchorsToParent : TestWindowManagerTools
+struct WindowPlacementAnchorsToParent : mt::TestWindowManagerTools
 {
     Size const parent_size{parent_width, parent_height};
     Size const initial_child_size{100, 50};

--- a/tests/unit-tests/scene/test_mediating_display_changer.cpp
+++ b/tests/unit-tests/scene/test_mediating_display_changer.cpp
@@ -52,22 +52,6 @@ using namespace testing;
 namespace
 {
 
-struct TestDisplayConfiguration : mtd::NullDisplayConfiguration
-{
-    std::vector<mg::DisplayConfigurationOutput> const outputs;
-    TestDisplayConfiguration(std::vector<mg::DisplayConfigurationOutput> const& items)
-        : outputs{items} {}
-    void for_each_output(std::function<void(mg::DisplayConfigurationOutput const&)> fun) const override
-    {
-        for (auto const& output : outputs)
-            fun(output);
-    }
-    std::unique_ptr<mg::DisplayConfiguration> clone() const override
-    {
-        return std::make_unique<TestDisplayConfiguration>(outputs);
-    }
-};
-
 class MockDisplayConfigurationPolicy : public mg::DisplayConfigurationPolicy
 {
 public:


### PR DESCRIPTION
Forgot to PR this earlier. This moves the implementation of `TestWindowManagerTools` to a new `test_window_manager_tools.cpp` file. It also moves `TestWindowManagerTools` into the `mir::test` namespace and adds tests for output updates. I needed similar tests for application zones, so I thought I'd add outputs as well.