### PR TITLE
Send shared_ptr instead of raw surface pointer from scene::Observer

### DIFF
--- a/include/server/mir/scene/observer.h
+++ b/include/server/mir/scene/observer.h
@@ -33,18 +33,19 @@ class Surface;
 class Observer
 {
 public:
-    virtual void surface_added(Surface* surface) = 0;
-    virtual void surface_removed(Surface* surface) = 0;
+    virtual void surface_added(std::shared_ptr<Surface> surface) = 0;
+    virtual void surface_removed(std::shared_ptr<Surface> surface) = 0;
     virtual void surfaces_reordered() = 0;
-    
-    // Used to indicate the scene has changed in some way beyond the present surfaces
-    // and will require full recomposition.
+
+    /// Used to indicate the scene has changed in some way beyond the present surfaces
+    /// and will require full recomposition.
     virtual void scene_changed() = 0;
 
-    // Called at observer registration to notify of already existing surfaces.
-    virtual void surface_exists(Surface* surface) = 0;
-    // Called when observer is unregistered, for example, to provide a place to
-    // unregister SurfaceObservers which may have been added in surface_added/exists
+    /// Called at observer registration to notify of already existing surfaces.
+    virtual void surface_exists(std::shared_ptr<Surface> surface) = 0;
+
+    /// Called when observer is unregistered, for example, to provide a place to
+    /// unregister SurfaceObservers which may have been added in surface_added/exists
     virtual void end_observation() = 0;
 
 protected:

--- a/include/server/mir/scene/observer.h
+++ b/include/server/mir/scene/observer.h
@@ -33,8 +33,8 @@ class Surface;
 class Observer
 {
 public:
-    virtual void surface_added(std::shared_ptr<Surface> surface) = 0;
-    virtual void surface_removed(std::shared_ptr<Surface> surface) = 0;
+    virtual void surface_added(std::shared_ptr<Surface> const& surface) = 0;
+    virtual void surface_removed(std::shared_ptr<Surface> const& surface) = 0;
     virtual void surfaces_reordered() = 0;
 
     /// Used to indicate the scene has changed in some way beyond the present surfaces
@@ -42,7 +42,7 @@ public:
     virtual void scene_changed() = 0;
 
     /// Called at observer registration to notify of already existing surfaces.
-    virtual void surface_exists(std::shared_ptr<Surface> surface) = 0;
+    virtual void surface_exists(std::shared_ptr<Surface> const& surface) = 0;
 
     /// Called when observer is unregistered, for example, to provide a place to
     /// unregister SurfaceObservers which may have been added in surface_added/exists

--- a/src/include/server/mir/scene/legacy_scene_change_notification.h
+++ b/src/include/server/mir/scene/legacy_scene_change_notification.h
@@ -48,13 +48,13 @@ public:
 
     ~LegacySceneChangeNotification();
 
-    void surface_added(Surface* surface) override;
-    void surface_removed(Surface* surface) override;
+    void surface_added(std::shared_ptr<Surface> surface) override;
+    void surface_removed(std::shared_ptr<Surface> surface) override;
     void surfaces_reordered() override;
     
     void scene_changed() override;
 
-    void surface_exists(Surface* surface) override;
+    void surface_exists(std::shared_ptr<Surface> surface) override;
     void end_observation() override;
 
 private:

--- a/src/include/server/mir/scene/legacy_scene_change_notification.h
+++ b/src/include/server/mir/scene/legacy_scene_change_notification.h
@@ -48,13 +48,13 @@ public:
 
     ~LegacySceneChangeNotification();
 
-    void surface_added(std::shared_ptr<Surface> surface) override;
-    void surface_removed(std::shared_ptr<Surface> surface) override;
+    void surface_added(std::shared_ptr<Surface> const& surface) override;
+    void surface_removed(std::shared_ptr<Surface> const& surface) override;
     void surfaces_reordered() override;
     
     void scene_changed() override;
 
-    void surface_exists(std::shared_ptr<Surface> surface) override;
+    void surface_exists(std::shared_ptr<Surface> const& surface) override;
     void end_observation() override;
 
 private:

--- a/src/include/server/mir/scene/null_observer.h
+++ b/src/include/server/mir/scene/null_observer.h
@@ -31,18 +31,18 @@ public:
     NullObserver() = default;
     virtual ~NullObserver() = default;
 
-    void surface_added(Surface* surface);
-    void surface_removed(Surface* surface);
-    void surfaces_reordered();
+    void surface_added(std::shared_ptr<Surface> surface) override;
+    void surface_removed(std::shared_ptr<Surface> surface) override;
+    void surfaces_reordered() override;
 
     // Used to indicate the scene has changed in some way beyond the present surfaces
     // and will require full recomposition.
-    void scene_changed();
+    void scene_changed() override;
     // Called at observer registration to notify of already existing surfaces.
-    void surface_exists(Surface* surface);
+    void surface_exists(std::shared_ptr<Surface> surface) override;
     // Called when observer is unregistered, for example, to provide a place to
     // unregister SurfaceObservers which may have been added in surface_added/exists
-    void end_observation();
+    void end_observation() override;
 
 protected:
     NullObserver(NullObserver const&) = delete;

--- a/src/include/server/mir/scene/null_observer.h
+++ b/src/include/server/mir/scene/null_observer.h
@@ -31,15 +31,15 @@ public:
     NullObserver() = default;
     virtual ~NullObserver() = default;
 
-    void surface_added(std::shared_ptr<Surface> surface) override;
-    void surface_removed(std::shared_ptr<Surface> surface) override;
+    void surface_added(std::shared_ptr<Surface> const& surface) override;
+    void surface_removed(std::shared_ptr<Surface> const& surface) override;
     void surfaces_reordered() override;
 
     // Used to indicate the scene has changed in some way beyond the present surfaces
     // and will require full recomposition.
     void scene_changed() override;
     // Called at observer registration to notify of already existing surfaces.
-    void surface_exists(std::shared_ptr<Surface> surface) override;
+    void surface_exists(std::shared_ptr<Surface> const& surface) override;
     // Called when observer is unregistered, for example, to provide a place to
     // unregister SurfaceObservers which may have been added in surface_added/exists
     void end_observation() override;

--- a/src/server/input/cursor_controller.cpp
+++ b/src/server/input/cursor_controller.cpp
@@ -122,13 +122,13 @@ struct UpdateCursorOnSceneChanges : ms::Observer
         }
     }
 
