### PR TITLE
Add mir_window_state_attached

### DIFF
--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -391,3 +391,12 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"typeinfo for miral::WindowManagementPolicy::ApplicationZoneAddendum@MIRAL_2.6" 2.6.0
  (c++)"vtable for miral::WindowManagementPolicy::ApplicationZoneAddendum@MIRAL_2.6" 2.6.0
  (c++)"miral::WindowManagementPolicy::ApplicationZoneAddendum::from(miral::WindowManagementPolicy*)@MIRAL_2.6" 2.6.0
+ MIRAL_2.7@MIRAL_2.7 2.7.0
+ (c++)"miral::WindowInfo::attached_edges() const@MIRAL_2.7" 2.7.0
+ (c++)"miral::WindowInfo::attached_edges(MirPlacementGravity)@MIRAL_2.7" 2.7.0
+ (c++)"miral::WindowInfo::exclusive_rect() const@MIRAL_2.7" 2.7.0
+ (c++)"miral::WindowInfo::exclusive_rect(mir::optional_value<mir::geometry::Rectangle> const&)@MIRAL_2.7" 2.7.0
+ (c++)"miral::WindowSpecification::attached_edges() const@MIRAL_2.7" 2.7.0
+ (c++)"miral::WindowSpecification::attached_edges()@MIRAL_2.7" 2.7.0
+ (c++)"miral::WindowSpecification::exclusive_rect() const@MIRAL_2.7" 2.7.0
+ (c++)"miral::WindowSpecification::exclusive_rect()@MIRAL_2.7" 2.7.0

--- a/include/core/mir_toolkit/common.h
+++ b/include/core/mir_toolkit/common.h
@@ -134,6 +134,7 @@ typedef enum MirSurfaceState
     mir_surface_state_fullscreen,
     mir_surface_state_horizmaximized,
     mir_surface_state_hidden,
+    mir_surface_state_attached,       /**< Used for panels, notifications and other windows attached to output edges */
     mir_surface_states
 } MirSurfaceState MIR_FOR_REMOVAL_IN_VERSION_1("use MirWindowState");
 
@@ -150,6 +151,7 @@ typedef enum MirWindowState
     mir_window_state_fullscreen,
     mir_window_state_horizmaximized,
     mir_window_state_hidden,
+    mir_window_state_attached,       /**< Used for panels, notifications and other windows attached to output edges */
     mir_window_states
 } MirWindowState;
 

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -119,6 +119,21 @@ struct WindowInfo
 
     auto depth_layer() const -> MirDepthLayer;
     void depth_layer(MirDepthLayer depth_layer);
+
+    /// Get the edges of the output that the window is attached to
+    /// (only meaningful for windows in state mir_window_state_attached)
+    auto attached_edges() const -> MirPlacementGravity;
+    /// Set the edges of the output that the window should be attached to
+    /// (only meaningful for windows in state mir_window_state_attached)
+    void attached_edges(MirPlacementGravity edges);
+
+    /// Mir will try to avoid occluding the area covered by this rectangle (relative to the window)
+    /// (only meaningful when the window is attached to an edge)
+    auto exclusive_rect() const -> mir::optional_value<mir::geometry::Rectangle>;
+    /// Set the area to keep exclusive to this window
+    /// (only meaningful when the window is attached to an edge)
+    void exclusive_rect(mir::optional_value<mir::geometry::Rectangle> const& rect);
+
 private:
     struct Self;
     std::unique_ptr<Self> self;

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -127,9 +127,33 @@ public:
 
     /**
      * The depth layer of a child window is updated with the depth layer of its parent, but can be overridden
+     *  @{
      */
     auto depth_layer() const -> mir::optional_value<MirDepthLayer> const&;
     auto depth_layer() -> mir::optional_value<MirDepthLayer>&;
