### PR TITLE
Add scene::Shell::add_observer/remove_observer

### DIFF
--- a/include/server/mir/shell/abstract_shell.h
+++ b/include/server/mir/shell/abstract_shell.h
@@ -144,6 +144,9 @@ public:
     void set_drag_and_drop_handle(std::vector<uint8_t> const& handle) override;
     void clear_drag_and_drop_handle() override;
 
+    void add_observer(std::shared_ptr<scene::Observer> const& observer) override;
+    void remove_observer(std::weak_ptr<scene::Observer> const& observer) override;
+
 protected:
     std::shared_ptr<InputTargeter> const input_targeter;
     std::shared_ptr<SurfaceStack> const surface_stack;

--- a/include/server/mir/shell/shell.h
+++ b/include/server/mir/shell/shell.h
@@ -40,6 +40,7 @@ class PromptSessionCreationParameters;
 class SessionCoordinator;
 class Surface;
 struct SurfaceCreationParameters;
+class Observer;
 }
 
 namespace shell
@@ -115,6 +116,9 @@ public:
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp,
         MirResizeEdge edge) = 0;
+
+    virtual void add_observer(std::shared_ptr<scene::Observer> const& observer) = 0;
+    virtual void remove_observer(std::weak_ptr<scene::Observer> const& observer) = 0;
 
 /** @} */
 };

--- a/include/server/mir/shell/shell_wrapper.h
+++ b/include/server/mir/shell/shell_wrapper.h
@@ -102,6 +102,9 @@ public:
         uint64_t timestamp,
         MirResizeEdge edge) override;
 
+    void add_observer(std::shared_ptr<scene::Observer> const& observer) override;
+    void remove_observer(std::weak_ptr<scene::Observer> const& observer) override;
+
     void add_display(geometry::Rectangle const& area) override;
     void remove_display(geometry::Rectangle const& area) override;
 

--- a/include/server/mir/shell/surface_stack.h
+++ b/include/server/mir/shell/surface_stack.h
@@ -33,6 +33,7 @@ class Surface;
 struct SurfaceCreationParameters;
 class SurfaceObserver;
 class Session;
+class Observer;
 }
 
 namespace shell
@@ -53,6 +54,9 @@ public:
     virtual void remove_surface(std::weak_ptr<scene::Surface> const& surface) = 0;
 
     virtual auto surface_at(geometry::Point) const -> std::shared_ptr<scene::Surface> = 0;
+
+    virtual void add_observer(std::shared_ptr<scene::Observer> const& observer) = 0;
+    virtual void remove_observer(std::weak_ptr<scene::Observer> const& observer) = 0;
 
 protected:
     SurfaceStack() = default;

--- a/include/server/mir/shell/surface_stack_wrapper.h
+++ b/include/server/mir/shell/surface_stack_wrapper.h
@@ -42,6 +42,9 @@ public:
 
     auto surface_at(geometry::Point) const -> std::shared_ptr<scene::Surface> override;
 
+    void add_observer(std::shared_ptr<scene::Observer> const& observer) override;
+    void remove_observer(std::weak_ptr<scene::Observer> const& observer) override;
+
 protected:
     std::shared_ptr<SurfaceStack> const wrapped;
 };

--- a/src/include/server/mir/frontend/shell.h
+++ b/src/include/server/mir/frontend/shell.h
@@ -35,6 +35,7 @@ namespace scene
 struct SurfaceCreationParameters;
 struct PromptSessionCreationParameters;
 class Surface;
+class Observer;
 }
 namespace shell { class SurfaceSpecification; }
 

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -508,3 +508,13 @@ void msh::AbstractShell::clear_drag_and_drop_handle()
 {
     input_targeter->clear_drag_and_drop_handle();
 }
+
+void msh::AbstractShell::add_observer(std::shared_ptr<scene::Observer> const& observer)
+{
+    surface_stack->add_observer(observer);
+}
+
+void msh::AbstractShell::remove_observer(std::weak_ptr<scene::Observer> const& observer)
+{
+    surface_stack->remove_observer(observer);
+}

