### PR TITLE
Add missing geometry overloads and converters

### DIFF
--- a/examples/example-server-lib/floating_window_manager.cpp
+++ b/examples/example-server-lib/floating_window_manager.cpp
@@ -374,8 +374,8 @@ bool FloatingWindowManagerPolicy::handle_keyboard_event(MirKeyboardEvent const* 
                     (modifications.size().is_set() ? modifications.size().value() : active_window.size()).width;
 
                 modifications.top_left() = window_info.needs_titlebar(window_info.type()) ?
-                                           active_output.top_right() - as_displacement({new_width, 0}) + title_bar_height :
-                                           active_output.top_right() - as_displacement({new_width, 0});
+                                           active_output.top_right() - Displacement{as_delta(new_width), 0} + title_bar_height :
+                                           active_output.top_right() - Displacement{as_delta(new_width), 0};
                 break;
             }
 

--- a/include/core/mir/geometry/dimensions.h
+++ b/include/core/mir/geometry/dimensions.h
@@ -169,6 +169,20 @@ inline constexpr DeltaX operator*(DeltaX const& dx, Scalar scale) { return scale
 template<typename Scalar>
 inline constexpr DeltaY operator*(DeltaY const& dy, Scalar scale) { return scale*dy; }
 
+// Converting between types is fine, as long as they are along the same axis
+inline constexpr Width as_width(DeltaX const& dx) { return Width{dx.as_int()}; }
+inline constexpr Height as_height(DeltaY const& dy) { return Height{dy.as_int()}; }
+inline constexpr X as_x(DeltaX const& dx) { return X{dx.as_int()}; }
+inline constexpr Y as_y(DeltaY const& dy) { return Y{dy.as_int()}; }
+inline constexpr DeltaX as_delta(X const& x) { return DeltaX{x.as_int()}; }
+inline constexpr DeltaY as_delta(Y const& y) { return DeltaY{y.as_int()}; }
+inline constexpr X as_x(Width const& w) { return X{w.as_int()}; }
+inline constexpr Y as_y(Height const& h) { return Y{h.as_int()}; }
+inline constexpr Width as_width(X const& x) { return Width{x.as_int()}; }
+inline constexpr Height as_height(Y const& y) { return Height{y.as_int()}; }
+inline constexpr DeltaX as_delta(Width const& w) { return DeltaX{w.as_int()}; }
+inline constexpr DeltaY as_delta(Height const& h) { return DeltaY{h.as_int()}; }
+
 template<typename Target, typename Source>
 inline constexpr Target dim_cast(Source s) { return Target(s.as_int()); }
 }

--- a/include/core/mir/geometry/dimensions.h
+++ b/include/core/mir/geometry/dimensions.h
@@ -118,22 +118,30 @@ inline constexpr DeltaX operator+(DeltaX lhs, DeltaX rhs) { return DeltaX(lhs.as
 inline constexpr DeltaY operator+(DeltaY lhs, DeltaY rhs) { return DeltaY(lhs.as_int() + rhs.as_int()); }
 inline constexpr DeltaX operator-(DeltaX lhs, DeltaX rhs) { return DeltaX(lhs.as_int() - rhs.as_int()); }
 inline constexpr DeltaY operator-(DeltaY lhs, DeltaY rhs) { return DeltaY(lhs.as_int() - rhs.as_int()); }
+inline DeltaX& operator+=(DeltaX& lhs, DeltaX rhs) { return lhs = lhs + rhs; }
+inline DeltaY& operator+=(DeltaY& lhs, DeltaY rhs) { return lhs = lhs + rhs; }
+inline DeltaX& operator-=(DeltaX& lhs, DeltaX rhs) { return lhs = lhs - rhs; }
+inline DeltaY& operator-=(DeltaY& lhs, DeltaY rhs) { return lhs = lhs - rhs; }
 
 // Adding deltas to co-ordinates is fine
 inline constexpr X operator+(X lhs, DeltaX rhs) { return X(lhs.as_int() + rhs.as_int()); }
 inline constexpr Y operator+(Y lhs, DeltaY rhs) { return Y(lhs.as_int() + rhs.as_int()); }
 inline constexpr X operator-(X lhs, DeltaX rhs) { return X(lhs.as_int() - rhs.as_int()); }
 inline constexpr Y operator-(Y lhs, DeltaY rhs) { return Y(lhs.as_int() - rhs.as_int()); }
-inline X& operator+=(X& lhs, DeltaX rhs) { return lhs = X(lhs.as_int() + rhs.as_int()); }
-inline Y& operator+=(Y& lhs, DeltaY rhs) { return lhs = Y(lhs.as_int() + rhs.as_int()); }
-inline X& operator-=(X& lhs, DeltaX rhs) { return lhs = X(lhs.as_int() - rhs.as_int()); }
-inline Y& operator-=(Y& lhs, DeltaY rhs) { return lhs = Y(lhs.as_int() - rhs.as_int()); }
+inline X& operator+=(X& lhs, DeltaX rhs) { return lhs = lhs + rhs; }
+inline Y& operator+=(Y& lhs, DeltaY rhs) { return lhs = lhs + rhs; }
+inline X& operator-=(X& lhs, DeltaX rhs) { return lhs = lhs - rhs; }
+inline Y& operator-=(Y& lhs, DeltaY rhs) { return lhs = lhs - rhs; }
 
 // Adding deltas to Width and Height is fine
 inline constexpr Width operator+(Width lhs, DeltaX rhs) { return Width(lhs.as_int() + rhs.as_int()); }
 inline constexpr Height operator+(Height lhs, DeltaY rhs) { return Height(lhs.as_int() + rhs.as_int()); }
 inline constexpr Width operator-(Width lhs, DeltaX rhs) { return Width(lhs.as_int() - rhs.as_int()); }
 inline constexpr Height operator-(Height lhs, DeltaY rhs) { return Height(lhs.as_int() - rhs.as_int()); }
+inline Width& operator+=(Width& lhs, DeltaX rhs) { return lhs = lhs + rhs; }
+inline Height& operator+=(Height& lhs, DeltaY rhs) { return lhs = lhs + rhs; }
+inline Width& operator-=(Width& lhs, DeltaX rhs) { return lhs = lhs - rhs; }
+inline Height& operator-=(Height& lhs, DeltaY rhs) { return lhs = lhs - rhs; }
 
 // Subtracting coordinates is fine
 inline constexpr DeltaX operator-(X lhs, X rhs) { return DeltaX(lhs.as_int() - rhs.as_int()); }

--- a/include/core/mir/geometry/displacement.h
+++ b/include/core/mir/geometry/displacement.h
@@ -21,6 +21,7 @@
 
 #include "mir/geometry/dimensions.h"
 #include "mir/geometry/point.h"
+#include "mir/geometry/size.h"
 
 #include <iosfwd>
 
@@ -107,7 +108,6 @@ inline constexpr Displacement operator*(Displacement const& disp, Scalar scale)
     return scale*disp;
 }
 
-#ifdef MIR_GEOMETRY_SIZE_H_
 inline constexpr Displacement as_displacement(Size const& size)
 {
     return Displacement{size.width.as_int(), size.height.as_int()};
@@ -117,7 +117,6 @@ inline constexpr Size as_size(Displacement const& disp)
 {
     return Size{disp.dx.as_int(), disp.dy.as_int()};
 }
-#endif
 }
 }
 

