### PR TITLE
Wayland frontend size management improvements

### DIFF
--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -111,6 +111,7 @@ private:
     void destroy() override;
 
     // from WindowWlSurfaceRole
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -284,14 +284,10 @@ auto mf::LayerSurfaceV1::get_exclusive_rect() const -> std::experimental::option
 
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
 {
-    // HACK: Leaving zero sizes zero causes a validation error, and setting them to window_size() causes
-    //       to not call WlSurfaceEventSink::handle_resize(). Setting them to 1 works for now. This will get fixed when
-    //       we refactor size negotiation between the window manager and the frontend.
-    if (width == 0)
-        width = 1;
-    if (height == 0)
-        height = 1;
-    WindowWlSurfaceRole::set_geometry(0, 0, width, height);
+    if (width > 0)
+        set_pending_width(geom::Width{width});
+    if (height > 0)
+        set_pending_height(geom::Height{height});
 }
 
 void mf::LayerSurfaceV1::set_anchor(uint32_t anchor)

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -333,8 +333,8 @@ protected:
         apply_spec(mods);
     }
 
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override {};
-
     void handle_active_change(bool /*is_now_active*/) override {};
 
     void handle_resize(std::experimental::optional<geometry::Point> const& /*new_top_left*/,

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -301,6 +301,8 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
 {
     surface->commit(state);
 
+    handle_commit();
+
     auto const session = get_session(client);
     auto size = pending_size();
     sink->latest_client_size(size);

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -91,15 +91,10 @@ void mf::WindowWlSurfaceRole::refresh_surface_data_now()
 
 void mf::WindowWlSurfaceRole::apply_spec(mir::shell::SurfaceSpecification const& new_spec)
 {
-    if (new_spec.width.is_set() || new_spec.height.is_set())
-    {
-        auto size = pending_size();
-        if (new_spec.width.is_set())
-            size.width = new_spec.width.value();
-        if (new_spec.height.is_set())
-            size.height = new_spec.height.value();
-        pending_explicit_size = size;
-    }
+    if (new_spec.width.is_set())
+        pending_explicit_width = new_spec.width.value();
+    if (new_spec.height.is_set())
+        pending_explicit_height = new_spec.height.value();
 
     if (surface_id().as_value())
     {
@@ -111,10 +106,19 @@ void mf::WindowWlSurfaceRole::apply_spec(mir::shell::SurfaceSpecification const&
     }
 }
 
-void mf::WindowWlSurfaceRole::set_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
+void mf::WindowWlSurfaceRole::set_pending_offset(std::experimental::optional<geom::Displacement> const& offset)
 {
-    surface->set_pending_offset({-x, -y});
-    pending_explicit_size = geom::Size{width, height};
+    surface->set_pending_offset(offset);
+}
+
+void mf::WindowWlSurfaceRole::set_pending_width(std::experimental::optional<geometry::Width> const& width)
+{
+    pending_explicit_width = width;
+}
+
+void mf::WindowWlSurfaceRole::set_pending_height(std::experimental::optional<geometry::Height> const& height)
+{
+    pending_explicit_height = height;
 }
 
 void mf::WindowWlSurfaceRole::set_title(std::string const& title)
@@ -252,20 +256,25 @@ void mf::WindowWlSurfaceRole::set_state_now(MirWindowState state)
 
 auto mf::WindowWlSurfaceRole::pending_size() const -> geom::Size
 {
-    if (pending_explicit_size)
-        return pending_explicit_size.value();
-    else
-        return current_size();
+    auto size = current_size();
+    if (pending_explicit_width)
+        size.width = pending_explicit_width.value();
+    if (pending_explicit_height)
+        size.height = pending_explicit_height.value();
+    return size;
 }
 
 auto mf::WindowWlSurfaceRole::current_size() const -> geom::Size
 {
-    if (!committed_size_set_explicitly && surface->buffer_size())
-        return surface->buffer_size().value();
-    else if (committed_size)
-        return committed_size.value();
-    else
-        return geometry::Size{640, 480};
+    auto size = committed_size.value_or(geom::Size{640, 480});
+    if (surface->buffer_size())
+    {
+        if (!committed_width_set_explicitly)
+            size.width = surface->buffer_size().value().width;
+        if (!committed_height_set_explicitly)
+            size.height = surface->buffer_size().value().height;
+    }
+    return size;
 }
 
 std::experimental::optional<geom::Size> mf::WindowWlSurfaceRole::requested_window_size()
@@ -323,11 +332,12 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
     }
 
     committed_size = size;
-    if (pending_explicit_size)
-    {
-        committed_size_set_explicitly = true;
-        pending_explicit_size = std::experimental::nullopt;
-    }
+    if (pending_explicit_width)
+        committed_width_set_explicitly = true;
+    if (pending_explicit_height)
+        committed_height_set_explicitly = true;
+    pending_explicit_width = std::experimental::nullopt;
+    pending_explicit_height = std::experimental::nullopt;
 }
 
 void mf::WindowWlSurfaceRole::visiblity(bool visible)

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -81,6 +81,10 @@ public:
 
     void set_state_now(MirWindowState state);
 
+    /// Gets called after the surface has committed (so current_size() may return the committed buffer size) but before
+    /// the Mir window is modified (so if a pending size is set or a spec is applied those changes will take effect)
+    virtual void handle_commit() = 0;
+
     virtual void handle_state_change(MirWindowState new_state) = 0;
     virtual void handle_active_change(bool is_now_active) = 0;
     virtual void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -68,7 +68,9 @@ public:
     void refresh_surface_data_now() override;
 
     void apply_spec(shell::SurfaceSpecification const& new_spec);
-    void set_geometry(int32_t x, int32_t y, int32_t width, int32_t height);
+    void set_pending_offset(std::experimental::optional<geometry::Displacement> const& offset);
+    void set_pending_width(std::experimental::optional<geometry::Width> const& width);
+    void set_pending_height(std::experimental::optional<geometry::Height> const& height);
     void set_title(std::string const& title);
     void initiate_interactive_move();
     void initiate_interactive_resize(MirResizeEdge edge);
@@ -111,10 +113,16 @@ private:
     std::unique_ptr<scene::SurfaceCreationParameters> const params;
 
     /// The explicitly set (not taken from the surface buffer size) uncommitted window size
-    std::experimental::optional<geometry::Size> pending_explicit_size;
+    /// @{
+    std::experimental::optional<geometry::Width> pending_explicit_width;
+    std::experimental::optional<geometry::Height> pending_explicit_height;
+    /// @}
 
     /// If the committed window size was set explicitly, rather than being taken from the buffer size
-    bool committed_size_set_explicitly{false};
+    /// @{
+    bool committed_width_set_explicitly{false};
+    bool committed_height_set_explicitly{false};
+    /// @}
 
     /// The last committed window size (either explicitly set or taken from the surface buffer size)
     std::experimental::optional<geometry::Size> committed_size;

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -148,6 +148,11 @@ void mf::WlSurface::clear_role()
     role = &null_role;
 }
 
