### PR TITLE
Add make_resource() to generated classes

### DIFF
--- a/src/server/frontend_wayland/data_device.cpp
+++ b/src/server/frontend_wayland/data_device.cpp
@@ -41,7 +41,7 @@ struct DataDevice;
 
 struct DataOffer : mw::DataOffer
 {
-    DataOffer(wl_resource* new_resource, DataSource* source, DataDevice* device);
+    DataOffer(DataSource* source, DataDevice* device);
 
     void accept(uint32_t serial, std::experimental::optional<std::string> const& mime_type) override
     {
@@ -288,12 +288,7 @@ void DataDevice::notify_new(DataSource* source)
 
     if (has_focus)
     {
-        wl_resource* new_resource = wl_resource_create(
-            client,
-            &mw::wl_data_offer_interface_data,
-            wl_resource_get_version(resource),
-            0);
-        current_offer = new DataOffer{new_resource, source, this};
+        current_offer = new DataOffer{source, this};
     }
 }
 
@@ -320,17 +315,12 @@ void DataDevice::focus_on(wl_client* focus)
 
     if (has_focus && current_source && !current_offer)
     {
-        wl_resource* new_resource = wl_resource_create(
-            client,
-            &mw::wl_data_offer_interface_data,
-            wl_resource_get_version(resource),
-            0);
-        current_offer = new DataOffer{new_resource, current_source, this};
+        current_offer = new DataOffer{current_source, this};
     }
 }
 
