### PR TITLE
Use scene::NullObserver and scene::NullSurfaceObserver where it makes sense

### DIFF
--- a/src/include/server/mir/scene/null_observer.h
+++ b/src/include/server/mir/scene/null_observer.h
@@ -35,6 +35,9 @@ public:
     void surface_removed(Surface* surface);
     void surfaces_reordered();
 
+    // Used to indicate the scene has changed in some way beyond the present surfaces
+    // and will require full recomposition.
+    void scene_changed();
     // Called at observer registration to notify of already existing surfaces.
     void surface_exists(Surface* surface);
     // Called when observer is unregistered, for example, to provide a place to

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -20,9 +20,9 @@
 
 #include "mir/input/scene.h"
 #include "mir/input/surface.h"
-#include "mir/scene/observer.h"
+#include "mir/scene/null_observer.h"
 #include "mir/scene/surface.h"
-#include "mir/scene/surface_observer.h"
+#include "mir/scene/null_surface_observer.h"
 #include "mir/events/event_builders.h"
 #include "mir_toolkit/mir_cookie.h"
 
@@ -40,8 +40,8 @@ namespace geom = mir::geometry;
 namespace
 {
 struct InputDispatcherSceneObserver :
-    public ms::Observer,
-    public ms::SurfaceObserver,
+    public ms::NullObserver,
+    public ms::NullSurfaceObserver,
     public std::enable_shared_from_this<InputDispatcherSceneObserver>
 {
     InputDispatcherSceneObserver(
@@ -61,19 +61,10 @@ struct InputDispatcherSceneObserver :
     {
         on_removed(surface);
     }
-    void surfaces_reordered() override
-    {
-    }
-    void scene_changed() override
-    {
-    }
 
     void surface_exists(ms::Surface* surface) override
     {
         surface->add_observer(shared_from_this());
-    }
-    void end_observation() override
-    {
     }
 
     void attrib_changed(ms::Surface const*, MirWindowAttrib /*attrib*/, int /*value*/) override
@@ -94,72 +85,6 @@ struct InputDispatcherSceneObserver :
     void hidden_set_to(ms::Surface const*, bool /*hide*/) override
     {
         // TODO: Do we need to listen to this?
-    }
-
-    void frame_posted(ms::Surface const*, int, mir::geometry::Size const&) override
-    {
-
-    }
-
-    void alpha_set_to(ms::Surface const*, float) override
-    {
-
-    }
-
-    void orientation_set_to(ms::Surface const*, MirOrientation) override
-    {
-
-    }
-
-    void transformation_set_to(ms::Surface const*, glm::mat4 const&) override
-    {
-
-    }
-
-    void reception_mode_set_to(ms::Surface const*, mir::input::InputReceptionMode) override
-    {
-    }
-
-    void cursor_image_set_to(ms::Surface const*, mir::graphics::CursorImage const&) override
-    {
-    }
-
-    void client_surface_close_requested(ms::Surface const*) override
-    {
-    }
-
-    void keymap_changed(
-        ms::Surface const*,
-        MirInputDeviceId,
-        std::string const&,
-        std::string const&,
-        std::string const&,
-        std::string const&) override
-    {
-    }
-
-    void renamed(ms::Surface const*, char const*) override
-    {
-    }
-
-    void cursor_image_removed(ms::Surface const*) override
-    {
-    }
-
-    void placed_relative(ms::Surface const*, mir::geometry::Rectangle const&) override
-    {
-    }
-
-    void input_consumed(ms::Surface const*, MirEvent const*) override
-    {
-    }
-
-    void start_drag_and_drop(ms::Surface const*, std::vector<uint8_t> const&) override
-    {
-    }
-
-    void depth_layer_set_to(ms::Surface const*, MirDepthLayer) override
-    {
     }
 
     std::function<void(ms::Surface*)> const on_removed;

--- a/src/server/scene/legacy_surface_change_notification.cpp
+++ b/src/server/scene/legacy_surface_change_notification.cpp
@@ -56,32 +56,9 @@ void ms::LegacySurfaceChangeNotification::alpha_set_to(Surface const*, float)
     notify_scene_change();
 }
 
-// An orientation change alone is not enough to trigger recomposition.
-void ms::LegacySurfaceChangeNotification::orientation_set_to(Surface const*, MirOrientation)
-{
-}
-
 void ms::LegacySurfaceChangeNotification::transformation_set_to(Surface const*, glm::mat4 const&)
 {
     notify_scene_change();
-}
-
-// An attrib change alone is not enough to trigger recomposition.
-void ms::LegacySurfaceChangeNotification::attrib_changed(Surface const*, MirWindowAttrib, int)
-{
-}
-
-// Cursor image change request is not enough to trigger recomposition.
-void ms::LegacySurfaceChangeNotification::cursor_image_set_to(Surface const*, graphics::CursorImage const&)
-{
-}
-
-void ms::LegacySurfaceChangeNotification::cursor_image_removed(Surface const*)
-{
-}
-
-void ms::LegacySurfaceChangeNotification::placed_relative(Surface const*, geometry::Rectangle const&)
-{
 }
 
 void ms::LegacySurfaceChangeNotification::reception_mode_set_to(Surface const*, input::InputReceptionMode)
@@ -89,31 +66,7 @@ void ms::LegacySurfaceChangeNotification::reception_mode_set_to(Surface const*, 
     notify_scene_change();
 }
 
-// A client close request is not enough to trigger recomposition.
-void ms::LegacySurfaceChangeNotification::client_surface_close_requested(Surface const*)
-{
-}
-
-// A keymap change is not enough to trigger recomposition
-void ms::LegacySurfaceChangeNotification::keymap_changed(Surface const*, MirInputDeviceId, std::string const&,
-                                                         std::string const&, std::string const&,
-                                                         std::string const&)
-{
-}
-
 void ms::LegacySurfaceChangeNotification::renamed(Surface const*, char const*)
 {
     notify_scene_change();
-}
-
-void ms::LegacySurfaceChangeNotification::input_consumed(Surface const*, MirEvent const*)
-{
-}
-
-void ms::LegacySurfaceChangeNotification::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&)
-{
-}
-
-void ms::LegacySurfaceChangeNotification::depth_layer_set_to(Surface const*, MirDepthLayer)
-{
 }

--- a/src/server/scene/legacy_surface_change_notification.h
+++ b/src/server/scene/legacy_surface_change_notification.h
@@ -19,7 +19,7 @@
 #ifndef MIR_SCENE_LEGACY_SURFACE_CHANGE_NOTIFICATION_H_
 #define MIR_SCENE_LEGACY_SURFACE_CHANGE_NOTIFICATION_H_
 
-#include "mir/scene/surface_observer.h"
+#include "mir/scene/null_surface_observer.h"
 
 #include <functional>
 
@@ -27,7 +27,7 @@ namespace mir
 {
 namespace scene
 {
-class LegacySurfaceChangeNotification : public mir::scene::SurfaceObserver
+class LegacySurfaceChangeNotification : public mir::scene::NullSurfaceObserver
 {
 public:
     LegacySurfaceChangeNotification(
@@ -39,25 +39,9 @@ public:
     void hidden_set_to(Surface const* surf, bool) override;
     void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) override;
     void alpha_set_to(Surface const* surf, float) override;
-    void orientation_set_to(Surface const* surf, MirOrientation orientation) override;
     void transformation_set_to(Surface const* surf, glm::mat4 const&) override;
-    void attrib_changed(Surface const* surf, MirWindowAttrib, int) override;
     void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) override;
-    void cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image) override;
-    void client_surface_close_requested(Surface const* surf) override;
-    void keymap_changed(
-        Surface const* surf,
-        MirInputDeviceId id,
-        std::string const& model,
-        std::string const& layout,
-        std::string const& variant,
-        std::string const& options) override;
     void renamed(Surface const* surf, char const*) override;
-    void cursor_image_removed(Surface const* surf) override;
-    void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
-    void input_consumed(Surface const* surf, MirEvent const* event) override;
-    void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
-    void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
 
 private:
     std::function<void()> const notify_scene_change;

--- a/src/server/scene/null_observer.cpp
+++ b/src/server/scene/null_observer.cpp
@@ -23,5 +23,6 @@ namespace ms = mir::scene;
 void ms::NullObserver::surface_added(ms::Surface* /* surface */) {}
 void ms::NullObserver::surface_removed(ms::Surface* /* surface */) {}
 void ms::NullObserver::surfaces_reordered() {}
+void ms::NullObserver::scene_changed() {}
 void ms::NullObserver::surface_exists(ms::Surface* /* surface */) {}
 void ms::NullObserver::end_observation() {}


### PR DESCRIPTION
This makes it easier to add surface properties without changing a bunch of observers that don't care