### PR TITLE
Switch from /** */ comments to /// comments

### DIFF
--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -125,35 +125,29 @@ public:
     auto confine_pointer() -> mir::optional_value<MirPointerConfinementState>&;
     auto userdata() -> mir::optional_value<std::shared_ptr<void>>&;
 
-    /**
-     * The depth layer of a child window is updated with the depth layer of its parent, but can be overridden
-     *  @{
-     */
+    /// The depth layer of a child window is updated with the depth layer of its parent, but can be overridden
+    ///@{
     auto depth_layer() const -> mir::optional_value<MirDepthLayer> const&;
     auto depth_layer() -> mir::optional_value<MirDepthLayer>&;
-    /** @}*/
+    ///@}
 
-    /**
-     * The set of window eges that are attched to edges of the output
-     * If attached to perpendicular edges, it is attached to the corner where the two edges intersect
-     * If attached to oposite edges (eg left and right), it is stretched across the output in that direction
-     * If all edges are specified, it takes up the entire output
-     *  @{
-     */
+    /// The set of window eges that are attched to edges of the output
+    /// If attached to perpendicular edges, it is attached to the corner where the two edges intersect
+    /// If attached to oposite edges (eg left and right), it is stretched across the output in that direction
+    /// If all edges are specified, it takes up the entire output
+    ///@{
     auto attached_edges() const -> mir::optional_value<MirPlacementGravity> const&;
     auto attached_edges() -> mir::optional_value<MirPlacementGravity>&;
-    /** @}*/
+    ///@}
 
-    /**
-     * The area over which the window should not be occluded
-     * Only meaningful for windows attached to an edge
-     * Setting to optional_value{} will not change the rect when this specification is applied
-     * Setting to optional_value{optional_value{}} will clear the exclusive rect
-     *  @{
-     */
+    /// The area over which the window should not be occluded
+    /// Only meaningful for windows attached to an edge
+    /// Setting to optional_value{} will not change the rect when this specification is applied
+    /// Setting to optional_value{optional_value{}} will clear the exclusive rect
+    ///@{
     auto exclusive_rect() const -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>> const&;
     auto exclusive_rect() -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>>&;
-    /** @} */
+    ///@}
 
 private:
     struct Self;

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -142,8 +142,8 @@ public:
 
     /// The area over which the window should not be occluded
     /// Only meaningful for windows attached to an edge
-    /// Setting to optional_value{} will not change the rect when this specification is applied
-    /// Setting to optional_value{optional_value{}} will clear the exclusive rect
+    /// If the outer optional is unset (the default), the window's exclusive rect is not changed by this spec
+    /// If the outer optional is set but the inner is not, the window's exclusive rect is cleared
     ///@{
     auto exclusive_rect() const -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>> const&;
     auto exclusive_rect() -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>>&;

--- a/include/server/mir/scene/surface_creation_parameters.h
+++ b/include/server/mir/scene/surface_creation_parameters.h
@@ -112,21 +112,15 @@ struct SurfaceCreationParameters
     mir::optional_value<std::vector<shell::StreamSpecification>> streams;
     mir::optional_value<MirPointerConfinementState> confine_pointer;
 
-    /**
-     * If the depth layer of a child surface isn't set, it gets the layer of its parent
-     */
+    /// If the depth layer of a child surface isn't set, it gets the layer of its parent
     optional_value<MirDepthLayer> depth_layer;
 
-    /**
-     * The edge of the output to attach this surface to
-     * Only used if the surface is in state mir_window_state_attached
-     */
+    /// The edge of the output to attach this surface to
+    /// Only used if the surface is in state mir_window_state_attached
     optional_value<MirPlacementGravity> attached_edges;
 
-    /**
-     * The area of this surface that will not be occluded
-     * Only used if surface is in state mir_window_state_attached and is attached to an edge (not a corner)
-     */
+    /// The area of this surface that will not be occluded
+    /// Only used if surface is in state mir_window_state_attached and is attached to an edge (not a corner)
     optional_value<geometry::Rectangle> exclusive_rect;
 };
 

--- a/include/server/mir/shell/surface_specification.h
+++ b/include/server/mir/shell/surface_specification.h
@@ -100,10 +100,8 @@ struct SurfaceSpecification
     optional_value<std::shared_ptr<graphics::CursorImage>> cursor_image;
     optional_value<StreamCursor> stream_cursor;
 
-    /**
-     * Child surfaces are by default created on the same layer as their parent, and updating the depth layer of a parent
-     * also updates all children.
-     */
+    /// Child surfaces are by default created on the same layer as their parent, and updating the depth layer of a parent
+    /// also updates all children.
     optional_value<MirDepthLayer> depth_layer;
 
     optional_value<MirPlacementGravity> attached_edges;


### PR DESCRIPTION
I prefer `///`. I thought `/** */` was standard in Mir, but I've been seeing more `///` comments and I don't want my relatively recent code to be part of the problem.