### PR TITLE
Add surface properties

### DIFF
--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -392,10 +392,14 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"vtable for miral::WindowManagementPolicy::ApplicationZoneAddendum@MIRAL_2.6" 2.6.0
  (c++)"miral::WindowManagementPolicy::ApplicationZoneAddendum::from(miral::WindowManagementPolicy*)@MIRAL_2.6" 2.6.0
  MIRAL_2.7@MIRAL_2.7 2.7.0
+ (c++)"miral::WindowInfo::application_id(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIRAL_2.7" 2.7.0
+ (c++)"miral::WindowInfo::application_id[abi:cxx11]() const@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowInfo::attached_edges() const@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowInfo::attached_edges(MirPlacementGravity)@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowInfo::exclusive_rect() const@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowInfo::exclusive_rect(mir::optional_value<mir::geometry::Rectangle> const&)@MIRAL_2.7" 2.7.0
+ (c++)"miral::WindowSpecification::application_id[abi:cxx11]() const@MIRAL_2.7" 2.7.0
+ (c++)"miral::WindowSpecification::application_id[abi:cxx11]()@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowSpecification::attached_edges() const@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowSpecification::attached_edges()@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowSpecification::exclusive_rect() const@MIRAL_2.7" 2.7.0

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -134,6 +134,13 @@ struct WindowInfo
     /// (only meaningful when the window is attached to an edge)
     void exclusive_rect(mir::optional_value<mir::geometry::Rectangle> const& rect);
 
+    /// The D-bus service name and basename of the app's .desktop file
+    /// See http://standards.freedesktop.org/desktop-entry-spec/
+    ///@{
+    auto application_id() const -> std::string;
+    void application_id(std::string const& application_id);
+    ///@}
+
 private:
     struct Self;
     std::unique_ptr<Self> self;

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -149,6 +149,13 @@ public:
     auto exclusive_rect() -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>>&;
     ///@}
 
+    /// The D-bus service name and basename of the app's .desktop file
+    /// See http://standards.freedesktop.org/desktop-entry-spec/
+    ///@{
+    auto application_id() const -> mir::optional_value<std::string> const&;
+    auto application_id() -> mir::optional_value<std::string>&;
+    ///@}
+
 private:
     struct Self;
     std::unique_ptr<Self> self;

--- a/include/server/mir/scene/null_surface_observer.h
+++ b/include/server/mir/scene/null_surface_observer.h
@@ -56,6 +56,7 @@ public:
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
     void application_id_set_to(Surface const* surf, std::string const& application_id) override;
+    void session_set_to(Surface const* surf, std::weak_ptr<Session> const& session) override;
 
 protected:
     NullSurfaceObserver(NullSurfaceObserver const&) = delete;

--- a/include/server/mir/scene/null_surface_observer.h
+++ b/include/server/mir/scene/null_surface_observer.h
@@ -55,6 +55,7 @@ public:
     void input_consumed(Surface const* surf, MirEvent const* event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
+    void application_id_set_to(Surface const* surf, std::string const& application_id) override;
 
 protected:
     NullSurfaceObserver(NullSurfaceObserver const&) = delete;

--- a/include/server/mir/scene/surface.h
+++ b/include/server/mir/scene/surface.h
@@ -127,6 +127,11 @@ public:
     virtual auto focus_state() const -> MirWindowFocusState = 0;
     virtual void set_focus_state(MirWindowFocusState focus_state) = 0;
 
+    /// Often the same as the session name, but on Wayland can be set on a per-window basis
+    /// See xdg_toplevel.set_app_id and http://standards.freedesktop.org/desktop-entry-spec/ for more details
+    /// Empty string if not set
+    virtual auto application_id() const -> std::string = 0;
+    virtual void set_application_id(std::string const& application_id) = 0;
 };
 }
 }

--- a/include/server/mir/scene/surface.h
+++ b/include/server/mir/scene/surface.h
@@ -117,11 +117,16 @@ public:
     virtual void placed_relative(geometry::Rectangle const& placement) = 0;
     virtual void start_drag_and_drop(std::vector<uint8_t> const& handle) = 0;
 
