### PR TITLE
Exclusive zone fixes

### DIFF
--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -392,6 +392,7 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"vtable for miral::WindowManagementPolicy::ApplicationZoneAddendum@MIRAL_2.6" 2.6.0
  (c++)"miral::WindowManagementPolicy::ApplicationZoneAddendum::from(miral::WindowManagementPolicy*)@MIRAL_2.6" 2.6.0
  MIRAL_2.7@MIRAL_2.7 2.7.0
+ (c++)"miral::Output::id() const@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowInfo::attached_edges() const@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowInfo::attached_edges(MirPlacementGravity)@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowInfo::exclusive_rect() const@MIRAL_2.7" 2.7.0

--- a/include/miral/miral/output.h
+++ b/include/miral/miral/output.h
@@ -95,6 +95,10 @@ public:
     /// current mode and orientation (rotation)
     auto extents() const -> Rectangle;
 
+    /// Mir's internal output ID
+    /// mostly useful for matching against a miral::WindowInfo::output_id
+    auto id() const -> int;
+
     auto valid() const -> bool;
 
     auto is_same_output(Output const& other) const -> bool;

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1310,19 +1310,18 @@ void miral::BasicWindowManager::place_and_size_for_state(
 
 auto miral::BasicWindowManager::fullscreen_rect_for(miral::WindowInfo const& window_info) const -> Rectangle
 {
-    auto const w = window_info.window();
-    Rectangle r = {(w.top_left()), w.size()};
-
     if (window_info.has_output_id())
     {
-        graphics::DisplayConfigurationOutputId id{window_info.output_id()};
-        if (display_layout->place_in_output(id, r))
-            return r;
+        for (auto const& display_area : display_areas)
+        {
+            if (display_area->output && display_area->output->id() == window_info.output_id())
+            {
+                return display_area->area;
+            }
+        }
     }
 
-    display_layout->size_to_output(r);
-
-    return r;
+    return display_area_for(window_info.window())->area;
 }
 
 void miral::BasicWindowManager::set_state(miral::WindowInfo& window_info, MirWindowState value)

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -980,6 +980,20 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
         }
     }
 
+    bool application_zones_need_update = false;
+    if (window_info.state() == mir_window_state_attached ||
+          (modifications.state().is_set() &&
+           modifications.state().value() == mir_window_state_attached))
+    {
+        if (modifications.state().is_set() ||
+            modifications.size().is_set() ||
+            modifications.attached_edges().is_set() ||
+            modifications.exclusive_rect().is_set())
+        {
+            application_zones_need_update = true;
+        }
+    }
+
     std::swap(window_info_tmp, window_info);
 
     auto& window = window_info.window();
@@ -1083,15 +1097,9 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
         set_state(window_info, modifications.state().value());
     }
 
