### PR TITLE
Make Layer Shell usable

### DIFF
--- a/examples/example-server-lib/floating_window_manager.cpp
+++ b/examples/example-server-lib/floating_window_manager.cpp
@@ -488,6 +488,7 @@ WindowSpecification FloatingWindowManagerPolicy::place_new_window(
     if (app_info.application() == decoration_provider->session())
     {
         parameters.type() = mir_window_type_decoration;
+        parameters.depth_layer() = mir_depth_layer_background;
     }
 
     bool const needs_titlebar = WindowInfo::needs_titlebar(parameters.type().value());

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -87,6 +87,18 @@ public:
     ~LayerSurfaceV1() = default;
 
 private:
+    void update_mir_surface();
+
+    /// Returns all anchored edges ored together
+    auto get_placement_gravity() const -> MirPlacementGravity;
+
+    /// Returns the edge from which we can have an exclusive zone
+    /// Returns only left, right, top, bottom, or center if we are not anchored to an edge
+    auto get_anchored_edge() const -> MirPlacementGravity;
+
+    /// Returns the rectangele in surface coords that this surface is exclusive for (if any)
+    auto get_exclusive_rect() const -> std::experimental::optional<geom::Rectangle>;
+
     // from wayland::LayerSurfaceV1
     void set_size(uint32_t width, uint32_t height) override;
     void set_anchor(uint32_t anchor) override;
@@ -103,6 +115,12 @@ private:
     void handle_resize(
         std::experimental::optional<geometry::Point> const& new_top_left,
         geometry::Size const& new_size) override;
+
+    uint32_t exclusive_zone{0};
+    bool anchored_left{false};
+    bool anchored_right{false};
+    bool anchored_top{false};
+    bool anchored_bottom{false};
 };
 
 }
@@ -167,6 +185,102 @@ mf::LayerSurfaceV1::LayerSurfaceV1(
     send_configure_event (serial, 0, 0);
 }
 
