### PR TITLE
LayerShellSurface: configure correctly

### DIFF
--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -111,6 +111,7 @@ private:
     void destroy() override;
 
     // from WindowWlSurfaceRole
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -284,14 +284,10 @@ auto mf::LayerSurfaceV1::get_exclusive_rect() const -> std::experimental::option
 
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
 {
-    // HACK: Leaving zero sizes zero causes a validation error, and setting them to window_size() causes
-    //       to not call WlSurfaceEventSink::handle_resize(). Setting them to 1 works for now. This will get fixed when
-    //       we refactor size negotiation between the window manager and the frontend.
-    if (width == 0)
-        width = 1;
-    if (height == 0)
-        height = 1;
-    WindowWlSurfaceRole::set_geometry(0, 0, width, height);
+    if (width > 0)
+        set_pending_width(geom::Width{width});
+    if (height > 0)
+        set_pending_height(geom::Height{height});
 }
 
 void mf::LayerSurfaceV1::set_anchor(uint32_t anchor)

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -24,6 +24,8 @@
 
 #include "mir/shell/surface_specification.h"
 #include <boost/throw_exception.hpp>
+#include <deque>
+#include <mutex>
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
@@ -88,7 +90,11 @@ public:
     ~LayerSurfaceV1() = default;
 
 private:
-    void update_mir_surface();
+    struct OptionalSize
+    {
+        std::experimental::optional<geom::Width> width;
+        std::experimental::optional<geom::Height> height;
+    };
 
     /// Returns all anchored edges ored together
     auto get_placement_gravity() const -> MirPlacementGravity;
@@ -99,6 +105,9 @@ private:
 
     /// Returns the rectangele in surface coords that this surface is exclusive for (if any)
     auto get_exclusive_rect() const -> std::experimental::optional<geom::Rectangle>;
+
+    /// Sends a configure event if needed
+    void configure();
 
     // from wayland::LayerSurfaceV1
     void set_size(uint32_t width, uint32_t height) override;
@@ -111,18 +120,24 @@ private:
     void destroy() override;
 
     // from WindowWlSurfaceRole
-    void handle_commit() override {};
+    void handle_commit() override;
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(
-        std::experimental::optional<geometry::Point> const& new_top_left,
-        geometry::Size const& new_size) override;
+        std::experimental::optional<geometry::Point> const& /*new_top_left*/,
+        geometry::Size const& /*new_size*/) override;
 
     uint32_t exclusive_zone{0};
     bool anchored_left{false};
     bool anchored_right{false};
     bool anchored_top{false};
     bool anchored_bottom{false};
+    std::experimental::optional<OptionalSize> pending_opt_size;
+    OptionalSize committed_opt_size;
+    bool configure_on_next_commit{true}; ///< If to send a .configure event at the end of the next or current commit
+    std::mutex commit_mutex; ///< NOT used for thready saftey. Used to check if we are currently committing
+    std::deque<std::pair<uint32_t, OptionalSize>> inflight_configures;
+    bool surface_data_dirty{false};
 };
 
 }
@@ -179,24 +194,10 @@ mf::LayerSurfaceV1::LayerSurfaceV1(
           layer_shell.shell,
           layer_shell.output_manager)
 {
+    // TODO: Error if surface has buffer attached or committed
     shell::SurfaceSpecification spec;
     spec.state = mir_window_state_attached;
     spec.depth_layer = layer;
-    apply_spec(spec);
-    auto const serial = wl_display_next_serial(wl_client_get_display(wayland::LayerSurfaceV1::client));
-    send_configure_event (serial, 0, 0);
-}
-
-void mf::LayerSurfaceV1::update_mir_surface()
-{
-    mir::optional_value<geom::Rectangle> exclusive_rect_mir;
-    std::experimental::optional<geom::Rectangle> exclusive_rect_std = get_exclusive_rect();
-    if (exclusive_rect_std)
-        exclusive_rect_mir = exclusive_rect_std.value();
-
-    shell::SurfaceSpecification spec;
-    spec.attached_edges = get_placement_gravity();
-    spec.exclusive_rect = exclusive_rect_mir;
     apply_spec(spec);
 }
 
