### PR TITLE
Better data structure for MultiMonitorArbiter::current_buffer_users.

### DIFF
--- a/src/server/compositor/multi_monitor_arbiter.h
+++ b/src/server/compositor/multi_monitor_arbiter.h
@@ -23,8 +23,8 @@
 #include "buffer_acquisition.h"
 #include <memory>
 #include <mutex>
-#include <deque>
-#include <set>
+#include <vector>
+#include <experimental/optional>
 
 namespace mir
 {
@@ -48,9 +48,13 @@ public:
     void advance_schedule();
 
 private:
+    void add_current_buffer_user(compositor::CompositorID id);
+    bool is_user_of_current_buffer(compositor::CompositorID id);
+    void clear_current_users();
+
     std::mutex mutable mutex;
     std::shared_ptr<graphics::Buffer> current_buffer;
-    std::set<compositor::CompositorID> current_buffer_users;
+    std::vector<std::experimental::optional<compositor::CompositorID>> current_buffer_users;
     std::shared_ptr<Schedule> schedule;
 };
 


### PR DESCRIPTION
A `std::set<>` is highly likely to be backed by some form of tree structure. While that's got better
asymptotic behaviour than a linear search through a vector, we're extremely unlikely to have more
than 10 outputs here, and the common case is *1* output.

There are other microöptimisations here - a SmallVec would be an obvious choice - but just do
the simplest thing because I haven't done any benchmarking ☺