### PR TITLE
Mitigate racy code in multi-process based tests

### DIFF
--- a/include/test/mir_test_framework/process.h
+++ b/include/test/mir_test_framework/process.h
@@ -74,7 +74,7 @@ public:
     ~Process();
 
     // Wait for the process to terminate, and return the results.
-    Result wait_for_termination(const std::chrono::milliseconds& timeout = std::chrono::milliseconds(60 * 1000));
+    Result wait_for_termination(const std::chrono::milliseconds& timeout = std::chrono::minutes(4));
 
     void kill();
     void terminate();

--- a/tests/mir_test_framework/process.cpp
+++ b/tests/mir_test_framework/process.cpp
@@ -139,11 +139,12 @@ mtf::Result mtf::Process::wait_for_termination(const std::chrono::milliseconds& 
             {
                 if (std::chrono::steady_clock::now() < tp)
                 {
-                    std::this_thread::yield();
+                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
                     continue;
                 }
                 else
                 {
+                    detach();
                     BOOST_THROW_EXCEPTION(
                         ::boost::enable_error_info(std::runtime_error("Timeout while waiting for child to change state"))
                         << errinfo_pid(pid));

--- a/tests/mir_test_framework/process.cpp
+++ b/tests/mir_test_framework/process.cpp
@@ -144,7 +144,6 @@ mtf::Result mtf::Process::wait_for_termination(const std::chrono::milliseconds& 
                 }
                 else
                 {
-                    detach();
                     BOOST_THROW_EXCEPTION(
                         ::boost::enable_error_info(std::runtime_error("Timeout while waiting for child to change state"))
                         << errinfo_pid(pid));


### PR DESCRIPTION
Mitigate racy code in multi-process based tests:

1. Give a stronger hint to the scheduler that "something else" should run; And,
2. Use a longer timeout before giving up

Hopefully this will reduce the incidence of #863.

NB This change should be safe to land empirically as:
1. It doesn't touch production code; and,
2. It only affects failing tests

(Most of the tests affected are based on the mirclient API, so we can anticipate the better fix of "delete the racy test".)