+void mf::WlSurface::set_pending_offset(std::experimental::optional<geom::Displacement> const& offset)
+{
+    pending.offset = offset;
+}
+
 std::unique_ptr<mf::WlSurface, std::function<void(mf::WlSurface*)>> mf::WlSurface::add_child(WlSubsurface* child)
 {
     children.push_back(child);

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -131,7 +131,7 @@ public:
 
     void set_role(WlSurfaceRole* role_);
     void clear_role();
-    void set_pending_offset(geometry::Displacement const& offset) { pending.offset = offset; }
+    void set_pending_offset(std::experimental::optional<geometry::Displacement> const& offset);
     std::unique_ptr<WlSurface, std::function<void(WlSurface*)>> add_child(WlSubsurface* child);
     void refresh_surface_data_now();
     void pending_invalidate_surface_data() { pending.invalidate_surface_data(); }

--- a/src/server/frontend_wayland/wl_surface_event_sink.cpp
+++ b/src/server/frontend_wayland/wl_surface_event_sink.cpp
@@ -87,9 +87,11 @@ void mf::WlSurfaceEventSink::handle_event(EventUPtr&& event)
 
 void mf::WlSurfaceEventSink::handle_resize(mir::geometry::Size const& new_size)
 {
-    requested_size = new_size;
     if (new_size != window_size)
+    {
+        requested_size = new_size;
         window->handle_resize(std::experimental::nullopt, new_size);
+    }
 }
 
 void mf::WlSurfaceEventSink::handle_input_event(MirInputEvent const* event)

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -102,7 +102,7 @@ public:
 
 private:
     static XdgToplevelStable* from(wl_resource* surface);
-    void send_configure(std::experimental::optional<geometry::Size> new_size);
+    void send_toplevel_configure();
 
     XdgSurfaceStable* const xdg_surface;
 };
@@ -484,21 +484,21 @@ void mf::XdgToplevelStable::set_minimized()
 
 void mf::XdgToplevelStable::handle_state_change(MirWindowState /*new_state*/)
 {
-    send_configure(std::experimental::nullopt);
+    send_toplevel_configure();
 }
 
 void mf::XdgToplevelStable::handle_active_change(bool /*is_now_active*/)
 {
-    send_configure(std::experimental::nullopt);
+    send_toplevel_configure();
 }
 
 void mf::XdgToplevelStable::handle_resize(std::experimental::optional<geometry::Point> const& /*new_top_left*/,
-                                          geometry::Size const& new_size)
+                                          geometry::Size const& /*new_size*/)
 {
-    send_configure(new_size);
+    send_toplevel_configure();
 }
 
