### PR TITLE
 Add frontend::Shell::add_observer/remove_observer 

### DIFF
--- a/src/include/server/mir/frontend/shell.h
+++ b/src/include/server/mir/frontend/shell.h
@@ -106,6 +106,9 @@ public:
         request_operation(session, surface_id, timestamp, request, optional_value<uint32_t>{});
     }
 
+    virtual void add_observer(std::shared_ptr<scene::Observer> const& observer) = 0;
+    virtual void remove_observer(std::weak_ptr<scene::Observer> const& observer) = 0;
+
 protected:
     Shell() = default;
     Shell(const Shell&) = delete;

--- a/src/server/frontend/shell_wrapper.cpp
+++ b/src/server/frontend/shell_wrapper.cpp
@@ -108,3 +108,13 @@ void mf::ShellWrapper::request_operation(
 {
     wrapped->request_operation(session, surface_id, timestamp, request, hint);
 }
+
+void mf::ShellWrapper::add_observer(std::shared_ptr<scene::Observer> const& observer)
+{
+    wrapped->add_observer(observer);
+}
+
+void mf::ShellWrapper::remove_observer(std::weak_ptr<scene::Observer> const& observer)
+{
+    wrapped->remove_observer(observer);
+}

--- a/src/server/frontend/shell_wrapper.h
+++ b/src/server/frontend/shell_wrapper.h
@@ -82,6 +82,9 @@ public:
         UserRequest request,
         optional_value <uint32_t> hint) override;
 
+    void add_observer(std::shared_ptr<scene::Observer> const& observer) override;
+    void remove_observer(std::weak_ptr<scene::Observer> const& observer) override;
+
 protected:
     std::shared_ptr<Shell> const wrapped;
 };

--- a/src/server/shell/frontend_shell.cpp
+++ b/src/server/shell/frontend_shell.cpp
@@ -186,3 +186,13 @@ void msh::FrontendShell::request_operation(
         break;
     }
 }
+
+void msh::FrontendShell::add_observer(std::shared_ptr<scene::Observer> const& observer)
+{
+    wrapped->add_observer(observer);
+}
+
+void msh::FrontendShell::remove_observer(std::weak_ptr<scene::Observer> const& observer)
+{
+    wrapped->remove_observer(observer);
+}

--- a/src/server/shell/frontend_shell.h
+++ b/src/server/shell/frontend_shell.h
@@ -93,6 +93,9 @@ struct FrontendShell : mf::Shell
         uint64_t timestamp,
         UserRequest request,
         optional_value <uint32_t> hint) override;
+
+    void add_observer(std::shared_ptr<scene::Observer> const& observer) override;
+    void remove_observer(std::weak_ptr<scene::Observer> const& observer) override;
 };
 }
 }

--- a/tests/include/mir/test/doubles/mock_shell.h
+++ b/tests/include/mir/test/doubles/mock_shell.h
@@ -75,6 +75,9 @@ struct MockShell : public frontend::Shell
 
     MOCK_METHOD5(request_operation, void(std::shared_ptr<frontend::Session> const &session,
         frontend::SurfaceId surface_id, uint64_t timestamp, UserRequest request, optional_value<uint32_t> hint));
+
+    MOCK_METHOD1(add_observer, void(std::shared_ptr<scene::Observer> const& observer));
+    MOCK_METHOD1(remove_observer, void(std::weak_ptr<scene::Observer> const& observer));
 };
 
 }


### PR DESCRIPTION
Allow adding a scene observer to the frontend shell (PRing to #943 instead of master)