### PR TITLE
Fix includes specified by mirwayland.pc

### DIFF
--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -35,6 +35,8 @@ set_target_properties(mirwayland
     LINK_DEPENDS ${symbol_map}
 )
 
+set(INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include/mirwayland")
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mirwayland.pc.in
     ${CMAKE_CURRENT_BINARY_DIR}/mirwayland.pc
     @ONLY
@@ -44,4 +46,3 @@ install(TARGETS     mirwayland                           LIBRARY DESTINATION "${
 install(FILES       ${CMAKE_CURRENT_BINARY_DIR}/mirwayland.pc    DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
 install(DIRECTORY   ${CMAKE_SOURCE_DIR}/include/wayland/mir      DESTINATION "include/mirwayland")
 
-set(INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include/mirwayland")


### PR DESCRIPTION
Fix INCLUDEDIR for the mirwayland.pc file. (Fixes #873)