### PR TITLE
Do not place parentless windows relative to existing windows

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -35,11 +35,6 @@
 using namespace mir;
 using namespace mir::geometry;
 
-namespace
-{
-int const title_bar_height = 12;
-}
-
 struct miral::BasicWindowManager::Locker
 {
     explicit Locker(miral::BasicWindowManager* self);
@@ -115,7 +110,7 @@ auto miral::BasicWindowManager::add_surface(
 
     auto& session_info = info_for(session);
 
-    WindowSpecification spec = policy->place_new_window(session_info, place_new_surface(session_info, params));
+    WindowSpecification spec = policy->place_new_window(session_info, place_new_surface(params));
 
     if (!spec.depth_layer().is_set() && spec.parent().is_set())
         if (auto parent_surface = spec.parent().value().lock())
@@ -1569,8 +1564,7 @@ auto miral::BasicWindowManager::can_activate_window_for_session_in_workspace(
     return new_focus;
 }
 
-auto miral::BasicWindowManager::place_new_surface(ApplicationInfo const& app_info, WindowSpecification parameters)
--> WindowSpecification
+auto miral::BasicWindowManager::place_new_surface(WindowSpecification parameters) -> WindowSpecification
 {
     if (!parameters.type().is_set())
         parameters.type() = mir_window_type_normal;
@@ -1594,24 +1588,6 @@ auto miral::BasicWindowManager::place_new_surface(ApplicationInfo const& app_inf
         parameters.size() = rect.size;
         parameters.state() = mir_window_state_fullscreen;
         positioned = true;
-    }
-    else if (!has_parent) // No parent => client can't suggest positioning
-    {
-        if (app_info.windows().size() > 0)
-        {
-            if (auto const default_window = app_info.windows()[0])
-            {
-                static Displacement const offset{title_bar_height, title_bar_height};
-
-                parameters.top_left() = default_window.top_left() + offset;
-
-                Rectangle display_for_app{default_window.top_left(), default_window.size()};
-
-                display_layout->size_to_output(display_for_app);
-
-                positioned = display_for_app.overlaps(Rectangle{parameters.top_left().value(), parameters.size().value()});
-            }
-        }
     }
 
     if (has_parent)

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -269,7 +269,7 @@ private:
         miral::Application const& session,
         std::vector<std::shared_ptr<Workspace>> const& workspaces) -> bool;
 
-    auto place_new_surface(ApplicationInfo const& app_info, WindowSpecification parameters) -> WindowSpecification;
+    auto place_new_surface(WindowSpecification parameters) -> WindowSpecification;
     auto place_relative(mir::geometry::Rectangle const& parent, miral::WindowSpecification const& parameters, Size size)
         -> mir::optional_value<Rectangle>;
 

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -40,6 +40,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     depth_layer.cpp
     output_updates.cpp
     application_zone.cpp
+    initial_window_placement.cpp
     ${MIRAL_TEST_SOURCES}
 )
 

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -27,7 +27,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     active_outputs.cpp
     command_line_option.cpp
     select_active_window.cpp
-    window_placement.cpp
+    popup_window_placement.cpp
     window_placement_anchors_to_parent.cpp
     drag_active_window.cpp
     modify_window_state.cpp

--- a/tests/miral/initial_window_placement.cpp
+++ b/tests/miral/initial_window_placement.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "test_window_manager_tools.h"
+
+using namespace miral;
+using namespace testing;
+namespace mt = mir::test;
+
+namespace
+{
+Rectangle const display_area{{0, 0}, {1280, 720}};
+
+struct InitialWindowPlacement : mt::TestWindowManagerTools
+{
+    void SetUp() override
+    {
+        basic_window_manager.add_display_for_testing(display_area);
+        basic_window_manager.add_session(session);
+    }
+
+    auto create_window(mir::scene::SurfaceCreationParameters creation_parameters) -> Window
+    {
+        Window result;
+
+        EXPECT_CALL(*window_manager_policy, advise_new_window(_))
+            .WillOnce(
+                Invoke(
+                    [&result](WindowInfo const& window_info)
+                        { result = window_info.window(); }));
+
+        basic_window_manager.add_surface(session, creation_parameters, &create_surface);
+        basic_window_manager.select_active_window(result);
+
+        // Clear the expectations used to capture the window
+        Mock::VerifyAndClearExpectations(window_manager_policy);
+
+        return result;
+    }
+};
+}
+
+/// Regression test for https://github.com/MirServer/mir/issues/899
+TEST_F(InitialWindowPlacement, window_is_not_placed_off_screen_when_existing_window_is_close_to_edge)
+{
+    Size first_size{40, 35};
+    Point first_top_left = display_area.bottom_right() - as_displacement(first_size);
+    Size second_size{200, 300};
+
+    Window first;
+    {
+        // Setting the top left in the initial params wasn't working, so we first create the window then move it
+        mir::scene::SurfaceCreationParameters params;
+        params.size = first_size;
+        first = create_window(params);
+        miral::WindowSpecification spec;
+        spec.top_left() = first_top_left;
+        basic_window_manager.modify_window(basic_window_manager.info_for(first), spec);
+    }
+
+    ASSERT_THAT(first.top_left(), Eq(first_top_left))
+        << "Could not run test as the first window could not be positioned correctly";
+
+    Window second;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.size = second_size;
+        second = create_window(params);
+    }
+    Rectangle second_area{second.top_left(), second.size()};
+
+    EXPECT_THAT(second_area.left(), Ge(display_area.left()));
+    EXPECT_THAT(second_area.top(), Ge(display_area.top()));
+    EXPECT_THAT(second_area.right(), Le(display_area.right()));
+    EXPECT_THAT(second_area.bottom(), Le(display_area.bottom()));
+}
+