+    /// The depth layer the surface is on
+    /// It will be kept above all surfaces on lower layers, and below surfaces on higher layers
     virtual auto depth_layer() const -> MirDepthLayer = 0;
-    /**
-     * When the depth layer is changed, the surface becomes the top surface on that layer
-     */
+    /// When the depth layer is changed, the surface becomes the top surface on that layer
     virtual void set_depth_layer(MirDepthLayer depth_layer) = 0;
+
+    /// If the window has focus
+    virtual auto focus_state() const -> MirWindowFocusState = 0;
+    virtual void set_focus_state(MirWindowFocusState focus_state) = 0;
+
 };
 }
 }

--- a/include/server/mir/scene/surface.h
+++ b/include/server/mir/scene/surface.h
@@ -44,6 +44,7 @@ struct StreamInfo
 };
 
 class SurfaceObserver;
+class Session;
 
 class Surface :
     public input::Surface,
@@ -132,6 +133,10 @@ public:
     /// Empty string if not set
     virtual auto application_id() const -> std::string = 0;
     virtual void set_application_id(std::string const& application_id) = 0;
+
+    /// Null if the surface does not belong to a session
+    virtual auto session() const -> std::weak_ptr<Session> = 0;
+    virtual void set_session(std::weak_ptr<Session> session) = 0;
 };
 }
 }

--- a/include/server/mir/scene/surface_creation_parameters.h
+++ b/include/server/mir/scene/surface_creation_parameters.h
@@ -122,6 +122,9 @@ struct SurfaceCreationParameters
     /// The area of this surface that will not be occluded
     /// Only used if surface is in state mir_window_state_attached and is attached to an edge (not a corner)
     optional_value<geometry::Rectangle> exclusive_rect;
+
+    /// See mir::scene::Surface::application_id()
+    optional_value<std::string> application_id;
 };
 
 bool operator==(const SurfaceCreationParameters& lhs, const SurfaceCreationParameters& rhs);

--- a/include/server/mir/scene/surface_observer.h
+++ b/include/server/mir/scene/surface_observer.h
@@ -28,6 +28,7 @@
 #include <glm/glm.hpp>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace mir
 {
@@ -44,6 +45,7 @@ class CursorImage;
 namespace scene
 {
 class Surface;
+class Session;
 
 class SurfaceObserver
 {
@@ -73,6 +75,7 @@ public:
     virtual void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) = 0;
     virtual void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) = 0;
     virtual void application_id_set_to(Surface const* surf, std::string const& application_id) = 0;
+    virtual void session_set_to(Surface const* surf, std::weak_ptr<Session> const& session) = 0;
 
 protected:
     SurfaceObserver() = default;

--- a/include/server/mir/scene/surface_observer.h
+++ b/include/server/mir/scene/surface_observer.h
@@ -72,6 +72,7 @@ public:
     virtual void input_consumed(Surface const* surf, MirEvent const* event) = 0;
     virtual void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) = 0;
     virtual void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) = 0;
+    virtual void application_id_set_to(Surface const* surf, std::string const& application_id) = 0;
 
 protected:
     SurfaceObserver() = default;

--- a/include/server/mir/shell/surface_specification.h
+++ b/include/server/mir/shell/surface_specification.h
@@ -106,6 +106,7 @@ struct SurfaceSpecification
 
     optional_value<MirPlacementGravity> attached_edges;
     optional_value<optional_value<geometry::Rectangle>> exclusive_rect;
+    optional_value<std::string> application_id;
 };
 }
 }

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -76,6 +76,8 @@ struct StubSurface : scene::Surface
     void set_focus_state(MirWindowFocusState new_state) override;
     std::string application_id() const override;
     void set_application_id(std::string const& application_id) override;
