### PR TITLE
Wayland: process output update notifications on the correct thread

### DIFF
--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "output_manager.h"
+#include "wayland_executor.h"
 
 #include <algorithm>
 
@@ -181,9 +182,10 @@ void mf::Output::resource_destructor(wl_resource* resource)
 }
 
 
-mf::OutputManager::OutputManager(wl_display* display, std::shared_ptr<MirDisplay> const& display_config) :
+mf::OutputManager::OutputManager(wl_display* display, std::shared_ptr<MirDisplay> const& display_config, std::shared_ptr<Executor> const& executor) :
     display_config_{display_config},
-    display{display}
+    display{display},
+    executor{executor}
 {
     display_config->register_interest(this);
     display_config->for_each_output(std::bind(&OutputManager::create_output, this, std::placeholders::_1));
@@ -229,23 +231,27 @@ void mf::OutputManager::create_output(mg::DisplayConfigurationOutput const& init
 
 void mf::OutputManager::handle_configuration_change(mg::DisplayConfiguration const& config)
 {
-    config.for_each_output([this](mg::DisplayConfigurationOutput const& output_config)
-        {
-            auto output_iter = outputs.find(output_config.id);
-            if (output_iter != outputs.end())
+    std::shared_ptr<mg::DisplayConfiguration> pconfig{config.clone()};
+    executor->spawn([config = std::move(pconfig), this]
+    {
+        config->for_each_output([this](mg::DisplayConfigurationOutput const& output_config)
             {
-                if (output_config.used)
+                auto output_iter = outputs.find(output_config.id);
+                if (output_iter != outputs.end())
                 {
-                    output_iter->second->handle_configuration_changed(output_config);
+                    if (output_config.used)
+                    {
+                        output_iter->second->handle_configuration_changed(output_config);
+                    }
+                    else
+                    {
+                        outputs.erase(output_iter);
+                    }
                 }
-                else
+                else if (output_config.used)
                 {
-                    outputs.erase(output_iter);
+                    outputs[output_config.id] = std::make_unique<Output>(display, output_config);
                 }
-            }
-            else if (output_config.used)
-            {
-                outputs[output_config.id] = std::make_unique<Output>(display, output_config);
-            }
-        });
+            });
+    });
 }

--- a/src/server/frontend_wayland/output_manager.h
+++ b/src/server/frontend_wayland/output_manager.h
@@ -67,7 +67,7 @@ private:
 class OutputManager : public OutputObserver
 {
 public:
-    OutputManager(wl_display* display, std::shared_ptr<MirDisplay> const& display_config);
+    OutputManager(wl_display* display, std::shared_ptr<MirDisplay> const& display_config, std::shared_ptr<Executor> const& executor);
     ~OutputManager();
 
     auto output_id_for(wl_client* client, std::experimental::optional<struct wl_resource*> const& /*output*/) const
@@ -85,6 +85,7 @@ private:
 
     std::shared_ptr<MirDisplay> const display_config_;
     wl_display* const display;
+    std::shared_ptr<Executor> const executor;
     std::unordered_map<graphics::DisplayConfigurationOutputId, std::unique_ptr<Output>> outputs;
 };
 }

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -660,7 +660,8 @@ mf::WaylandConnector::WaylandConnector(
     seat_global = std::make_unique<mf::WlSeat>(display.get(), input_hub, seat, executor);
     output_manager = std::make_unique<mf::OutputManager>(
         display.get(),
-        display_config);
+        display_config,
+        executor);
 
     data_device_manager_global = mf::create_data_device_manager(display.get());
 


### PR DESCRIPTION
Wayland: process output update notifications on the correct thread. (Fixes: #886)