--- a/tests/miral/popup_window_placement.cpp
+++ b/tests/miral/popup_window_placement.cpp
@@ -41,7 +41,7 @@ mir::shell::SurfaceSpecification edge_attachment(Rectangle const& aux_rect, MirE
     return result;
 }
 
-struct WindowPlacement : mt::TestWindowManagerTools
+struct PopupWindowPlacement : mt::TestWindowManagerTools
 {
     Size const initial_parent_size{600, 400};
     Size const initial_child_size{300, 300};
@@ -116,7 +116,7 @@ struct WindowPlacement : mt::TestWindowManagerTools
 };
 }
 
-TEST_F(WindowPlacement, fixture_sets_up_parent_and_child)
+TEST_F(PopupWindowPlacement, fixture_sets_up_parent_and_child)
 {
     ASSERT_THAT(parent, Ne(null_window));
     ASSERT_THAT(parent.size(), Eq(initial_parent_size));
@@ -139,7 +139,7 @@ TEST_F(WindowPlacement, fixture_sets_up_parent_and_child)
  * edges in the given rectangle.
  */
 
-TEST_F(WindowPlacement, given_aux_rect_away_from_right_side_edge_attachment_vertical_attaches_to_right_edge)
+TEST_F(PopupWindowPlacement, given_aux_rect_away_from_right_side_edge_attachment_vertical_attaches_to_right_edge)
 {
     modification = edge_attachment(rectangle_away_from_rhs, mir_edge_attachment_vertical);
 
@@ -150,7 +150,7 @@ TEST_F(WindowPlacement, given_aux_rect_away_from_right_side_edge_attachment_vert
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_right_side_edge_attachment_vertical_attaches_to_left_edge)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_right_side_edge_attachment_vertical_attaches_to_left_edge)
 {
     modification = edge_attachment(rectangle_near_rhs, mir_edge_attachment_vertical);
 
@@ -161,7 +161,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_right_side_edge_attachment_vertical_
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_both_sides_edge_attachment_vertical_attaches_to_right_edge)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_both_sides_edge_attachment_vertical_attaches_to_right_edge)
 {
     modification = edge_attachment(rectangle_near_both_sides, mir_edge_attachment_vertical);
 
@@ -172,7 +172,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_both_sides_edge_attachment_vertical_
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_away_from_bottom_edge_attachment_horizontal_attaches_to_bottom_edge)
+TEST_F(PopupWindowPlacement, given_aux_rect_away_from_bottom_edge_attachment_horizontal_attaches_to_bottom_edge)
 {
     modification = edge_attachment(rectangle_away_from_bottom, mir_edge_attachment_horizontal);
 
@@ -183,7 +183,7 @@ TEST_F(WindowPlacement, given_aux_rect_away_from_bottom_edge_attachment_horizont
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_bottom_edge_attachment_horizontal_attaches_to_top_edge)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_bottom_edge_attachment_horizontal_attaches_to_top_edge)
 {
     modification = edge_attachment(rectangle_near_bottom, mir_edge_attachment_horizontal);
 
@@ -194,7 +194,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_bottom_edge_attachment_horizontal_at
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_both_sides_edge_attachment_any_attaches_to_bottom_edge)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_both_sides_edge_attachment_any_attaches_to_bottom_edge)
 {
     modification = edge_attachment(rectangle_near_both_sides, mir_edge_attachment_any);
 
@@ -205,7 +205,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_both_sides_edge_attachment_any_attac
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_both_sides_and_bottom_edge_attachment_any_attaches_to_top_edge)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_both_sides_and_bottom_edge_attachment_any_attaches_to_top_edge)
 {
     modification = edge_attachment(rectangle_near_both_sides_and_bottom, mir_edge_attachment_any);
 
@@ -216,7 +216,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_both_sides_and_bottom_edge_attachmen
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_all_sides_attachment_any_attaches_to_right_edge)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_all_sides_attachment_any_attaches_to_right_edge)
 {
     modification = edge_attachment(rectangle_near_all_sides, mir_edge_attachment_any);
 
@@ -282,7 +282,7 @@ auto position_of(MirPlacementGravity rect_gravity, Rectangle rectangle) -> Point
 }
 }
 
