### PR TITLE
Fix FTBFS with protobuf 3.8

### DIFF
--- a/src/client/rpc/mir_basic_rpc_channel.cpp
+++ b/src/client/rpc/mir_basic_rpc_channel.cpp
@@ -26,6 +26,10 @@
 #include "mir/protobuf/protocol_version.h"
 #include "mir/log.h"
 
+#if GOOGLE_PROTOBUF_VERSION >= 3008000
+#include <google/protobuf/stubs/callback.h>
+#endif
+
 #include <sstream>
 
 namespace mclr = mir::client::rpc;

--- a/src/include/common/mir/protobuf/display_server.h
+++ b/src/include/common/mir/protobuf/display_server.h
@@ -20,6 +20,9 @@
 #define MIR_PROTOBUF_DISPLAY_SERVER_H_
 
 #include "mir_protobuf.pb.h"
+#if GOOGLE_PROTOBUF_VERSION >= 3008000
+#include <google/protobuf/stubs/callback.h>
+#endif
 
 namespace mir
 {

--- a/src/include/common/mir/protobuf/display_server_debug.h
+++ b/src/include/common/mir/protobuf/display_server_debug.h
@@ -20,6 +20,9 @@
 #define MIR_PROTOBUF_DISPLAY_SERVER_DEBUG_H_
 
 #include "mir_protobuf.pb.h"
+#if GOOGLE_PROTOBUF_VERSION >= 3008000
+#include <google/protobuf/stubs/callback.h>
+#endif
 
 namespace mir
 {


### PR DESCRIPTION
Add header that needs to be explicitly included for protobuf 3.8. (Fixes #913)