-DataOffer::DataOffer(wl_resource* new_resource, DataSource* source, DataDevice* device) :
-    mw::DataOffer(new_resource, Version<3>()),
+DataOffer::DataOffer(DataSource* source, DataDevice* device) :
+    mw::DataOffer(mw::DataOffer::make_resource(device->resource), Version<3>()),
     source{source}
 {
     source->add_listener(this);

--- a/src/wayland/generated/wayland_wrapper.cpp
+++ b/src/wayland/generated/wayland_wrapper.cpp
@@ -70,6 +70,19 @@ struct mw::Callback::Thunks
 
 int const mw::Callback::Thunks::supported_version = 1;
 
+auto mw::Callback::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_callback_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::Callback::Callback(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -179,6 +192,19 @@ struct mw::Compositor::Thunks
 };
 
 int const mw::Compositor::Thunks::supported_version = 4;
+
+auto mw::Compositor::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_compositor_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::Compositor::Compositor(struct wl_resource* resource, Version<4>)
     : client{wl_resource_get_client(resource)},
@@ -299,6 +325,19 @@ struct mw::ShmPool::Thunks
 
 int const mw::ShmPool::Thunks::supported_version = 1;
 
+auto mw::ShmPool::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_shm_pool_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::ShmPool::ShmPool(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -406,6 +445,19 @@ struct mw::Shm::Thunks
 
 int const mw::Shm::Thunks::supported_version = 1;
 
+auto mw::Shm::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_shm_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::Shm::Shm(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -496,6 +548,19 @@ struct mw::Buffer::Thunks
 };
 
 int const mw::Buffer::Thunks::supported_version = 1;
+
+auto mw::Buffer::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_buffer_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::Buffer::Buffer(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
@@ -626,6 +691,19 @@ struct mw::DataOffer::Thunks
 
 int const mw::DataOffer::Thunks::supported_version = 3;
 
+auto mw::DataOffer::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_data_offer_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::DataOffer::DataOffer(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -753,6 +831,19 @@ struct mw::DataSource::Thunks
 };
 
 int const mw::DataSource::Thunks::supported_version = 3;
+
+auto mw::DataSource::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_data_source_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::DataSource::DataSource(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
@@ -926,6 +1017,19 @@ struct mw::DataDevice::Thunks
 };
 
 int const mw::DataDevice::Thunks::supported_version = 3;
+
+auto mw::DataDevice::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_data_device_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::DataDevice::DataDevice(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
@@ -1120,6 +1224,19 @@ struct mw::DataDeviceManager::Thunks
 
 int const mw::DataDeviceManager::Thunks::supported_version = 3;
 
+auto mw::DataDeviceManager::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_data_device_manager_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::DataDeviceManager::DataDeviceManager(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -1236,6 +1353,19 @@ struct mw::Shell::Thunks
 };
 
 int const mw::Shell::Thunks::supported_version = 1;
+
+auto mw::Shell::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_shell_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::Shell::Shell(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
@@ -1451,6 +1581,19 @@ struct mw::ShellSurface::Thunks
 };
 
 int const mw::ShellSurface::Thunks::supported_version = 1;
+
+auto mw::ShellSurface::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_shell_surface_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::ShellSurface::ShellSurface(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
@@ -1729,6 +1872,19 @@ struct mw::Surface::Thunks
 
 int const mw::Surface::Thunks::supported_version = 4;
 
+auto mw::Surface::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_surface_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::Surface::Surface(struct wl_resource* resource, Version<4>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -1930,6 +2086,19 @@ struct mw::Seat::Thunks
 
 int const mw::Seat::Thunks::supported_version = 6;
 
+auto mw::Seat::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_seat_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::Seat::Seat(struct wl_resource* resource, Version<6>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -2063,6 +2232,19 @@ struct mw::Pointer::Thunks
 };
 
 int const mw::Pointer::Thunks::supported_version = 6;
+
+auto mw::Pointer::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_pointer_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::Pointer::Pointer(struct wl_resource* resource, Version<6>)
     : client{wl_resource_get_client(resource)},
@@ -2228,6 +2410,19 @@ struct mw::Keyboard::Thunks
 
 int const mw::Keyboard::Thunks::supported_version = 6;
 
+auto mw::Keyboard::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_keyboard_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::Keyboard::Keyboard(struct wl_resource* resource, Version<6>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -2344,6 +2539,19 @@ struct mw::Touch::Thunks
 };
 
 int const mw::Touch::Thunks::supported_version = 6;
+
+auto mw::Touch::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_touch_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::Touch::Touch(struct wl_resource* resource, Version<6>)
     : client{wl_resource_get_client(resource)},
@@ -2501,6 +2709,19 @@ struct mw::Output::Thunks
 
 int const mw::Output::Thunks::supported_version = 3;
 
+auto mw::Output::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_output_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::Output::Output(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -2652,6 +2873,19 @@ struct mw::Region::Thunks
 
 int const mw::Region::Thunks::supported_version = 1;
 
+auto mw::Region::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_region_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::Region::Region(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -2761,6 +2995,19 @@ struct mw::Subcompositor::Thunks
 };
 
 int const mw::Subcompositor::Thunks::supported_version = 1;
+
+auto mw::Subcompositor::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_subcompositor_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::Subcompositor::Subcompositor(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
@@ -2912,6 +3159,19 @@ struct mw::Subsurface::Thunks
 };
 
 int const mw::Subsurface::Thunks::supported_version = 1;
+
+auto mw::Subsurface::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &wl_subsurface_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::Subsurface::Subsurface(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},

--- a/src/wayland/generated/wayland_wrapper.h
+++ b/src/wayland/generated/wayland_wrapper.h
@@ -27,6 +27,7 @@ public:
 
     static Callback* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Callback(struct wl_resource* resource, Version<1>);
     virtual ~Callback() = default;
 
@@ -56,6 +57,7 @@ public:
 
     static Compositor* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Compositor(struct wl_resource* resource, Version<4>);
     virtual ~Compositor() = default;
 
@@ -92,6 +94,7 @@ public:
 
     static ShmPool* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     ShmPool(struct wl_resource* resource, Version<1>);
     virtual ~ShmPool() = default;
 
@@ -117,6 +120,7 @@ public:
 
     static Shm* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Shm(struct wl_resource* resource, Version<1>);
     virtual ~Shm() = default;
 
@@ -228,6 +232,7 @@ public:
 
     static Buffer* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Buffer(struct wl_resource* resource, Version<1>);
     virtual ~Buffer() = default;
 
@@ -258,6 +263,7 @@ public:
 
     static DataOffer* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     DataOffer(struct wl_resource* resource, Version<3>);
     virtual ~DataOffer() = default;
 
@@ -306,6 +312,7 @@ public:
 
     static DataSource* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     DataSource(struct wl_resource* resource, Version<3>);
     virtual ~DataSource() = default;
 
@@ -357,6 +364,7 @@ public:
 
     static DataDevice* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     DataDevice(struct wl_resource* resource, Version<3>);
     virtual ~DataDevice() = default;
 
@@ -404,6 +412,7 @@ public:
 
     static DataDeviceManager* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     DataDeviceManager(struct wl_resource* resource, Version<3>);
     virtual ~DataDeviceManager() = default;
 
@@ -448,6 +457,7 @@ public:
 
     static Shell* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Shell(struct wl_resource* resource, Version<1>);
     virtual ~Shell() = default;
 
@@ -488,6 +498,7 @@ public:
 
     static ShellSurface* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     ShellSurface(struct wl_resource* resource, Version<1>);
     virtual ~ShellSurface() = default;
 
@@ -557,6 +568,7 @@ public:
 
     static Surface* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Surface(struct wl_resource* resource, Version<4>);
     virtual ~Surface() = default;
 
@@ -604,6 +616,7 @@ public:
 
     static Seat* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Seat(struct wl_resource* resource, Version<6>);
     virtual ~Seat() = default;
 
@@ -659,6 +672,7 @@ public:
 
     static Pointer* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Pointer(struct wl_resource* resource, Version<6>);
     virtual ~Pointer() = default;
 
@@ -735,6 +749,7 @@ public:
 
     static Keyboard* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Keyboard(struct wl_resource* resource, Version<6>);
     virtual ~Keyboard() = default;
 
@@ -788,6 +803,7 @@ public:
 
     static Touch* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Touch(struct wl_resource* resource, Version<6>);
     virtual ~Touch() = default;
 
@@ -832,6 +848,7 @@ public:
 
     static Output* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Output(struct wl_resource* resource, Version<3>);
     virtual ~Output() = default;
 
@@ -910,6 +927,7 @@ public:
 
     static Region* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Region(struct wl_resource* resource, Version<1>);
     virtual ~Region() = default;
 
@@ -935,6 +953,7 @@ public:
 
     static Subcompositor* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Subcompositor(struct wl_resource* resource, Version<1>);
     virtual ~Subcompositor() = default;
 
@@ -976,6 +995,7 @@ public:
 
     static Subsurface* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     Subsurface(struct wl_resource* resource, Version<1>);
     virtual ~Subsurface() = default;
 

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
@@ -110,6 +110,19 @@ struct mw::LayerShellV1::Thunks
 
 int const mw::LayerShellV1::Thunks::supported_version = 1;
 
+auto mw::LayerShellV1::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &zwlr_layer_shell_v1_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::LayerShellV1::LayerShellV1(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -286,6 +299,19 @@ struct mw::LayerSurfaceV1::Thunks
 };
 
 int const mw::LayerSurfaceV1::Thunks::supported_version = 1;
+
+auto mw::LayerSurfaceV1::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &zwlr_layer_surface_v1_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::LayerSurfaceV1::LayerSurfaceV1(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
@@ -27,6 +27,7 @@ public:
 
     static LayerShellV1* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     LayerShellV1(struct wl_resource* resource, Version<1>);
     virtual ~LayerShellV1() = default;
 
@@ -77,6 +78,7 @@ public:
 
     static LayerSurfaceV1* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     LayerSurfaceV1(struct wl_resource* resource, Version<1>);
     virtual ~LayerSurfaceV1() = default;
 

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
@@ -116,6 +116,19 @@ struct mw::XdgOutputManagerV1::Thunks
 
 int const mw::XdgOutputManagerV1::Thunks::supported_version = 2;
 
+auto mw::XdgOutputManagerV1::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &zxdg_output_manager_v1_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::XdgOutputManagerV1::XdgOutputManagerV1(struct wl_resource* resource, Version<2>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -199,6 +212,19 @@ struct mw::XdgOutputV1::Thunks
 };
 
 int const mw::XdgOutputV1::Thunks::supported_version = 2;
+
+auto mw::XdgOutputV1::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &zxdg_output_v1_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::XdgOutputV1::XdgOutputV1(struct wl_resource* resource, Version<2>)
     : client{wl_resource_get_client(resource)},

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
@@ -27,6 +27,7 @@ public:
 
     static XdgOutputManagerV1* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     XdgOutputManagerV1(struct wl_resource* resource, Version<2>);
     virtual ~XdgOutputManagerV1() = default;
 
@@ -63,6 +64,7 @@ public:
 
     static XdgOutputV1* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     XdgOutputV1(struct wl_resource* resource, Version<2>);
     virtual ~XdgOutputV1() = default;
 

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
@@ -156,6 +156,19 @@ struct mw::XdgShellV6::Thunks
 
 int const mw::XdgShellV6::Thunks::supported_version = 1;
 
+auto mw::XdgShellV6::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &zxdg_shell_v6_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::XdgShellV6::XdgShellV6(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -332,6 +345,19 @@ struct mw::XdgPositionerV6::Thunks
 
 int const mw::XdgPositionerV6::Thunks::supported_version = 1;
 
+auto mw::XdgPositionerV6::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &zxdg_positioner_v6_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::XdgPositionerV6::XdgPositionerV6(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -474,6 +500,19 @@ struct mw::XdgSurfaceV6::Thunks
 };
 
 int const mw::XdgSurfaceV6::Thunks::supported_version = 1;
+
+auto mw::XdgSurfaceV6::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &zxdg_surface_v6_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::XdgSurfaceV6::XdgSurfaceV6(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
@@ -746,6 +785,19 @@ struct mw::XdgToplevelV6::Thunks
 
 int const mw::XdgToplevelV6::Thunks::supported_version = 1;
 
+auto mw::XdgToplevelV6::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &zxdg_toplevel_v6_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::XdgToplevelV6::XdgToplevelV6(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -883,6 +935,19 @@ struct mw::XdgPopupV6::Thunks
 };
 
 int const mw::XdgPopupV6::Thunks::supported_version = 1;
+
+auto mw::XdgPopupV6::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &zxdg_popup_v6_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::XdgPopupV6::XdgPopupV6(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -27,6 +27,7 @@ public:
 
     static XdgShellV6* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     XdgShellV6(struct wl_resource* resource, Version<1>);
     virtual ~XdgShellV6() = default;
 
@@ -82,6 +83,7 @@ public:
 
     static XdgPositionerV6* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     XdgPositionerV6(struct wl_resource* resource, Version<1>);
     virtual ~XdgPositionerV6() = default;
 
@@ -145,6 +147,7 @@ public:
 
     static XdgSurfaceV6* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     XdgSurfaceV6(struct wl_resource* resource, Version<1>);
     virtual ~XdgSurfaceV6() = default;
 
@@ -186,6 +189,7 @@ public:
 
     static XdgToplevelV6* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     XdgToplevelV6(struct wl_resource* resource, Version<1>);
     virtual ~XdgToplevelV6() = default;
 
@@ -252,6 +256,7 @@ public:
 
     static XdgPopupV6* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     XdgPopupV6(struct wl_resource* resource, Version<1>);
     virtual ~XdgPopupV6() = default;
 

--- a/src/wayland/generated/xdg-shell_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell_wrapper.cpp
@@ -156,6 +156,19 @@ struct mw::XdgWmBase::Thunks
 
 int const mw::XdgWmBase::Thunks::supported_version = 1;
 
+auto mw::XdgWmBase::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &xdg_wm_base_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::XdgWmBase::XdgWmBase(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -332,6 +345,19 @@ struct mw::XdgPositioner::Thunks
 
 int const mw::XdgPositioner::Thunks::supported_version = 1;
 
+auto mw::XdgPositioner::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &xdg_positioner_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::XdgPositioner::XdgPositioner(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -479,6 +505,19 @@ struct mw::XdgSurface::Thunks
 };
 
 int const mw::XdgSurface::Thunks::supported_version = 1;
+
+auto mw::XdgSurface::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &xdg_surface_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::XdgSurface::XdgSurface(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
@@ -751,6 +790,19 @@ struct mw::XdgToplevel::Thunks
 
 int const mw::XdgToplevel::Thunks::supported_version = 1;
 
+auto mw::XdgToplevel::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &xdg_toplevel_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::XdgToplevel::XdgToplevel(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -888,6 +940,19 @@ struct mw::XdgPopup::Thunks
 };
 
 int const mw::XdgPopup::Thunks::supported_version = 1;
+
+auto mw::XdgPopup::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &xdg_popup_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::XdgPopup::XdgPopup(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},

--- a/src/wayland/generated/xdg-shell_wrapper.h
+++ b/src/wayland/generated/xdg-shell_wrapper.h
@@ -27,6 +27,7 @@ public:
 
     static XdgWmBase* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     XdgWmBase(struct wl_resource* resource, Version<1>);
     virtual ~XdgWmBase() = default;
 
@@ -82,6 +83,7 @@ public:
 
     static XdgPositioner* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     XdgPositioner(struct wl_resource* resource, Version<1>);
     virtual ~XdgPositioner() = default;
 
@@ -153,6 +155,7 @@ public:
 
     static XdgSurface* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     XdgSurface(struct wl_resource* resource, Version<1>);
     virtual ~XdgSurface() = default;
 
@@ -194,6 +197,7 @@ public:
 
     static XdgToplevel* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     XdgToplevel(struct wl_resource* resource, Version<1>);
     virtual ~XdgToplevel() = default;
 
@@ -260,6 +264,7 @@ public:
 
     static XdgPopup* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     XdgPopup(struct wl_resource* resource, Version<1>);
     virtual ~XdgPopup() = default;
 

--- a/src/wayland/generator/interface.h
+++ b/src/wayland/generator/interface.h
@@ -49,6 +49,8 @@ public:
     void populate_required_interfaces(std::set<std::string>& interfaces) const; // fills the set with interfaces used
 
 private:
+    Emitter make_resource_prototype() const;
+    Emitter make_resource_impl() const;
     Emitter constructor_prototype() const;
     Emitter constructor_impl() const;
     Emitter constructor_args() const;

--- a/tests/miral/generated/server-decoration_wrapper.cpp
+++ b/tests/miral/generated/server-decoration_wrapper.cpp
@@ -104,6 +104,19 @@ struct mw::ServerDecorationManager::Thunks
 
 int const mw::ServerDecorationManager::Thunks::supported_version = 1;
 
+auto mw::ServerDecorationManager::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &org_kde_kwin_server_decoration_manager_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
+
 mw::ServerDecorationManager::ServerDecorationManager(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
@@ -206,6 +219,19 @@ struct mw::ServerDecoration::Thunks
 };
 
 int const mw::ServerDecoration::Thunks::supported_version = 1;
+
+auto mw::ServerDecoration::make_resource(wl_resource* parent_resource) -> wl_resource*
+{
+    wl_client* client = wl_resource_get_client(parent_resource);
+    int version = wl_resource_get_version(parent_resource);
+    wl_resource* new_resource = wl_resource_create(client, &org_kde_kwin_server_decoration_interface_data, version, 0);
+    if (new_resource == nullptr)
+    {
+        wl_client_post_no_memory(client);
+        BOOST_THROW_EXCEPTION(std::bad_alloc{});
+    }
+    return new_resource;
+}
 
 mw::ServerDecoration::ServerDecoration(struct wl_resource* resource, Version<1>)
     : client{wl_resource_get_client(resource)},

--- a/tests/miral/generated/server-decoration_wrapper.h
+++ b/tests/miral/generated/server-decoration_wrapper.h
@@ -27,6 +27,7 @@ public:
 
     static ServerDecorationManager* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     ServerDecorationManager(struct wl_resource* resource, Version<1>);
     virtual ~ServerDecorationManager() = default;
 
@@ -76,6 +77,7 @@ public:
 
     static ServerDecoration* from(struct wl_resource*);
 
+    static auto make_resource(wl_resource* parent_resource) -> wl_resource*;
     ServerDecoration(struct wl_resource* resource, Version<1>);
     virtual ~ServerDecoration() = default;
 


### PR DESCRIPTION
Allows the server to create new Wayland resources instead of them coming from the client. The new resource can then be past into the constructor of a Wayland object, just like new resources from clients. Calling `make_resource()` explicitly shows that a new `wl_resource` is created, and the given resource is the parent.

Fixes #871, alternative to #877