### PR TITLE
Fix google::protobuf::closure related errors (protobuf 3.8.0)

### DIFF
--- a/src/client/rpc/mir_basic_rpc_channel.h
+++ b/src/client/rpc/mir_basic_rpc_channel.h
@@ -27,6 +27,8 @@
 #include <condition_variable>
 #include <functional>
 
+#include <google/protobuf/stubs/callback.h>
+
 namespace google
 {
 namespace protobuf

--- a/src/include/common/mir/protobuf/display_server.h
+++ b/src/include/common/mir/protobuf/display_server.h
@@ -19,6 +19,7 @@
 #ifndef MIR_PROTOBUF_DISPLAY_SERVER_H_
 #define MIR_PROTOBUF_DISPLAY_SERVER_H_
 
+#include <google/protobuf/stubs/callback.h>
 #include "mir_protobuf.pb.h"
 
 namespace mir

--- a/src/include/common/mir/protobuf/display_server_debug.h
+++ b/src/include/common/mir/protobuf/display_server_debug.h
@@ -19,6 +19,7 @@
 #ifndef MIR_PROTOBUF_DISPLAY_SERVER_DEBUG_H_
 #define MIR_PROTOBUF_DISPLAY_SERVER_DEBUG_H_
 
+#include <google/protobuf/stubs/callback.h>
 #include "mir_protobuf.pb.h"
 
 namespace mir


### PR DESCRIPTION
I am not familiar with the codebase, this is just a makeshift patch that made it compile with protobuf 3.8.0. Creating the PR as requested in #913.

To do things properly, we'll need some kind of check for the protobuf version or maybe an entirely different approach of doing things. Feedback welcome :wink: 

Fixes #913