### PR TITLE
Wayland frontend: update window size more correctly

### DIFF
--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -253,7 +253,7 @@ auto mf::LayerSurfaceV1::get_exclusive_rect() const -> std::experimental::option
         return std::experimental::nullopt;
 
     auto edge = get_anchored_edge();
-    auto size = window_size().value_or(geom::Size{1, 1});
+    auto size = pending_size();
 
     switch (edge)
     {

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -87,8 +87,15 @@ public:
 protected:
     std::shared_ptr<bool> const destroyed;
 
-    std::experimental::optional<geometry::Size> window_size() const;
-    std::experimental::optional<geometry::Size> requested_window_size(); // Window size requested by Mir
+    /// The size the window will be after the next commit
+    auto pending_size() const -> geometry::Size;
+
+    /// The size the window currently is (the committed size, or a reasonable default if it has never committed)
+    auto current_size() const -> geometry::Size;
+
+    /// Window size requested by Mir
+    std::experimental::optional<geometry::Size> requested_window_size();
+
     MirWindowState window_state();
     bool is_active();
     uint64_t latest_timestamp_ns();
@@ -102,8 +109,16 @@ private:
     OutputManager* output_manager;
     std::shared_ptr<WlSurfaceEventSink> const sink;
     std::unique_ptr<scene::SurfaceCreationParameters> const params;
-    std::experimental::optional<geometry::Size> pending_window_size;
-    std::experimental::optional<geometry::Size> committed_window_size;
+
+    /// The explicitly set (not taken from the surface buffer size) uncommitted window size
+    std::experimental::optional<geometry::Size> pending_explicit_size;
+
+    /// If the committed window size was set explicitly, rather than being taken from the buffer size
+    bool committed_size_set_explicitly{false};
+
+    /// The last committed window size (either explicitly set or taken from the surface buffer size)
+    std::experimental::optional<geometry::Size> committed_size;
+
     SurfaceId surface_id_;
     std::unique_ptr<shell::SurfaceSpecification> pending_changes;
 


### PR DESCRIPTION
As far as I know, the previous behavior wasn't causing any bugs. It was, however causing `modify_window()` to get called unnecessarily each frame in some cases (tested with wlroots/examples/simple). The reason was that `pending_window_size` wasn't getting set, so `committed_window_size` wasn't getting updated so it thought the size had changed each time. Now it correctly managers pending and current size, and keeps track of if the size has been set explicitly.

This entire system probably will need a rewrite at some point, but now is not the time.