### PR TITLE
Make mgek::EGLOutput::~EGLOutput() noexcept

### DIFF
--- a/src/platforms/eglstream-kms/server/egl_output.cpp
+++ b/src/platforms/eglstream-kms/server/egl_output.cpp
@@ -16,6 +16,8 @@
  * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
  */
 
+#include "mir/log.h"
+
 #include <epoxy/egl.h>
 
 #include "egl_output.h"

--- a/src/platforms/eglstream-kms/server/egl_output.cpp
+++ b/src/platforms/eglstream-kms/server/egl_output.cpp
@@ -150,19 +150,18 @@ mgek::EGLOutput::EGLOutput(
 
 }
 
-mgek::EGLOutput::~EGLOutput() noexcept(false)
+mgek::EGLOutput::~EGLOutput()
 {
-    auto const uncaught_exception = std::uncaught_exception();
     try
     {
         restore_saved_crtc();
     }
-    catch(...)
+    catch(std::exception const& e)
     {
-        if (!uncaught_exception)
-        {
-            throw;
-        }
+        log(logging::Severity::error,
+            MIR_LOG_COMPONENT_FALLBACK,
+            std::make_exception_ptr(e),
+            "Failed to restore saved crtc");
     }
 }
 

--- a/src/platforms/eglstream-kms/server/egl_output.h
+++ b/src/platforms/eglstream-kms/server/egl_output.h
@@ -41,7 +41,7 @@ class EGLOutput : public DisplayConfigurationOutput
 {
 public:
     EGLOutput(int drm_fd, EGLDisplay dpy, EGLOutputPortEXT connector);
-    ~EGLOutput() noexcept(false);
+    ~EGLOutput();
 
     void reset();
     void configure(size_t kms_mode_index);


### PR DESCRIPTION
We use mgek::EGLOutput with std::shared_ptr and std::vector.

We may not throw from the destructor when used with the standard library.

Therefore: Make mgek::EGLOutput::~EGLOutput() noexcept. (Might "fix" #858, or expose an underlying issue.)