### PR TITLE
Wlcs integration doesn't need a MockGL

### DIFF
--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -10,7 +10,6 @@ target_link_libraries(
   miral_wlcs_integration
 
   miral-test-framework
-  mir-test-doubles-platform-static
   ${WAYLAND_CLIENT_LDFLAGS} ${WAYLAND_CLIENT_LIBRARIES}
 )
 

--- a/tests/acceptance-tests/wayland/miral_integration.cpp
+++ b/tests/acceptance-tests/wayland/miral_integration.cpp
@@ -50,7 +50,6 @@
 #include "mir_test_framework/fake_input_device.h"
 #include "mir/input/device_capability.h"
 #include "mir/input/input_device_info.h"
-#include "mir/test/doubles/mock_gl.h"
 #include "mir/frontend/session.h"
 #include "mir/scene/session_listener.h"
 #include "mir/scene/surface.h"
@@ -548,7 +547,6 @@ struct MirWlcsDisplayServer : miral::TestDisplayServer, public WlcsDisplayServer
     auto build_window_manager_policy(miral::WindowManagerTools const& tools)
     -> std::unique_ptr<TestWindowManagerPolicy> override;
 
-    testing::NiceMock<mir::test::doubles::MockGL> mockgl;
     std::shared_ptr<ResourceMapper> const resource_mapper{std::make_shared<ResourceMapper>()};
     std::shared_ptr<InputEventListener> event_listener;
     std::shared_ptr<mir::Executor> executor;


### PR DESCRIPTION
Wlcs integration doesn't need a MockGL.