+    std::weak_ptr<scene::Session> session() const  override;
+    void set_session(std::weak_ptr<scene::Session> session) override;
 };
 }
 }

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -72,6 +72,8 @@ struct StubSurface : scene::Surface
     void start_drag_and_drop(std::vector<uint8_t> const& handle) override;
     MirDepthLayer depth_layer() const override;
     void set_depth_layer(MirDepthLayer depth_layer) override;
+    MirWindowFocusState focus_state() const override;
+    void set_focus_state(MirWindowFocusState new_state) override;
 };
 }
 }

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -74,6 +74,8 @@ struct StubSurface : scene::Surface
     void set_depth_layer(MirDepthLayer depth_layer) override;
     MirWindowFocusState focus_state() const override;
     void set_focus_state(MirWindowFocusState new_state) override;
+    std::string application_id() const override;
+    void set_application_id(std::string const& application_id) override;
 };
 }
 }

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -59,6 +59,7 @@ public:
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
     void application_id_set_to(Surface const* surf, std::string const& application_id) override;
+    void session_set_to(Surface const* surf, std::weak_ptr<Session> const& session) override;
 };
 
 }

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -58,6 +58,7 @@ public:
     void input_consumed(Surface const* surf, MirEvent const* event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
+    void application_id_set_to(Surface const* surf, std::string const& application_id) override;
 };
 
 }

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -942,6 +942,7 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
     COPY_IF_SET(depth_layer);
     COPY_IF_SET(attached_edges);
     COPY_IF_SET(exclusive_rect);
