### PR TITLE
[wlcs test fixture] Configure wayland extensions

### DIFF
--- a/include/test/miral/test_display_server.h
+++ b/include/test/miral/test_display_server.h
@@ -48,6 +48,7 @@ private:
 struct TestDisplayServer : private TestRuntimeEnvironment
 {
     TestDisplayServer();
+    TestDisplayServer(int argc, char const** argv);
 
     virtual ~TestDisplayServer();
 

--- a/tests/acceptance-tests/wayland/miral_integration.cpp
+++ b/tests/acceptance-tests/wayland/miral_integration.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <miral/test_wlcs_display_server.h>
+#include <miral/wayland_extensions.h>
 
 namespace
 {
@@ -45,9 +46,24 @@ WlcsIntegrationDescriptor const* get_descriptor(WlcsDisplayServer const* /*serve
     return &descriptor;
 }
 
+struct TestWlcsDisplayServer : miral::TestWlcsDisplayServer
+{
+    miral::WaylandExtensions wayland_extensions;
+
+    TestWlcsDisplayServer(int argc, char const** argv) :
+        miral::TestWlcsDisplayServer{argc, argv}
+    {
+        for (auto const& extension : wayland_extensions.supported())
+        {
+            wayland_extensions.enable(extension);
+        }
+        add_server_init(wayland_extensions);
+    }
+};
+
 WlcsDisplayServer* wlcs_create_server(int argc, char const** argv)
 {
-    auto server = new miral::TestWlcsDisplayServer(argc, argv);
+    auto server = new TestWlcsDisplayServer(argc, argv);
 
     server->get_descriptor = &get_descriptor;
     return server;

--- a/tests/mir_test_framework/test_display_server.cpp
+++ b/tests/mir_test_framework/test_display_server.cpp
@@ -50,7 +50,12 @@ char const* const trace_option = "window-management-trace";
 }
 
 miral::TestDisplayServer::TestDisplayServer() :
-    runner{1, dummy_args}
+    TestDisplayServer{1, dummy_args}
+{
+}
+
+miral::TestDisplayServer::TestDisplayServer(int argc, char const** argv) :
+    runner{argc, argv}
 {
     add_to_environment("MIR_SERVER_PLATFORM_GRAPHICS_LIB", mtf::server_platform("graphics-dummy.so").c_str());
     add_to_environment("MIR_SERVER_PLATFORM_INPUT_LIB", mtf::server_platform("input-stub.so").c_str());

--- a/tests/mir_test_framework/test_wlcs_display_server.cpp
+++ b/tests/mir_test_framework/test_wlcs_display_server.cpp
@@ -800,6 +800,7 @@ WlcsTouch* wlcs_server_create_touch(WlcsDisplayServer* server)
 }
 
 miral::TestWlcsDisplayServer::TestWlcsDisplayServer(int argc, char const** argv) :
+    TestDisplayServer{argc, argv},
     resource_mapper{std::make_shared<ResourceMapper>()},
     event_listener{std::make_shared<InputEventListener>(*this)}
 {
@@ -815,14 +816,12 @@ miral::TestWlcsDisplayServer::TestWlcsDisplayServer(int argc, char const** argv)
     add_to_environment("MIR_SERVER_WAYLAND_SOCKET_NAME", "wlcs-tests");
     add_to_environment("WAYLAND_DISPLAY", "wlcs-tests");
 
-    add_server_init([this, argc, argv](mir::Server& server)
+    add_server_init([this](mir::Server& server)
         {
             server.override_the_session_listener([this]()
                 {
                     return resource_mapper;
                 });
-
-            server.set_command_line(argc, argv);
 
             server.wrap_cursor_listener(
                 [this](auto const& wrappee)


### PR DESCRIPTION
[wlcs test fixture] Configure wayland extensions. (Fixes #906)

1. Ensure all supported Wayland extensions are switched on by default.
2. Fix command-line processing so that `--wayland-extensions` can be used.
