### PR TITLE
Allow frontend to add scene observer

### DIFF
--- a/include/server/mir/shell/abstract_shell.h
+++ b/include/server/mir/shell/abstract_shell.h
@@ -144,6 +144,9 @@ public:
     void set_drag_and_drop_handle(std::vector<uint8_t> const& handle) override;
     void clear_drag_and_drop_handle() override;
 
+    void add_observer(std::shared_ptr<scene::Observer> const& observer) override;
+    void remove_observer(std::weak_ptr<scene::Observer> const& observer) override;
+
 protected:
     std::shared_ptr<InputTargeter> const input_targeter;
     std::shared_ptr<SurfaceStack> const surface_stack;

--- a/include/server/mir/shell/shell.h
+++ b/include/server/mir/shell/shell.h
@@ -40,6 +40,7 @@ class PromptSessionCreationParameters;
 class SessionCoordinator;
 class Surface;
 struct SurfaceCreationParameters;
+class Observer;
 }
 
 namespace shell
@@ -115,6 +116,9 @@ public:
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp,
         MirResizeEdge edge) = 0;
+
+    virtual void add_observer(std::shared_ptr<scene::Observer> const& observer) = 0;
+    virtual void remove_observer(std::weak_ptr<scene::Observer> const& observer) = 0;
 
 /** @} */
 };

--- a/include/server/mir/shell/shell_wrapper.h
+++ b/include/server/mir/shell/shell_wrapper.h
@@ -102,6 +102,9 @@ public:
         uint64_t timestamp,
         MirResizeEdge edge) override;
 
+    void add_observer(std::shared_ptr<scene::Observer> const& observer) override;
+    void remove_observer(std::weak_ptr<scene::Observer> const& observer) override;
+
     void add_display(geometry::Rectangle const& area) override;
     void remove_display(geometry::Rectangle const& area) override;
 

--- a/include/server/mir/shell/surface_stack.h
+++ b/include/server/mir/shell/surface_stack.h
@@ -33,6 +33,7 @@ class Surface;
 struct SurfaceCreationParameters;
 class SurfaceObserver;
 class Session;
+class Observer;
 }
 
 namespace shell
@@ -53,6 +54,9 @@ public:
     virtual void remove_surface(std::weak_ptr<scene::Surface> const& surface) = 0;
 
     virtual auto surface_at(geometry::Point) const -> std::shared_ptr<scene::Surface> = 0;
+
+    virtual void add_observer(std::shared_ptr<scene::Observer> const& observer) = 0;
+    virtual void remove_observer(std::weak_ptr<scene::Observer> const& observer) = 0;
 
 protected:
     SurfaceStack() = default;

--- a/include/server/mir/shell/surface_stack_wrapper.h
+++ b/include/server/mir/shell/surface_stack_wrapper.h
@@ -42,6 +42,9 @@ public:
 
     auto surface_at(geometry::Point) const -> std::shared_ptr<scene::Surface> override;
 
+    void add_observer(std::shared_ptr<scene::Observer> const& observer) override;
+    void remove_observer(std::weak_ptr<scene::Observer> const& observer) override;
+
 protected:
     std::shared_ptr<SurfaceStack> const wrapped;
 };

--- a/spread.yaml
+++ b/spread.yaml
@@ -22,8 +22,6 @@ backends:
                 image: ubuntu-os-cloud/ubuntu-1804-lts
             - ubuntu-19.04-64:
                 image: ubuntu-os-cloud/ubuntu-1904
-            - ubuntu-devel-64:
-                image: ubuntu-os-cloud/ubuntu-1810
             - fedora-29-64
             - fedora-30-64
             - fedora-rawhide-64

--- a/src/include/server/mir/frontend/shell.h
+++ b/src/include/server/mir/frontend/shell.h
@@ -35,6 +35,7 @@ namespace scene
 struct SurfaceCreationParameters;
 struct PromptSessionCreationParameters;
 class Surface;
+class Observer;
 }
 namespace shell { class SurfaceSpecification; }
 

--- a/src/include/server/mir/scene/null_observer.h
+++ b/src/include/server/mir/scene/null_observer.h
@@ -35,6 +35,9 @@ public:
     void surface_removed(Surface* surface);
     void surfaces_reordered();
 
+    // Used to indicate the scene has changed in some way beyond the present surfaces
+    // and will require full recomposition.
+    void scene_changed();
     // Called at observer registration to notify of already existing surfaces.
     void surface_exists(Surface* surface);
     // Called when observer is unregistered, for example, to provide a place to

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -20,9 +20,9 @@
 
 #include "mir/input/scene.h"
 #include "mir/input/surface.h"