+    COPY_IF_SET(application_id);
 
 #undef COPY_IF_SET
 

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -473,8 +473,10 @@ global:
 MIRAL_2.7 {
 global:
   extern "C++" {
+    miral::WindowInfo::application_id*;
     miral::WindowInfo::attached_edges*;
     miral::WindowInfo::exclusive_rect*;
+    miral::WindowSpecification::application_id*;
     miral::WindowSpecification::attached_edges*;
     miral::WindowSpecification::exclusive_rect*;
   };

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -652,3 +652,19 @@ void miral::WindowInfo::exclusive_rect(mir::optional_value<mir::geometry::Rectan
 {
     self->exclusive_rect = rect;
 }
+
+auto miral::WindowInfo::application_id() const -> std::string
+{
+    std::shared_ptr<mir::scene::Surface> surface = window();
+    if (surface)
+        return surface->application_id();
+    else
+        return "";
+}
+
+void miral::WindowInfo::application_id(std::string const& application_id)
+{
+    std::shared_ptr<mir::scene::Surface> surface = window();
+    if (surface)
+        return surface->set_application_id(application_id);
+}

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -62,6 +62,7 @@ struct miral::WindowSpecification::Self
     mir::optional_value<MirDepthLayer> depth_layer;
     mir::optional_value<MirPlacementGravity> attached_edges;
     mir::optional_value<mir::optional_value<mir::geometry::Rectangle>> exclusive_rect;
+    mir::optional_value<std::string> application_id;
     mir::optional_value<std::shared_ptr<void>> userdata;
 };
 
@@ -95,7 +96,8 @@ miral::WindowSpecification::Self::Self(mir::shell::SurfaceSpecification const& s
     confine_pointer(spec.confine_pointer),
     depth_layer(spec.depth_layer),
     attached_edges(spec.attached_edges),
-    exclusive_rect(spec.exclusive_rect)
+    exclusive_rect(spec.exclusive_rect),
+    application_id(spec.application_id)
 {
     if (spec.aux_rect_placement_offset_x.is_set() && spec.aux_rect_placement_offset_y.is_set())
         aux_rect_placement_offset = Displacement{spec.aux_rect_placement_offset_x.value(), spec.aux_rect_placement_offset_y.value()};
@@ -223,7 +225,8 @@ miral::WindowSpecification::Self::Self(mir::scene::SurfaceCreationParameters con
     confine_pointer(params.confine_pointer),
     depth_layer(params.depth_layer),
     attached_edges(params.attached_edges),
-    exclusive_rect(params.exclusive_rect)
+    exclusive_rect(params.exclusive_rect),
+    application_id(params.application_id)
 {
     if (params.aux_rect_placement_offset_x.is_set() && params.aux_rect_placement_offset_y.is_set())
         aux_rect_placement_offset = Displacement{params.aux_rect_placement_offset_x.value(), params.aux_rect_placement_offset_y.value()};
@@ -295,6 +298,7 @@ void miral::WindowSpecification::Self::update(mir::scene::SurfaceCreationParamet
     copy_if_set(params.depth_layer, depth_layer);
     copy_if_set(params.attached_edges, attached_edges);
     copy_if_set(params.exclusive_rect, exclusive_rect.value());
+    copy_if_set(params.application_id, application_id);
 
     if (aux_rect_placement_offset.is_set())
     {
@@ -622,6 +626,16 @@ auto miral::WindowSpecification::exclusive_rect()
     -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>>&
 {
     return self->exclusive_rect;
+}
+
+auto miral::WindowSpecification::application_id() const -> mir::optional_value<std::string> const&
+{
+    return self->application_id;
+}
+
+auto miral::WindowSpecification::application_id() -> mir::optional_value<std::string>&
+{
+    return self->application_id;
 }
 
 auto miral::WindowSpecification::userdata() -> mir::optional_value<std::shared_ptr<void>>&

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -133,6 +133,18 @@ void mf::WindowWlSurfaceRole::set_title(std::string const& title)
     }
 }
 
+void mf::WindowWlSurfaceRole::set_application_id(std::string const& application_id)
+{
+    if (surface_id().as_value())
+    {
+        spec().application_id = application_id;
+    }
+    else
+    {
+        params->application_id = application_id;
+    }
+}
+
 void mf::WindowWlSurfaceRole::initiate_interactive_move()
 {
     if (surface_id().as_value())

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -72,6 +72,7 @@ public:
     void set_pending_width(std::experimental::optional<geometry::Width> const& width);
     void set_pending_height(std::experimental::optional<geometry::Height> const& height);
     void set_title(std::string const& title);
+    void set_application_id(std::string const& application_id);
     void initiate_interactive_move();
     void initiate_interactive_resize(MirResizeEdge edge);
     void set_parent(optional_value<SurfaceId> parent_id);

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -82,7 +82,7 @@ public:
     void destroy() override;
     void set_parent(std::experimental::optional<struct wl_resource*> const& parent) override;
     void set_title(std::string const& title) override;
-    void set_app_id(std::string const& /*app_id*/) override;
+    void set_app_id(std::string const& app_id) override;
     void show_window_menu(struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y) override;
     void move(struct wl_resource* seat, uint32_t serial) override;
     void resize(struct wl_resource* seat, uint32_t serial, uint32_t edges) override;
@@ -387,10 +387,9 @@ void mf::XdgToplevelStable::set_title(std::string const& title)
     WindowWlSurfaceRole::set_title(title);
 }
 
-void mf::XdgToplevelStable::set_app_id(std::string const& /*app_id*/)
+void mf::XdgToplevelStable::set_app_id(std::string const& app_id)
 {
-    // Logically this sets the session name, but Mir doesn't allow this (currently) and
-    // allowing e.g. "session_for_client(client)->name(app_id);" would break the libmirserver ABI
+    WindowWlSurfaceRole::set_application_id(app_id);
 }
 
 void mf::XdgToplevelStable::show_window_menu(struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y)

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -103,7 +103,7 @@ public:
     void destroy() override;
     void set_parent(std::experimental::optional<struct wl_resource*> const& parent) override;
     void set_title(std::string const& title) override;
-    void set_app_id(std::string const& /*app_id*/) override;
+    void set_app_id(std::string const& app_id) override;
     void show_window_menu(struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y) override;
     void move(struct wl_resource* seat, uint32_t serial) override;
     void resize(struct wl_resource* seat, uint32_t serial, uint32_t edges) override;
@@ -394,10 +394,9 @@ void mf::XdgToplevelV6::set_title(std::string const& title)
     WindowWlSurfaceRole::set_title(title);
 }
 
-void mf::XdgToplevelV6::set_app_id(std::string const& /*app_id*/)
+void mf::XdgToplevelV6::set_app_id(std::string const& app_id)
 {
-    // Logically this sets the session name, but Mir doesn't allow this (currently) and
-    // allowing e.g. "session_for_client(client)->name(app_id);" would break the libmirserver ABI
+    WindowWlSurfaceRole::set_application_id(app_id);
 }
 
 void mf::XdgToplevelV6::show_window_menu(struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y)

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -80,6 +80,7 @@ ms::ApplicationSession::~ApplicationSession()
     for (auto const& pair_id_surface : surfaces)
     {
         session_listener->destroying_surface(*this, pair_id_surface.second);
+        pair_id_surface.second->set_session({});
         surface_stack->remove_surface(pair_id_surface.second);
     }
 }
@@ -166,6 +167,7 @@ mf::SurfaceId ms::ApplicationSession::create_surface(
         surface->set_depth_layer(params.depth_layer.value());
     if (params.application_id.is_set())
         surface->set_application_id(params.application_id.value());
+    surface->set_session(shared_from_this());
 
     return id;
 }
@@ -430,6 +432,7 @@ void ms::ApplicationSession::destroy_surface(std::unique_lock<std::mutex>& lock,
 
     lock.unlock();
 
+    surface->set_session({});
     surface_stack->remove_surface(surface);
 }
 

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -164,6 +164,8 @@ mf::SurfaceId ms::ApplicationSession::create_surface(
         surface->set_input_region(params.input_shape.value());
     if (params.depth_layer.is_set())
         surface->set_depth_layer(params.depth_layer.value());
+    if (params.application_id.is_set())
+        surface->set_application_id(params.application_id.value());
 
     return id;
 }

--- a/src/server/scene/application_session.h
+++ b/src/server/scene/application_session.h
@@ -50,7 +50,9 @@ class SnapshotStrategy;
 class BufferStreamFactory;
 class SurfaceFactory;
 
-class ApplicationSession : public Session
+class ApplicationSession
+    : public Session,
+      public std::enable_shared_from_this<ApplicationSession>
 {
 public:
     ApplicationSession(

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -970,3 +970,17 @@ void mir::scene::BasicSurface::set_application_id(std::string const& application
     }
     observers.application_id_set_to(this, application_id);
 }
+
+auto mir::scene::BasicSurface::session() const -> std::weak_ptr<Session>
+{
+    std::unique_lock<std::mutex> lg(guard);
+    return session_;
+}
+
+void mir::scene::BasicSurface::set_session(std::weak_ptr<Session> session)
+{
+    {
+        std::unique_lock<std::mutex> lg(guard);
+        session_ = session;
+    }
+}

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -165,6 +165,12 @@ void ms::SurfaceObservers::application_id_set_to(Surface const* surf, std::strin
                  { observer->application_id_set_to(surf, application_id); });
 }
 
+void ms::SurfaceObservers::session_set_to(Surface const* surf, std::weak_ptr<Session> const& session)
+{
+    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
+                 { observer->session_set_to(surf, session); });
+}
+
 struct ms::CursorStreamImageAdapter
 {
     CursorStreamImageAdapter(ms::BasicSurface &surface)
@@ -983,4 +989,5 @@ void mir::scene::BasicSurface::set_session(std::weak_ptr<Session> session)
         std::unique_lock<std::mutex> lg(guard);
         session_ = session;
     }
+    observers.session_set_to(this, session);
 }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -159,6 +159,12 @@ void ms::SurfaceObservers::depth_layer_set_to(Surface const* surf, MirDepthLayer
                  { observer->depth_layer_set_to(surf, depth_layer); });
 }
 