+    /** @}*/
+
+    /**
+     * The set of window eges that are attched to edges of the output
+     * If attached to perpendicular edges, it is attached to the corner where the two edges intersect
+     * If attached to oposite edges (eg left and right), it is stretched across the output in that direction
+     * If all edges are specified, it takes up the entire output
+     *  @{
+     */
+    auto attached_edges() const -> mir::optional_value<MirPlacementGravity> const&;
+    auto attached_edges() -> mir::optional_value<MirPlacementGravity>&;
+    /** @}*/
+
+    /**
+     * The area over which the window should not be occluded
+     * Only meaningful for windows attached to an edge
+     * Setting to optional_value{} will not change the rect when this specification is applied
+     * Setting to optional_value{optional_value{}} will clear the exclusive rect
+     *  @{
+     */
+    auto exclusive_rect() const -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>> const&;
+    auto exclusive_rect() -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>>&;
+    /** @} */
 
 private:
     struct Self;

--- a/include/server/mir/scene/surface_creation_parameters.h
+++ b/include/server/mir/scene/surface_creation_parameters.h
@@ -116,6 +116,18 @@ struct SurfaceCreationParameters
      * If the depth layer of a child surface isn't set, it gets the layer of its parent
      */
     optional_value<MirDepthLayer> depth_layer;
+
+    /**
+     * The edge of the output to attach this surface to
+     * Only used if the surface is in state mir_window_state_attached
+     */
+    optional_value<MirPlacementGravity> attached_edges;
+
+    /**
+     * The area of this surface that will not be occluded
+     * Only used if surface is in state mir_window_state_attached and is attached to an edge (not a corner)
+     */
+    optional_value<geometry::Rectangle> exclusive_rect;
 };
 
 bool operator==(const SurfaceCreationParameters& lhs, const SurfaceCreationParameters& rhs);

--- a/include/server/mir/shell/surface_specification.h
+++ b/include/server/mir/shell/surface_specification.h
@@ -105,6 +105,9 @@ struct SurfaceSpecification
      * also updates all children.
      */
     optional_value<MirDepthLayer> depth_layer;
+
+    optional_value<MirPlacementGravity> attached_edges;
+    optional_value<optional_value<geometry::Rectangle>> exclusive_rect;
 };
 }
 }

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -153,6 +153,10 @@ auto miral::BasicWindowManager::add_surface(
         break;
     }
 
+    case mir_window_state_attached:
+        place_attached(window_info);
+        break;
+
     default:
         break;
     }
@@ -1091,6 +1095,12 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
         set_state(window_info, modifications.state().value());
     }
 
+    if (window_info.state() == mir_window_state_attached)
+    {
+        if (modifications.state().is_set() || modifications.attached_edges().is_set())
+            place_attached(window_info);
+    }
+
     if (modifications.confine_pointer().is_set())
         std::shared_ptr<scene::Surface>(window)->set_confine_pointer_state(modifications.confine_pointer().value());
 }
@@ -1122,6 +1132,54 @@ void miral::BasicWindowManager::place_and_size(WindowInfo& root, Point const& ne
     }
 
     move_tree(root, new_pos - root.window().top_left());