+void mf::LayerSurfaceV1::update_mir_surface()
+{
+    mir::optional_value<geom::Rectangle> exclusive_rect_mir;
+    std::experimental::optional<geom::Rectangle> exclusive_rect_std = get_exclusive_rect();
+    if (exclusive_rect_std)
+        exclusive_rect_mir = exclusive_rect_std.value();
+
+    shell::SurfaceSpecification spec;
+    spec.attached_edges = get_placement_gravity();
+    spec.exclusive_rect = exclusive_rect_mir;
+    apply_spec(spec);
+}
+
+auto mf::LayerSurfaceV1::get_placement_gravity() const -> MirPlacementGravity
+{
+    MirPlacementGravity edges = mir_placement_gravity_center;
+
+    if (anchored_left)
+        edges = MirPlacementGravity(edges | mir_placement_gravity_west);
+
+    if (anchored_right)
+        edges = MirPlacementGravity(edges | mir_placement_gravity_east);
+
+    if (anchored_top)
+        edges = MirPlacementGravity(edges | mir_placement_gravity_north);
+
+    if (anchored_bottom)
+        edges = MirPlacementGravity(edges | mir_placement_gravity_south);
+
+    return edges;
+}
+
+auto mf::LayerSurfaceV1::get_anchored_edge() const -> MirPlacementGravity
+{
+    MirPlacementGravity h_edge = mir_placement_gravity_center;
+    MirPlacementGravity v_edge = mir_placement_gravity_center;
+
+    if (anchored_left != anchored_right)
+    {
+        if (anchored_left)
+            h_edge = mir_placement_gravity_east;
+        else
+            h_edge = mir_placement_gravity_west;
+    }
+
+    if (anchored_top != anchored_bottom)
+    {
+        if (anchored_top)
+            v_edge = mir_placement_gravity_north;
+        else
+            v_edge = mir_placement_gravity_south;
+    }
+
+    if (h_edge == mir_placement_gravity_center)
+        return v_edge;
+    else if (v_edge == mir_placement_gravity_center)
+        return h_edge;
+    else
+        return mir_placement_gravity_center;
+}
+
+auto mf::LayerSurfaceV1::get_exclusive_rect() const -> std::experimental::optional<geom::Rectangle>
+{
+    if (exclusive_zone <= 0)
+        return std::experimental::nullopt;
+
+    auto edge = get_anchored_edge();
+    auto size = window_size().value_or(geom::Size{1, 1});
+
+    switch (edge)
+    {
+    case mir_placement_gravity_west:
+        return geom::Rectangle{
+            {0, 0},
+            {exclusive_zone, size.height}};
+
+    case mir_placement_gravity_east:
+        return geom::Rectangle{
+            {geom::as_x(size.width) - geom::DeltaX{exclusive_zone}, 0},
+            {exclusive_zone, size.height}};
+
+    case mir_placement_gravity_north:
+        return geom::Rectangle{
+            {0, 0},
+            {size.width, exclusive_zone}};
+
+    case mir_placement_gravity_south:
+        return geom::Rectangle{
+            {0, geom::as_y(size.height) - geom::DeltaY{exclusive_zone}},
+            {size.width, exclusive_zone}};
+
+    default:
+        return std::experimental::nullopt;
+    }
+}
+
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
 {
     // HACK: Leaving zero sizes zero causes a validation error, and setting them to window_size() causes
@@ -181,28 +295,18 @@ void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
 
 void mf::LayerSurfaceV1::set_anchor(uint32_t anchor)
 {
-    MirPlacementGravity edges = mir_placement_gravity_center;
+    anchored_left = anchor & Anchor::left;
+    anchored_right = anchor & Anchor::right;
+    anchored_top = anchor & Anchor::top;
+    anchored_bottom = anchor & Anchor::bottom;
 
-    if (anchor & Anchor::top)
-        edges = MirPlacementGravity(edges | mir_placement_gravity_north);
-
-    if (anchor & Anchor::bottom)
-        edges = MirPlacementGravity(edges | mir_placement_gravity_south);
-
-    if (anchor & Anchor::left)
-        edges = MirPlacementGravity(edges | mir_placement_gravity_west);
-
-    if (anchor & Anchor::right)
-        edges = MirPlacementGravity(edges | mir_placement_gravity_east);
-
-    shell::SurfaceSpecification spec;
-    spec.attached_edges = edges;
-    apply_spec(spec);
+    update_mir_surface();
 }
 
 void mf::LayerSurfaceV1::set_exclusive_zone(int32_t zone)
 {
-    (void)zone;
+    exclusive_zone = zone;
+    update_mir_surface();
 }
 
 void mf::LayerSurfaceV1::set_margin(int32_t top, int32_t right, int32_t bottom, int32_t left)

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -130,6 +130,8 @@ mf::LayerSurfaceV1::LayerSurfaceV1(wl_resource* new_resource, WlSurface* surface
     shell::SurfaceSpecification spec;
     spec.state = mir_window_state_attached;
     apply_spec(spec);
+    auto const serial = wl_display_next_serial(wl_client_get_display(wayland::LayerSurfaceV1::client));
+    send_configure_event (serial, 0, 0);
 }
 
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
@@ -196,5 +198,7 @@ void mf::LayerSurfaceV1::handle_resize(
     geometry::Size const& new_size)
 {
     (void)new_top_left;
-    (void)new_size;
+
+    auto const serial = wl_display_next_serial(wl_client_get_display(wayland::LayerSurfaceV1::client));
+    send_configure_event (serial, new_size.width.as_int(), new_size.height.as_int());
 }

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -136,6 +136,13 @@ mf::LayerSurfaceV1::LayerSurfaceV1(wl_resource* new_resource, WlSurface* surface
 
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
 {
+    // HACK: Leaving zero sizes zero causes a validation error, and setting them to window_size() causes
+    //       to not call WlSurfaceEventSink::handle_resize(). Setting them to 1 works for now. This will get fixed when
+    //       we refactor size negotiation between the window manager and the frontend.
+    if (width == 0)
+        width = 1;
+    if (height == 0)
+        height = 1;
     WindowWlSurfaceRole::set_geometry(0, 0, width, height);
 }
 

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -240,7 +240,7 @@ void mf::WindowWlSurfaceRole::set_state_now(MirWindowState state)
     }
 }
 
-std::experimental::optional<geom::Size> mf::WindowWlSurfaceRole::window_size()
+std::experimental::optional<geom::Size> mf::WindowWlSurfaceRole::window_size() const
 {
     if (pending_window_size)
         return pending_window_size;

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -87,7 +87,7 @@ public:
 protected:
     std::shared_ptr<bool> const destroyed;
 
-    std::experimental::optional<geometry::Size> window_size();
+    std::experimental::optional<geometry::Size> window_size() const;
     std::experimental::optional<geometry::Size> requested_window_size(); // Window size requested by Mir
     MirWindowState window_state();
     bool is_active();


### PR DESCRIPTION
This implements the bulk of Layer Shell features:
* Anchors
* Depth layers
* Resizing
* Exclusive zones

Still needs WLCS tests, that will be my next mir related thing. You can test manually with gtk-layer-demo from [GTK Layer Shell](https://github.com/wmww/gtk-layer-shell).