+void ms::SurfaceObservers::application_id_set_to(Surface const* surf, std::string const& application_id)
+{
+    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
+                 { observer->application_id_set_to(surf, application_id); });
+}
+
 struct ms::CursorStreamImageAdapter
 {
     CursorStreamImageAdapter(ms::BasicSurface &surface)
@@ -948,4 +954,19 @@ void mir::scene::BasicSurface::set_focus_state(MirWindowFocusState new_state)
 
     if (needs_update)
         observers.attrib_changed(this, mir_window_attrib_focus, new_state);
+}
+
+auto mir::scene::BasicSurface::application_id() const -> std::string
+{
+    std::unique_lock<std::mutex> lg(guard);
+    return application_id_;
+}
+
+void mir::scene::BasicSurface::set_application_id(std::string const& application_id)
+{
+    {
+        std::unique_lock<std::mutex> lg(guard);
+        application_id_ = application_id;
+    }
+    observers.application_id_set_to(this, application_id);
 }

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -148,6 +148,9 @@ public:
     auto focus_state() const -> MirWindowFocusState override;
     void set_focus_state(MirWindowFocusState new_state) override;
 
+    auto application_id() const -> std::string override;
+    void set_application_id(std::string const& application_id) override;
+
 private:
     bool visible(std::unique_lock<std::mutex>&) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