+}
+
+void miral::BasicWindowManager::place_attached(WindowInfo& root)
+{
+    if (root.state() != mir_window_state_attached)
+        fatal_error("BasicWindowManager::place_attached() called for window not in state mir_window_state_attached");
+
+    MirPlacementGravity edges = root.attached_edges();
+    Size size = root.window().size();
+    auto area = display_area_for(root.window());
+    Rectangle application_zone = area->application_zone.extents();
+    Point top_left{};
+    bool needs_resize = true;
+
+    if ((edges & mir_placement_gravity_west) &&
+        (edges & mir_placement_gravity_east))
+    {
+        size.width = application_zone.size.width;
+        needs_resize = true;
+    }
+
+    if ((edges & mir_placement_gravity_north) &&
+        (edges & mir_placement_gravity_south))
+    {
+        size.height = application_zone.size.height;
+        needs_resize = true;
+    }
+
+    if (needs_resize)
+    {
+        root.window().resize(size);
+    }
+
+    if (edges & mir_placement_gravity_west)
+        top_left.x = application_zone.left();
+    else if (edges & mir_placement_gravity_east)
+        top_left.x = application_zone.right() - (size.width - Width{0});
+    else
+        top_left.x = application_zone.top_left.x + (application_zone.size.width - size.width) * 0.5;
+
+    if (edges & mir_placement_gravity_north)
+        top_left.y = application_zone.top();
+    else if (edges & mir_placement_gravity_south)
+        top_left.y = application_zone.bottom() - (size.height - Height{0});
+    else
+        top_left.y = application_zone.top_left.y + (application_zone.size.height - size.height) * 0.5;
+
+    move_tree(root, top_left - root.window().top_left());
 }
 
 void miral::BasicWindowManager::place_and_size_for_state(

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -948,6 +948,8 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
     COPY_IF_SET(userdata);
     COPY_IF_SET(shell_chrome);
     COPY_IF_SET(depth_layer);
+    COPY_IF_SET(attached_edges);
+    COPY_IF_SET(exclusive_rect);
 
 #undef COPY_IF_SET
 

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -278,6 +278,7 @@ private:
     void erase(miral::WindowInfo const& info);
     void validate_modification_request(WindowSpecification const& modifications, WindowInfo const& window_info) const;
     void place_and_size(WindowInfo& root, Point const& new_pos, Size const& new_size);
+    void place_attached(WindowInfo& root);
     void set_state(miral::WindowInfo& window_info, MirWindowState value);
     auto fullscreen_rect_for(WindowInfo const& window_info) const -> Rectangle;
     void remove_window(Application const& application, miral::WindowInfo const& info);

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -469,3 +469,13 @@ global:
     vtable?for?miral::Zone;
   };
 } MIRAL_2.5;
+
+MIRAL_2.7 {
+global:
+  extern "C++" {
+    miral::WindowInfo::attached_edges*;
+    miral::WindowInfo::exclusive_rect*;
+    miral::WindowSpecification::attached_edges*;
+    miral::WindowSpecification::exclusive_rect*;
+  };
+} MIRAL_2.6;

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -94,6 +94,8 @@ struct miral::WindowInfo::Self
     mir::optional_value<int> output_id;
     MirShellChrome shell_chrome;
     MirDepthLayer depth_layer;
+    MirPlacementGravity attached_edges;
+    mir::optional_value<mir::geometry::Rectangle> exclusive_rect;
     std::shared_ptr<void> userdata;
 };
 
@@ -114,10 +116,14 @@ miral::WindowInfo::Self::Self(Window window, WindowSpecification const& params) 
     min_aspect(optional_value_or_default(params.min_aspect(), default_min_aspect_ratio)),
     max_aspect(optional_value_or_default(params.max_aspect(), default_max_aspect_ratio)),
     shell_chrome(optional_value_or_default(params.shell_chrome(), mir_shell_chrome_normal)),
