### PR TITLE
[Wayland] To accommodate GTK3 publish bespoke extensions before wl_seat

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -604,6 +604,10 @@ auto mir::frontend::WaylandExtensions::get_extension(std::string const& name) co
     return {};
 }
 
+void mf::WaylandExtensions::run_builders(wl_display*, std::function<void(std::function<void()>&& work)> const&)
+{
+}
+
 mf::WaylandConnector::WaylandConnector(
     optional_value<std::string> const& display_name,
     std::shared_ptr<mf::Shell> const& shell,
@@ -642,6 +646,11 @@ mf::WaylandConnector::WaylandConnector(
         "wl_display_set_global_filter() is unavailable in libwayland-dev "
         WAYLAND_VERSION);
 #endif
+
+    // Run the builders before creating the seat (because that's what GTK3 expects)
+    extensions->run_builders(
+        display.get(),
+        [executor=executor](std::function<void()>&& work) { executor->spawn(std::move(work)); });
 
     /*
      * Here be Dragons!

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -69,6 +69,8 @@ public:
     WaylandExtensions(WaylandExtensions const&) = delete;
     WaylandExtensions& operator=(WaylandExtensions const&) = delete;
 
+    virtual void run_builders(wl_display* display, std::function<void(std::function<void()>&& work)> const& run_on_wayland_mainloop);
+
     void init(wl_display* display, std::shared_ptr<Shell> const& shell, WlSeat* seat, OutputManager* const output_manager);
 
     auto get_extension(std::string const& name) const -> std::shared_ptr<void>;

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -77,11 +77,11 @@ auto configure_wayland_extensions(
             extension{extension}, x11_enabled{x11_enabled}, wayland_extension_hooks{wayland_extension_hooks} {}
 
     protected:
-        virtual void custom_extensions(
+        void custom_extensions(
             wl_display* display,
             std::shared_ptr<mf::Shell> const& shell,
             mf::WlSeat* seat,
-            mf::OutputManager* const output_manager)
+            mf::OutputManager* const output_manager) override
         {
             if (extension.find(mw::Shell::interface_name) != extension.end())
                 add_extension(
@@ -112,7 +112,9 @@ auto configure_wayland_extensions(
                 add_extension("x11-support", std::make_shared<mf::XWaylandWMShell>(shell, *seat, output_manager));
         }
 
-        void run_builders(wl_display* display, std::function<void(std::function<void()>&& work)> const& run_on_wayland_mainloop) override
+        void run_builders(
+            wl_display* display,
+            std::function<void(std::function<void()>&& work)> const& run_on_wayland_mainloop) override
         {
             for (auto const& hook : wayland_extension_hooks)
             {

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -108,18 +108,17 @@ auto configure_wayland_extensions(
                     mw::XdgOutputManagerV1::interface_name,
                     create_xdg_output_manager_v1(display, output_manager));
 
-            std::function<void(std::function<void()>&& work)> run_on_wayland_mainloop = [seat](std::function<void()>&& work)
-                {
-                    seat->spawn(std::move(work));
-                };
+            if (x11_enabled)
+                add_extension("x11-support", std::make_shared<mf::XWaylandWMShell>(shell, *seat, output_manager));
+        }
+
+        void run_builders(wl_display* display, std::function<void(std::function<void()>&& work)> const& run_on_wayland_mainloop) override
+        {
             for (auto const& hook : wayland_extension_hooks)
             {
                 if (extension.find(hook.name) != extension.end())
                     add_extension(hook.name, hook.builder(display, run_on_wayland_mainloop));
             }
-
-            if (x11_enabled)
-                add_extension("x11-support", std::make_shared<mf::XWaylandWMShell>(shell, *seat, output_manager));
         }
 
         std::set<std::string> const extension;


### PR DESCRIPTION
[Wayland] To accommodate GTK3 publish bespoke extensions before wl_seat. (Fixes #922)