### PR TITLE
Layer shell popups

### DIFF
--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -160,11 +160,7 @@ void mf::LayerSurfaceV1::set_keyboard_interactivity(uint32_t keyboard_interactiv
 
 void mf::LayerSurfaceV1::get_popup(struct wl_resource* popup)
 {
-    auto popup_window_role =
-        static_cast<WindowWlSurfaceRole*>(
-            static_cast<XdgPopupStable*>(
-                static_cast<wayland::XdgPopup*>(
-                    wl_resource_get_user_data(popup))));
+    auto* const popup_window_role = XdgPopupStable::from(popup);
 
     mir::shell::SurfaceSpecification specification;
     specification.parent_id = surface_id();

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -20,6 +20,7 @@
 
 #include "wl_surface.h"
 #include "window_wl_surface_role.h"
+#include "xdg_shell_stable.h"
 
 #include "mir/shell/surface_specification.h"
 
@@ -159,7 +160,16 @@ void mf::LayerSurfaceV1::set_keyboard_interactivity(uint32_t keyboard_interactiv
 
 void mf::LayerSurfaceV1::get_popup(struct wl_resource* popup)
 {
-    (void)popup;
+    auto popup_window_role =
+        static_cast<WindowWlSurfaceRole*>(
+            static_cast<XdgPopupStable*>(
+                static_cast<wayland::XdgPopup*>(
+                    wl_resource_get_user_data(popup))));
+
+    mir::shell::SurfaceSpecification specification;
+    specification.parent_id = surface_id();
+
+    popup_window_role->apply_spec(specification);
 }
 
 void mf::LayerSurfaceV1::ack_configure(uint32_t serial)

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -25,6 +25,8 @@
 #include "mir/shell/surface_specification.h"
 #include "mir/log.h"
 
+#include <boost/throw_exception.hpp>
+
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
 namespace mw = mir::wayland;
@@ -323,6 +325,14 @@ void mf::XdgPopupStable::handle_resize(const std::experimental::optional<geometr
                              cached_size.value().height.as_int());
         xdg_surface->send_configure();
     }
+}
+
+auto mf::XdgPopupStable::from(wl_resource* resource) -> XdgPopupStable*
+{
+    auto popup = dynamic_cast<XdgPopupStable*>(wayland::XdgPopup::from(resource));
+    if (!popup)
+        BOOST_THROW_EXCEPTION(std::runtime_error("Invalid resource given to XdgPopupStable::from()"));
+    return popup;
 }
 
 // XdgToplevelStable

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -211,16 +211,18 @@ void mf::XdgSurfaceStable::get_popup(
     std::experimental::optional<struct wl_resource*> const& parent_surface,
     wl_resource* positioner)
 {
-    std::experimental::optional<WindowWlSurfaceRole*> parent_window_role;
+    std::experimental::optional<WlSurfaceRole*> parent_role;
     if (parent_surface)
     {
         XdgSurfaceStable* parent_xdg_surface = XdgSurfaceStable::from(parent_surface.value());
-        parent_window_role = parent_xdg_surface->window_role();
-        if (!parent_window_role)
+        std::experimental::optional<WindowWlSurfaceRole*> parent_window_role = parent_xdg_surface->window_role();
+        if (parent_window_role)
+            parent_role = static_cast<WlSurfaceRole*>(parent_window_role.value());
+        else
             log_warning("Parent window of a popup has no role");
     }
 
-    auto popup = new XdgPopupStable{new_popup, this, parent_window_role, positioner, surface};
+    auto popup = new XdgPopupStable{new_popup, this, parent_role, positioner, surface};
     set_window_role(popup);
 }
 

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -20,6 +20,7 @@
 #define MIR_FRONTEND_XDG_SHELL_STABLE_H
 
 #include "xdg-shell_wrapper.h"
+#include "window_wl_surface_role.h"
 
 namespace mir
 {
@@ -30,6 +31,8 @@ class Shell;
 class Surface;
 class WlSeat;
 class OutputManager;
+class WlSurface;
+class XdgSurfaceStable;
 
 class XdgShellStable : public wayland::XdgWmBase::Global
 {
@@ -44,6 +47,32 @@ public:
 private:
     class Instance;
     void bind(wl_resource* new_resource) override;
+};
+
+class XdgPopupStable : public wayland::XdgPopup, public WindowWlSurfaceRole
+{
+public:
+    XdgPopupStable(
+        wl_resource* new_resource,
+        XdgSurfaceStable* xdg_surface,
+        std::experimental::optional<WlSurfaceRole*> parent_role,
+        wl_resource* positioner,
+        WlSurface* surface);
+
+    void grab(struct wl_resource* seat, uint32_t serial) override;
+    void destroy() override;
+
+    void handle_state_change(MirWindowState /*new_state*/) override {};
+    void handle_active_change(bool /*is_now_active*/) override {};
+    void handle_resize(
+        std::experimental::optional<geometry::Point> const& new_top_left,
+        geometry::Size const& new_size) override;
+
+private:
+    std::experimental::optional<geometry::Point> cached_top_left;
+    std::experimental::optional<geometry::Size> cached_size;
+
+    XdgSurfaceStable* const xdg_surface;
 };
 
 }

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -68,6 +68,8 @@ public:
         std::experimental::optional<geometry::Point> const& new_top_left,
         geometry::Size const& new_size) override;
 
+    static auto from(wl_resource* resource) -> XdgPopupStable*;
+
 private:
     std::experimental::optional<geometry::Point> cached_top_left;
     std::experimental::optional<geometry::Size> cached_size;


### PR DESCRIPTION
Allow layer shell surfaces to make XDG popups.

If you desire to test you can do so with gtk-layer-demo from [GTK Layer Shell](https://github.com/wmww/gtk-layer-shell), though It's probably sufficient to just convince yourself it doesn't break XDG shell. WLCS tests will be ready at some point.