-TEST_F(WindowPlacement, given_no_hints_can_attach_by_every_gravity)
+TEST_F(PopupWindowPlacement, given_no_hints_can_attach_by_every_gravity)
 {
     modification.aux_rect() = Rectangle{{100, 50}, { 20, 20}};
     modification.placement_hints() = MirPlacementHints{};
@@ -309,7 +309,7 @@ TEST_F(WindowPlacement, given_no_hints_can_attach_by_every_gravity)
     }
 }
 
-TEST_F(WindowPlacement, given_no_hints_can_attach_by_offset_at_every_gravity)
+TEST_F(PopupWindowPlacement, given_no_hints_can_attach_by_offset_at_every_gravity)
 {
     auto const offset = Displacement{42, 13};
 
@@ -339,7 +339,7 @@ TEST_F(WindowPlacement, given_no_hints_can_attach_by_offset_at_every_gravity)
     }
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_right_side_and_offset_placement_is_flipped)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_right_side_and_offset_placement_is_flipped)
 {
     DeltaX const x_offset{42};
     DeltaY const y_offset{13};
@@ -357,7 +357,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_right_side_and_offset_placement_is_f
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_bottom_and_offset_placement_is_flipped)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_bottom_and_offset_placement_is_flipped)
 {
     DeltaX const x_offset{42};
     DeltaY const y_offset{13};
@@ -375,7 +375,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_bottom_and_offset_placement_is_flipp
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_bottom_right_and_offset_placement_is_flipped_both_ways)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_bottom_right_and_offset_placement_is_flipped_both_ways)
 {
     Displacement const displacement{42, 13};
 
@@ -392,7 +392,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_bottom_right_and_offset_placement_is
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_right_side_placement_can_slide_in_x)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_right_side_placement_can_slide_in_x)
 {
     modification.aux_rect() = rectangle_near_rhs;
     modification.placement_hints() = mir_placement_hints_slide_x;
@@ -406,7 +406,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_right_side_placement_can_slide_in_x)
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_left_side_placement_can_slide_in_x)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_left_side_placement_can_slide_in_x)
 {
     Rectangle const rectangle_near_left_side{{0, 20}, {20, 20}};
 
@@ -422,7 +422,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_left_side_placement_can_slide_in_x)
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_bottom_placement_can_slide_in_y)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_bottom_placement_can_slide_in_y)
 {
     modification.aux_rect() = rectangle_near_bottom;
     modification.placement_hints() = mir_placement_hints_slide_y;
@@ -438,7 +438,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_bottom_placement_can_slide_in_y)
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_top_placement_can_slide_in_y)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_top_placement_can_slide_in_y)
 {
     modification.aux_rect() = rectangle_near_all_sides;
     modification.placement_hints() = mir_placement_hints_slide_y;
@@ -452,7 +452,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_top_placement_can_slide_in_y)
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_bottom_right_and_offset_placement_can_slide_in_x_and_y)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_bottom_right_and_offset_placement_can_slide_in_x_and_y)
 {
     modification.aux_rect() = rectangle_near_both_bottom_right;
     modification.placement_hints() = mir_placement_hints_slide_any;
@@ -466,7 +466,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_bottom_right_and_offset_placement_ca
     ASSERT_THAT(child.top_left(), Eq(expected_position));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_right_side_placement_can_resize_in_x)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_right_side_placement_can_resize_in_x)
 {
     modification.aux_rect() = rectangle_near_rhs;
     modification.placement_hints() = mir_placement_hints_resize_x;
@@ -483,7 +483,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_right_side_placement_can_resize_in_x
     ASSERT_THAT(child.size(), Eq(expected_size));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_left_side_placement_can_resize_in_x)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_left_side_placement_can_resize_in_x)
 {
     Rectangle const rectangle_near_left_side{{0, 20}, {20, 20}};
 
@@ -502,7 +502,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_left_side_placement_can_resize_in_x)
     ASSERT_THAT(child.size(), Eq(expected_size));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_bottom_placement_can_resize_in_y)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_bottom_placement_can_resize_in_y)
 {
     modification.aux_rect() = rectangle_near_bottom;
     modification.placement_hints() = mir_placement_hints_resize_y;
@@ -519,7 +519,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_bottom_placement_can_resize_in_y)
     ASSERT_THAT(child.size(), Eq(expected_size));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_top_placement_can_resize_in_y)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_top_placement_can_resize_in_y)
 {
     modification.aux_rect() = rectangle_near_all_sides;
     modification.placement_hints() = mir_placement_hints_resize_y;
@@ -536,7 +536,7 @@ TEST_F(WindowPlacement, given_aux_rect_near_top_placement_can_resize_in_y)
     ASSERT_THAT(child.size(), Eq(expected_size));
 }
 
-TEST_F(WindowPlacement, given_aux_rect_near_bottom_right_and_offset_placement_can_resize_in_x_and_y)
+TEST_F(PopupWindowPlacement, given_aux_rect_near_bottom_right_and_offset_placement_can_resize_in_x_and_y)
 {
     modification.aux_rect() = rectangle_near_both_bottom_right;
     modification.placement_hints() = mir_placement_hints_resize_any;


### PR DESCRIPTION
It may be useful to review this commit-by-commit. This fixes #899 by simply removing the code that tries to position parent-less windows relative to existing windows of the same application. In some cases the old behavior may be desirable, but `BasicWindowManager` is too complex already to continue adding support for complex unneeded features. If in the future we build a more modular, abstracted and generally better engineered window manager, we can think about reintroducing such features. Also, the old behavior was untested, so it must not have been *that* important.