### PR TITLE
Printf common WLCS integration error

### DIFF
--- a/tests/mir_test_framework/test_wlcs_display_server.cpp
+++ b/tests/mir_test_framework/test_wlcs_display_server.cpp
@@ -386,9 +386,14 @@ public:
         {
             if (listeners.last_wl_window == nullptr)
             {
-                BOOST_THROW_EXCEPTION((
-                    std::runtime_error{
-                        "Called Shell::create_surface() without first creating a wl_shell_surface?"}));
+                auto message =
+                    "miral::TestWlcsDisplayServer::ResourceMapper::resource_created()"
+                    " did not detect the shell surface used for a wl_surface."
+                    " You might need to add a new protocol to the `is_window` list.";
+                // We printf because Mir logging is suppressed, the exception is not surfaced, and it's a pain to track this down
+                printf("\x1b[31;1mERROR:\x1b[0m %s\n", message);
+                fflush(stdout);
+                BOOST_THROW_EXCEPTION((std::runtime_error{message}));
             }
 
             auto stream = surface->primary_buffer_stream();


### PR DESCRIPTION
Every time a new shell surface protocol is added, I forget to add it to the `is_window` list. That's all good and well, except the error gets eaten by Mir and I end up digging through GDB to solve the strange bug. This clarifies the error, and more importantly, actually shows it.