-    if (window_info.state() == mir_window_state_attached)
+    if (application_zones_need_update)
     {
-        if (modifications.state().is_set() ||
-            modifications.size().is_set() ||
-            modifications.attached_edges().is_set() ||
-            modifications.exclusive_rect().is_set())
-        {
-            update_windows_for_outputs();
-        }
+        update_windows_for_outputs();
     }
 
     if (modifications.confine_pointer().is_set())

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1659,7 +1659,8 @@ auto miral::BasicWindowManager::place_new_surface(WindowSpecification parameters
     if (!parameters.state().is_set())
         parameters.state() = mir_window_state_restored;
 
-    auto const active_output_area = active_display_area()->application_zone.extents();;
+    auto const display_area = active_display_area();
+    auto const application_zone = display_area->application_zone.extents();;
     auto const height = parameters.size().value().height.as_int();
 
     bool positioned = false;
@@ -1716,28 +1717,32 @@ auto miral::BasicWindowManager::place_new_surface(WindowSpecification parameters
 
     if (!positioned)
     {
-        auto centred = active_output_area.top_left
-                       + 0.5*(as_displacement(active_output_area.size) - as_displacement(parameters.size().value()))
-                       - DeltaY{(active_output_area.size.height.as_int()-height)/6};
+        auto centred = application_zone.top_left
+                       + 0.5*(as_displacement(application_zone.size) - as_displacement(parameters.size().value()))
+                       - DeltaY{(application_zone.size.height.as_int()-height)/6};
 
         switch (parameters.state().value())
         {
         case mir_window_state_fullscreen:
+            parameters.top_left() = display_area->area.top_left;
+            parameters.size() = display_area->area.size;
+            break;
+
         case mir_window_state_maximized:
-            parameters.top_left() = active_output_area.top_left;
-            parameters.size() = active_output_area.size;
+            parameters.top_left() = application_zone.top_left;
+            parameters.size() = application_zone.size;
             break;
 
         case mir_window_state_vertmaximized:
-            centred.y = active_output_area.top_left.y;
+            centred.y = application_zone.top_left.y;
             parameters.top_left() = centred;
-            parameters.size() = Size{parameters.size().value().width, active_output_area.size.height};
+            parameters.size() = Size{parameters.size().value().width, application_zone.size.height};
             break;
 
         case mir_window_state_horizmaximized:
-            centred.x = active_output_area.top_left.x;
+            centred.x = application_zone.top_left.x;
             parameters.top_left() = centred;
-            parameters.size() = Size{active_output_area.size.width, parameters.size().value().height};
+            parameters.size() = Size{application_zone.size.width, parameters.size().value().height};
             break;
 
         default:

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -278,7 +278,10 @@ private:
     void erase(miral::WindowInfo const& info);
     void validate_modification_request(WindowSpecification const& modifications, WindowInfo const& window_info) const;
     void place_and_size(WindowInfo& root, Point const& new_pos, Size const& new_size);
-    void place_attached_to_zone(WindowInfo& info, mir::geometry::Rectangle const& application_zone);
+    void place_attached_to_zone(
+        WindowInfo& info,
+        mir::geometry::Rectangle const& application_zone,
+        mir::geometry::Rectangle const& output_area);
     void set_state(miral::WindowInfo& window_info, MirWindowState value);
     auto fullscreen_rect_for(WindowInfo const& window_info) const -> Rectangle;
     void remove_window(Application const& application, miral::WindowInfo const& info);

--- a/src/miral/output.cpp
+++ b/src/miral/output.cpp
@@ -85,6 +85,11 @@ auto miral::Output::extents() const -> Rectangle
     return self->extents();
 }
 
+auto miral::Output::id() const -> int
+{
+    return self->id.as_value();
+}
+
 auto miral::Output::valid() const -> bool
 {
     return self->valid();

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -473,6 +473,7 @@ global:
 MIRAL_2.7 {
 global:
   extern "C++" {
+    miral::Output::id*;
     miral::WindowInfo::attached_edges*;
     miral::WindowInfo::exclusive_rect*;
     miral::WindowSpecification::attached_edges*;

--- a/tests/miral/window_placement_attached.cpp
+++ b/tests/miral/window_placement_attached.cpp
@@ -342,6 +342,62 @@ TEST_P(WindowPlacementAttached, window_respects_exclusive_zone_when_maximized)
     EXPECT_THAT(normal.size(), Eq(zone.size));
 }
 
+TEST_P(WindowPlacementAttached, fullscreen_window_ignores_exclusive_zone)
+{
+    AttachedEdges edges = GetParam();
+    Size window_size{120, 80};
+    Rectangle exclusive_rect{{0, 0}, window_size};
+
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_attached;
+        params.attached_edges = edges;
+        params.size = window_size;
+        params.exclusive_rect = exclusive_rect;
+        create_window(params);
+    }
+
+    Window normal;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_fullscreen;
+        normal = create_window(params);
+    }
+
+    EXPECT_THAT(normal.top_left(), Eq(display_area.top_left));
+    EXPECT_THAT(normal.size(), Eq(display_area.size));
+}
+
+TEST_P(WindowPlacementAttached, window_ignores_exclusive_zone_when_fullscreened)
+{
+    AttachedEdges edges = GetParam();
+    Size window_size{120, 80};
+    Rectangle exclusive_rect{{0, 0}, window_size};
+
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_attached;
+        params.attached_edges = edges;
+        params.size = window_size;
+        params.exclusive_rect = exclusive_rect;
+        create_window(params);
+    }
+
+    Window normal;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_restored;
+        normal = create_window(params);
+    }
+
+    mir::shell::SurfaceSpecification spec;
+    spec.state = mir_window_state_fullscreen;
+    basic_window_manager.modify_surface(session, normal, spec);
+
+    EXPECT_THAT(normal.top_left(), Eq(display_area.top_left));
+    EXPECT_THAT(normal.size(), Eq(display_area.size));
+}
+
 TEST_P(WindowPlacementAttached, stretched_attached_window_ignores_exclusive_zone)
 {
     AttachedEdges edges = GetParam();

--- a/tests/miral/window_placement_attached.cpp
+++ b/tests/miral/window_placement_attached.cpp
@@ -525,6 +525,68 @@ TEST_P(WindowPlacementAttached, exclusive_zone_is_cleared_when_window_is_removed
     EXPECT_THAT(normal.size(), Eq(display_area.size));
 }
 
+TEST_P(WindowPlacementAttached, exclusive_zone_is_cleared_when_window_becomes_non_attached)
+{
+    AttachedEdges edges = GetParam();
+    Size window_size{120, 80};
+    Rectangle exclusive_rect{{0, 0}, window_size};
+
+    Window attached;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_attached;
+        params.attached_edges = edges;
+        params.size = window_size;
+        params.exclusive_rect = exclusive_rect;
+        attached = create_window(params);
+    }
+
+    Window normal;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_maximized;
+        normal = create_window(params);
+    }
+
+    mir::shell::SurfaceSpecification spec;
+    spec.state = mir_window_state_restored;
+    basic_window_manager.modify_surface(session, attached, spec);
+
+    EXPECT_THAT(normal.top_left(), Eq(display_area.top_left));
+    EXPECT_THAT(normal.size(), Eq(display_area.size));
+}
+
+TEST_P(WindowPlacementAttached, exclusive_zone_is_cleared_when_exclusive_rect_cleared)
+{
+    AttachedEdges edges = GetParam();
+    Size window_size{120, 80};
+    Rectangle exclusive_rect{{0, 0}, window_size};
+
+    Window attached;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_attached;
+        params.attached_edges = edges;
+        params.size = window_size;
+        params.exclusive_rect = exclusive_rect;
+        attached = create_window(params);
+    }
+
+    Window normal;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_maximized;
+        normal = create_window(params);
+    }
+
+    mir::shell::SurfaceSpecification spec;
+    spec.exclusive_rect = mir::optional_value<mir::optional_value<Rectangle>>{{}};
+    basic_window_manager.modify_surface(session, attached, spec);
+
+    EXPECT_THAT(normal.top_left(), Eq(display_area.top_left));
+    EXPECT_THAT(normal.size(), Eq(display_area.size));
+}
+
 INSTANTIATE_TEST_CASE_P(WindowPlacementAttached, WindowPlacementAttached, ::testing::Values(
     mir_placement_gravity_center,
     mir_placement_gravity_west,

--- a/tests/miral/window_placement_attached.cpp
+++ b/tests/miral/window_placement_attached.cpp
@@ -342,7 +342,7 @@ TEST_P(WindowPlacementAttached, window_respects_exclusive_zone_when_maximized)
     EXPECT_THAT(normal.size(), Eq(zone.size));
 }
 
-TEST_P(WindowPlacementAttached, attached_non_exclusive_window_respects_exclusive_zone)
+TEST_P(WindowPlacementAttached, stretched_attached_window_ignores_exclusive_zone)
 {
     AttachedEdges edges = GetParam();
     Size window_size{120, 80};
@@ -368,10 +368,10 @@ TEST_P(WindowPlacementAttached, attached_non_exclusive_window_respects_exclusive
             mir_placement_gravity_west);
         attached = create_window(params);
     }
-    Rectangle zone = apply_exclusive_zone(display_area, exclusive_rect, window_size, edges);
+    Rectangle without_exclusive_zone = display_area;
 
-    EXPECT_THAT(attached.top_left(), Eq(zone.top_left));
-    EXPECT_THAT(attached.size(), Eq(zone.size));
+    EXPECT_THAT(attached.top_left(), Eq(without_exclusive_zone.top_left));
+    EXPECT_THAT(attached.size(), Eq(without_exclusive_zone.size));
 }
 
 TEST_P(WindowPlacementAttached, maximized_window_respects_multiple_stacked_exclusive_zones)


### PR DESCRIPTION
Fixes the following issues:
* Fixes #953: Makes new fullscreen windows ignore exclusive zones
* Places windows correctly when they are fullscreened
* Adjusts maximized windows when an exclusive window becomes not attached
* Tests everything mentioned