-    void surface_added(std::shared_ptr<ms::Surface> surface) override
+    void surface_added(std::shared_ptr<ms::Surface> const& surface) override
     {
         add_surface_observer(surface.get());
         cursor_controller->update_cursor_image();
     }
 
-    void surface_removed(std::shared_ptr<ms::Surface> surface) override
+    void surface_removed(std::shared_ptr<ms::Surface> const& surface) override
     {
         {
             std::unique_lock<decltype(surface_observers_guard)> lg(surface_observers_guard);
@@ -152,7 +152,7 @@ struct UpdateCursorOnSceneChanges : ms::Observer
         cursor_controller->update_cursor_image();
     }
 
-    void surface_exists(std::shared_ptr<ms::Surface> surface) override
+    void surface_exists(std::shared_ptr<ms::Surface> const& surface) override
     {
         add_surface_observer(surface.get());
         cursor_controller->update_cursor_image();

--- a/src/server/input/cursor_controller.cpp
+++ b/src/server/input/cursor_controller.cpp
@@ -122,16 +122,17 @@ struct UpdateCursorOnSceneChanges : ms::Observer
         }
     }
 
-    void surface_added(ms::Surface *surface)
+    void surface_added(std::shared_ptr<ms::Surface> surface) override
     {
-        add_surface_observer(surface);
+        add_surface_observer(surface.get());
         cursor_controller->update_cursor_image();
     }