@@ -185,6 +188,7 @@ private:
     std::unique_ptr<CursorStreamImageAdapter> const cursor_stream_adapter;
 
     MirDepthLayer depth_layer_ = mir_depth_layer_application;
+    std::string application_id_;
 };
 
 }

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -151,6 +151,9 @@ public:
     auto application_id() const -> std::string override;
     void set_application_id(std::string const& application_id) override;
 
+    auto session() const -> std::weak_ptr<Session> override;
+    void set_session(std::weak_ptr<Session> session) override;
+
 private:
     bool visible(std::unique_lock<std::mutex>&) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
@@ -189,6 +192,8 @@ private:
 
     MirDepthLayer depth_layer_ = mir_depth_layer_application;
     std::string application_id_;
+
+    std::weak_ptr<Session> session_;
 };
 
 }

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -145,6 +145,9 @@ public:
     auto depth_layer() const -> MirDepthLayer override;
     void set_depth_layer(MirDepthLayer depth_layer) override;
 
+    auto focus_state() const -> MirWindowFocusState override;
+    void set_focus_state(MirWindowFocusState new_state) override;
+
 private:
     bool visible(std::unique_lock<std::mutex>&) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
@@ -152,7 +155,6 @@ private:
     int set_dpi(int);
     MirWindowVisibility set_visibility(MirWindowVisibility v);
     int set_swap_interval(int);
-    MirWindowFocusState set_focus_state(MirWindowFocusState f);
     MirOrientationMode set_preferred_orientation(MirOrientationMode mode);
 
     SurfaceObservers observers;

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -46,3 +46,4 @@ void ms::NullSurfaceObserver::input_consumed(Surface const*, MirEvent const*) {}
 void ms::NullSurfaceObserver::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&) {}
 void ms::NullSurfaceObserver::depth_layer_set_to(Surface const*, MirDepthLayer) {}
 void ms::NullSurfaceObserver::application_id_set_to(Surface const*, std::string const&) {}
+void ms::NullSurfaceObserver::session_set_to(Surface const*, std::weak_ptr<Session> const&) {}

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -45,3 +45,4 @@ void ms::NullSurfaceObserver::placed_relative(Surface const*, geometry::Rectangl
 void ms::NullSurfaceObserver::input_consumed(Surface const*, MirEvent const*) {}
 void ms::NullSurfaceObserver::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&) {}
 void ms::NullSurfaceObserver::depth_layer_set_to(Surface const*, MirDepthLayer) {}
+void ms::NullSurfaceObserver::application_id_set_to(Surface const*, std::string const&) {}