@@ -227,9 +228,9 @@ auto mf::LayerSurfaceV1::get_anchored_edge() const -> MirPlacementGravity
     if (anchored_left != anchored_right)
     {
         if (anchored_left)
-            h_edge = mir_placement_gravity_east;
-        else
             h_edge = mir_placement_gravity_west;
+        else
+            h_edge = mir_placement_gravity_east;
     }
 
     if (anchored_top != anchored_bottom)
@@ -283,12 +284,42 @@ auto mf::LayerSurfaceV1::get_exclusive_rect() const -> std::experimental::option
     }
 }
 
+void mf::LayerSurfaceV1::configure()
+{
+    // TODO: Error if told to configure on an axis the window is not streatched along
+
+    OptionalSize configure_size{std::experimental::nullopt, std::experimental::nullopt};
+    auto requested = requested_window_size().value_or(current_size());
+
+    if (anchored_left && anchored_right)
+        configure_size.width = requested.width;
+    if (anchored_bottom && anchored_top)
+        configure_size.height = requested.height;
+
+    if (committed_opt_size.width)
+        configure_size.width = committed_opt_size.width.value();
+    if (committed_opt_size.height)
+        configure_size.height = committed_opt_size.height.value();
+
+    auto const serial = wl_display_next_serial(wl_client_get_display(wayland::LayerSurfaceV1::client));
+    if (!inflight_configures.empty() && serial <= inflight_configures.back().first)
+        BOOST_THROW_EXCEPTION(std::runtime_error("Generated invalid configure serial"));
+    inflight_configures.push_back(std::make_pair(serial, configure_size));
+
+    send_configure_event(
+        serial,
+        configure_size.width.value_or(geom::Width{0}).as_uint32_t(),
+        configure_size.height.value_or(geom::Height{0}).as_uint32_t());
+}
+
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
 {
+    pending_opt_size = {std::experimental::nullopt, std::experimental::nullopt};
     if (width > 0)
-        set_pending_width(geom::Width{width});
+        pending_opt_size.value().width = geom::Width{width};
     if (height > 0)
-        set_pending_height(geom::Height{height});
+        pending_opt_size.value().height = geom::Height{height};
+    configure_on_next_commit = true;
 }
 
 void mf::LayerSurfaceV1::set_anchor(uint32_t anchor)
@@ -297,14 +328,13 @@ void mf::LayerSurfaceV1::set_anchor(uint32_t anchor)
     anchored_right = anchor & Anchor::right;
     anchored_top = anchor & Anchor::top;
     anchored_bottom = anchor & Anchor::bottom;
-
-    update_mir_surface();
+    surface_data_dirty = true;
 }
 
 void mf::LayerSurfaceV1::set_exclusive_zone(int32_t zone)
 {
     exclusive_zone = zone;
-    update_mir_surface();
+    surface_data_dirty = true;
 }
 
 void mf::LayerSurfaceV1::set_margin(int32_t top, int32_t right, int32_t bottom, int32_t left)
@@ -332,7 +362,19 @@ void mf::LayerSurfaceV1::get_popup(struct wl_resource* popup)
 
 void mf::LayerSurfaceV1::ack_configure(uint32_t serial)
 {
-    (void)serial;
+    while (!inflight_configures.empty() && inflight_configures.front().first < serial)
+    {
+        inflight_configures.pop_front();
+    }
+
+    if (inflight_configures.empty() || inflight_configures.front().first != serial)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error(
+            "Could not find acked configure with serial " + std::to_string(serial)));
+    }
+
+    pending_opt_size = inflight_configures.front().second;
+    inflight_configures.pop_front();
 }
 
 void mf::LayerSurfaceV1::destroy()
@@ -340,12 +382,45 @@ void mf::LayerSurfaceV1::destroy()
     destroy_wayland_object();
 }
 
