### PR TITLE
wayland/generator: Add a constructor-from-parent for objects that can be server-constructed

### DIFF
--- a/src/server/frontend_wayland/data_device.cpp
+++ b/src/server/frontend_wayland/data_device.cpp
@@ -41,7 +41,7 @@ struct DataDevice;
 
 struct DataOffer : mw::DataOffer
 {
-    DataOffer(wl_resource* new_resource, DataSource* source, DataDevice* device);
+    DataOffer(DataSource* source, DataDevice* device);
 
     void accept(uint32_t serial, std::experimental::optional<std::string> const& mime_type) override
     {
@@ -288,12 +288,7 @@ void DataDevice::notify_new(DataSource* source)
 
     if (has_focus)
     {
-        wl_resource* new_resource = wl_resource_create(
-            client,
-            &mw::wl_data_offer_interface_data,
-            wl_resource_get_version(resource),
-            0);
-        current_offer = new DataOffer{new_resource, source, this};
+        current_offer = new DataOffer{source, this};
     }
 }
 
@@ -320,17 +315,12 @@ void DataDevice::focus_on(wl_client* focus)
 
     if (has_focus && current_source && !current_offer)
     {
-        wl_resource* new_resource = wl_resource_create(
-            client,
-            &mw::wl_data_offer_interface_data,
-            wl_resource_get_version(resource),
-            0);
-        current_offer = new DataOffer{new_resource, current_source, this};
+        current_offer = new DataOffer{current_source, this};
     }
 }
 
