### PR TITLE
Window manager: fix attached and maximized window placement

### DIFF
--- a/src/client/event_printer.cpp
+++ b/src/client/event_printer.cpp
@@ -275,6 +275,7 @@ std::ostream& mir::operator<<(std::ostream& out, MirWindowState state)
     PRINT(mir_window_state,fullscreen);
     PRINT(mir_window_state,horizmaximized);
     PRINT(mir_window_state,hidden);
+    PRINT(mir_window_state,attached);
     default:
         return out << static_cast<int>(state) << "<INVALID>";
     }

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -2381,7 +2381,7 @@ auto miral::BasicWindowManager::apply_exclusive_rect_to_application_zone(
 
     Rectangle zone{original_zone};
 
-    /// Not that we got rid of stretched attachments, the only states we care about are the following four:
+    /// Now that we got rid of stretched attachments, the only states we care about are the following four:
     switch (edges)
     {
     case mir_placement_gravity_west:

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1103,6 +1103,7 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
     if (window_info.state() == mir_window_state_attached)
     {
         if (modifications.state().is_set() ||
+            modifications.size().is_set() ||
             modifications.attached_edges().is_set() ||
             modifications.exclusive_rect().is_set())
         {

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1653,7 +1653,7 @@ auto miral::BasicWindowManager::place_new_surface(WindowSpecification parameters
     if (!parameters.state().is_set())
         parameters.state() = mir_window_state_restored;
 
-    auto const active_output_area = active_output();
+    auto const active_output_area = active_display_area()->application_zone.extents();;
     auto const height = parameters.size().value().height.as_int();
 
     bool positioned = false;

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -285,6 +285,7 @@ private:
     void refocus(Application const& application, Window const& parent,
                  std::vector<std::shared_ptr<Workspace>> const& workspaces_containing_window);
     auto workspaces_containing(Window const& window) const -> std::vector<std::shared_ptr<Workspace>>;
+    auto active_display_area() const -> std::shared_ptr<DisplayArea>;
     auto display_area_for(Window const& window) const -> std::shared_ptr<DisplayArea>;
     /// Returns the application zone area after shrinking it for the exclusive zone if needed
     static auto apply_exclusive_rect_to_application_zone(

--- a/src/miral/window_management_trace.cpp
+++ b/src/miral/window_management_trace.cpp
@@ -150,6 +150,9 @@ auto dump_of(miral::WindowInfo const& info) -> std::string
         if (info.height_inc() != miral::default_height_inc) APPEND(height_inc);
         if (info.min_aspect() != miral::default_min_aspect_ratio) APPEND(min_aspect);
         if (info.max_aspect() != miral::default_max_aspect_ratio) APPEND(max_aspect);
+        if (info.depth_layer() != mir_depth_layer_application) APPEND(depth_layer);
+        if (info.attached_edges() != 0) APPEND(attached_edges);
+        if (info.exclusive_rect() != mir::geometry::Rectangle{{}, {}}) APPEND(exclusive_rect);
         APPEND(preferred_orientation);
         APPEND(confine_pointer);
 
@@ -197,6 +200,9 @@ auto dump_of(miral::WindowSpecification const& specification) -> std::string
 //        APPEND_IF_SET(input_mode);
         APPEND_IF_SET(shell_chrome);
         APPEND_IF_SET(confine_pointer);
+        APPEND_IF_SET(depth_layer);
+        APPEND_IF_SET(attached_edges);
+        APPEND_IF_SET(exclusive_rect);
 #undef  APPEND_IF_SET
     }
 

--- a/tests/miral/initial_window_placement.cpp
+++ b/tests/miral/initial_window_placement.cpp
@@ -90,3 +90,36 @@ TEST_F(InitialWindowPlacement, window_is_not_placed_off_screen_when_existing_win
     EXPECT_THAT(second_area.bottom(), Le(display_area.bottom()));
 }
 
+TEST_F(InitialWindowPlacement, initially_maximized_window_covers_output)
+{
+    Window window;
+    {
+        // Setting the top left in the initial params wasn't working, so we first create the window then move it
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_maximized;
+        window = create_window(params);
+    }
+
+    ASSERT_THAT(window.top_left(), Eq(display_area.top_left));
+    ASSERT_THAT(window.size(), Eq(display_area.size));
+}
+
+TEST_F(InitialWindowPlacement, initially_maximized_window_covers_only_one_output)
+{
+    auto display_config = create_fake_display_configuration({
+        display_area,
+        {display_area.top_right(), display_area.size}});
+    notify_configuration_applied(display_config);
+
+    Window window;
+    {
+        // Setting the top left in the initial params wasn't working, so we first create the window then move it
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_maximized;
+        window = create_window(params);
+    }
+
+    ASSERT_THAT(window.top_left(), Eq(display_area.top_left));
+    ASSERT_THAT(window.size(), Eq(display_area.size));
+}
+

--- a/tests/miral/window_placement_attached.cpp
+++ b/tests/miral/window_placement_attached.cpp
@@ -220,6 +220,35 @@ TEST_P(WindowPlacementAttached, window_is_placed_correctly_when_attached_edges_c
     EXPECT_THAT(window.size(), Eq(placement.size));
 }
 
+TEST_P(WindowPlacementAttached, window_is_placed_correctly_when_size_changes)
+{
+    AttachedEdges edges = GetParam();
+    Size initial_size{70, 90};
+    Size new_size{140, 80};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_attached;
+        params.attached_edges = edges;
+        params.size = initial_size;
+        window = create_window(params);
+    }
+    auto const& info = basic_window_manager.info_for(window);
+
+    WindowSpecification spec;
+    spec.size() = new_size;
+    window_manager_tools.modify_window(window, spec);
+
+    Rectangle placement{placement_for_attachement(display_area, new_size, edges)};
+    AttachedEdges actual_edges = info.attached_edges();
+
+    EXPECT_THAT(info.state(), Eq(mir_window_state_attached));
+    EXPECT_THAT(actual_edges, Eq(edges));
+    EXPECT_THAT(window.top_left(), Eq(placement.top_left));
+    EXPECT_THAT(window.size(), Eq(placement.size));
+}
+
 TEST_P(WindowPlacementAttached, window_is_placed_correctly_when_put_in_attached_state)
 {
     AttachedEdges edges = GetParam();

--- a/tests/miral/window_placement_attached.cpp
+++ b/tests/miral/window_placement_attached.cpp
@@ -301,11 +301,41 @@ TEST_P(WindowPlacementAttached, maximized_window_respects_exclusive_zone)
     Window normal;
     {
         mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_maximized;
         normal = create_window(params);
-        mir::shell::SurfaceSpecification spec;
-        spec.state = mir_window_state_maximized;
-        basic_window_manager.modify_surface(session, normal, spec);
     }
+    Rectangle zone = apply_exclusive_zone(display_area, exclusive_rect, window_size, edges);
+
+    EXPECT_THAT(normal.top_left(), Eq(zone.top_left));
+    EXPECT_THAT(normal.size(), Eq(zone.size));
+}
+
+TEST_P(WindowPlacementAttached, window_respects_exclusive_zone_when_maximized)
+{
+    AttachedEdges edges = GetParam();
+    Size window_size{120, 80};
+    Rectangle exclusive_rect{{0, 0}, window_size};
+
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_attached;
+        params.attached_edges = edges;
+        params.size = window_size;
+        params.exclusive_rect = exclusive_rect;
+        create_window(params);
+    }
+
+    Window normal;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_restored;
+        normal = create_window(params);
+    }
+
+    mir::shell::SurfaceSpecification spec;
+    spec.state = mir_window_state_maximized;
+    basic_window_manager.modify_surface(session, normal, spec);
+
     Rectangle zone = apply_exclusive_zone(display_area, exclusive_rect, window_size, edges);
 
     EXPECT_THAT(normal.top_left(), Eq(zone.top_left));
@@ -373,10 +403,8 @@ TEST_P(WindowPlacementAttached, maximized_window_respects_multiple_stacked_exclu
     Window normal;
     {
         mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_maximized;
         normal = create_window(params);
-        mir::shell::SurfaceSpecification spec;
-        spec.state = mir_window_state_maximized;
-        basic_window_manager.modify_surface(session, normal, spec);
     }
     Rectangle zone = apply_exclusive_zone(display_area, exclusive_rect_a, window_a_size, edges);
     zone = apply_exclusive_zone(zone, exclusive_rect_b, window_b_size, edges);
@@ -403,10 +431,8 @@ TEST_P(WindowPlacementAttached, maximized_window_respects_exclusive_zone_smaller
     Window normal;
     {
         mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_maximized;
         normal = create_window(params);
-        mir::shell::SurfaceSpecification spec;
-        spec.state = mir_window_state_maximized;
-        basic_window_manager.modify_surface(session, normal, spec);
     }
     Rectangle zone = apply_exclusive_zone(display_area, exclusive_rect, window_size, edges);
 
@@ -433,15 +459,9 @@ TEST_P(WindowPlacementAttached, exclusive_zone_is_cleared_when_window_is_removed
     Window normal;
     {
         mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_maximized;
         normal = create_window(params);
-        mir::shell::SurfaceSpecification spec;
-        spec.state = mir_window_state_maximized;
-        basic_window_manager.modify_surface(session, normal, spec);
     }
-    Rectangle zone = apply_exclusive_zone(display_area, exclusive_rect, window_size, edges);
-
-    EXPECT_THAT(normal.top_left(), Eq(zone.top_left));
-    EXPECT_THAT(normal.size(), Eq(zone.size));
 
     basic_window_manager.remove_surface(session, attached);
 


### PR DESCRIPTION
Fixes and tests some logic around attached and maximized windows. The biggest part of the diff is the logic of `active_output()` being moved into the new `active_display_area()` (which `active_output()` then uses).