-void mf::LayerSurfaceV1::handle_resize(
-    std::experimental::optional<geometry::Point> const& new_top_left,
-    geometry::Size const& new_size)
+void mf::LayerSurfaceV1::handle_commit()
 {
-    (void)new_top_left;
+    std::lock_guard<std::mutex> comitting{commit_mutex};
 
-    auto const serial = wl_display_next_serial(wl_client_get_display(wayland::LayerSurfaceV1::client));
-    send_configure_event (serial, new_size.width.as_int(), new_size.height.as_int());
+    if (pending_opt_size)
+    {
+        if (pending_opt_size.value().width)
+            set_pending_width(pending_opt_size.value().width.value());
+        if (pending_opt_size.value().height)
+            set_pending_height(pending_opt_size.value().height.value());
+        committed_opt_size = pending_opt_size.value();
+        pending_opt_size = std::experimental::nullopt;
+        surface_data_dirty = true;
+    }
+
+    if (surface_data_dirty)
+    {
+        std::experimental::optional<geom::Rectangle> exclusive_rect_std = get_exclusive_rect();
+        mir::optional_value<geom::Rectangle> exclusive_rect_mir;
+        if (exclusive_rect_std)
+            exclusive_rect_mir = exclusive_rect_std.value();
+
+        shell::SurfaceSpecification spec;
+        spec.attached_edges = get_placement_gravity();
+        spec.exclusive_rect = exclusive_rect_mir;
+        apply_spec(spec);
+        surface_data_dirty = false;
+    }
+
+    if (configure_on_next_commit)
+    {
+        configure();
+        configure_on_next_commit = false;
+    }
+}
+
+void mf::LayerSurfaceV1::handle_resize(
+    std::experimental::optional<geom::Point> const& /*new_top_left*/,
+    geom::Size const& /*new_size*/)
+{
+    configure();
 }

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -314,7 +314,7 @@ void mf::LayerSurfaceV1::configure()
 
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
 {
-    pending_opt_size = {std::experimental::nullopt, std::experimental::nullopt};
+    pending_opt_size = OptionalSize{std::experimental::nullopt, std::experimental::nullopt};
     if (width > 0)
         pending_opt_size.value().width = geom::Width{width};
     if (height > 0)

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -333,8 +333,8 @@ protected:
         apply_spec(mods);
     }
 
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override {};
-
     void handle_active_change(bool /*is_now_active*/) override {};
 
     void handle_resize(std::experimental::optional<geometry::Point> const& /*new_top_left*/,

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -301,6 +301,8 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
 {
     surface->commit(state);
 
+    handle_commit();
+
     auto const session = get_session(client);
     auto size = pending_size();
     sink->latest_client_size(size);

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -311,7 +311,6 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
     {
         auto const scene_surface = scene_surface_from(session, surface_id_);
 
-
         if (!committed_size || size != committed_size.value())
         {
             spec().width = size.width;

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -91,15 +91,10 @@ void mf::WindowWlSurfaceRole::refresh_surface_data_now()
 
 void mf::WindowWlSurfaceRole::apply_spec(mir::shell::SurfaceSpecification const& new_spec)
 {
-    if (new_spec.width.is_set() || new_spec.height.is_set())
-    {
-        auto size = pending_size();
-        if (new_spec.width.is_set())
-            size.width = new_spec.width.value();
-        if (new_spec.height.is_set())
-            size.height = new_spec.height.value();
-        pending_explicit_size = size;
-    }
+    if (new_spec.width.is_set())
+        pending_explicit_width = new_spec.width.value();
+    if (new_spec.height.is_set())
+        pending_explicit_height = new_spec.height.value();
 
     if (surface_id().as_value())
     {
@@ -111,10 +106,19 @@ void mf::WindowWlSurfaceRole::apply_spec(mir::shell::SurfaceSpecification const&
     }
 }
 
-void mf::WindowWlSurfaceRole::set_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
+void mf::WindowWlSurfaceRole::set_pending_offset(std::experimental::optional<geom::Displacement> const& offset)
 {
-    surface->set_pending_offset({-x, -y});
-    pending_explicit_size = geom::Size{width, height};
+    surface->set_pending_offset(offset);
+}
+
+void mf::WindowWlSurfaceRole::set_pending_width(std::experimental::optional<geometry::Width> const& width)
+{
+    pending_explicit_width = width;
+}
+
+void mf::WindowWlSurfaceRole::set_pending_height(std::experimental::optional<geometry::Height> const& height)
+{
+    pending_explicit_height = height;
 }
 
 void mf::WindowWlSurfaceRole::set_title(std::string const& title)
@@ -252,20 +256,25 @@ void mf::WindowWlSurfaceRole::set_state_now(MirWindowState state)
 
 auto mf::WindowWlSurfaceRole::pending_size() const -> geom::Size
 {
-    if (pending_explicit_size)
-        return pending_explicit_size.value();
-    else
-        return current_size();
+    auto size = current_size();
+    if (pending_explicit_width)
+        size.width = pending_explicit_width.value();
+    if (pending_explicit_height)
+        size.height = pending_explicit_height.value();
+    return size;
 }
 
 auto mf::WindowWlSurfaceRole::current_size() const -> geom::Size
 {
-    if (!committed_size_set_explicitly && surface->buffer_size())
-        return surface->buffer_size().value();
-    else if (committed_size)
-        return committed_size.value();
-    else
-        return geometry::Size{640, 480};
+    auto size = committed_size.value_or(geom::Size{640, 480});
+    if (surface->buffer_size())
+    {
+        if (!committed_width_set_explicitly)
+            size.width = surface->buffer_size().value().width;
+        if (!committed_height_set_explicitly)
+            size.height = surface->buffer_size().value().height;
+    }
+    return size;
 }
 
 std::experimental::optional<geom::Size> mf::WindowWlSurfaceRole::requested_window_size()
@@ -323,11 +332,12 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
     }
 
     committed_size = size;
-    if (pending_explicit_size)
-    {
-        committed_size_set_explicitly = true;
-        pending_explicit_size = std::experimental::nullopt;
-    }
+    if (pending_explicit_width)
+        committed_width_set_explicitly = true;
+    if (pending_explicit_height)
+        committed_height_set_explicitly = true;
+    pending_explicit_width = std::experimental::nullopt;
+    pending_explicit_height = std::experimental::nullopt;
 }
 
 void mf::WindowWlSurfaceRole::visiblity(bool visible)

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -81,6 +81,10 @@ public:
 
     void set_state_now(MirWindowState state);
 
+    /// Gets called after the surface has committed (so current_size() may return the committed buffer size) but before
+    /// the Mir window is modified (so if a pending size is set or a spec is applied those changes will take effect)
+    virtual void handle_commit() = 0;
+
     virtual void handle_state_change(MirWindowState new_state) = 0;
     virtual void handle_active_change(bool is_now_active) = 0;
     virtual void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -68,7 +68,9 @@ public:
     void refresh_surface_data_now() override;
 
     void apply_spec(shell::SurfaceSpecification const& new_spec);
-    void set_geometry(int32_t x, int32_t y, int32_t width, int32_t height);
+    void set_pending_offset(std::experimental::optional<geometry::Displacement> const& offset);
+    void set_pending_width(std::experimental::optional<geometry::Width> const& width);
+    void set_pending_height(std::experimental::optional<geometry::Height> const& height);
     void set_title(std::string const& title);
     void initiate_interactive_move();
     void initiate_interactive_resize(MirResizeEdge edge);
@@ -111,10 +113,16 @@ private:
     std::unique_ptr<scene::SurfaceCreationParameters> const params;
 
     /// The explicitly set (not taken from the surface buffer size) uncommitted window size
-    std::experimental::optional<geometry::Size> pending_explicit_size;
+    /// @{
+    std::experimental::optional<geometry::Width> pending_explicit_width;
+    std::experimental::optional<geometry::Height> pending_explicit_height;
+    /// @}
 
     /// If the committed window size was set explicitly, rather than being taken from the buffer size
-    bool committed_size_set_explicitly{false};
+    /// @{
+    bool committed_width_set_explicitly{false};
+    bool committed_height_set_explicitly{false};
+    /// @}
 
     /// The last committed window size (either explicitly set or taken from the surface buffer size)
     std::experimental::optional<geometry::Size> committed_size;

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -148,6 +148,11 @@ void mf::WlSurface::clear_role()
     role = &null_role;
 }
 
+void mf::WlSurface::set_pending_offset(std::experimental::optional<geom::Displacement> const& offset)
+{
+    pending.offset = offset;
+}
+
 std::unique_ptr<mf::WlSurface, std::function<void(mf::WlSurface*)>> mf::WlSurface::add_child(WlSubsurface* child)
 {
     children.push_back(child);

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -131,7 +131,7 @@ public:
 
     void set_role(WlSurfaceRole* role_);
     void clear_role();
-    void set_pending_offset(geometry::Displacement const& offset) { pending.offset = offset; }
+    void set_pending_offset(std::experimental::optional<geometry::Displacement> const& offset);
     std::unique_ptr<WlSurface, std::function<void(WlSurface*)>> add_child(WlSubsurface* child);
     void refresh_surface_data_now();
     void pending_invalidate_surface_data() { pending.invalidate_surface_data(); }

--- a/src/server/frontend_wayland/wl_surface_event_sink.cpp
+++ b/src/server/frontend_wayland/wl_surface_event_sink.cpp
@@ -87,9 +87,11 @@ void mf::WlSurfaceEventSink::handle_event(EventUPtr&& event)
 
 void mf::WlSurfaceEventSink::handle_resize(mir::geometry::Size const& new_size)
 {
-    requested_size = new_size;
     if (new_size != window_size)
+    {
+        requested_size = new_size;
         window->handle_resize(std::experimental::nullopt, new_size);
+    }
 }
 
 void mf::WlSurfaceEventSink::handle_input_event(MirInputEvent const* event)

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -102,7 +102,7 @@ public:
 
 private:
     static XdgToplevelStable* from(wl_resource* surface);
-    void send_configure(std::experimental::optional<geometry::Size> new_size);
+    void send_toplevel_configure();
 
     XdgSurfaceStable* const xdg_surface;
 };
@@ -484,21 +484,21 @@ void mf::XdgToplevelStable::set_minimized()
 
 void mf::XdgToplevelStable::handle_state_change(MirWindowState /*new_state*/)
 {
-    send_configure(std::experimental::nullopt);
+    send_toplevel_configure();
 }
 
 void mf::XdgToplevelStable::handle_active_change(bool /*is_now_active*/)
 {
-    send_configure(std::experimental::nullopt);
+    send_toplevel_configure();
 }
 
 void mf::XdgToplevelStable::handle_resize(std::experimental::optional<geometry::Point> const& /*new_top_left*/,
-                                          geometry::Size const& new_size)
+                                          geometry::Size const& /*new_size*/)
 {
-    send_configure(new_size);
+    send_toplevel_configure();
 }
 
-void mf::XdgToplevelStable::send_configure(std::experimental::optional<geometry::Size> new_size)
+void mf::XdgToplevelStable::send_toplevel_configure()
 {
     wl_array states;
     wl_array_init(&states);
@@ -527,9 +527,8 @@ void mf::XdgToplevelStable::send_configure(std::experimental::optional<geometry:
         break;
     }
 
-    geom::Size size = new_size.value_or(
-        requested_window_size().value_or(
-            geom::Size{})); // 0 size values means default for toplevel comfigure
+    // 0 sizes means default for toplevel configure
+    geom::Size size = requested_window_size().value_or(geom::Size{0, 0});
 
     send_configure_event(size.width.as_int(), size.height.as_int(), &states);
     wl_array_release(&states);

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -94,6 +94,7 @@ public:
     void unset_fullscreen() override;
     void set_minimized() override;
 
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override;
     void handle_active_change(bool /*is_now_active*/) override;
     void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -231,7 +231,11 @@ void mf::XdgSurfaceStable::get_popup(
 void mf::XdgSurfaceStable::set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
 {
     if (auto& role = window_role())
-        role.value()->set_geometry(x, y, width, height);
+    {
+        role.value()->set_pending_offset(geom::Displacement{-x, -y});
+        role.value()->set_pending_width(geom::Width{width});
+        role.value()->set_pending_height(geom::Height{height});
+    }
 }
 
 void mf::XdgSurfaceStable::ack_configure(uint32_t serial)

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -62,6 +62,7 @@ public:
     void grab(struct wl_resource* seat, uint32_t serial) override;
     void destroy() override;
 
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -122,7 +122,7 @@ public:
 
 private:
     static XdgToplevelV6* from(wl_resource* surface);
-    void send_configure(std::experimental::optional<geometry::Size> new_size);
+    void send_toplevel_configure();
 
     XdgSurfaceV6* const xdg_surface;
 };
@@ -490,21 +490,21 @@ void mf::XdgToplevelV6::set_minimized()
 
 void mf::XdgToplevelV6::handle_state_change(MirWindowState /*new_state*/)
 {
-    send_configure(std::experimental::nullopt);
+    send_toplevel_configure();
 }
 
 void mf::XdgToplevelV6::handle_active_change(bool /*is_now_active*/)
 {
-    send_configure(std::experimental::nullopt);
+    send_toplevel_configure();
 }
 
 void mf::XdgToplevelV6::handle_resize(std::experimental::optional<geometry::Point> const& /*new_top_left*/,
-                       geometry::Size const& new_size)
+                       geometry::Size const& /*new_size*/)
 {
-    send_configure(new_size);
+    send_toplevel_configure();
 }
 
-void mf::XdgToplevelV6::send_configure(std::experimental::optional<geometry::Size> new_size)
+void mf::XdgToplevelV6::send_toplevel_configure()
 {
     wl_array states;
     wl_array_init(&states);
@@ -533,9 +533,8 @@ void mf::XdgToplevelV6::send_configure(std::experimental::optional<geometry::Siz
         break;
     }
 
-    geom::Size size = new_size.value_or(
-        requested_window_size().value_or(
-            geom::Size{})); // 0 size values means default for toplevel comfigure
+    // 0 sizes means default for toplevel configure
+    geom::Size size = requested_window_size().value_or(geom::Size{0, 0});
 
     send_configure_event(size.width.as_int(), size.height.as_int(), &states);
     wl_array_release(&states);

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -80,6 +80,7 @@ public:
     void grab(struct wl_resource* seat, uint32_t serial) override;
     void destroy() override;
 
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(
@@ -113,6 +114,7 @@ public:
     void unset_fullscreen() override;
     void set_minimized() override;
 
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override;
     void handle_active_change(bool /*is_now_active*/) override;
     void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -240,7 +240,11 @@ void mf::XdgSurfaceV6::get_popup(wl_resource* new_popup, struct wl_resource* par
 void mf::XdgSurfaceV6::set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
 {
     if (auto& role = window_role())
-        role.value()->set_geometry(x, y, width, height);
+    {
+        role.value()->set_pending_offset(geom::Displacement{-x, -y});
+        role.value()->set_pending_width(geom::Width{width});
+        role.value()->set_pending_height(geom::Height{height});
+    }
 }
 
 void mf::XdgSurfaceV6::ack_configure(uint32_t serial)

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
@@ -56,6 +56,7 @@ public:
 protected:
     void destroy() override;
     void set_transient(struct wl_resource* parent, int32_t x, int32_t y, uint32_t flags);
+    void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left, geometry::Size const& new_size) override;

--- a/tests/mir_test_framework/test_wlcs_display_server.cpp
+++ b/tests/mir_test_framework/test_wlcs_display_server.cpp
@@ -523,7 +523,8 @@ private:
 
         bool const is_window = strcmp(wl_resource_get_class(resource), "wl_shell_surface") == 0 ||
                                strcmp(wl_resource_get_class(resource), "zxdg_surface_v6") == 0 ||
-                               strcmp(wl_resource_get_class(resource), "xdg_surface") == 0;
+                               strcmp(wl_resource_get_class(resource), "xdg_surface") == 0 ||
+                               strcmp(wl_resource_get_class(resource), "zwlr_layer_surface_v1") == 0;
 
         if (is_surface)
         {


### PR DESCRIPTION
Correct layer shell behavior so that it passes the new WLCS tests. On top of #925.