-#include "mir/scene/observer.h"
+#include "mir/scene/null_observer.h"
 #include "mir/scene/surface.h"
-#include "mir/scene/surface_observer.h"
+#include "mir/scene/null_surface_observer.h"
 #include "mir/events/event_builders.h"
 #include "mir_toolkit/mir_cookie.h"
 
@@ -40,8 +40,8 @@ namespace geom = mir::geometry;
 namespace
 {
 struct InputDispatcherSceneObserver :
-    public ms::Observer,
-    public ms::SurfaceObserver,
+    public ms::NullObserver,
+    public ms::NullSurfaceObserver,
     public std::enable_shared_from_this<InputDispatcherSceneObserver>
 {
     InputDispatcherSceneObserver(
@@ -61,19 +61,10 @@ struct InputDispatcherSceneObserver :
     {
         on_removed(surface);
     }
-    void surfaces_reordered() override
-    {
-    }
-    void scene_changed() override
-    {
-    }
 
     void surface_exists(ms::Surface* surface) override
     {
         surface->add_observer(shared_from_this());
-    }
-    void end_observation() override
-    {
     }
 
     void attrib_changed(ms::Surface const*, MirWindowAttrib /*attrib*/, int /*value*/) override
@@ -94,72 +85,6 @@ struct InputDispatcherSceneObserver :
     void hidden_set_to(ms::Surface const*, bool /*hide*/) override
     {
         // TODO: Do we need to listen to this?
-    }
-
-    void frame_posted(ms::Surface const*, int, mir::geometry::Size const&) override
-    {
-
-    }
-
-    void alpha_set_to(ms::Surface const*, float) override
-    {
-
-    }
-
-    void orientation_set_to(ms::Surface const*, MirOrientation) override
-    {
-
-    }
-
-    void transformation_set_to(ms::Surface const*, glm::mat4 const&) override
-    {
-
-    }
-
-    void reception_mode_set_to(ms::Surface const*, mir::input::InputReceptionMode) override
-    {
-    }
-
-    void cursor_image_set_to(ms::Surface const*, mir::graphics::CursorImage const&) override
-    {
-    }
-
-    void client_surface_close_requested(ms::Surface const*) override
-    {
-    }
-
-    void keymap_changed(
-        ms::Surface const*,
-        MirInputDeviceId,
-        std::string const&,
-        std::string const&,
-        std::string const&,
-        std::string const&) override
-    {
-    }
-
-    void renamed(ms::Surface const*, char const*) override
-    {
-    }
-
-    void cursor_image_removed(ms::Surface const*) override
-    {
-    }
-
-    void placed_relative(ms::Surface const*, mir::geometry::Rectangle const&) override
-    {
-    }
-
-    void input_consumed(ms::Surface const*, MirEvent const*) override
-    {
-    }
-
-    void start_drag_and_drop(ms::Surface const*, std::vector<uint8_t> const&) override
-    {
-    }
-
-    void depth_layer_set_to(ms::Surface const*, MirDepthLayer) override
-    {
     }
 
     std::function<void(ms::Surface*)> const on_removed;

--- a/src/server/scene/legacy_surface_change_notification.cpp
+++ b/src/server/scene/legacy_surface_change_notification.cpp
@@ -56,32 +56,9 @@ void ms::LegacySurfaceChangeNotification::alpha_set_to(Surface const*, float)
     notify_scene_change();
 }
 
-// An orientation change alone is not enough to trigger recomposition.
-void ms::LegacySurfaceChangeNotification::orientation_set_to(Surface const*, MirOrientation)
-{
-}
-
 void ms::LegacySurfaceChangeNotification::transformation_set_to(Surface const*, glm::mat4 const&)
 {
     notify_scene_change();
-}
-
-// An attrib change alone is not enough to trigger recomposition.
-void ms::LegacySurfaceChangeNotification::attrib_changed(Surface const*, MirWindowAttrib, int)
-{
-}
-
-// Cursor image change request is not enough to trigger recomposition.
-void ms::LegacySurfaceChangeNotification::cursor_image_set_to(Surface const*, graphics::CursorImage const&)
-{
-}
-
-void ms::LegacySurfaceChangeNotification::cursor_image_removed(Surface const*)
-{
-}
-
-void ms::LegacySurfaceChangeNotification::placed_relative(Surface const*, geometry::Rectangle const&)
-{
 }
 
 void ms::LegacySurfaceChangeNotification::reception_mode_set_to(Surface const*, input::InputReceptionMode)
@@ -89,31 +66,7 @@ void ms::LegacySurfaceChangeNotification::reception_mode_set_to(Surface const*, 
     notify_scene_change();
 }
 
-// A client close request is not enough to trigger recomposition.
-void ms::LegacySurfaceChangeNotification::client_surface_close_requested(Surface const*)
-{
-}
-
-// A keymap change is not enough to trigger recomposition
-void ms::LegacySurfaceChangeNotification::keymap_changed(Surface const*, MirInputDeviceId, std::string const&,
-                                                         std::string const&, std::string const&,
-                                                         std::string const&)
-{
-}
-
 void ms::LegacySurfaceChangeNotification::renamed(Surface const*, char const*)
 {
     notify_scene_change();
-}
-
-void ms::LegacySurfaceChangeNotification::input_consumed(Surface const*, MirEvent const*)
-{
-}
-
-void ms::LegacySurfaceChangeNotification::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&)
-{
-}
-
-void ms::LegacySurfaceChangeNotification::depth_layer_set_to(Surface const*, MirDepthLayer)
-{
 }

--- a/src/server/scene/legacy_surface_change_notification.h
+++ b/src/server/scene/legacy_surface_change_notification.h
@@ -19,7 +19,7 @@
 #ifndef MIR_SCENE_LEGACY_SURFACE_CHANGE_NOTIFICATION_H_
 #define MIR_SCENE_LEGACY_SURFACE_CHANGE_NOTIFICATION_H_
 
-#include "mir/scene/surface_observer.h"
+#include "mir/scene/null_surface_observer.h"
 
 #include <functional>
 
@@ -27,7 +27,7 @@ namespace mir
 {
 namespace scene
 {
-class LegacySurfaceChangeNotification : public mir::scene::SurfaceObserver
+class LegacySurfaceChangeNotification : public mir::scene::NullSurfaceObserver
 {
 public:
     LegacySurfaceChangeNotification(
@@ -39,25 +39,9 @@ public:
     void hidden_set_to(Surface const* surf, bool) override;
     void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) override;
     void alpha_set_to(Surface const* surf, float) override;
-    void orientation_set_to(Surface const* surf, MirOrientation orientation) override;
     void transformation_set_to(Surface const* surf, glm::mat4 const&) override;
-    void attrib_changed(Surface const* surf, MirWindowAttrib, int) override;
     void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) override;
-    void cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image) override;
-    void client_surface_close_requested(Surface const* surf) override;
-    void keymap_changed(
-        Surface const* surf,
-        MirInputDeviceId id,
-        std::string const& model,
-        std::string const& layout,
-        std::string const& variant,
-        std::string const& options) override;
     void renamed(Surface const* surf, char const*) override;
-    void cursor_image_removed(Surface const* surf) override;
-    void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
-    void input_consumed(Surface const* surf, MirEvent const* event) override;
-    void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
-    void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
 
 private:
     std::function<void()> const notify_scene_change;

--- a/src/server/scene/null_observer.cpp
+++ b/src/server/scene/null_observer.cpp
@@ -23,5 +23,6 @@ namespace ms = mir::scene;
 void ms::NullObserver::surface_added(ms::Surface* /* surface */) {}
 void ms::NullObserver::surface_removed(ms::Surface* /* surface */) {}
 void ms::NullObserver::surfaces_reordered() {}
+void ms::NullObserver::scene_changed() {}
 void ms::NullObserver::surface_exists(ms::Surface* /* surface */) {}
 void ms::NullObserver::end_observation() {}

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -508,3 +508,13 @@ void msh::AbstractShell::clear_drag_and_drop_handle()
 {
     input_targeter->clear_drag_and_drop_handle();
 }
+
+void msh::AbstractShell::add_observer(std::shared_ptr<scene::Observer> const& observer)
+{
+    surface_stack->add_observer(observer);
+}
+
+void msh::AbstractShell::remove_observer(std::weak_ptr<scene::Observer> const& observer)
+{
+    surface_stack->remove_observer(observer);
+}

--- a/src/server/shell/shell_wrapper.cpp
+++ b/src/server/shell/shell_wrapper.cpp
@@ -150,6 +150,16 @@ void msh::ShellWrapper::request_resize(
     wrapped->request_resize(session, surface, timestamp, edge);
 }
 
+void msh::ShellWrapper::add_observer(std::shared_ptr<scene::Observer> const& observer)
+{
+    wrapped->add_observer(observer);
+}
+
+void msh::ShellWrapper::remove_observer(std::weak_ptr<scene::Observer> const& observer)
+{
+    wrapped->remove_observer(observer);
+}
+
 void msh::ShellWrapper::add_display(geometry::Rectangle const& area)
 {
     wrapped->add_display(area);

--- a/src/server/shell/surface_stack_wrapper.cpp
+++ b/src/server/shell/surface_stack_wrapper.cpp
@@ -55,3 +55,13 @@ auto msh::SurfaceStackWrapper::surface_at(geometry::Point point) const -> std::s
 {
     return wrapped->surface_at(point);
 }
+
+void msh::SurfaceStackWrapper::add_observer(std::shared_ptr<scene::Observer> const& observer)
+{
+    wrapped->add_observer(observer);
+}
+
+void msh::SurfaceStackWrapper::remove_observer(std::weak_ptr<scene::Observer> const& observer)
+{
+    wrapped->remove_observer(observer);
+}

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -973,3 +973,13 @@ MIR_SERVER_1.3 {
     non-virtual?thunk?to?mir::scene::NullSurfaceObserver::depth_layer_set_to*;
   };
 } MIR_SERVER_1.2;
+
+MIR_SERVER_1.4 {
+ global:
+  extern "C++" {
+    mir::shell::ShellWrapper::add_observer*;
+    mir::shell::ShellWrapper::remove_observer*;
+    mir::shell::SurfaceStackWrapper::add_observer*;
+    mir::shell::SurfaceStackWrapper::remove_observer*;
+  };
+} MIR_SERVER_1.3;

--- a/tests/include/mir/test/doubles/mock_shell.h
+++ b/tests/include/mir/test/doubles/mock_shell.h
@@ -75,6 +75,9 @@ struct MockShell : public frontend::Shell
 
     MOCK_METHOD5(request_operation, void(std::shared_ptr<frontend::Session> const &session,
         frontend::SurfaceId surface_id, uint64_t timestamp, UserRequest request, optional_value<uint32_t> hint));
+
+    MOCK_METHOD1(add_observer, void(std::shared_ptr<scene::Observer> const& observer));
+    MOCK_METHOD1(remove_observer, void(std::weak_ptr<scene::Observer> const& observer));
 };
 
 }