--- a/include/core/mir/geometry/displacement.h
+++ b/include/core/mir/geometry/displacement.h
@@ -117,6 +117,16 @@ inline constexpr Size as_size(Displacement const& disp)
 {
     return Size{disp.dx.as_int(), disp.dy.as_int()};
 }
+
+inline constexpr Displacement as_displacement(Point const& point)
+{
+    return Displacement{point.x.as_int(), point.y.as_int()};
+}
+
+inline constexpr Point as_point(Displacement const& disp)
+{
+    return Point{disp.dx.as_int(), disp.dy.as_int()};
+}
 }
 }
 

--- a/include/core/mir/geometry/size.h
+++ b/include/core/mir/geometry/size.h
@@ -20,6 +20,7 @@
 #define MIR_GEOMETRY_SIZE_H_
 
 #include "mir/geometry/dimensions.h"
+#include "point.h"
 #include <iosfwd>
 
 namespace mir
@@ -62,6 +63,16 @@ template<typename Scalar>
 inline constexpr Size operator*(Size const& size, Scalar scale)
 {
     return scale*size;
+}
+
+inline constexpr Size as_size(Point const& point)
+{
+    return Size{point.x.as_int(), point.y.as_int()};
+}
+
+inline constexpr Point as_point(Size const& size)
+{
+    return Point{size.width.as_int(), size.height.as_int()};
 }
 }
 }

--- a/include/core/mir/geometry/size.h
+++ b/include/core/mir/geometry/size.h
@@ -63,18 +63,6 @@ inline constexpr Size operator*(Size const& size, Scalar scale)
 {
     return scale*size;
 }
-
-#ifdef MIR_GEOMETRY_DISPLACEMENT_H_
-inline constexpr Displacement as_displacement(Size const& size)
-{
-    return Displacement{size.width.as_int(), size.height.as_int()};
-}
-
-inline constexpr Size as_size(Displacement const& disp)
-{
-    return Size{disp.dx.as_int(), disp.dy.as_int()};
-}
-#endif
 }
 }
 

--- a/tests/miral/display_reconfiguration.cpp
+++ b/tests/miral/display_reconfiguration.cpp
@@ -80,7 +80,8 @@ TEST_F(DisplayConfiguration, given_fullscreen_windows_reconfiguring_displays_doe
     mods.state() = mir_window_state_fullscreen;
     window_manager_tools.modify_window(window, mods);
 
-    Rectangle const new_display{display_area.top_left+as_displacement({display_width, Height{0}}), display_area.size};
+    Rectangle const new_display{
+        display_area.top_left + Displacement{as_delta(display_width), 0}, display_area.size};
 
     basic_window_manager.add_display_for_testing(new_display);
     basic_window_manager.remove_display(new_display);


### PR DESCRIPTION
Add a functions to make our ~over-engineered~ expressive and typesafe geometry system more usable. Hopefully this will get rid of randomly subtracting `Width{}` or `X{}` from everything in the expression until it compiles.