### PR TITLE
Send wl_buffer.release on the Wayland thread

### DIFF
--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -337,6 +337,7 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
             {
                 mir_buffer = WlShmBuffer::mir_buffer_from_wl_buffer(
                     buffer,
+                    executor,
                     std::move(executor_send_frame_callbacks));
                 tracepoint(
                     mir_server_wayland,

--- a/src/server/frontend_wayland/wlshmbuffer.h
+++ b/src/server/frontend_wayland/wlshmbuffer.h
@@ -32,6 +32,8 @@
 
 namespace mir
 {
+class Executor;
+
 namespace frontend
 {
 
@@ -46,6 +48,7 @@ public:
 
     static std::shared_ptr <graphics::Buffer> mir_buffer_from_wl_buffer(
         wl_resource *buffer,
+        std::shared_ptr<Executor> executor,
         std::function<void()> &&on_consumed);
 
     std::shared_ptr <graphics::NativeBuffer> native_buffer_handle() const override;
@@ -71,6 +74,7 @@ public:
 private:
     WlShmBuffer(
         wl_resource *buffer,
+        std::shared_ptr<Executor>,
         std::function<void()> &&on_consumed);
 
     static void on_buffer_destroyed(wl_listener *listener, void *);
@@ -95,6 +99,8 @@ private:
 
     bool consumed;
     std::function<void()> on_consumed;
+
+    std::shared_ptr<Executor> executor;
 };
 }
 }

--- a/src/server/frontend_wayland/wlshmbuffer.h
+++ b/src/server/frontend_wayland/wlshmbuffer.h
@@ -29,6 +29,7 @@
 #include <functional>
 #include <mutex>
 #include <string>
+#include <experimental/optional>
 
 namespace mir
 {
@@ -79,17 +80,22 @@ private:
 
     static void on_buffer_destroyed(wl_listener *listener, void *);
 
+    struct WaylandResources
+    {
+        WaylandResources(wl_resource *resource);
+
+        std::mutex mutex;
+        wl_resource* const resource;
+        std::experimental::optional<wl_shm_buffer* const> buffer;
+    };
+
     struct DestructionShim
     {
-        std::shared_ptr <std::mutex> const mutex = std::make_shared<std::mutex>();
-        std::weak_ptr <WlShmBuffer> associated_buffer;
+        std::weak_ptr<WaylandResources> resources;
         wl_listener destruction_listener;
     };
 
-    std::shared_ptr <std::mutex> buffer_mutex;
-
-    wl_shm_buffer *buffer;
-    wl_resource *const resource;
+    std::shared_ptr<WaylandResources> wayland;
 
     geometry::Size const size_;
     geometry::Stride const stride_;

--- a/src/server/frontend_wayland/wlshmbuffer.h
+++ b/src/server/frontend_wayland/wlshmbuffer.h
@@ -45,6 +45,10 @@ class WlShmBuffer :
     public renderer::software::PixelSource
 {
 public:
+    WlShmBuffer(
+        wl_resource *buffer,
+        std::shared_ptr<Executor>,
+        std::function<void()> &&on_consumed);
     ~WlShmBuffer();
 
     static std::shared_ptr <graphics::Buffer> mir_buffer_from_wl_buffer(
@@ -73,10 +77,8 @@ public:
     geometry::Stride stride() const override;
 
 private:
-    WlShmBuffer(
-        wl_resource *buffer,
-        std::shared_ptr<Executor>,
-        std::function<void()> &&on_consumed);
+    WlShmBuffer(WlShmBuffer const&) = delete;
+    WlShmBuffer& operator=(WlShmBuffer const&) = delete;
 
     static void on_buffer_destroyed(wl_listener *listener, void *);
 
@@ -85,13 +87,16 @@ private:
         WaylandResources(wl_resource *resource);
 
         std::mutex mutex;
-        wl_resource* const resource;
+        std::experimental::optional<wl_resource* const> resource;
         std::experimental::optional<wl_shm_buffer* const> buffer;
     };
 
     struct DestructionShim
     {
+        DestructionShim(wl_resource* buffer_resource);
+
         std::weak_ptr<WaylandResources> resources;
+        std::weak_ptr<WlShmBuffer> mir_buffer;
         wl_listener destruction_listener;
     };
 


### PR DESCRIPTION
Appears to fix a longstanding crash. The Wayland debug feature I built to detect thread errors tells me this was the only instance of such a problem in Mir (at least in the standard features I've tested with). Fixes #951 