### PR TITLE
Add a package config file for mircommon

### DIFF
--- a/debian/libmircommon-dev.install
+++ b/debian/libmircommon-dev.install
@@ -1,2 +1,3 @@
 usr/include/mircommon
 usr/lib/*/libmircommon.so
+usr/lib/*/pkgconfig/mircommon.pc

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -79,3 +79,12 @@ install(
   DIRECTORY ${CMAKE_SOURCE_DIR}/include/common/mir
   DESTINATION "include/mircommon"
 )
+
+set(LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}")
+set(INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include")
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mircommon.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/mircommon.pc
+    @ONLY
+)
+install(FILES       ${CMAKE_CURRENT_BINARY_DIR}/mircommon.pc    DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")

--- a/src/common/mircommon.pc.in
+++ b/src/common/mircommon.pc.in
@@ -1,0 +1,9 @@
+libdir=@LIBDIR@
+includedir=@INCLUDEDIR@/mircommon
+
+Name: mircommon
+Description: Mir server library
+Version: @MIR_VERSION@
+Requires: mircore
+Libs: -L${libdir} -lmircommon
+Cflags: -I${includedir}

--- a/src/platform/mirplatform.pc.in
+++ b/src/platform/mirplatform.pc.in
@@ -6,6 +6,6 @@ includedir=@INCLUDEDIR@
 Name: mirplatform
 Description: Mir platform library
 Version: @MIR_VERSION@
-Requires: mircore
-Libs: -L@LIBDIR@ -lmirplatform -lmircommon
+Requires: mircommon, mircore
+Libs: -L@LIBDIR@ -lmirplatform
 Cflags: -I@INCLUDEDIR@ -I@COMMON_INCLUDEDIR@

--- a/src/wayland/mirwayland.pc.in
+++ b/src/wayland/mirwayland.pc.in
@@ -5,6 +5,6 @@ includedir=@INCLUDEDIR@
 Name: mirwayland
 Description: Mir Wayland library
 Version: @MIRAL_VERSION@
-Requires: mircore
+Requires: mircommon, mircore
 Libs: -L${libdir} -lmirwayland
 Cflags: -I${includedir}


### PR DESCRIPTION
Add a package config file for mircommon and reference it mirwayland and mirplatform. (Fixes: #868)