-    depth_layer(optional_value_or_default(params.depth_layer(), mir_depth_layer_application))
+    depth_layer(optional_value_or_default(params.depth_layer(), mir_depth_layer_application)),
+    attached_edges(optional_value_or_default(params.attached_edges(), mir_placement_gravity_center))
 {
     if (params.output_id().is_set())
         output_id = params.output_id().value();
+
+    if (params.exclusive_rect().is_set())
+        exclusive_rect = params.exclusive_rect().value();
 
     if (params.userdata().is_set())
         userdata = params.userdata().value();
@@ -625,4 +631,24 @@ auto miral::WindowInfo::depth_layer() const -> MirDepthLayer
 void miral::WindowInfo::depth_layer(MirDepthLayer depth_layer)
 {
     self->depth_layer = depth_layer;
+}
+
+auto miral::WindowInfo::attached_edges() const -> MirPlacementGravity
+{
+    return self->attached_edges;
+}
+
+void miral::WindowInfo::attached_edges(MirPlacementGravity edges)
+{
+    self->attached_edges = edges;
+}
+
+auto miral::WindowInfo::exclusive_rect() const -> mir::optional_value<mir::geometry::Rectangle>
+{
+    return self->exclusive_rect;
+}
+
+void miral::WindowInfo::exclusive_rect(mir::optional_value<mir::geometry::Rectangle> const& rect)
+{
+    self->exclusive_rect = rect;
 }

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -60,6 +60,8 @@ struct miral::WindowSpecification::Self
     mir::optional_value<MirShellChrome> shell_chrome;
     mir::optional_value<MirPointerConfinementState> confine_pointer;
     mir::optional_value<MirDepthLayer> depth_layer;
+    mir::optional_value<MirPlacementGravity> attached_edges;
+    mir::optional_value<mir::optional_value<mir::geometry::Rectangle>> exclusive_rect;
     mir::optional_value<std::shared_ptr<void>> userdata;
 };
 