-    void surface_removed(ms::Surface *surface)
+
+    void surface_removed(std::shared_ptr<ms::Surface> surface) override
     {
         {
             std::unique_lock<decltype(surface_observers_guard)> lg(surface_observers_guard);
-            auto it = surface_observers.find(surface);
+            auto it = surface_observers.find(surface.get());
             if (it != surface_observers.end())
             {
                 surface->remove_observer(it->second);
@@ -140,23 +141,24 @@ struct UpdateCursorOnSceneChanges : ms::Observer
         }
         cursor_controller->update_cursor_image();
     }
-    void surfaces_reordered()
+
+    void surfaces_reordered() override
     {
         cursor_controller->update_cursor_image();
     }
 
-    void scene_changed()
+    void scene_changed() override
     {
         cursor_controller->update_cursor_image();
     }
 
-    void surface_exists(ms::Surface *surface)
+    void surface_exists(std::shared_ptr<ms::Surface> surface) override
     {
-        add_surface_observer(surface);
+        add_surface_observer(surface.get());
         cursor_controller->update_cursor_image();
     }
 
-    void end_observation()
+    void end_observation() override
     {
         std::unique_lock<decltype(surface_observers_guard)> lg(surface_observers_guard);
         for (auto &kv : surface_observers)

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -45,7 +45,7 @@ struct InputDispatcherSceneObserver :
     public std::enable_shared_from_this<InputDispatcherSceneObserver>
 {
     InputDispatcherSceneObserver(
-        std::function<void(ms::Surface*)> const& on_removed,
+        std::function<void(std::shared_ptr<ms::Surface>)> const& on_removed,
         std::function<void(ms::Surface const*)> const& on_surface_moved,
         std::function<void()> const& on_surface_resized)
         : on_removed(on_removed),
@@ -53,16 +53,18 @@ struct InputDispatcherSceneObserver :
           on_surface_resized{on_surface_resized}
     {
     }
-    void surface_added(ms::Surface* surface) override
+
+    void surface_added(std::shared_ptr<ms::Surface> surface) override
     {
         surface->add_observer(shared_from_this());
     }
-    void surface_removed(ms::Surface* surface) override
+
+    void surface_removed(std::shared_ptr<ms::Surface> surface) override
     {
         on_removed(surface);
     }
 
-    void surface_exists(ms::Surface* surface) override
+    void surface_exists(std::shared_ptr<ms::Surface> surface) override
     {
         surface->add_observer(shared_from_this());
     }
@@ -87,7 +89,7 @@ struct InputDispatcherSceneObserver :
         // TODO: Do we need to listen to this?
     }
 
-    std::function<void(ms::Surface*)> const on_removed;
+    std::function<void(std::shared_ptr<ms::Surface>)> const on_removed;
     std::function<void(ms::Surface const*)> const on_surface_moved;
     std::function<void()> const on_surface_resized;
 };
@@ -150,7 +152,10 @@ mi::SurfaceInputDispatcher::SurfaceInputDispatcher(std::shared_ptr<mi::Scene> co
       started(false)
 {
     scene_observer = std::make_shared<InputDispatcherSceneObserver>(
-        [this](ms::Surface* s){surface_removed(s);},
+        std::bind(
+            std::mem_fn(&SurfaceInputDispatcher::surface_removed),
+            this,
+            std::placeholders::_1),
         std::bind(
             std::mem_fn(&SurfaceInputDispatcher::surface_moved),
             this,
@@ -185,12 +190,12 @@ bool compare_surfaces(std::shared_ptr<mi::Surface> const& input_surface, ms::Sur
 }
 }
 
-void mi::SurfaceInputDispatcher::surface_removed(ms::Surface *surface)
+void mi::SurfaceInputDispatcher::surface_removed(std::shared_ptr<ms::Surface> surface)
 {
     std::lock_guard<std::mutex> lg(dispatcher_mutex);
 
     auto strong_focus = focus_surface.lock();
-    if (strong_focus && compare_surfaces(strong_focus, surface))
+    if (strong_focus && compare_surfaces(strong_focus, surface.get()))
     {
         set_focus_locked(lg, nullptr);
     }
@@ -198,16 +203,16 @@ void mi::SurfaceInputDispatcher::surface_removed(ms::Surface *surface)
     for (auto& kv : pointer_state_by_id)
     {
         auto& state = kv.second;
-        if (compare_surfaces(state.current_target, surface))
+        if (compare_surfaces(state.current_target, surface.get()))
             state.current_target.reset();
-        if (compare_surfaces(state.gesture_owner, surface))
+        if (compare_surfaces(state.gesture_owner, surface.get()))
             state.gesture_owner.reset();
     }
 
     for (auto& kv : touch_state_by_id)
     {
         auto& state = kv.second;
-        if (compare_surfaces(state.gesture_owner, surface))
+        if (compare_surfaces(state.gesture_owner, surface.get()))
             state.gesture_owner.reset();
     }
 }

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -54,17 +54,17 @@ struct InputDispatcherSceneObserver :
     {
     }
 
-    void surface_added(std::shared_ptr<ms::Surface> surface) override
+    void surface_added(std::shared_ptr<ms::Surface> const& surface) override
     {
         surface->add_observer(shared_from_this());
     }
 
-    void surface_removed(std::shared_ptr<ms::Surface> surface) override
+    void surface_removed(std::shared_ptr<ms::Surface> const& surface) override
     {
         on_removed(surface);
     }
 
-    void surface_exists(std::shared_ptr<ms::Surface> surface) override
+    void surface_exists(std::shared_ptr<ms::Surface> const& surface) override
     {
         surface->add_observer(shared_from_this());
     }

--- a/src/server/input/surface_input_dispatcher.h
+++ b/src/server/input/surface_input_dispatcher.h
@@ -71,7 +71,7 @@ private:
 
     void set_focus_locked(std::lock_guard<std::mutex> const&, std::shared_ptr<input::Surface> const&);
 
-    void surface_removed(scene::Surface* surface);
+    void surface_removed(std::shared_ptr<scene::Surface> surface);
 
     void surface_moved(scene::Surface const* moved_surface);
     void surface_resized();

--- a/src/server/scene/legacy_scene_change_notification.cpp
+++ b/src/server/scene/legacy_scene_change_notification.cpp
@@ -115,7 +115,7 @@ void ms::LegacySceneChangeNotification::add_surface_observer(ms::Surface* surfac
     }
 }
 
-void ms::LegacySceneChangeNotification::surface_added(std::shared_ptr<ms::Surface> surface)
+void ms::LegacySceneChangeNotification::surface_added(std::shared_ptr<ms::Surface> const& surface)
 {
     add_surface_observer(surface.get());
 
@@ -124,12 +124,12 @@ void ms::LegacySceneChangeNotification::surface_added(std::shared_ptr<ms::Surfac
         scene_notify_change();
 }
 
-void ms::LegacySceneChangeNotification::surface_exists(std::shared_ptr<ms::Surface> surface)
+void ms::LegacySceneChangeNotification::surface_exists(std::shared_ptr<ms::Surface> const& surface)
 {
     add_surface_observer(surface.get());
 }
     
-void ms::LegacySceneChangeNotification::surface_removed(std::shared_ptr<ms::Surface> surface)
+void ms::LegacySceneChangeNotification::surface_removed(std::shared_ptr<ms::Surface> const& surface)
 {
     {
         std::unique_lock<decltype(surface_observers_guard)> lg(surface_observers_guard);

--- a/src/server/scene/legacy_scene_change_notification.cpp
+++ b/src/server/scene/legacy_scene_change_notification.cpp
@@ -115,25 +115,25 @@ void ms::LegacySceneChangeNotification::add_surface_observer(ms::Surface* surfac
     }
 }
 
-void ms::LegacySceneChangeNotification::surface_added(ms::Surface* surface)
+void ms::LegacySceneChangeNotification::surface_added(std::shared_ptr<ms::Surface> surface)
 {
-    add_surface_observer(surface);
+    add_surface_observer(surface.get());
 
     // If the surface already has content we need to (re)composite
     if (!buffer_notify_change && surface->visible())
         scene_notify_change();
 }
 
-void ms::LegacySceneChangeNotification::surface_exists(ms::Surface* surface)
+void ms::LegacySceneChangeNotification::surface_exists(std::shared_ptr<ms::Surface> surface)
 {
-    add_surface_observer(surface);
+    add_surface_observer(surface.get());
 }
     
-void ms::LegacySceneChangeNotification::surface_removed(ms::Surface* surface)
+void ms::LegacySceneChangeNotification::surface_removed(std::shared_ptr<ms::Surface> surface)
 {
     {
         std::unique_lock<decltype(surface_observers_guard)> lg(surface_observers_guard);
-        auto it = surface_observers.find(surface);
+        auto it = surface_observers.find(surface.get());
         if (it != surface_observers.end())
         {
             surface->remove_observer(it->second);

--- a/src/server/scene/null_observer.cpp
+++ b/src/server/scene/null_observer.cpp
@@ -20,9 +20,9 @@
 
 namespace ms = mir::scene;
 
-void ms::NullObserver::surface_added(ms::Surface* /* surface */) {}
-void ms::NullObserver::surface_removed(ms::Surface* /* surface */) {}
+void ms::NullObserver::surface_added(std::shared_ptr<ms::Surface> /* surface */) {}
+void ms::NullObserver::surface_removed(std::shared_ptr<ms::Surface> /* surface */) {}
 void ms::NullObserver::surfaces_reordered() {}
 void ms::NullObserver::scene_changed() {}
-void ms::NullObserver::surface_exists(ms::Surface* /* surface */) {}
+void ms::NullObserver::surface_exists(std::shared_ptr<ms::Surface> /* surface */) {}
 void ms::NullObserver::end_observation() {}

--- a/src/server/scene/null_observer.cpp
+++ b/src/server/scene/null_observer.cpp
@@ -20,9 +20,9 @@
 
 namespace ms = mir::scene;
 
-void ms::NullObserver::surface_added(std::shared_ptr<ms::Surface> /* surface */) {}
-void ms::NullObserver::surface_removed(std::shared_ptr<ms::Surface> /* surface */) {}
+void ms::NullObserver::surface_added(std::shared_ptr<ms::Surface> const& /* surface */) {}
+void ms::NullObserver::surface_removed(std::shared_ptr<ms::Surface> const& /* surface */) {}
 void ms::NullObserver::surfaces_reordered() {}
 void ms::NullObserver::scene_changed() {}
-void ms::NullObserver::surface_exists(std::shared_ptr<ms::Surface> /* surface */) {}
+void ms::NullObserver::surface_exists(std::shared_ptr<ms::Surface> const& /* surface */) {}
 void ms::NullObserver::end_observation() {}

--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -273,7 +273,7 @@ void ms::SurfaceStack::add_surface(
         surface->add_observer(surface_observer);
     }
     surface->set_reception_mode(input_mode);
-    observers.surface_added(surface.get());
+    observers.surface_added(surface);
 
     report->surface_added(surface.get(), surface.get()->name());
 }
@@ -303,7 +303,7 @@ void ms::SurfaceStack::remove_surface(std::weak_ptr<Surface> const& surface)
 
     if (found_surface)
     {
-        observers.surface_removed(keep_alive.get());
+        observers.surface_removed(keep_alive);
         report->surface_removed(keep_alive.get(), keep_alive.get()->name());
     }
     // TODO: error logging when surface not found
@@ -462,7 +462,7 @@ void ms::SurfaceStack::add_observer(std::shared_ptr<ms::Observer> const& observe
     {
         for (auto const& surface : layer)
         {
-            observer->surface_exists(surface.get());
+            observer->surface_exists(surface);
         }
     }
 }
@@ -478,13 +478,13 @@ void ms::SurfaceStack::remove_observer(std::weak_ptr<ms::Observer> const& observ
     observers.remove(o);
 }
 
-void ms::Observers::surface_added(ms::Surface* surface) 
+void ms::Observers::surface_added(std::shared_ptr<Surface> surface)
 {
     for_each([&](std::shared_ptr<Observer> const& observer)
         { observer->surface_added(surface); });
 }
 
-void ms::Observers::surface_removed(ms::Surface* surface)
+void ms::Observers::surface_removed(std::shared_ptr<Surface> surface)
 {
     for_each([&](std::shared_ptr<Observer> const& observer)
         { observer->surface_removed(surface); });
@@ -502,7 +502,7 @@ void ms::Observers::scene_changed()
         { observer->scene_changed(); });
 }
 
-void ms::Observers::surface_exists(ms::Surface* surface)
+void ms::Observers::surface_exists(std::shared_ptr<Surface> surface)
 {
     for_each([&](std::shared_ptr<Observer> const& observer)
         { observer->surface_exists(surface); });

--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -478,13 +478,13 @@ void ms::SurfaceStack::remove_observer(std::weak_ptr<ms::Observer> const& observ
     observers.remove(o);
 }
 
-void ms::Observers::surface_added(std::shared_ptr<Surface> surface)
+void ms::Observers::surface_added(std::shared_ptr<Surface> const& surface)
 {
     for_each([&](std::shared_ptr<Observer> const& observer)
         { observer->surface_added(surface); });
 }
 
-void ms::Observers::surface_removed(std::shared_ptr<Surface> surface)
+void ms::Observers::surface_removed(std::shared_ptr<Surface> const& surface)
 {
     for_each([&](std::shared_ptr<Observer> const& observer)
         { observer->surface_removed(surface); });
@@ -502,7 +502,7 @@ void ms::Observers::scene_changed()
         { observer->scene_changed(); });
 }
 
-void ms::Observers::surface_exists(std::shared_ptr<Surface> surface)
+void ms::Observers::surface_exists(std::shared_ptr<Surface> const& surface)
 {
     for_each([&](std::shared_ptr<Observer> const& observer)
         { observer->surface_exists(surface); });

--- a/src/server/scene/surface_stack.h
+++ b/src/server/scene/surface_stack.h
@@ -54,11 +54,11 @@ class Observers : public Observer, BasicObservers<Observer>
 {
 public:
    // ms::Observer
-   void surface_added(Surface* surface) override;
-   void surface_removed(Surface* surface) override;
+   void surface_added(std::shared_ptr<Surface> surface) override;
+   void surface_removed(std::shared_ptr<Surface> surface) override;
    void surfaces_reordered() override;
    void scene_changed() override;
-   void surface_exists(Surface* surface) override;
+   void surface_exists(std::shared_ptr<Surface> surface) override;
    void end_observation() override;
 
    using BasicObservers<Observer>::add;

--- a/src/server/scene/surface_stack.h
+++ b/src/server/scene/surface_stack.h
@@ -54,11 +54,11 @@ class Observers : public Observer, BasicObservers<Observer>
 {
 public:
    // ms::Observer
-   void surface_added(std::shared_ptr<Surface> surface) override;
-   void surface_removed(std::shared_ptr<Surface> surface) override;
+   void surface_added(std::shared_ptr<Surface> const& surface) override;
+   void surface_removed(std::shared_ptr<Surface> const& surface) override;
    void surfaces_reordered() override;
    void scene_changed() override;
-   void surface_exists(std::shared_ptr<Surface> surface) override;
+   void surface_exists(std::shared_ptr<Surface> const& surface) override;
    void end_observation() override;
 
    using BasicObservers<Observer>::add;

--- a/tests/unit-tests/input/test_cursor_controller.cpp
+++ b/tests/unit-tests/input/test_cursor_controller.cpp
@@ -206,7 +206,7 @@ struct StubScene : public mtd::StubInputScene
         {
             observers.for_each([&target](std::shared_ptr<ms::Observer> const& observer)
             {
-                observer->surface_exists(target.get());
+                observer->surface_exists(target);
             });
         }
     }
@@ -224,7 +224,7 @@ struct StubScene : public mtd::StubInputScene
         targets.push_back(surface);
         observers.for_each([&surface](std::shared_ptr<ms::Observer> const& observer)
         {
-            observer->surface_added(surface.get());
+            observer->surface_added(surface);
         });
     }
 

--- a/tests/unit-tests/input/test_surface_input_dispatcher.cpp
+++ b/tests/unit-tests/input/test_surface_input_dispatcher.cpp
@@ -73,7 +73,7 @@ struct StubInputScene : public mtd::StubInputScene
         auto surface = std::make_shared<MockSurfaceWithGeometry>(geometry);
         surfaces.add(surface);
 
-        observer->surface_added(surface.get());
+        observer->surface_added(surface);
         
         return surface;
     }
@@ -81,7 +81,7 @@ struct StubInputScene : public mtd::StubInputScene
     void remove_surface(std::shared_ptr<ms::Surface> const& surface)
     {
         surfaces.remove(surface);
-        observer->surface_removed(surface.get());
+        observer->surface_removed(surface);
     }
 
     std::shared_ptr<mtd::MockSurface> add_surface()
@@ -101,7 +101,7 @@ struct StubInputScene : public mtd::StubInputScene
         assert(observer == nullptr);
         observer = new_observer;
 	surfaces.for_each([this](std::shared_ptr<ms::Surface> const& surface) {
-		observer->surface_exists(surface.get());
+		observer->surface_exists(surface);
         });
     }
     

--- a/tests/unit-tests/scene/test_surface_stack.cpp
+++ b/tests/unit-tests/scene/test_surface_stack.cpp
@@ -75,12 +75,12 @@ struct MockCallback
 
 struct MockSceneObserver : public ms::Observer
 {
-    MOCK_METHOD1(surface_added, void(std::shared_ptr<ms::Surface>));
-    MOCK_METHOD1(surface_removed, void(std::shared_ptr<ms::Surface>));
+    MOCK_METHOD1(surface_added, void(std::shared_ptr<ms::Surface> const&));
+    MOCK_METHOD1(surface_removed, void(std::shared_ptr<ms::Surface> const&));
     MOCK_METHOD0(surfaces_reordered, void());
     MOCK_METHOD0(scene_changed, void());
 
-    MOCK_METHOD1(surface_exists, void(std::shared_ptr<ms::Surface>));
+    MOCK_METHOD1(surface_exists, void(std::shared_ptr<ms::Surface> const&));
     MOCK_METHOD0(end_observation, void());
 };
 


### PR DESCRIPTION
We discussed earlier using `weak_ptr` instead of `shared_ptr`, but I decided that would require otherwise unnecessary locks and checks. It would always be safe to assume the given weak pointer would be valid during the notification calls, but then why not indicate that with a shared_ptr? I think its fine to pass share_ptrs around as long as we only store weak pointers.