-void mf::XdgToplevelStable::send_configure(std::experimental::optional<geometry::Size> new_size)
+void mf::XdgToplevelStable::send_toplevel_configure()
 {
     wl_array states;
     wl_array_init(&states);
@@ -527,9 +527,8 @@ void mf::XdgToplevelStable::send_configure(std::experimental::optional<geometry:
         break;
     }
 
-    geom::Size size = new_size.value_or(
-        requested_window_size().value_or(
-            geom::Size{})); // 0 size values means default for toplevel comfigure
+    // 0 sizes means default for toplevel configure
+    geom::Size size = requested_window_size().value_or(geom::Size{0, 0});
 
     send_configure_event(size.width.as_int(), size.height.as_int(), &states);
     wl_array_release(&states);

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -94,6 +94,7 @@ public:
     void unset_fullscreen() override;
     void set_minimized() override;
 
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override;
     void handle_active_change(bool /*is_now_active*/) override;
     void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -231,7 +231,11 @@ void mf::XdgSurfaceStable::get_popup(
 void mf::XdgSurfaceStable::set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
 {
     if (auto& role = window_role())
-        role.value()->set_geometry(x, y, width, height);
+    {
+        role.value()->set_pending_offset(geom::Displacement{-x, -y});
+        role.value()->set_pending_width(geom::Width{width});
+        role.value()->set_pending_height(geom::Height{height});
+    }
 }
 
 void mf::XdgSurfaceStable::ack_configure(uint32_t serial)

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -62,6 +62,7 @@ public:
     void grab(struct wl_resource* seat, uint32_t serial) override;
     void destroy() override;
 
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -122,7 +122,7 @@ public:
 
 private:
     static XdgToplevelV6* from(wl_resource* surface);
-    void send_configure(std::experimental::optional<geometry::Size> new_size);
+    void send_toplevel_configure();
 
     XdgSurfaceV6* const xdg_surface;
 };
@@ -490,21 +490,21 @@ void mf::XdgToplevelV6::set_minimized()
 
 void mf::XdgToplevelV6::handle_state_change(MirWindowState /*new_state*/)
 {
-    send_configure(std::experimental::nullopt);
+    send_toplevel_configure();
 }
 
 void mf::XdgToplevelV6::handle_active_change(bool /*is_now_active*/)
 {
-    send_configure(std::experimental::nullopt);
+    send_toplevel_configure();
 }
 
 void mf::XdgToplevelV6::handle_resize(std::experimental::optional<geometry::Point> const& /*new_top_left*/,
-                       geometry::Size const& new_size)
+                       geometry::Size const& /*new_size*/)
 {
-    send_configure(new_size);
+    send_toplevel_configure();
 }
 
-void mf::XdgToplevelV6::send_configure(std::experimental::optional<geometry::Size> new_size)
+void mf::XdgToplevelV6::send_toplevel_configure()
 {
     wl_array states;
     wl_array_init(&states);
@@ -533,9 +533,8 @@ void mf::XdgToplevelV6::send_configure(std::experimental::optional<geometry::Siz
         break;
     }
 
-    geom::Size size = new_size.value_or(
-        requested_window_size().value_or(
-            geom::Size{})); // 0 size values means default for toplevel comfigure
+    // 0 sizes means default for toplevel configure
+    geom::Size size = requested_window_size().value_or(geom::Size{0, 0});
 
     send_configure_event(size.width.as_int(), size.height.as_int(), &states);
     wl_array_release(&states);

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -80,6 +80,7 @@ public:
     void grab(struct wl_resource* seat, uint32_t serial) override;
     void destroy() override;
 
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(
@@ -113,6 +114,7 @@ public:
     void unset_fullscreen() override;
     void set_minimized() override;
 
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override;
     void handle_active_change(bool /*is_now_active*/) override;
     void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -240,7 +240,11 @@ void mf::XdgSurfaceV6::get_popup(wl_resource* new_popup, struct wl_resource* par
 void mf::XdgSurfaceV6::set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
 {
     if (auto& role = window_role())
-        role.value()->set_geometry(x, y, width, height);
+    {
+        role.value()->set_pending_offset(geom::Displacement{-x, -y});
+        role.value()->set_pending_width(geom::Width{width});
+        role.value()->set_pending_height(geom::Height{height});
+    }
 }
 
 void mf::XdgSurfaceV6::ack_configure(uint32_t serial)

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
@@ -56,6 +56,7 @@ public:
 protected:
     void destroy() override;
     void set_transient(struct wl_resource* parent, int32_t x, int32_t y, uint32_t flags);
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left, geometry::Size const& new_size) override;


### PR DESCRIPTION
This PR is mostly to lay the groundwork for fixes to layer shell.
* It splits `WindowWlSurfaceRole::set_geometry()` into `::set_offset()`, `::set_width()` and `::set_height()`
* It has some fixes and simplification for how XDG surfaces send the `.configure` event
* It adds a new `WindowWlSurfaceRole::handle_commit()` virtual method, which will be needed by `LayerSurfaceV1`, but will also probably end up being useful for other things.