### PR TITLE
scene::Surface: Add focus state getter/setter

### DIFF
--- a/include/server/mir/scene/surface.h
+++ b/include/server/mir/scene/surface.h
@@ -117,11 +117,16 @@ public:
     virtual void placed_relative(geometry::Rectangle const& placement) = 0;
     virtual void start_drag_and_drop(std::vector<uint8_t> const& handle) = 0;
 
+    /// The depth layer the surface is on
+    /// It will be kept above all surfaces on lower layers, and below surfaces on higher layers
     virtual auto depth_layer() const -> MirDepthLayer = 0;
-    /**
-     * When the depth layer is changed, the surface becomes the top surface on that layer
-     */
+    /// When the depth layer is changed, the surface becomes the top surface on that layer
     virtual void set_depth_layer(MirDepthLayer depth_layer) = 0;
+
+    /// If the window has focus
+    virtual auto focus_state() const -> MirWindowFocusState = 0;
+    virtual void set_focus_state(MirWindowFocusState focus_state) = 0;
+
 };
 }
 }

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -72,6 +72,8 @@ struct StubSurface : scene::Surface
     void start_drag_and_drop(std::vector<uint8_t> const& handle) override;
     MirDepthLayer depth_layer() const override;
     void set_depth_layer(MirDepthLayer depth_layer) override;
+    MirWindowFocusState focus_state() const override;
+    void set_focus_state(MirWindowFocusState new_state) override;
 };
 }
 }

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -145,6 +145,9 @@ public:
     auto depth_layer() const -> MirDepthLayer override;
     void set_depth_layer(MirDepthLayer depth_layer) override;
 
+    auto focus_state() const -> MirWindowFocusState override;
+    void set_focus_state(MirWindowFocusState new_state) override;
+
 private:
     bool visible(std::unique_lock<std::mutex>&) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
@@ -152,7 +155,6 @@ private:
     int set_dpi(int);
     MirWindowVisibility set_visibility(MirWindowVisibility v);
     int set_swap_interval(int);
-    MirWindowFocusState set_focus_state(MirWindowFocusState f);
     MirOrientationMode set_preferred_orientation(MirOrientationMode mode);
 
     SurfaceObservers observers;

--- a/tests/include/mir/test/doubles/stub_scene_surface.h
+++ b/tests/include/mir/test/doubles/stub_scene_surface.h
@@ -97,6 +97,9 @@ public:
 
     auto depth_layer() const -> MirDepthLayer override { return mir_depth_layer_application; }
     void set_depth_layer(MirDepthLayer /*depth_layer*/) override {}
+
+    auto focus_state() const -> MirWindowFocusState override { return mir_window_focus_state_unfocused; }
+    void set_focus_state(MirWindowFocusState /*focus_state*/) override {}
 };
 
 }

--- a/tests/mir_test_framework/stub_surface.cpp
+++ b/tests/mir_test_framework/stub_surface.cpp
@@ -206,6 +206,15 @@ void mtd::StubSurface::set_depth_layer(MirDepthLayer /*depth_layer*/)
 {
 }
 
+MirWindowFocusState mtd::StubSurface::focus_state() const
+{
+    return mir_window_focus_state_unfocused;
+}
+
+void mtd::StubSurface::set_focus_state(MirWindowFocusState /*new_state*/)
+{
+}
+
 namespace
 {
 // Ensure we don't accidentally have an abstract class


### PR DESCRIPTION
The focus state was accessible from the old attrib system, but needs a getter and setter with that deprecated.