### PR TITLE
Let frontend look up a surface with the SurfaceId

### DIFF
--- a/include/server/mir/frontend/session.h
+++ b/include/server/mir/frontend/session.h
@@ -51,7 +51,9 @@ class Session
 public:
     virtual ~Session() = default;
 
+    /// Throws std::out_of_range if the surface is invalid
     virtual SurfaceId get_surface_id(Surface* surface) const = 0;
+    /// Throws std::out_of_range if the id is invalid
     virtual std::shared_ptr<Surface> get_surface(SurfaceId surface) const = 0;
 
     virtual std::shared_ptr<BufferStream> get_buffer_stream(BufferStreamId stream) const = 0;

--- a/include/server/mir/frontend/session.h
+++ b/include/server/mir/frontend/session.h
@@ -51,6 +51,7 @@ class Session
 public:
     virtual ~Session() = default;
 
+    virtual SurfaceId get_surface_id(Surface* surface) const = 0;
     virtual std::shared_ptr<Surface> get_surface(SurfaceId surface) const = 0;
 
     virtual std::shared_ptr<BufferStream> get_buffer_stream(BufferStreamId stream) const = 0;

--- a/include/test/mir/test/doubles/stub_session.h
+++ b/include/test/mir/test/doubles/stub_session.h
@@ -32,8 +32,9 @@ struct StubSession : scene::Session
 {
     StubSession(pid_t pid = -1);
 
-    std::shared_ptr<frontend::Surface> get_surface(
-        frontend::SurfaceId surface) const override;
+    frontend::SurfaceId get_surface_id(frontend::Surface* surface) const override;
+
+    std::shared_ptr<frontend::Surface> get_surface(frontend::SurfaceId surface) const override;
 
     std::string name() const override;
 

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -173,7 +173,7 @@ ms::ApplicationSession::Surfaces::const_iterator ms::ApplicationSession::checked
 {
     auto p = surfaces.find(id);
     if (p == surfaces.end())
-        BOOST_THROW_EXCEPTION(std::runtime_error("Invalid SurfaceId"));
+        BOOST_THROW_EXCEPTION(std::out_of_range("Invalid SurfaceId"));
     return p;
 }
 
@@ -181,7 +181,7 @@ ms::ApplicationSession::Streams::const_iterator ms::ApplicationSession::checked_
 {
     auto p = streams.find(id);
     if (p == streams.end())
-        BOOST_THROW_EXCEPTION(std::runtime_error("Invalid BufferStreamId"));
+        BOOST_THROW_EXCEPTION(std::out_of_range("Invalid BufferStreamId"));
     return p;
 }
 
@@ -189,7 +189,7 @@ ms::ApplicationSession::Ids::const_iterator ms::ApplicationSession::checked_find
 {
     auto p = ids.find(surface);
     if (p == ids.end())
-        BOOST_THROW_EXCEPTION(std::runtime_error("Invalid surface"));
+        BOOST_THROW_EXCEPTION(std::out_of_range("Invalid surface"));
     return p;
 }
 

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -193,6 +193,12 @@ ms::ApplicationSession::Ids::const_iterator ms::ApplicationSession::checked_find
     return p;
 }
 
+mf::SurfaceId ms::ApplicationSession::get_surface_id(mf::Surface* surface) const
+{
+    std::unique_lock<std::mutex> lock(surfaces_and_streams_mutex);
+    return checked_find(dynamic_cast<Surface*>(surface))->second;
+}
+
 std::shared_ptr<mf::Surface> ms::ApplicationSession::get_surface(mf::SurfaceId id) const
 {
     return surface(id);

--- a/src/server/scene/application_session.h
+++ b/src/server/scene/application_session.h
@@ -71,6 +71,7 @@ public:
         SurfaceCreationParameters const& params,
         std::shared_ptr<frontend::EventSink> const& surface_sink) override;
     void destroy_surface(frontend::SurfaceId surface) override;
+    frontend::SurfaceId get_surface_id(frontend::Surface* surface) const override;
     std::shared_ptr<frontend::Surface> get_surface(frontend::SurfaceId surface) const override;
     std::shared_ptr<Surface> surface(frontend::SurfaceId surface) const override;
     std::shared_ptr<Surface> surface_after(std::shared_ptr<Surface> const&) const override;

--- a/src/server/scene/application_session.h
+++ b/src/server/scene/application_session.h
@@ -122,16 +122,22 @@ private:
     OutputPropertiesCache output_cache;
 
     typedef std::map<frontend::SurfaceId, std::shared_ptr<Surface>> Surfaces;
+    typedef std::map<Surface*, frontend::SurfaceId> Ids;
     typedef std::map<frontend::BufferStreamId, std::shared_ptr<compositor::BufferStream>> Streams;
     Surfaces::const_iterator checked_find(frontend::SurfaceId id) const;
     Streams::const_iterator checked_find(frontend::BufferStreamId id) const;
+    Ids::const_iterator checked_find(Surface* surface) const;
     std::mutex mutable surfaces_and_streams_mutex;
     Surfaces surfaces;
+    Ids ids;
     Streams streams;
 
     std::map<frontend::SurfaceId, frontend::BufferStreamId> default_content_map;
 
-    void destroy_surface(std::unique_lock<std::mutex>& lock, Surfaces::const_iterator in_surfaces);
+    void destroy_surface(
+        std::unique_lock<std::mutex>& lock,
+        Surfaces::const_iterator surface_iter,
+        Ids::const_iterator id_iter);
 };
 
 }

--- a/tests/include/mir/test/doubles/mock_scene_session.h
+++ b/tests/include/mir/test/doubles/mock_scene_session.h
@@ -42,6 +42,7 @@ struct MockSceneSession : public scene::Session
             scene::SurfaceCreationParameters const&,
             std::shared_ptr<frontend::EventSink> const&));
     MOCK_METHOD1(destroy_surface, void(frontend::SurfaceId));
+    MOCK_CONST_METHOD1(get_surface_id, frontend::SurfaceId(frontend::Surface*));
     MOCK_CONST_METHOD1(get_surface, std::shared_ptr<frontend::Surface>(frontend::SurfaceId));
     MOCK_CONST_METHOD1(surface, std::shared_ptr<scene::Surface>(frontend::SurfaceId));
     MOCK_CONST_METHOD1(surface_after, std::shared_ptr<scene::Surface>(std::shared_ptr<scene::Surface> const&));

--- a/tests/mir_test_framework/stub_session.cpp
+++ b/tests/mir_test_framework/stub_session.cpp
@@ -26,6 +26,11 @@ mtd::StubSession::StubSession(pid_t pid)
     : pid(pid)
 {}
 
+mir::frontend::SurfaceId mtd::StubSession::get_surface_id(frontend::Surface* /*surface*/) const
+{
+    return {};
+}
+
 std::shared_ptr<mir::frontend::Surface> mtd::StubSession::get_surface(
     mir::frontend::SurfaceId /*surface*/) const
 {


### PR DESCRIPTION
This adds `frontend::Session::get_surface_id(Surface*)`, which is implemented efficiently using a new id-to-shared_ptr map. The new map also allows for a more efficient implementation of `ApplicationSession::destroy_surface()`. Previously a single surface destroy call was O(N) based on the current number of surfaces. Now it's the complexity of a `map::find()` (O(log n)).