@@ -91,7 +93,9 @@ miral::WindowSpecification::Self::Self(mir::shell::SurfaceSpecification const& s
     input_mode(),
     shell_chrome(spec.shell_chrome),
     confine_pointer(spec.confine_pointer),
-    depth_layer(spec.depth_layer)
+    depth_layer(spec.depth_layer),
+    attached_edges(spec.attached_edges),
+    exclusive_rect(spec.exclusive_rect)
 {
     if (spec.aux_rect_placement_offset_x.is_set() && spec.aux_rect_placement_offset_y.is_set())
         aux_rect_placement_offset = Displacement{spec.aux_rect_placement_offset_x.value(), spec.aux_rect_placement_offset_y.value()};
@@ -217,7 +221,9 @@ miral::WindowSpecification::Self::Self(mir::scene::SurfaceCreationParameters con
     input_mode(static_cast<InputReceptionMode>(params.input_mode)),
     shell_chrome(params.shell_chrome),
     confine_pointer(params.confine_pointer),
-    depth_layer(params.depth_layer)
+    depth_layer(params.depth_layer),
+    attached_edges(params.attached_edges),
+    exclusive_rect(params.exclusive_rect)
 {
     if (params.aux_rect_placement_offset_x.is_set() && params.aux_rect_placement_offset_y.is_set())
         aux_rect_placement_offset = Displacement{params.aux_rect_placement_offset_x.value(), params.aux_rect_placement_offset_y.value()};
@@ -287,6 +293,8 @@ void miral::WindowSpecification::Self::update(mir::scene::SurfaceCreationParamet
     copy_if_set(params.surface_placement_gravity, window_placement_gravity);
     copy_if_set(params.aux_rect_placement_gravity, aux_rect_placement_gravity);
     copy_if_set(params.depth_layer, depth_layer);
+    copy_if_set(params.attached_edges, attached_edges);
+    copy_if_set(params.exclusive_rect, exclusive_rect.value());
 
     if (aux_rect_placement_offset.is_set())
     {
@@ -454,6 +462,22 @@ auto miral::WindowSpecification::confine_pointer() const -> mir::optional_value<
     return self->confine_pointer;
 }
 
+auto miral::WindowSpecification::depth_layer() const -> mir::optional_value<MirDepthLayer> const&
+{
+    return self->depth_layer;
+}
+
+auto miral::WindowSpecification::attached_edges() const -> mir::optional_value<MirPlacementGravity> const&
+{
+    return self->attached_edges;
+}
+
+auto miral::WindowSpecification::exclusive_rect() const
+    -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>> const&
+{
+    return self->exclusive_rect;
+}
+
 auto miral::WindowSpecification::userdata() const -> mir::optional_value<std::shared_ptr<void>> const&
 {
     return self->userdata;
@@ -584,17 +608,23 @@ auto miral::WindowSpecification::confine_pointer() -> mir::optional_value<MirPoi
     return self->confine_pointer;
 }
 
-auto miral::WindowSpecification::userdata() -> mir::optional_value<std::shared_ptr<void>>&
-{
-    return self->userdata;
-}
-
-auto miral::WindowSpecification::depth_layer() const -> mir::optional_value<MirDepthLayer> const&
-{
-    return self->depth_layer;
-}
-
 auto miral::WindowSpecification::depth_layer() -> mir::optional_value<MirDepthLayer>&
 {
     return self->depth_layer;
+}
+
+auto miral::WindowSpecification::attached_edges() -> mir::optional_value<MirPlacementGravity>&
+{
+    return self->attached_edges;
+}
+
+auto miral::WindowSpecification::exclusive_rect()
+    -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>>&
+{
+    return self->exclusive_rect;
+}
+
+auto miral::WindowSpecification::userdata() -> mir::optional_value<std::shared_ptr<void>>&
+{
+    return self->userdata;
 }

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -21,6 +21,8 @@
 #include "wl_surface.h"
 #include "window_wl_surface_role.h"
 
+#include "mir/shell/surface_specification.h"
+
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
 namespace mw = mir::wayland;
@@ -121,6 +123,9 @@ mf::LayerSurfaceV1::LayerSurfaceV1(wl_resource* new_resource, WlSurface* surface
           layer_shell.shell,
           layer_shell.output_manager)
 {
+    shell::SurfaceSpecification spec;
+    spec.state = mir_window_state_attached;
+    apply_spec(spec);
 }
 
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)

--- a/src/server/scene/surface_creation_parameters.cpp
+++ b/src/server/scene/surface_creation_parameters.cpp
@@ -198,6 +198,10 @@ void ms::SurfaceCreationParameters::update_from(msh::SurfaceSpecification const&
         confine_pointer = that.confine_pointer;
     if (that.depth_layer.is_set())
         depth_layer = that.depth_layer;
+    if (that.attached_edges.is_set())
+        attached_edges = that.attached_edges;
+    if (that.exclusive_rect.is_set())
+        exclusive_rect = that.exclusive_rect.value();
     // TODO: should SurfaceCreationParameters support cursors?
 //     if (that.cursor_image.is_set())
 //         cursor_image = that.cursor_image;

--- a/src/server/shell/surface_specification.cpp
+++ b/src/server/shell/surface_specification.cpp
@@ -48,7 +48,9 @@ bool msh::SurfaceSpecification::is_empty() const
         !parent.is_set() &&
         !input_shape.is_set() &&
         !shell_chrome.is_set() &&
-        !depth_layer.is_set();
+        !depth_layer.is_set() &&
+        !attached_edges.is_set() &&
+        !exclusive_rect.is_set();
 }
 
 void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
@@ -119,4 +121,8 @@ void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
         stream_cursor = that.stream_cursor;
     if (that.depth_layer.is_set())
         depth_layer = that.depth_layer;
+    if (that.attached_edges.is_set())
+        attached_edges = that.attached_edges;
+    if (that.exclusive_rect.is_set())
+        exclusive_rect = that.exclusive_rect;
 }

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -41,6 +41,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     output_updates.cpp
     application_zone.cpp
     initial_window_placement.cpp
+    window_placement_attached.cpp
     ${MIRAL_TEST_SOURCES}
 )
 

--- a/tests/miral/window_placement_attached.cpp
+++ b/tests/miral/window_placement_attached.cpp
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "test_window_manager_tools.h"
+
+using namespace miral;
+using namespace testing;
+namespace mt = mir::test;
+
+namespace
+{
+X const display_left{30};
+Y const display_top{40};
+Width const display_width{1280};
+Height const display_height{720};
+
+Rectangle const display_area{{display_left,  display_top},
+                             {display_width, display_height}};
+
+// there is some wierdness overloading the raw MirPlacementGravity stream operator in Clang, so we wrap it in a struct
+struct AttachedEdges
+{
+    AttachedEdges(MirPlacementGravity edges) : edges{edges} {}
+    AttachedEdges(int edges) : AttachedEdges((MirPlacementGravity)edges) {}
+    operator MirPlacementGravity() const { return edges; }
+    auto operator==(AttachedEdges const& other) const -> bool { return edges == other.edges; }
+    MirPlacementGravity edges;
+};
+
+std::ostream &operator <<(std::ostream &o, AttachedEdges edges)
+{
+    o << "MirPlacementGravity{center";
+    if (edges & mir_placement_gravity_north)
+        o << " | north";
+    if (edges & mir_placement_gravity_south)
+        o << " | south";
+    if (edges & mir_placement_gravity_east)
+        o << " | east";
+    if (edges & mir_placement_gravity_west)
+        o << " | west";
+    o << "}";
+    return o;
+}
+
+struct WindowPlacementAttached : mt::TestWindowManagerTools, WithParamInterface<AttachedEdges>
+{
+    void SetUp() override
+    {
+        basic_window_manager.add_display_for_testing(display_area);
+        basic_window_manager.add_session(session);
+    }
+
+    auto create_window(mir::scene::SurfaceCreationParameters creation_parameters) -> Window
+    {
+        Window result;
+
+        EXPECT_CALL(*window_manager_policy, advise_new_window(_))
+            .WillOnce(
+                Invoke(
+                    [&result](WindowInfo const& window_info)
+                        { result = window_info.window(); }));
+
+        basic_window_manager.add_surface(session, creation_parameters, &create_surface);
+        basic_window_manager.select_active_window(result);
+
+        // Clear the expectations used to capture the window
+        Mock::VerifyAndClearExpectations(window_manager_policy);
+
+        return result;
+    }
+
+    auto placement_for_attachement(Rectangle output_rect, Size window_size, MirPlacementGravity edges) -> Rectangle
+    {
+        std::experimental::optional<X> left;
+        std::experimental::optional<Y> top;
+        std::experimental::optional<X> right;
+        std::experimental::optional<Y> bottom;
+
+        if (edges & mir_placement_gravity_west)
+            left = output_rect.left();
+        if (edges & mir_placement_gravity_east)
+            right = output_rect.right();
+        if (edges & mir_placement_gravity_north)
+            top = output_rect.top();
+        if (edges & mir_placement_gravity_south)
+            bottom = output_rect.bottom();
+
+        if (!left)
+        {
+            if (right)
+                left = right.value() - DeltaX{window_size.width.as_int()};
+            else
+                left = output_rect.left() + DeltaX{(output_rect.size.width - window_size.width).as_int() / 2};
+        }
+        if (!right)
+            right = left.value() + DeltaX{window_size.width.as_int()};
+
+        if (!top)
+        {
+            if (bottom)
+                top = bottom.value() - DeltaY{window_size.height.as_int()};
+            else
+                top = output_rect.top() + DeltaY{(output_rect.size.height - window_size.height).as_int() / 2};
+        }
+        if (!bottom)
+            bottom = top.value() + DeltaY{window_size.height.as_int()};
+
+        Point top_left{left.value(), top.value()};
+        Size size{as_size(Displacement{right.value() - left.value(), bottom.value() - top.value()})};
+
+        return Rectangle{top_left, size};
+    }
+};
+}
+
+TEST_P(WindowPlacementAttached, window_is_initially_placed_correctly)
+{
+    AttachedEdges edges = GetParam();
+    Size window_size{120, 80};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_attached;
+        params.attached_edges = edges;
+        params.size = window_size;
+        window = create_window(params);
+    }
+    auto const& info = basic_window_manager.info_for(window);
+
+    Rectangle placement{placement_for_attachement(display_area, window_size, edges)};
+    AttachedEdges actual_edges = info.attached_edges();
+
+    EXPECT_THAT(info.state(), Eq(mir_window_state_attached));
+    EXPECT_THAT(actual_edges, Eq(edges));
+    EXPECT_THAT(window.top_left(), Eq(placement.top_left));
+    EXPECT_THAT(window.size(), Eq(placement.size));
+}
+
+TEST_P(WindowPlacementAttached, window_is_placed_correctly_when_attached_edges_change)
+{
+    AttachedEdges edges = GetParam();
+    Size window_size{70, 90};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_attached;
+        params.attached_edges = mir_placement_gravity_southwest;
+        params.size = window_size;
+        window = create_window(params);
+    }
+    auto const& info = basic_window_manager.info_for(window);
+
+    WindowSpecification spec;
+    spec.attached_edges() = edges;
+    window_manager_tools.modify_window(window, spec);
+
+    Rectangle placement{placement_for_attachement(display_area, window_size, edges)};
+    AttachedEdges actual_edges = info.attached_edges();
+
+    EXPECT_THAT(info.state(), Eq(mir_window_state_attached));
+    EXPECT_THAT(actual_edges, Eq(edges));
+    EXPECT_THAT(window.top_left(), Eq(placement.top_left));
+    EXPECT_THAT(window.size(), Eq(placement.size));
+}
+
+TEST_P(WindowPlacementAttached, window_is_placed_correctly_when_put_in_attached_state)
+{
+    AttachedEdges edges = GetParam();
+    Point initial_top_left{60, 80};
+    Size window_size{100, 110};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_restored;
+        params.attached_edges = edges;
+        params.size = window_size;
+        params.top_left = initial_top_left;
+        window = create_window(params);
+    }
+    auto const& info = basic_window_manager.info_for(window);
+
+    Rectangle placement{placement_for_attachement(display_area, window_size, edges)};
+
+    EXPECT_THAT(info.state(), Eq(mir_window_state_restored));
+    EXPECT_THAT(window.top_left(), Ne(placement.top_left));
+
+    WindowSpecification spec;
+    spec.state() = mir_window_state_attached;
+    window_manager_tools.modify_window(window, spec);
+
+    AttachedEdges actual_edges = info.attached_edges();
+
+    EXPECT_THAT(info.state(), Eq(mir_window_state_attached));
+    EXPECT_THAT(actual_edges, Eq(edges));
+    EXPECT_THAT(window.top_left(), Eq(placement.top_left));
+    EXPECT_THAT(window.size(), Eq(placement.size));
+}
+
+INSTANTIATE_TEST_CASE_P(WindowPlacementAttached, WindowPlacementAttached, ::testing::Values(
+    mir_placement_gravity_center,
+    mir_placement_gravity_west,
+    mir_placement_gravity_east,
+    mir_placement_gravity_north,
+    mir_placement_gravity_south,
+    mir_placement_gravity_northwest,
+    mir_placement_gravity_northeast,
+    mir_placement_gravity_southwest,
+    mir_placement_gravity_southeast,
+    mir_placement_gravity_west | mir_placement_gravity_east,
+    mir_placement_gravity_west | mir_placement_gravity_east | mir_placement_gravity_north,
+    mir_placement_gravity_west | mir_placement_gravity_east | mir_placement_gravity_south,
+    mir_placement_gravity_north | mir_placement_gravity_south,
+    mir_placement_gravity_north | mir_placement_gravity_south | mir_placement_gravity_east,
+    mir_placement_gravity_north | mir_placement_gravity_south | mir_placement_gravity_west,
+    mir_placement_gravity_north | mir_placement_gravity_south | mir_placement_gravity_east | mir_placement_gravity_west
+));


### PR DESCRIPTION
Add the `mir_surface_type_attached` window state, and two new properties to windows: `attached_edges` and `exclusive_rect`. These will be important for implementing layer surfaces. I still need to add tests, but I want to throw this up now so I can start getting feedback on it.