--- a/src/server/shell/shell_wrapper.cpp
+++ b/src/server/shell/shell_wrapper.cpp
@@ -150,6 +150,16 @@ void msh::ShellWrapper::request_resize(
     wrapped->request_resize(session, surface, timestamp, edge);
 }
 
+void msh::ShellWrapper::add_observer(std::shared_ptr<scene::Observer> const& observer)
+{
+    wrapped->add_observer(observer);
+}
+
+void msh::ShellWrapper::remove_observer(std::weak_ptr<scene::Observer> const& observer)
+{
+    wrapped->remove_observer(observer);
+}
+
 void msh::ShellWrapper::add_display(geometry::Rectangle const& area)
 {
     wrapped->add_display(area);

--- a/src/server/shell/surface_stack_wrapper.cpp
+++ b/src/server/shell/surface_stack_wrapper.cpp
@@ -55,3 +55,13 @@ auto msh::SurfaceStackWrapper::surface_at(geometry::Point point) const -> std::s
 {
     return wrapped->surface_at(point);
 }
+
+void msh::SurfaceStackWrapper::add_observer(std::shared_ptr<scene::Observer> const& observer)
+{
+    wrapped->add_observer(observer);
+}
+
+void msh::SurfaceStackWrapper::remove_observer(std::weak_ptr<scene::Observer> const& observer)
+{
+    wrapped->remove_observer(observer);
+}

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -973,3 +973,13 @@ MIR_SERVER_1.3 {
     non-virtual?thunk?to?mir::scene::NullSurfaceObserver::depth_layer_set_to*;
   };
 } MIR_SERVER_1.2;
+
+MIR_SERVER_1.4 {
+ global:
+  extern "C++" {
+    mir::shell::ShellWrapper::add_observer*;
+    mir::shell::ShellWrapper::remove_observer*;
+    mir::shell::SurfaceStackWrapper::add_observer*;
+    mir::shell::SurfaceStackWrapper::remove_observer*;
+  };
+} MIR_SERVER_1.3;

--- a/tests/include/mir/test/doubles/mock_surface_stack.h
+++ b/tests/include/mir/test/doubles/mock_surface_stack.h
@@ -41,6 +41,9 @@ struct MockSurfaceStack : public shell::SurfaceStack
 
     MOCK_METHOD1(remove_surface, void(std::weak_ptr<scene::Surface> const& surface));
     MOCK_CONST_METHOD1(surface_at, std::shared_ptr<scene::Surface>(geometry::Point));
+
+    MOCK_METHOD1(add_observer, void(std::shared_ptr<scene::Observer> const& observer));
+    MOCK_METHOD1(remove_observer, void(std::weak_ptr<scene::Observer> const& observer));
 };
 
 }

--- a/tests/integration-tests/session_management.cpp
+++ b/tests/integration-tests/session_management.cpp
@@ -85,6 +85,15 @@ struct TestSurfaceStack : public msh::SurfaceStack
         wrapped->raise(surface);
     }
 
+    void add_observer(std::shared_ptr<ms::Observer> const& observer) override
+    {
+        wrapped->add_observer(observer);
+    }
+
+    void remove_observer(std::weak_ptr<ms::Observer> const& observer) override
+    {
+        wrapped->remove_observer(observer);
+    }
 };
 
 struct TestConfiguration : public mir_test_framework::StubbedServerConfiguration

--- a/tests/unit-tests/scene/test_application_session.cpp
+++ b/tests/unit-tests/scene/test_application_session.cpp
@@ -128,6 +128,12 @@ struct StubSurfaceStack : public msh::SurfaceStack
     {
         return std::shared_ptr<ms::Surface>{};
     }
+    void add_observer(std::shared_ptr<ms::Observer> const&) override
+    {
+    }
+    void remove_observer(std::weak_ptr<ms::Observer> const&) override
+    {
+    }
 };
 
 struct ApplicationSession : public testing::Test


### PR DESCRIPTION
Allows anywhere with access to `scene::Scene` to add a `scene::Observer`.