-DataOffer::DataOffer(wl_resource* new_resource, DataSource* source, DataDevice* device) :
-    mw::DataOffer(new_resource, Version<3>()),
+DataOffer::DataOffer(DataSource* source, DataDevice* device) :
+    mw::DataOffer(*device),
     source{source}
 {
     source->add_listener(this);

--- a/src/wayland/generated/wayland_wrapper.cpp
+++ b/src/wayland/generated/wayland_wrapper.cpp
@@ -626,9 +626,9 @@ struct mw::DataOffer::Thunks
 
 int const mw::DataOffer::Thunks::supported_version = 3;
 
-mw::DataOffer::DataOffer(struct wl_resource* resource, Version<3>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+mw::DataOffer::DataOffer(DataDevice const& parent)
+    : client{wl_resource_get_client(parent.resource)},
+      resource{wl_resource_create(client, &wl_data_offer_interface_data, wl_resource_get_version(parent.resource), 0)}
 {
     if (resource == nullptr)
     {

--- a/src/wayland/generated/wayland_wrapper.h
+++ b/src/wayland/generated/wayland_wrapper.h
@@ -20,6 +20,27 @@ namespace mir
 namespace wayland
 {
 
+class Callback;
+class Compositor;
+class ShmPool;
+class Shm;
+class Buffer;
+class DataOffer;
+class DataSource;
+class DataDevice;
+class DataDeviceManager;
+class Shell;
+class ShellSurface;
+class Surface;
+class Seat;
+class Pointer;
+class Keyboard;
+class Touch;
+class Output;
+class Region;
+class Subcompositor;
+class Subsurface;
+
 class Callback : public Resource
 {
 public:
@@ -258,7 +279,7 @@ public:
 
     static DataOffer* from(struct wl_resource*);
 
-    DataOffer(struct wl_resource* resource, Version<3>);
+    DataOffer(DataDevice const& parent);
     virtual ~DataOffer() = default;
 
     void send_offer_event(std::string const& mime_type) const;

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
@@ -20,6 +20,9 @@ namespace mir
 namespace wayland
 {
 
+class LayerShellV1;
+class LayerSurfaceV1;
+
 class LayerShellV1 : public Resource
 {
 public:

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
@@ -20,6 +20,9 @@ namespace mir
 namespace wayland
 {
 
+class XdgOutputManagerV1;
+class XdgOutputV1;
+
 class XdgOutputManagerV1 : public Resource
 {
 public:

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -20,6 +20,12 @@ namespace mir
 namespace wayland
 {
 
+class XdgShellV6;
+class XdgPositionerV6;
+class XdgSurfaceV6;
+class XdgToplevelV6;
+class XdgPopupV6;
+
 class XdgShellV6 : public Resource
 {
 public:

--- a/src/wayland/generated/xdg-shell_wrapper.h
+++ b/src/wayland/generated/xdg-shell_wrapper.h
@@ -20,6 +20,12 @@ namespace mir
 namespace wayland
 {
 
+class XdgWmBase;
+class XdgPositioner;
+class XdgSurface;
+class XdgToplevel;
+class XdgPopup;
+
 class XdgWmBase : public Resource
 {
 public:

--- a/src/wayland/generator/interface.cpp
+++ b/src/wayland/generator/interface.cpp
@@ -24,20 +24,38 @@
 
 namespace
 {
+class AsRange
+{
+public:
+    using const_iterator = std::unordered_multimap<std::string, std::string>::const_iterator;
+    explicit AsRange(std::pair<const_iterator, const_iterator> stupid_api)
+        : range{std::move(stupid_api)}
+    {
+    }
+
+    const_iterator begin()
+    {
+        return range.first;
+    }
+
+    const_iterator end()
+    {
+        return range.second;
+    }
+
+private:
+    std::pair<const_iterator, const_iterator> const range;
+};
+
 auto matching_keys_to_vector(
     std::unordered_multimap<std::string, std::string> const& map,
     std::function<std::string(std::string)> const& name_transform,
     std::string key)
 {
-    auto range = map.equal_range(key);
-
-    if (range.first == map.end())
-        return std::vector<std::string>{};
-
     std::vector<std::string> interfaces;
-    for (auto it = range.first; it != range.second; ++it)
+    for (auto const& i : AsRange{map.equal_range(key)})
     {
-        interfaces.push_back(name_transform(it->second));
+        interfaces.push_back(name_transform(i.second));
     }
     return interfaces;
 }

--- a/src/wayland/generator/interface.cpp
+++ b/src/wayland/generator/interface.cpp
@@ -79,7 +79,7 @@ Emitter Interface::declaration() const
             {"static char const constexpr* interface_name = \"", wl_name, "\";"},
             {"static ", generated_name, "* from(struct wl_resource*);"},
             Lines {
-                             constructor_prototypes(),
+                constructor_prototypes(),
                 destructor_prototype(),
             },
             event_prototypes(),

--- a/src/wayland/generator/interface.h
+++ b/src/wayland/generator/interface.h
@@ -27,6 +27,7 @@
 
 #include <experimental/optional>
 #include <functional>
+#include <map>
 #include <unordered_set>
 
 class Method;
@@ -41,17 +42,21 @@ class Interface
 public:
     Interface(xmlpp::Element const& node,
               std::function<std::string(std::string)> const& name_transform,
-              std::unordered_set<std::string> const& constructable_interfaces);
+              std::unordered_set<std::string> const& constructible_interfaces,
+              std::unordered_multimap<std::string, std::string> const& event_constructable_interfaces);
 
+    std::string class_name() const;
     Emitter declaration() const;
     Emitter implementation() const;
     Emitter wl_interface_init() const;
     void populate_required_interfaces(std::set<std::string>& interfaces) const; // fills the set with interfaces used
 
 private:
-    Emitter constructor_prototype() const;
+    Emitter constructor_prototypes() const;
     Emitter constructor_impl() const;
+    Emitter constructor_impl(std::string const& parent_interface) const;
     Emitter constructor_args() const;
+    Emitter constructor_args(std::string const& parent_interface) const;
     Emitter destructor_prototype() const;
     Emitter virtual_request_prototypes() const;
     Emitter event_prototypes() const;
@@ -74,10 +79,13 @@ private:
     int const version;
     std::string const generated_name;
     std::string const nmspace;
+    bool const has_server_constructor;
+    bool const has_client_constructor;
     std::experimental::optional<Global> const global;
     std::vector<Request> const requests;
     std::vector<Event> const events;
     std::vector<Enum> const enums;
+    std::vector<std::string> const parent_interfaces;
     bool const has_vtable;
 };
 


### PR DESCRIPTION
[Wayland] Add a constructor-from-parent for objects that can be server-constructed. (Fixes: #871)