--- a/src/server/scene/surface_creation_parameters.cpp
+++ b/src/server/scene/surface_creation_parameters.cpp
@@ -202,6 +202,8 @@ void ms::SurfaceCreationParameters::update_from(msh::SurfaceSpecification const&
         attached_edges = that.attached_edges;
     if (that.exclusive_rect.is_set())
         exclusive_rect = that.exclusive_rect.value();
+    if (that.application_id.is_set())
+        application_id = that.application_id.value();
     // TODO: should SurfaceCreationParameters support cursors?
 //     if (that.cursor_image.is_set())
 //         cursor_image = that.cursor_image;
@@ -224,7 +226,11 @@ bool ms::operator==(
         lhs.type == rhs.type &&
         lhs.preferred_orientation == rhs.preferred_orientation &&
         lhs.parent_id == rhs.parent_id &&
-        lhs.content_id == rhs.content_id;
+        lhs.content_id == rhs.content_id &&
+        lhs.depth_layer == rhs.depth_layer &&
+        lhs.attached_edges == rhs.attached_edges &&
+        lhs.exclusive_rect == rhs.exclusive_rect &&
+        lhs.application_id == rhs.application_id;
 }
 
 bool ms::operator!=(

--- a/src/server/shell/surface_specification.cpp
+++ b/src/server/shell/surface_specification.cpp
@@ -50,7 +50,8 @@ bool msh::SurfaceSpecification::is_empty() const
         !shell_chrome.is_set() &&
         !depth_layer.is_set() &&
         !attached_edges.is_set() &&
-        !exclusive_rect.is_set();
+        !exclusive_rect.is_set() &&
+        !application_id.is_set();
 }
 
 void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
@@ -125,4 +126,6 @@ void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
         attached_edges = that.attached_edges;
     if (that.exclusive_rect.is_set())
         exclusive_rect = that.exclusive_rect;
+    if (that.application_id.is_set())
+        application_id = that.application_id;
 }

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -973,3 +973,10 @@ MIR_SERVER_1.3 {
     non-virtual?thunk?to?mir::scene::NullSurfaceObserver::depth_layer_set_to*;
   };
 } MIR_SERVER_1.2;
+
+MIR_SERVER_1.4 {
+ global:
+  extern "C++" {
+    mir::scene::NullSurfaceObserver::application_id_set_to*;
+  };
+} MIR_SERVER_1.3;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -978,5 +978,6 @@ MIR_SERVER_1.4 {
  global:
   extern "C++" {
     mir::scene::NullSurfaceObserver::application_id_set_to*;
+    mir::scene::NullSurfaceObserver::session_set_to*;
   };
 } MIR_SERVER_1.3;

--- a/tests/acceptance-tests/test_client_cursor_api.cpp
+++ b/tests/acceptance-tests/test_client_cursor_api.cpp
@@ -89,6 +89,7 @@ public:
     MOCK_METHOD2(start_drag_and_drop, void(msc::Surface const*, std::vector<uint8_t> const& handle));
     MOCK_METHOD2(depth_layer_set_to, void(msc::Surface const*, MirDepthLayer depth_layer));
     MOCK_METHOD2(application_id_set_to, void(msc::Surface const*, std::string const& application_id));
+    MOCK_METHOD2(session_set_to, void(msc::Surface const*, std::weak_ptr<msc::Session> const& session));
 };
 
 

--- a/tests/acceptance-tests/test_client_cursor_api.cpp
+++ b/tests/acceptance-tests/test_client_cursor_api.cpp
@@ -88,6 +88,7 @@ public:
     MOCK_METHOD2(input_consumed, void(msc::Surface const*, MirEvent const*));
     MOCK_METHOD2(start_drag_and_drop, void(msc::Surface const*, std::vector<uint8_t> const& handle));
     MOCK_METHOD2(depth_layer_set_to, void(msc::Surface const*, MirDepthLayer depth_layer));
+    MOCK_METHOD2(application_id_set_to, void(msc::Surface const*, std::string const& application_id));
 };
 
 

--- a/tests/include/mir/test/doubles/stub_scene_surface.h
+++ b/tests/include/mir/test/doubles/stub_scene_surface.h
@@ -100,6 +100,9 @@ public:
 
     auto focus_state() const -> MirWindowFocusState override { return mir_window_focus_state_unfocused; }
     void set_focus_state(MirWindowFocusState /*focus_state*/) override {}
