### PR TITLE
Track registering miral::WaylandExtensions objects with mir::Servers and error if there is more than one

### DIFF
--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -43,6 +43,10 @@ auto vec2set(std::vector<std::string> vec) -> std::set<std::string>
     return std::set<std::string>{vec.begin(), vec.end()};
 }
 
+// If a user inadvertently supplies more than one miral::WaylandExtensions to
+// MirRunner::run_with() then the implementation here would quietly break.
+// To avoid this we track the extensions against all servers in the process.
+// See: https://github.com/MirServer/mir/issues/875
 struct StaticExtensionTracker
 {
     static void add_server_extension(mir::Server* server, void* extension)
@@ -81,6 +85,8 @@ struct StaticExtensionTracker
     }
 
 private:
+    // It's extremely unlikely that there's more than a couple, so lock contention
+    // is a non-issue and a vector is a suitable data.
     struct ExtensionTracker{ mir::Server* server; void* extension; };
     static std::mutex mutex;
     static std::vector<ExtensionTracker> extensions;

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -27,6 +27,7 @@
 #include <mir/options/option.h>
 #include <mir/options/configuration.h>
 
+#include <algorithm>
 #include <mutex>
 #include <set>
 #include <vector>
@@ -74,14 +75,9 @@ struct StaticExtensionTracker
     {
         std::lock_guard<decltype(mutex)> lock{mutex};
 
-        for (auto x = begin(extensions); x != end(extensions); ++x)
-        {
-            if (x->extension == extension)
-            {
-                extensions.erase(x);
-                return;
-            }
-        }
+        extensions.erase(
+            remove_if(begin(extensions), end(extensions), [extension](auto& x) { return x.extension == extension; }),
+            end(extensions));
     }
 
 private:


### PR DESCRIPTION
Track registering miral::WaylandExtensions objects with mir::Servers and error if there is more than one. (Fixes #875)