--- a/tests/include/mir/test/doubles/mock_surface_stack.h
+++ b/tests/include/mir/test/doubles/mock_surface_stack.h
@@ -41,6 +41,9 @@ struct MockSurfaceStack : public shell::SurfaceStack
 
     MOCK_METHOD1(remove_surface, void(std::weak_ptr<scene::Surface> const& surface));
     MOCK_CONST_METHOD1(surface_at, std::shared_ptr<scene::Surface>(geometry::Point));
+
+    MOCK_METHOD1(add_observer, void(std::shared_ptr<scene::Observer> const& observer));
+    MOCK_METHOD1(remove_observer, void(std::weak_ptr<scene::Observer> const& observer));
 };
 
 }

--- a/tests/integration-tests/session_management.cpp
+++ b/tests/integration-tests/session_management.cpp
@@ -85,6 +85,15 @@ struct TestSurfaceStack : public msh::SurfaceStack
         wrapped->raise(surface);
     }
 
+    void add_observer(std::shared_ptr<ms::Observer> const& observer) override
+    {
+        wrapped->add_observer(observer);
+    }
+
+    void remove_observer(std::weak_ptr<ms::Observer> const& observer) override
+    {
+        wrapped->remove_observer(observer);
+    }
 };
 
 struct TestConfiguration : public mir_test_framework::StubbedServerConfiguration

--- a/tests/unit-tests/scene/test_application_session.cpp
+++ b/tests/unit-tests/scene/test_application_session.cpp
@@ -128,6 +128,12 @@ struct StubSurfaceStack : public msh::SurfaceStack
     {
         return std::shared_ptr<ms::Surface>{};
     }
+    void add_observer(std::shared_ptr<ms::Observer> const&) override
+    {
+    }
+    void remove_observer(std::weak_ptr<ms::Observer> const&) override
+    {
+    }
 };
 
 struct ApplicationSession : public testing::Test


### PR DESCRIPTION
This gives a path for the Wayland frontend to add a `scene::Observer` so it can get notified about surfaces that are created or destroyed.

I also made some classes inherit from `scene::NullObserver` instead of `scene::Observer` so they don't have to override methods they don't use.