+
+    auto application_id() const -> std::string override { return ""; }
+    void set_application_id(std::string const& /*application_id*/) override {}
 };
 
 }

--- a/tests/include/mir/test/doubles/stub_scene_surface.h
+++ b/tests/include/mir/test/doubles/stub_scene_surface.h
@@ -103,6 +103,9 @@ public:
 
     auto application_id() const -> std::string override { return ""; }
     void set_application_id(std::string const& /*application_id*/) override {}
+
+    auto session() const -> std::weak_ptr<scene::Session> override { return {}; }
+    void set_session(std::weak_ptr<scene::Session> /*session*/) override {}
 };
 
 }

--- a/tests/include/mir/test/doubles/stub_scene_surface.h
+++ b/tests/include/mir/test/doubles/stub_scene_surface.h
@@ -97,6 +97,9 @@ public:
 
     auto depth_layer() const -> MirDepthLayer override { return mir_depth_layer_application; }
     void set_depth_layer(MirDepthLayer /*depth_layer*/) override {}
+
+    auto focus_state() const -> MirWindowFocusState override { return mir_window_focus_state_unfocused; }
+    void set_focus_state(MirWindowFocusState /*focus_state*/) override {}
 };
 
 }

--- a/tests/mir_test_framework/stub_surface.cpp
+++ b/tests/mir_test_framework/stub_surface.cpp
@@ -206,6 +206,15 @@ void mtd::StubSurface::set_depth_layer(MirDepthLayer /*depth_layer*/)
 {
 }
 
+MirWindowFocusState mtd::StubSurface::focus_state() const
+{
+    return mir_window_focus_state_unfocused;
+}
+
+void mtd::StubSurface::set_focus_state(MirWindowFocusState /*new_state*/)
+{
+}
+
 namespace
 {
 // Ensure we don't accidentally have an abstract class

--- a/tests/mir_test_framework/stub_surface.cpp
+++ b/tests/mir_test_framework/stub_surface.cpp
@@ -224,6 +224,15 @@ void mtd::StubSurface::set_application_id(std::string const& /*application_id*/)
 {
 }
 
+std::weak_ptr<mir::scene::Session> mtd::StubSurface::session() const
+{
+    return {};
+}
+
+void mtd::StubSurface::set_session(std::weak_ptr<scene::Session> /*session*/)
+{
+}
+
 namespace
 {
 // Ensure we don't accidentally have an abstract class

--- a/tests/mir_test_framework/stub_surface.cpp
+++ b/tests/mir_test_framework/stub_surface.cpp
@@ -215,6 +215,15 @@ void mtd::StubSurface::set_focus_state(MirWindowFocusState /*new_state*/)
 {
 }
 
+std::string mtd::StubSurface::application_id() const
+{
+    return "";
+}
+
+void mtd::StubSurface::set_application_id(std::string const& /*application_id*/)
+{
+}
+
 namespace
 {
 // Ensure we don't accidentally have an abstract class


### PR DESCRIPTION
Adds or partially adds the following 3 properties to surfaces. I'm putting them all in one PR to reduce merge conflicts and for simplicity. If you'd rather review them separately, say the word and I'll do them one at a time.

* Focus state
  * Needed because it appears to be missing from `scene::Surface`
  * Already stored on `BasicSurface`, and accessible with the deprecated attribute system
  * Needed to add a `scene::Surface` setter and getter
  * Did not need to get added to the surface observer, as it is already handled in `attrib_changed()`
  * No changes to the frontend or MirAL needed
* Application ID
  * Added to `scene::Surface` and `scene::SurfaceObserver`
  * Added to `SurfaceSpecification` and `SurfaceCreationParameters`
  * Set from the Wayland frontend
  * Exposed in MirAL, as it might be useful to the shell
* Session
  * Added `scene::Surface` setter and getter
  * Added to the observer
  * No changes to the frontend or MirAL needed
  * Set from `ApplicationSession`
  * Application session needed to support `std::shared_from_this<>` to be able to set the property
  * Needed to be a weak or shared session pointer so it could be used in calls to `modify_surface()`