### PR TITLE
Application zone

### DIFF
--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -368,3 +368,19 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"miral::WindowInfo::depth_layer(MirDepthLayer)@MIRAL_2.6" 2.6.0
  (c++)"miral::WindowSpecification::depth_layer() const@MIRAL_2.6" 2.6.0
  (c++)"miral::WindowSpecification::depth_layer()@MIRAL_2.6" 2.6.0
+ (c++)"miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_create(miral::Zone const&)@MIRAL_2.6" 2.6.0
+ (c++)"miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_delete(miral::Zone const&)@MIRAL_2.6" 2.6.0
+ (c++)"miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_update(miral::Zone const&, miral::Zone const&)@MIRAL_2.6" 2.6.0
+ (c++)"miral::Zone::extents(mir::geometry::Rectangle const&)@MIRAL_2.6" 2.6.0
+ (c++)"miral::Zone::Zone(mir::geometry::Rectangle const&)@MIRAL_2.6" 2.6.0
+ (c++)"miral::Zone::Zone(miral::Zone const&)@MIRAL_2.6" 2.6.0
+ (c++)"miral::Zone::Zone(mir::geometry::Rectangle const&)@MIRAL_2.6" 2.6.0
+ (c++)"miral::Zone::Zone(miral::Zone const&)@MIRAL_2.6" 2.6.0
+ (c++)"miral::Zone::~Zone()@MIRAL_2.6" 2.6.0
+ (c++)"miral::Zone::~Zone()@MIRAL_2.6" 2.6.0
+ (c++)"miral::Zone::operator=(miral::Zone const&)@MIRAL_2.6" 2.6.0
+ (c++)"miral::Zone::is_same_zone(miral::Zone const&) const@MIRAL_2.6" 2.6.0
+ (c++)"miral::Zone::extents() const@MIRAL_2.6" 2.6.0
+ (c++)"miral::Zone::operator==(miral::Zone const&) const@MIRAL_2.6" 2.6.0
+ (c++)"typeinfo for miral::WindowManagementPolicy::ApplicationZoneAddendum@MIRAL_2.6" 2.6.0
+ (c++)"vtable for miral::WindowManagementPolicy::ApplicationZoneAddendum@MIRAL_2.6" 2.6.0

--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -384,3 +384,4 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"miral::Zone::operator==(miral::Zone const&) const@MIRAL_2.6" 2.6.0
  (c++)"typeinfo for miral::WindowManagementPolicy::ApplicationZoneAddendum@MIRAL_2.6" 2.6.0
  (c++)"vtable for miral::WindowManagementPolicy::ApplicationZoneAddendum@MIRAL_2.6" 2.6.0
+ (c++)"miral::WindowManagementPolicy::ApplicationZoneAddendum::from(miral::WindowManagementPolicy*)@MIRAL_2.6" 2.6.0

--- a/examples/example-server-lib/tiling_window_manager.cpp
+++ b/examples/example-server-lib/tiling_window_manager.cpp
@@ -21,7 +21,7 @@
 #include <miral/application_info.h>
 #include <miral/window_info.h>
 #include <miral/window_manager_tools.h>
-#include <miral/output.h>
+#include <miral/zone.h>
 
 #include <linux/input.h>
 #include <algorithm>
@@ -655,15 +655,15 @@ void TilingWindowManagerPolicy::advise_end()
     dirty_tiles = false;
 }
 
-void TilingWindowManagerPolicy::advise_output_create(const Output& output)
+void TilingWindowManagerPolicy::advise_application_zone_create(miral::Zone const& zone)
 {
-    displays.add(output.extents());
+    displays.add(zone.extents());
     dirty_tiles = true;
 }
 
-void TilingWindowManagerPolicy::advise_output_update(const Output& updated, const Output& original)
+void TilingWindowManagerPolicy::advise_application_zone_update(miral::Zone const& updated, miral::Zone const& original)
 {
-    if (!equivalent_display_area(updated, original))
+    if (original.extents() != updated.extents())
     {
         displays.remove(original.extents());
         displays.add(updated.extents());
@@ -672,9 +672,9 @@ void TilingWindowManagerPolicy::advise_output_update(const Output& updated, cons
     }
 }
 
-void TilingWindowManagerPolicy::advise_output_delete(Output const& output)
+void TilingWindowManagerPolicy::advise_application_zone_delete(miral::Zone const& zone)
 {
-    displays.remove(output.extents());
+    displays.remove(zone.extents());
     dirty_tiles = true;
 }
 

--- a/examples/example-server-lib/tiling_window_manager.h
+++ b/examples/example-server-lib/tiling_window_manager.h
@@ -44,7 +44,9 @@ using namespace mir::geometry;
 //  o Maximize/restore current window (to tile height): Shift-F11
 //  o Maximize/restore current window (to tile width): Ctrl-F11
 //  o client requests to maximize, vertically maximize & restore
-class TilingWindowManagerPolicy : public miral::WindowManagementPolicy
+class TilingWindowManagerPolicy
+    : public miral::WindowManagementPolicy,
+      public miral::WindowManagementPolicy::ApplicationZoneAddendum
 {
 public:
     explicit TilingWindowManagerPolicy(miral::WindowManagerTools const& tools, std::shared_ptr<SplashSession> const& spinner,
@@ -79,9 +81,9 @@ public:
         Rectangle const& new_placement) override;
 
 private:
-    void advise_output_create(miral::Output const& output) override;
-    void advise_output_update(miral::Output const& updated, miral::Output const& original) override;
-    void advise_output_delete(miral::Output const& output) override;
+    void advise_application_zone_create(miral::Zone const& zone) override;
+    void advise_application_zone_update(miral::Zone const& updated, miral::Zone const& original) override;
+    void advise_application_zone_delete(miral::Zone const& zone) override;
 
     static const int modifier_mask =
         mir_input_event_modifier_alt |

--- a/include/miral/miral/window_management_policy.h
+++ b/include/miral/miral/window_management_policy.h
@@ -288,6 +288,12 @@ public:
         virtual ~ApplicationZoneAddendum() = default;
         ApplicationZoneAddendum(ApplicationZoneAddendum const&) = delete;
         ApplicationZoneAddendum& operator=(ApplicationZoneAddendum const&) = delete;
+        /**
+         * Attempts to dynamic_cast the given policy into an ApplicationZoneAddendum.
+         * If successful, returns the casted pointer.
+         * If unsuccessful, retuns a static instance of an ApplicationZoneAddendum with the functions stubbed out.
+         */
+        static auto from(WindowManagementPolicy* policy) -> ApplicationZoneAddendum*;
 
     /** @name notification of changes to the current application zones
     * An application zone is the area a maximized application will fill.

--- a/include/miral/miral/window_management_policy.h
+++ b/include/miral/miral/window_management_policy.h
@@ -269,22 +269,38 @@ public:
      */
     virtual auto confirm_inherited_move(WindowInfo const& window_info, Displacement movement) -> Rectangle = 0;
 
-/** @name notification of changes to the current application zones
- * An application zone is the area a maximized application will fill.
- * There is often (but not necessarily) one zone per output.
- * The areas normal applications windows should avoid (such as the areas covered by panels)
- * will not be part of an application zone
- *  @{ */
-    virtual void advise_application_zone_create(Zone const& application_zone);
-    virtual void advise_application_zone_update(Zone const& updated, Zone const& original);
-    virtual void advise_application_zone_delete(Zone const& application_zone);
-
-/** @} */
-
     virtual ~WindowManagementPolicy() = default;
     WindowManagementPolicy() = default;
     WindowManagementPolicy(WindowManagementPolicy const&) = delete;
     WindowManagementPolicy& operator=(WindowManagementPolicy const&) = delete;
+
+/**
+* Handle additional requests related to application zones
+*
+* \note This interface is intended to be implemented by a WindowManagementPolicy implementation. We can't add these
+* functions directly to that interface without breaking ABI (the vtable could be incompatible). When initializing the
+* window manager this interface will be detected by dynamic_cast and registered accordingly.
+*  @{ */
+    class ApplicationZoneAddendum
+    {
+    public:
+        ApplicationZoneAddendum() = default;
+        virtual ~ApplicationZoneAddendum() = default;
+        ApplicationZoneAddendum(ApplicationZoneAddendum const&) = delete;
+        ApplicationZoneAddendum& operator=(ApplicationZoneAddendum const&) = delete;
+
+    /** @name notification of changes to the current application zones
+    * An application zone is the area a maximized application will fill.
+    * There is often (but not necessarily) one zone per output.
+    * The areas normal applications windows should avoid (such as the areas covered by panels)
+    * will not be part of an application zone
+    *  @{ */
+        virtual void advise_application_zone_create(Zone const& application_zone);
+        virtual void advise_application_zone_update(Zone const& updated, Zone const& original);
+        virtual void advise_application_zone_delete(Zone const& application_zone);
+    /** @} */
+    };
+/** @} */
 };
 
 class WindowManagerTools;

--- a/include/miral/miral/window_management_policy.h
+++ b/include/miral/miral/window_management_policy.h
@@ -31,6 +31,7 @@ class Window;
 class WindowSpecification;
 struct ApplicationInfo;
 class Output;
+class Zone;
 struct WindowInfo;
 
 /**
@@ -267,6 +268,18 @@ public:
      * @return the confirmed placement of the window
      */
     virtual auto confirm_inherited_move(WindowInfo const& window_info, Displacement movement) -> Rectangle = 0;
+
+/** @name notification of changes to the current application zones
+ * An application zone is the area a maximized application will fill.
+ * There is often (but not necessarily) one zone per output.
+ * The areas normal applications windows should avoid (such as the areas covered by panels)
+ * will not be part of an application zone
+ *  @{ */
+    virtual void advise_application_zone_create(Zone const& application_zone);
+    virtual void advise_application_zone_update(Zone const& updated, Zone const& original);
+    virtual void advise_application_zone_delete(Zone const& application_zone);
+
+/** @} */
 
     virtual ~WindowManagementPolicy() = default;
     WindowManagementPolicy() = default;

--- a/include/miral/miral/zone.h
+++ b/include/miral/miral/zone.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIRAL_ZONE_H
+#define MIRAL_ZONE_H
+
+#include <mir_toolkit/common.h>
+
+#include <mir/geometry/rectangle.h>
+#include <mir/int_wrapper.h>
+
+#include <memory>
+
+namespace miral
+{
+using namespace mir::geometry;
+
+/// A rectangular area of the display.
+/// Not tied to a specific output.
+class Zone
+{
+public:
+
+    Zone(Rectangle const& extents); ///< Create a new zone with the given extents
+    Zone(Zone const& other); ///< Makes a copy of the underlying private data
+    Zone& operator=(Zone const& other); ///< Copies private data by value
+    ~Zone();
+
+    /// Returns false if any properties are different (even if they are the same zone)
+    /// Will always return false if they are different zones (even if they have the same extents)
+    auto operator==(Zone const& other) const -> bool;
+
+    /// Multiple zone objects with different extents may be the "same" zone. For example, the arguments of
+    /// miral::WindowManagementPolicy::advise_output_update() are old and new instances of the same zone, so
+    /// updated.is_same_zone(original) will return true even though the extents may not be equal.
+    auto is_same_zone(Zone const& other) const -> bool;
+
+    /// The area of this zone in global display coordinates
+    auto extents() const -> Rectangle;
+
+    /// Set the extents of this zone
+    /// Does not make this a different zone
+    void extents(Rectangle const& extents);
+
+private:
+    class Self;
+    std::unique_ptr<Self> self;
+};
+}
+
+#endif // MIRAL_ZONE_H

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(miral SHARED
     window_manager_tools.cpp            ${miral_include}/miral/window_manager_tools.h
                                         ${miral_include}/miral/lambda_as_function.h
     x11_support.cpp                     ${miral_include}/miral/x11_support.h
+    zone.cpp                            ${miral_include}/miral/zone.h
 )
 
 check_cxx_compiler_flag(-Wno-attribute-alias HAS_W_NO_ATTRIBUTE_ALIAS)

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -38,19 +38,6 @@ using namespace mir::geometry;
 namespace
 {
 int const title_bar_height = 12;
-
-auto get_application_zone_addendum(std::unique_ptr<miral::WindowManagementPolicy> const& policy)
-    -> miral::WindowManagementPolicy::ApplicationZoneAddendum*
-{
-    auto result = dynamic_cast<miral::WindowManagementPolicy::ApplicationZoneAddendum*>(policy.get());
-
-    if (result)
-        return result;
-
-    static miral::WindowManagementPolicy::ApplicationZoneAddendum null_application_zone_addendum;
-
-    return &null_application_zone_addendum;
-}
 }
 
 struct miral::BasicWindowManager::Locker
@@ -91,7 +78,7 @@ miral::BasicWindowManager::BasicWindowManager(
     display_layout(display_layout),
     persistent_surface_store{persistent_surface_store},
     policy(build(WindowManagerTools{this})),
-    policy_application_zone_addendum{get_application_zone_addendum(policy)},
+    policy_application_zone_addendum{WindowManagementPolicy::ApplicationZoneAddendum::from(policy.get())},
     display_config_monitor{std::make_shared<DisplayConfigurationListeners>()}
 {
     display_config_monitor->add_listener(this);

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -151,8 +151,11 @@ auto miral::BasicWindowManager::add_surface(
     case mir_window_state_maximized:
     case mir_window_state_vertmaximized:
     case mir_window_state_horizmaximized:
-        maximized_surfaces.insert(window_info.window());
+    {
+        auto window_area = area_for_window(window);
+        window_area->attached_windows.insert(window);
         break;
+    }
 
     default:
         break;
@@ -226,7 +229,8 @@ void miral::BasicWindowManager::remove_window(Application const& application, mi
     info_for(application).remove_window(info.window());
     mru_active_windows.erase(info.window());
     fullscreen_surfaces.erase(info.window());
-    maximized_surfaces.erase(info.window());
+    for (auto& area : window_areas)
+        area->attached_windows.erase(info.window());
 
     application->destroy_surface(info.window());
 
@@ -634,6 +638,56 @@ auto miral::BasicWindowManager::workspaces_containing(Window const& window) cons
     }
 
     return workspaces_containing_window;
+}
+
+auto miral::BasicWindowManager::area_for_window(Window const& window) const -> std::shared_ptr<WindowArea>
+{
+    for (auto& area : window_areas)
+    {
+        for (auto& area_window : area->attached_windows)
+        {
+            if (area_window == window)
+                return area;
+        }
+    }
+
+    // If the window is not explicity attached to any area, find the area it overlaps most with
+    Rectangle window_rect{window.top_left(), window.size()};
+    int max_overlap_area = 0;
+    int min_distance = INT_MAX;
+    std::experimental::optional<std::shared_ptr<WindowArea>> best_area;
+    for (auto& area : window_areas)
+    {
+        auto const intersection = window_rect.intersection_with(area->area).size;
+        auto const intersection_area = intersection.width.as_int() * intersection.height.as_int();
+        if (intersection_area > max_overlap_area)
+        {
+            // Find the area with the biggest overlap
+            best_area = area;
+            max_overlap_area = intersection_area;
+        }
+        else if (max_overlap_area == 0)
+        {
+            // or if none overlap, find the area that is closest
+            auto distance = std::max(
+                std::max(
+                    window_rect.left() - area->area.right(),
+                    area->area.left() - window_rect.right()).as_int(),
+                std::max(
+                    window_rect.top() - area->area.bottom(),
+                    area->area.top() - window_rect.bottom()).as_int());
+            if (distance < min_distance)
+            {
+                best_area = area;
+                min_distance = distance;
+            }
+        }
+    }
+
+    if (best_area)
+        return best_area.value();
+    else
+        return std::make_shared<WindowArea>(window_rect);
 }
 
 void miral::BasicWindowManager::focus_next_within_application()
@@ -1092,7 +1146,6 @@ void miral::BasicWindowManager::place_and_size_for_state(
             return;
     }
 
-    auto const display_area = const_cast<miral::BasicWindowManager*>(this)->active_output();
     auto const window = window_info.window();
 
     auto restore_rect = window_info.restore_rect();
@@ -1131,6 +1184,8 @@ void miral::BasicWindowManager::place_and_size_for_state(
     if (modifications.size().is_set())
         restore_rect.size = modifications.size().value();
 
+    auto const window_area = area_for_window(window);
+    auto const application_zone = window_area->application_zone.extents();
     Rectangle rect;
 
     switch (new_state)
@@ -1140,18 +1195,18 @@ void miral::BasicWindowManager::place_and_size_for_state(
         break;
 
     case mir_window_state_maximized:
-        rect = policy->confirm_placement_on_display(window_info, new_state, display_area);
+        rect = policy->confirm_placement_on_display(window_info, new_state, application_zone);
         break;
 
     case mir_window_state_horizmaximized:
-        rect.top_left = {display_area.top_left.x, restore_rect.top_left.y};
-        rect.size = {display_area.size.width, restore_rect.size.height};
+        rect.top_left = {application_zone.left(), restore_rect.top()};
+        rect.size = {application_zone.size.width, restore_rect.size.height};
         rect = policy->confirm_placement_on_display(window_info, new_state, rect);
         break;
 
     case mir_window_state_vertmaximized:
-        rect.top_left = {restore_rect.top_left.x, display_area.top_left.y};
-        rect.size = {restore_rect.size.width, display_area.size.height};
+        rect.top_left = {restore_rect.left(), application_zone.top()};
+        rect.size = {restore_rect.size.width, application_zone.size.height};
         rect = policy->confirm_placement_on_display(window_info, new_state, rect);
         break;
 
@@ -1207,11 +1262,15 @@ void miral::BasicWindowManager::set_state(miral::WindowInfo& window_info, MirWin
     case mir_window_state_maximized:
     case mir_window_state_vertmaximized:
     case mir_window_state_horizmaximized:
-        maximized_surfaces.insert(window);
+    {
+        auto area = area_for_window(window);
+        area->attached_windows.insert(window);
         break;
+    }
 
     default:
-        maximized_surfaces.erase(window);
+        for (auto& area : window_areas)
+            area->attached_windows.erase(window);
     }
 
     if (window_info.state() == value)
@@ -2222,6 +2281,7 @@ void miral::BasicWindowManager::add_display_for_testing(mir::geometry::Rectangle
 {
     Locker lock{this};
     outputs.add(area);
+    window_areas.push_back(std::make_shared<WindowArea>(area));
 
     update_windows_for_outputs();
 }
@@ -2229,28 +2289,68 @@ void miral::BasicWindowManager::add_display_for_testing(mir::geometry::Rectangle
 void miral::BasicWindowManager::advise_output_create(miral::Output const& output)
 {
     Locker lock{this};
+
     outputs.add(output.extents());
+
+    auto area = std::make_shared<WindowArea>(output);
+    window_areas.push_back(area);
 
     update_windows_for_outputs();
     policy->advise_output_create(output);
+    policy->advise_application_zone_create(area->application_zone);
 }
 
 void miral::BasicWindowManager::advise_output_update(miral::Output const& updated, miral::Output const& original)
 {
     Locker lock{this};
+
     outputs.remove(original.extents());
     outputs.add(updated.extents());
 
+    std::vector<std::pair<Zone, Zone>> zone_updates;
+    for (auto& area : window_areas)
+    {
+        if (area->output && area->output.value().is_same_output(original))
+        {
+            area->output = updated;
+            Zone updated_zone{area->application_zone}; // Important to create from old zone, so it is seen as the same
+            updated_zone.extents(updated.extents());
+            zone_updates.push_back(std::make_pair(updated_zone, area->application_zone));
+            area->application_zone = updated_zone;
+        }
+    }
+
     update_windows_for_outputs();
     policy->advise_output_update(updated, original);
+    for (auto& i : zone_updates)
+        policy->advise_application_zone_update(i.first, i.second);
 }
 
 void miral::BasicWindowManager::advise_output_delete(miral::Output const& output)
 {
     Locker lock{this};
+
+    std::vector<std::shared_ptr<WindowArea>> removed_areas;
+    for (auto const& area : window_areas)
+    {
+        if (area->output && area->output.value().is_same_output(output))
+            removed_areas.push_back(area);
+    }
+
+    window_areas.erase(
+        std::remove_if(
+            window_areas.begin(),
+            window_areas.end(),
+            [&](auto area){
+                return area->output && area->output.value().is_same_output(output);
+            }),
+        window_areas.end());
+
     outputs.remove(output.extents());
 
     update_windows_for_outputs();
+    for (auto& area : removed_areas)
+        policy->advise_application_zone_delete(area->application_zone);
     policy->advise_output_delete(output);
 }
 
@@ -2270,39 +2370,53 @@ void miral::BasicWindowManager::update_windows_for_outputs()
     if (outputs.size() == 0)
         return;
 
-    auto const display_area = outputs.bounding_rectangle();
-
-    for (auto const& window : maximized_surfaces)
+    for (auto& area : window_areas)
     {
-        if (window)
+        for (auto const& window : area->attached_windows)
         {
-            auto& info1 = info_for(window);
+            if (!window)
+                continue;
 
-            Rectangle rect{window.top_left(), window.size()};
+            auto& window_info = info_for(window);
+            Rectangle const original_window_rect{window.top_left(), window.size()};
+            Rectangle updated_window_rect{original_window_rect};
+            Rectangle application_zone = area->application_zone.extents();
+            bool update_window = false;
 
-            switch (info1.state())
+            switch (window_info.state())
             {
             case mir_window_state_maximized:
-                rect = policy->confirm_placement_on_display(info1, mir_window_state_maximized, display_area);
-                place_and_size(info1, rect.top_left, rect.size);
+                updated_window_rect = application_zone;
+                update_window = true;
                 break;
 
             case mir_window_state_horizmaximized:
-                rect.top_left.x = display_area.top_left.x;
-                rect.size.width = display_area.size.width;
-                rect = policy->confirm_placement_on_display(info1, mir_window_state_horizmaximized, rect);
-                place_and_size(info1, rect.top_left, rect.size);
+                updated_window_rect.top_left.x = application_zone.top_left.x;
+                updated_window_rect.size.width = application_zone.size.width;
+                update_window = true;
                 break;
 
             case mir_window_state_vertmaximized:
-                rect.top_left.y = display_area.top_left.y;
-                rect.size.height = display_area.size.height;
-                rect = policy->confirm_placement_on_display(info1, mir_window_state_vertmaximized, rect);
-                place_and_size(info1, rect.top_left, rect.size);
+                updated_window_rect.top_left.y = application_zone.top_left.y;
+                updated_window_rect.size.height = application_zone.size.height;
+                update_window = true;
                 break;
 
             default:
                 break;
+            }
+
+            // TODO: Maybe remove update_window and update only if the rect has changed?
+            // This would probably be more correct, but also may or may not break existing users
+            // if (updated_window_rect != original_window_rect)
+
+            if (update_window)
+            {
+                updated_window_rect = policy->confirm_placement_on_display(
+                    window_info,
+                    window_info.state(),
+                    updated_window_rect);
+                place_and_size(window_info, updated_window_rect.top_left, updated_window_rect.size);
             }
         }
     }

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -197,16 +197,16 @@ public:
 
 private:
     /// An area for windows to be placed in
-    struct WindowArea
+    struct DisplayArea
     {
-        WindowArea(Output const& output)
+        DisplayArea(Output const& output)
             : area{output.extents()},
               application_zone{Zone{output.extents()}},
               output{output}
         {
         }
 
-        WindowArea(Rectangle const& area)
+        DisplayArea(Rectangle const& area)
             : area{area},
               application_zone{Zone{area}}
         {
@@ -246,7 +246,7 @@ private:
     MirEvent const* last_input_event{nullptr};
     miral::MRUWindowList mru_active_windows;
     std::set<Window> fullscreen_surfaces;
-    std::vector<std::shared_ptr<WindowArea>> window_areas; ///< For now these will map 1:1 to outputs, but this should not be assumed
+    std::vector<std::shared_ptr<DisplayArea>> display_areas; ///< For now these will map 1:1 to outputs, but this should not be assumed
 
     friend class Workspace;
     using wwbimap_t = boost::bimap<
@@ -284,7 +284,7 @@ private:
     void refocus(Application const& application, Window const& parent,
                  std::vector<std::shared_ptr<Workspace>> const& workspaces_containing_window);
     auto workspaces_containing(Window const& window) const -> std::vector<std::shared_ptr<Workspace>>;
-    auto area_for_window(Window const& window) const -> std::shared_ptr<WindowArea>;
+    auto display_area_for(Window const& window) const -> std::shared_ptr<DisplayArea>;
 
     void advise_output_create(Output const& output) override;
     void advise_output_update(Output const& updated, Output const& original) override;

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -239,6 +239,7 @@ private:
     std::shared_ptr<DeadWorkspaces> const dead_workspaces{std::make_shared<DeadWorkspaces>()};
 
     std::unique_ptr<WindowManagementPolicy> const policy;
+    WindowManagementPolicy::ApplicationZoneAddendum* const policy_application_zone_addendum;
 
     std::mutex mutex;
     SessionInfoMap app_info;

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -50,10 +50,6 @@ namespace graphics { class DisplayConfigurationObserver; }
 
 namespace miral
 {
-class WorkspacePolicy;
-class WindowManagementPolicyAddendum2;
-class WindowManagementPolicyAddendum3;
-class WindowManagementPolicyAddendum4;
 class DisplayConfigurationListeners;
 
 using mir::shell::SurfaceSet;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -439,6 +439,7 @@ global:
     miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_create*;
     miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_delete*;
     miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_update*;
+    miral::WindowManagementPolicy::ApplicationZoneAddendum::from*;
     miral::WindowManagementPolicy::ApplicationZoneAddendum::operator*;
     miral::WindowSpecification::depth_layer*;
     miral::Zone::?Zone*;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -430,17 +430,36 @@ global:
 MIRAL_2.6 {
 global:
   extern "C++" {
+    miral::WaylandExtension::?WaylandExtension*;
+    miral::WaylandExtension::Context::run_on_wayland_mainloop*;
+    miral::WaylandExtension::Context::wayland_display*;
     miral::WindowInfo::depth_layer*;
-    miral::WindowSpecification::depth_layer*;
-    miral::Zone::Zone*;
-    miral::Zone::?Zone*;
-    miral::Zone::operator*;
-    miral::Zone::is_same_zone*;
-    miral::Zone::extents*;
-    typeinfo?for?miral::WindowManagementPolicy::ApplicationZoneAddendum;
-    vtable?for?miral::WindowManagementPolicy::ApplicationZoneAddendum;
+    miral::WindowManagementPolicy::ApplicationZoneAddendum::?ApplicationZoneAddendum*;
+    miral::WindowManagementPolicy::ApplicationZoneAddendum::ApplicationZoneAddendum*;
     miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_create*;
     miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_delete*;
     miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_update*;
+    miral::WindowManagementPolicy::ApplicationZoneAddendum::operator*;
+    miral::WindowSpecification::depth_layer*;
+    miral::Zone::?Zone*;
+    miral::Zone::Zone*;
+    miral::Zone::extents*;
+    miral::Zone::is_same_zone*;
+    miral::Zone::operator*;
+    non-virtual?thunk?to?miral::WaylandExtension::?WaylandExtension*;
+    non-virtual?thunk?to?miral::WindowManagementPolicy::ApplicationZoneAddendum::?ApplicationZoneAddendum*;
+    non-virtual?thunk?to?miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_create*;
+    non-virtual?thunk?to?miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_delete*;
+    non-virtual?thunk?to?miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_update*;
+    typeinfo?for?miral::WaylandExtension;
+    typeinfo?for?miral::WaylandExtension::Context;
+    typeinfo?for?miral::WaylandExtension::Instance;
+    typeinfo?for?miral::WindowManagementPolicy::ApplicationZoneAddendum;
+    typeinfo?for?miral::Zone;
+    vtable?for?miral::WaylandExtension;
+    vtable?for?miral::WaylandExtension::Context;
+    vtable?for?miral::WaylandExtension::Instance;
+    vtable?for?miral::WindowManagementPolicy::ApplicationZoneAddendum;
+    vtable?for?miral::Zone;
   };
 } MIRAL_2.5;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -432,5 +432,10 @@ global:
   extern "C++" {
     miral::WindowInfo::depth_layer*;
     miral::WindowSpecification::depth_layer*;
+    miral::Zone::Zone*;
+    miral::Zone::?Zone*;
+    miral::Zone::operator*;
+    miral::Zone::is_same_zone*;
+    miral::Zone::extents*;
   };
 } MIRAL_2.5;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -437,5 +437,8 @@ global:
     miral::Zone::operator*;
     miral::Zone::is_same_zone*;
     miral::Zone::extents*;
+    miral::WindowManagementPolicy::advise_application_zone_create*;
+    miral::WindowManagementPolicy::advise_application_zone_delete*;
+    miral::WindowManagementPolicy::advise_application_zone_update*;
   };
 } MIRAL_2.5;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -437,8 +437,10 @@ global:
     miral::Zone::operator*;
     miral::Zone::is_same_zone*;
     miral::Zone::extents*;
-    miral::WindowManagementPolicy::advise_application_zone_create*;
-    miral::WindowManagementPolicy::advise_application_zone_delete*;
-    miral::WindowManagementPolicy::advise_application_zone_update*;
+    typeinfo?for?miral::WindowManagementPolicy::ApplicationZoneAddendum;
+    vtable?for?miral::WindowManagementPolicy::ApplicationZoneAddendum;
+    miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_create*;
+    miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_delete*;
+    miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_update*;
   };
 } MIRAL_2.5;

--- a/src/miral/window_management_policy.cpp
+++ b/src/miral/window_management_policy.cpp
@@ -35,3 +35,6 @@ void miral::WindowManagementPolicy::advise_removing_from_workspace(std::shared_p
 void miral::WindowManagementPolicy::advise_output_create(Output const& /*output*/) {}
 void miral::WindowManagementPolicy::advise_output_update(Output const& /*updated*/, Output const& /*original*/) {}
 void miral::WindowManagementPolicy::advise_output_delete(Output const& /*output*/) {}
+void miral::WindowManagementPolicy::advise_application_zone_create(Zone const& /*application_zone*/) {}
+void miral::WindowManagementPolicy::advise_application_zone_update(Zone const& /*updated*/, Zone const& /*original*/) {}
+void miral::WindowManagementPolicy::advise_application_zone_delete(Zone const& /*application_zone*/) {}

--- a/src/miral/window_management_policy.cpp
+++ b/src/miral/window_management_policy.cpp
@@ -35,6 +35,7 @@ void miral::WindowManagementPolicy::advise_removing_from_workspace(std::shared_p
 void miral::WindowManagementPolicy::advise_output_create(Output const& /*output*/) {}
 void miral::WindowManagementPolicy::advise_output_update(Output const& /*updated*/, Output const& /*original*/) {}
 void miral::WindowManagementPolicy::advise_output_delete(Output const& /*output*/) {}
-void miral::WindowManagementPolicy::advise_application_zone_create(Zone const& /*application_zone*/) {}
-void miral::WindowManagementPolicy::advise_application_zone_update(Zone const& /*updated*/, Zone const& /*original*/) {}
-void miral::WindowManagementPolicy::advise_application_zone_delete(Zone const& /*application_zone*/) {}
+
+void miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_create(Zone const& /*application_zone*/) {}
+void miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_update(Zone const& /*updated*/, Zone const& /*original*/) {}
+void miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_delete(Zone const& /*application_zone*/) {}

--- a/src/miral/window_management_policy.cpp
+++ b/src/miral/window_management_policy.cpp
@@ -36,6 +36,17 @@ void miral::WindowManagementPolicy::advise_output_create(Output const& /*output*
 void miral::WindowManagementPolicy::advise_output_update(Output const& /*updated*/, Output const& /*original*/) {}
 void miral::WindowManagementPolicy::advise_output_delete(Output const& /*output*/) {}
 
+auto miral::WindowManagementPolicy::ApplicationZoneAddendum::from(WindowManagementPolicy* policy)
+    -> ApplicationZoneAddendum*
+{
+    auto result = dynamic_cast<miral::WindowManagementPolicy::ApplicationZoneAddendum*>(policy);
+    if (result)
+        return result;
+
+    static miral::WindowManagementPolicy::ApplicationZoneAddendum null_application_zone_addendum;
+    return &null_application_zone_addendum;
+}
+
 void miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_create(Zone const& /*application_zone*/) {}
 void miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_update(Zone const& /*updated*/, Zone const& /*original*/) {}
 void miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_delete(Zone const& /*application_zone*/) {}

--- a/src/miral/window_management_trace.cpp
+++ b/src/miral/window_management_trace.cpp
@@ -21,6 +21,7 @@
 
 #include <miral/application_info.h>
 #include <miral/output.h>
+#include <miral/zone.h>
 #include <miral/window_info.h>
 
 #include <mir/scene/session.h>
@@ -344,13 +345,19 @@ auto dump_of(miral::Output const& output) -> std::string
 {
     return dump_of(output.extents());
 }
+
+auto dump_of(miral::Zone const& zone) -> std::string
+{
+    return dump_of(zone.extents());
+}
 }
 
 miral::WindowManagementTrace::WindowManagementTrace(
     WindowManagerTools const& wrapped,
     WindowManagementPolicyBuilder const& builder) :
     wrapped{wrapped},
-    policy(builder(WindowManagerTools{this}))
+    policy(builder(WindowManagerTools{this})),
+    policy_application_zone_addendum{WindowManagementPolicy::ApplicationZoneAddendum::from(policy.get())}
 {
 }
 
@@ -891,5 +898,26 @@ void miral::WindowManagementTrace::advise_output_delete(Output const& output)
 try {
     mir::log_info("%s output=%s", __func__, dump_of(output).c_str());
     return policy->advise_output_delete(output);
+}
+MIRAL_TRACE_EXCEPTION
+
+void miral::WindowManagementTrace::advise_application_zone_create(Zone const& application_zone)
+try {
+    mir::log_info("%s application_zone=%s", __func__, dump_of(application_zone).c_str());
+    return policy_application_zone_addendum->advise_application_zone_create(application_zone);
+}
+MIRAL_TRACE_EXCEPTION
+
+void miral::WindowManagementTrace::advise_application_zone_update(Zone const& updated, Zone const& original)
+try {
+    mir::log_info("%s updated=%s, original=%s", __func__, dump_of(updated).c_str(), dump_of(original).c_str());
+    return policy_application_zone_addendum->advise_application_zone_update(updated, original);
+}
+MIRAL_TRACE_EXCEPTION
+
+void miral::WindowManagementTrace::advise_application_zone_delete(Zone const& application_zone)
+try {
+    mir::log_info("%s application_zone=%s", __func__, dump_of(application_zone).c_str());
+    return policy_application_zone_addendum->advise_application_zone_delete(application_zone);
 }
 MIRAL_TRACE_EXCEPTION

--- a/src/miral/window_management_trace.h
+++ b/src/miral/window_management_trace.h
@@ -29,8 +29,10 @@
 
 namespace miral
 {
-class WindowManagementTrace : public WindowManagementPolicy,
-    WindowManagerToolsImplementation
+class WindowManagementTrace
+    : public WindowManagementPolicy,
+      public WindowManagementPolicy::ApplicationZoneAddendum,
+      WindowManagerToolsImplementation
 {
 public:
     WindowManagementTrace(WindowManagerTools const& wrapped, WindowManagementPolicyBuilder const& builder);
@@ -160,9 +162,16 @@ public:
 
     void advise_output_delete(Output const& output) override;
 
+    void advise_application_zone_create(Zone const& application_zone) override;
+
+    void advise_application_zone_update(Zone const& updated, Zone const& original) override;
+
+    void advise_application_zone_delete(Zone const& application_zone) override;
+
 private:
     WindowManagerTools wrapped;
     std::unique_ptr<miral::WindowManagementPolicy> const policy;
+    miral::WindowManagementPolicy::ApplicationZoneAddendum* const policy_application_zone_addendum;
     std::atomic<unsigned> mutable trace_count;
     std::function<void()> log_input;
 };

--- a/src/miral/zone.cpp
+++ b/src/miral/zone.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "miral/zone.h"
+
+#include <atomic>
+
+class miral::Zone::Self
+{
+public:
+    struct IdTag;
+
+    Self(mir::IntWrapper<IdTag> id, Rectangle const& extents)
+        : id{id}, extents{extents}
+    {
+    }
+
+    auto operator=(Self const&) -> Self& = default;
+
+    mir::IntWrapper<IdTag> id;
+    Rectangle extents;
+
+    static auto new_id() -> mir::IntWrapper<IdTag>
+    {
+        static std::atomic<int> next_id{1};
+        return mir::IntWrapper<IdTag>{next_id++};
+    }
+};
+
+miral::Zone::Zone(Rectangle const& extents)
+    : self{std::make_unique<Self>(Self::new_id(), extents)}
+{
+}
+
+miral::Zone::Zone(Zone const& other)
+    : self{std::make_unique<Self>(other.self->id, other.self->extents)}
+{
+}
+
+miral::Zone& miral::Zone::operator=(Zone const& other)
+{
+    *self = *other.self;
+    return *this;
+}
+
+miral::Zone::~Zone() = default;
+
+auto miral::Zone::operator==(Zone const& other) const -> bool
+{
+    return self->id == other.self->id
+        && self->extents == other.self->extents;
+}
+
+auto miral::Zone::is_same_zone(Zone const& other) const -> bool
+{
+    return self->id == other.self->id;
+}
+
+auto miral::Zone::extents() const -> Rectangle
+{
+    return self->extents;
+}
+
+void miral::Zone::extents(Rectangle const& extents)
+{
+    self->extents = extents;
+}

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -53,6 +53,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     test_window_manager_tools.cpp           test_window_manager_tools.h
     depth_layer.cpp
     output_updates.cpp
+    application_zone.cpp
 )
 
 set_source_files_properties(static_display_config.cpp PROPERTIES COMPILE_FLAGS

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -77,6 +77,7 @@ mir_add_wrapped_executable(miral-test NOINSTALL
     wayland_extensions.cpp
     workspaces.cpp
     drag_and_drop.cpp
+    zone.cpp
     server_example_decoration.cpp server_example_decoration.h
     org_kde_kwin_server_decoration.c org_kde_kwin_server_decoration.h
     generated/server-decoration_wrapper.cpp generated/server-decoration_wrapper.h

--- a/tests/miral/application_zone.cpp
+++ b/tests/miral/application_zone.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2017 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "test_window_manager_tools.h"
+#include "mir/test/doubles/mock_display_configuration.h"
+#include "mir/graphics/display_configuration_observer.h"
+
+using namespace miral;
+using namespace testing;
+namespace mt = mir::test;
+
+namespace
+{
+Rectangle const display_area_a{{20, 30}, {600, 400}};
+Rectangle const display_area_b{{620, 0}, {800, 500}};
+
+struct ApplicationZone : mt::TestWindowManagerTools
+{
+    void SetUp() override
+    {
+        basic_window_manager.add_session(session);
+    }
+};
+}
+
+TEST_F(ApplicationZone, application_zone_created_for_output)
+{
+    miral::Zone zone_a{{{}, {}}};
+    auto display_config_a = create_fake_display_configuration({display_area_a});
+
+    EXPECT_CALL(*window_manager_policy, advise_application_zone_create(_))
+        .WillOnce(Invoke([&](Zone const& zone){ zone_a = zone; }));
+
+    notify_configuration_applied(display_config_a);
+
+    Mock::VerifyAndClearExpectations(window_manager_policy);
+    EXPECT_THAT(zone_a.extents(), Eq(display_area_a));
+}
+
+TEST_F(ApplicationZone, multiple_outputs_lead_to_multiple_application_zones)
+{
+    miral::Zone zone_a{{{}, {}}};
+    miral::Zone zone_b{{{}, {}}};
+    auto display_config_a_b = create_fake_display_configuration({display_area_a, display_area_b});
+
+    EXPECT_CALL(*window_manager_policy, advise_application_zone_create(_))
+        .WillOnce(Invoke([&](Zone const& zone){ zone_a = zone; }))
+        .WillOnce(Invoke([&](Zone const& zone){ zone_b = zone; }));
+
+    notify_configuration_applied(display_config_a_b);
+
+    Mock::VerifyAndClearExpectations(window_manager_policy);
+    EXPECT_THAT(zone_a.extents(), Eq(display_area_a));
+    EXPECT_THAT(zone_b.extents(), Eq(display_area_b));
+    EXPECT_FALSE(zone_a.is_same_zone(zone_b));
+}
+
+TEST_F(ApplicationZone, updating_output_updates_application_zone)
+{
+    miral::Zone zone_a_initial{{{}, {}}};
+    miral::Zone zone_a_original{{{}, {}}};
+    miral::Zone zone_b{{{}, {}}};
+    auto display_config_a = create_fake_display_configuration({display_area_a});
+    auto display_config_b = create_fake_display_configuration({display_area_b});
+
+    EXPECT_CALL(*window_manager_policy, advise_application_zone_create(_))
+        .WillOnce(Invoke([&](Zone const& zone){ zone_a_initial = zone; }));
+
+    notify_configuration_applied(display_config_a);
+
+    // Before continuing with the test, we must insure zone_a_initial has been set
+    Mock::VerifyAndClearExpectations(window_manager_policy);
+
+    EXPECT_CALL(*window_manager_policy, advise_application_zone_update(_, _))
+        .WillOnce(Invoke([&](Zone const& updated, Zone const& original){
+            zone_a_original = original;
+            zone_b = updated;
+        }));
+
+    notify_configuration_applied(display_config_b);
+
+    Mock::VerifyAndClearExpectations(window_manager_policy);
+    EXPECT_TRUE(zone_a_initial.is_same_zone(zone_a_original));
+    EXPECT_TRUE(zone_a_original.is_same_zone(zone_b));
+
+    EXPECT_THAT(zone_a_initial, Eq(zone_a_original));
+
+    EXPECT_THAT(zone_a_initial.extents(), Eq(display_area_a));
+    EXPECT_THAT(zone_a_original.extents(), Eq(display_area_a));
+    EXPECT_THAT(zone_b.extents(), Eq(display_area_b));
+}
+
+TEST_F(ApplicationZone, removing_output_deletes_application_zone)
+{
+    miral::Zone zone_a{{{}, {}}};
+    miral::Zone zone_b{{{}, {}}};
+    miral::Zone deleted_zone{{{}, {}}};
+    auto display_config_a_b = create_fake_display_configuration({display_area_a, display_area_b});
+    auto display_config_a = create_fake_display_configuration({display_area_a});
+
+    EXPECT_CALL(*window_manager_policy, advise_application_zone_create(_))
+        .WillOnce(Invoke([&](Zone const& zone){ zone_a = zone; }))
+        .WillOnce(Invoke([&](Zone const& zone){ zone_b = zone; }));
+
+    notify_configuration_applied(display_config_a_b);
+
+    Mock::VerifyAndClearExpectations(window_manager_policy);
+
+    EXPECT_CALL(*window_manager_policy, advise_application_zone_delete(_))
+        .WillOnce(Invoke([&](Zone const& zone){ deleted_zone = zone; }));
+
+    notify_configuration_applied(display_config_a);
+
+    Mock::VerifyAndClearExpectations(window_manager_policy);
+
+    EXPECT_TRUE(deleted_zone.is_same_zone(zone_b));
+    EXPECT_THAT(deleted_zone, Eq(zone_b));
+}

--- a/tests/miral/output_updates.cpp
+++ b/tests/miral/output_updates.cpp
@@ -153,8 +153,8 @@ TEST_F(OutputUpdates, policy_notified_of_output_delete)
 
 TEST_F(OutputUpdates, maximized_window_not_moved_when_new_output_connected)
 {
-    auto display_config_a = create_mock_display_configuration({display_area_a});
-    auto display_config_a_b = create_mock_display_configuration({display_area_a, display_area_b});
+    auto display_config_a = create_fake_display_configuration({display_area_a});
+    auto display_config_a_b = create_fake_display_configuration({display_area_a, display_area_b});
     notify_configuration_applied(display_config_a);
 
     mir::scene::SurfaceCreationParameters creation_parameters;
@@ -175,8 +175,8 @@ TEST_F(OutputUpdates, maximized_window_not_moved_when_new_output_connected)
 
 TEST_F(OutputUpdates, maximized_window_moved_with_its_output)
 {
-    auto display_config_a = create_mock_display_configuration({display_area_a});
-    auto display_config_b = create_mock_display_configuration({display_area_b});
+    auto display_config_a = create_fake_display_configuration({display_area_a});
+    auto display_config_b = create_fake_display_configuration({display_area_b});
     notify_configuration_applied(display_config_a);
 
     mir::scene::SurfaceCreationParameters creation_parameters;

--- a/tests/miral/test_window_manager_tools.h
+++ b/tests/miral/test_window_manager_tools.h
@@ -40,7 +40,9 @@ class DisplayConfiguration;
 namespace test
 {
 
-struct MockWindowManagerPolicy : miral::CanonicalWindowManagerPolicy
+struct MockWindowManagerPolicy
+    : miral::CanonicalWindowManagerPolicy,
+      miral::WindowManagementPolicy::ApplicationZoneAddendum
 {
     using miral::CanonicalWindowManagerPolicy::CanonicalWindowManagerPolicy;
 
@@ -55,6 +57,9 @@ struct MockWindowManagerPolicy : miral::CanonicalWindowManagerPolicy
     MOCK_METHOD1(advise_output_create, void(miral::Output const&));
     MOCK_METHOD2(advise_output_update, void(miral::Output const&, miral::Output const&));
     MOCK_METHOD1(advise_output_delete, void(miral::Output const&));
+    MOCK_METHOD1(advise_application_zone_create, void(miral::Zone const&));
+    MOCK_METHOD2(advise_application_zone_update, void(miral::Zone const&, miral::Zone const&));
+    MOCK_METHOD1(advise_application_zone_delete, void(miral::Zone const&));
 
     void handle_request_drag_and_drop(miral::WindowInfo& /*window_info*/) {}
     void handle_request_move(miral::WindowInfo& /*window_info*/, MirInputEvent const* /*input_event*/) {}

--- a/tests/miral/zone.cpp
+++ b/tests/miral/zone.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include <miral/zone.h>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace testing;
+using namespace mir::geometry;
+
+struct Zone : public testing::Test
+{
+};
+
+TEST_F(Zone, zone_returns_correct_extents)
+{
+    mir::geometry::Rectangle extents{{50, 60}, {70, 80}};
+    miral::Zone zone{extents};
+
+    EXPECT_THAT(zone.extents(), Eq(extents));
+}
+
+TEST_F(Zone, can_modify_zone_extents)
+{
+    mir::geometry::Rectangle a{{50, 60}, {70, 80}};
+    mir::geometry::Rectangle b{{10, 20}, {30, 40}};
+
+    miral::Zone zone{a};
+    zone.extents(b);
+
+    EXPECT_THAT(zone.extents(), Not(Eq(a))) << "Extents not modified";
+    EXPECT_THAT(zone.extents(), Eq(b));
+}
+
+TEST_F(Zone, zone_is_same_as_self)
+{
+    miral::Zone zone{{{50, 60}, {70, 80}}};
+
+    EXPECT_TRUE(zone.is_same_zone(zone));
+}
+
+TEST_F(Zone, zone_extents_copied)
+{
+    mir::geometry::Rectangle extents{{50, 60}, {70, 80}};
+
+    miral::Zone zone_a{extents};
+    auto zone_b = zone_a;
+    miral::Zone zone_c{zone_a};
+
+    EXPECT_THAT(zone_b.extents(), Eq(extents));
+    EXPECT_THAT(zone_c.extents(), Eq(extents));
+}
+
+TEST_F(Zone, zone_same_after_copy)
+{
+    miral::Zone zone_a{{{50, 60}, {70, 80}}};
+    auto zone_b = zone_a;
+    miral::Zone zone_c{zone_a};
+
+    EXPECT_TRUE(zone_a.is_same_zone(zone_b));
+    EXPECT_TRUE(zone_c.is_same_zone(zone_a));
+    EXPECT_TRUE(zone_b.is_same_zone(zone_c));
+}
+
+TEST_F(Zone, zone_same_after_modify)
+{
+    miral::Zone zone_a{{{50, 60}, {70, 80}}};
+    miral::Zone zone_b{zone_a};
+    zone_b.extents({{10, 20}, {30, 40}});
+
+    EXPECT_TRUE(zone_a.is_same_zone(zone_b));
+}
+
+TEST_F(Zone, zone_equal_to_copy)
+{
+    miral::Zone zone_a{{{50, 60}, {70, 80}}};
+    miral::Zone zone_b{zone_a};
+
+    EXPECT_THAT(zone_a, Eq(zone_b));
+}
+
+TEST_F(Zone, zone_not_equal_to_modified_same_zone)
+{
+    miral::Zone zone_a{{{50, 60}, {70, 80}}};
+    miral::Zone zone_b{zone_a};
+    zone_b.extents({{10, 20}, {30, 40}});
+
+    EXPECT_THAT(zone_a, Not(Eq(zone_b)));
+}
+
+TEST_F(Zone, zone_not_equal_to_different_zone_with_same_extents)
+{
+    mir::geometry::Rectangle extents{{50, 60}, {70, 80}};
+    miral::Zone zone_a{extents};
+    miral::Zone zone_b{extents};
+
+    EXPECT_THAT(zone_a, Not(Eq(zone_b)));
+}


### PR DESCRIPTION
Adds a new `Zone` class to miral and updates about application zones. These are the areas we talked about which maximized windows will fill. Right now there is one application zone per output and each covers the entire area of its output, but they will shrink to accommodate exclusive zones when layer shell is implemented. On top of #855