### PR TITLE
Move wayland event unpacking to event sink

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -231,11 +231,6 @@ void setup_new_client_handler(wl_display* display, std::shared_ptr<mf::Shell> co
 }
 }
 
-int64_t mir_input_event_get_event_time_ms(const MirInputEvent* event)
-{
-    return mir_input_event_get_event_time(event) / 1000000;
-}
-
 class WlCompositor : public wayland::Compositor::Global
 {
 public:

--- a/src/server/frontend_wayland/wayland_utils.h
+++ b/src/server/frontend_wayland/wayland_utils.h
@@ -59,9 +59,6 @@ inline auto run_unless(std::shared_ptr<bool> const& condition, Callable&& callab
 }
 
 auto get_mir_client_session(wl_client* client) -> std::shared_ptr<MirClientSession>;
-
-int64_t mir_input_event_get_event_time_ms(const MirInputEvent* event);
-
 }
 }
 

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -23,17 +23,12 @@
 
 #include <vector>
 #include <functional>
+#include <chrono>
 
 // from <xkbcommon/xkbcommon.h>
 struct xkb_keymap;
 struct xkb_state;
 struct xkb_context;
-
-// from "mir_toolkit/events/event.h"
-struct MirKeyboardEvent;
-struct MirSurfaceEvent;
-typedef struct MirSurfaceEvent MirWindowEvent;
-struct MirKeymapEvent;
 
 namespace mir
 {
@@ -60,9 +55,9 @@ public:
 
     ~WlKeyboard();
 
-    void handle_keyboard_event(MirKeyboardEvent const* event, WlSurface* surface);
-    void handle_window_event(MirWindowEvent const* event, WlSurface* surface);
-    void handle_keymap_event(MirKeymapEvent const* event, WlSurface* surface);
+    void key(std::chrono::milliseconds const& ms, int scancode, bool down);
+    void focussed(WlSurface* surface, bool focussed);
+    void set_keymap(char const* const buffer, size_t length);
     void set_keymap(mir::input::Keymap const& new_keymap);
 
 private:

--- a/src/server/frontend_wayland/wl_surface_event_sink.h
+++ b/src/server/frontend_wayland/wl_surface_event_sink.h
@@ -79,7 +79,7 @@ public:
 
     void disconnect() { *destroyed = true; }
 
-protected:
+private:
     WlSeat* const seat;
     wl_client* const client;
     WlSurface* const surface;
@@ -89,12 +89,17 @@ protected:
     std::experimental::optional<geometry::Size> requested_size;
     bool has_focus{false};
     MirWindowState current_state{mir_window_state_unknown};
+    MirPointerButtons last_pointer_buttons{0};
+    std::experimental::optional<mir::geometry::Point> last_pointer_position;
     std::shared_ptr<bool> const destroyed;
 
-private:
     void handle_input_event(MirInputEvent const* event);
     void handle_keymap_event(MirKeymapEvent const* event);
     void handle_window_event(MirWindowEvent const* event);
+    void handle_keyboard_event(std::chrono::milliseconds const& ms, MirKeyboardEvent const* event);
+    void handle_pointer_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
+    void handle_pointer_button_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
+    void handle_pointer_motion_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
 };
 }
 }

--- a/src/server/frontend_wayland/wl_surface_event_sink.h
+++ b/src/server/frontend_wayland/wl_surface_event_sink.h
@@ -100,6 +100,7 @@ private:
     void handle_pointer_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
     void handle_pointer_button_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
     void handle_pointer_motion_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
+    void handle_touch_event(std::chrono::milliseconds const& ms, MirTouchEvent const* event);
 };
 }
 }

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -83,7 +83,7 @@ void mf::WlTouch::motion(
     }
 
     // TODO: do this better, using parent
-    auto const position_on_final = final_surface->second->total_offset() + position_on_parent;
+    auto const position_on_final = position_on_parent - final_surface->second->total_offset();
 
     send_motion_event(
         ms.count(),

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -27,6 +27,7 @@
 
 namespace mf = mir::frontend;
 namespace mw = mir::wayland;
+namespace geom = mir::geometry;
 
 mf::WlTouch::WlTouch(
     wl_resource* new_resource,
@@ -41,99 +42,73 @@ mf::WlTouch::~WlTouch()
     on_destroy(this);
 }
 
-void mf::WlTouch::handle_event(MirTouchEvent const* touch_ev, WlSurface* main_surface)
-{
-    // TODO: support for touches on subsurfaces
-    auto const input_ev = mir_touch_event_input_event(touch_ev);
-    auto const ev = mir::client::Event{mir_input_event_get_event(input_ev)};
-
-    for (auto i = 0u; i < mir_touch_event_point_count(touch_ev); ++i)
-    {
-        auto const point = geometry::Point{mir_touch_event_axis_value(touch_ev, i, mir_touch_axis_x),
-                                           mir_touch_event_axis_value(touch_ev, i, mir_touch_axis_y)};
-        auto const touch_id = mir_touch_event_id(touch_ev, i);
-        auto const action = mir_touch_event_action(touch_ev, i);
-
-        switch (action)
-        {
-        case mir_touch_action_down:
-        {
-            auto const transformed = main_surface->transform_point(point);
-            handle_down(transformed.position,
-                        transformed.surface,
-                        mir_input_event_get_event_time_ms(input_ev),
-                        touch_id);
-            break;
-        }
-        case mir_touch_action_up:
-            handle_up(mir_input_event_get_event_time_ms(input_ev), touch_id);
-            break;
-        case mir_touch_action_change:
-        {
-            auto current_surface = focused_surface_for_ids.find(touch_id);
-            if (current_surface == focused_surface_for_ids.end())
-            {
-                log_warning("WlTouch::handle_event() called with mir_touch_action_change action but touch id that has not been registered");
-            }
-            else
-            {
-                auto const transformed_point = current_surface->second->total_offset() + point;
-                send_motion_event(mir_input_event_get_event_time_ms(input_ev),
-                                  touch_id,
-                                  transformed_point.x.as_int(),
-                                  transformed_point.y.as_int());
-            }
-            break;
-        }
-        case mir_touch_actions:
-            /*
-             * We should never receive an event with this action set;
-             * the only way would be if a *new* action has been added
-             * to the enum, and this hasn't been updated.
-             *
-             * There's nothing to do here, but don't use default: so
-             * that the compiler will warn if a new enum value is added.
-             */
-            break;
-        }
-    }
-
-    if (mir_touch_event_point_count(touch_ev) > 0)
-    {
-        /*
-         * This is mostly paranoia; I assume we won't actually be called
-         * with an empty touch event.
-         *
-         * Regardless, the Wayland protocol requires that there be at least
-         * one event sent before we send the ending frame, so make that explicit.
-         */
-        send_frame_event();
-    }
-}
-
 void mf::WlTouch::release()
 {
     destroy_wayland_object();
 }
 
-void mf::WlTouch::handle_down(mir::geometry::Point position, WlSurface* surface, uint32_t time, int32_t id)
+void mf::WlTouch::down(
+    std::chrono::milliseconds const& ms,
+    int32_t touch_id,
+    WlSurface* parent,
+    geometry::Point const& position_on_parent)
 {
-    focused_surface_for_ids[id] = surface;
-    // TODO: Why is this not wl_display_next_serial()?
-    send_down_event(wl_display_get_serial(wl_client_get_display(client)),
-                    time,
-                    surface->raw_resource(),
-                    id,
-                    position.x.as_int(),
-                    position.y.as_int());
+    auto const final = parent->transform_point(position_on_parent);
+    auto const serial = wl_display_next_serial(wl_client_get_display(client));
+
+    focused_surface_for_ids[touch_id] = final.surface;
+
+    send_down_event(
+        serial,
+        ms.count(),
+        final.surface->raw_resource(),
+        touch_id,
+        final.position.x.as_int(),
+        final.position.y.as_int());
+    can_send_frame = true;
 }
 
-void mf::WlTouch::handle_up(uint32_t time, int32_t id)
+void mf::WlTouch::motion(
+    std::chrono::milliseconds const& ms,
+    int32_t touch_id,
+    WlSurface* /* parent */,
+    geometry::Point const& position_on_parent)
 {
-    focused_surface_for_ids.erase(id);
-    // TODO: Why is this not wl_display_next_serial()?
-    send_up_event(wl_display_get_serial(wl_client_get_display(client)),
-                  time,
-                  id);
+    auto const final_surface = focused_surface_for_ids.find(touch_id);
+
+    if (final_surface == focused_surface_for_ids.end())
+    {
+        log_warning("WlTouch::motion() called with invalid ID");
+        return;
+    }
+
+    // TODO: do this better, using parent
+    auto const position_on_final = final_surface->second->total_offset() + position_on_parent;
+
+    send_motion_event(
+        ms.count(),
+        touch_id,
+        position_on_final.x.as_int(),
+        position_on_final.y.as_int());
+    can_send_frame = true;
 }
 
+void mf::WlTouch::up(std::chrono::milliseconds const& ms, int32_t touch_id)
+{
+    auto const serial = wl_display_next_serial(wl_client_get_display(client));
+
+    focused_surface_for_ids.erase(touch_id);
+
+    send_up_event(
+        serial,
+        ms.count(),
+        touch_id);
+    can_send_frame = true;
+}
+
+void mf::WlTouch::frame()
+{
+    if (can_send_frame)
+        send_frame_event();
+    can_send_frame = false;
+}

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -23,11 +23,9 @@
 
 #include "mir/geometry/point.h"
 
-#include <map>
+#include <unordered_map>
 #include <functional>
-
-// from "mir_toolkit/events/event.h"
-struct MirTouchEvent;
+#include <chrono>
 
 namespace mir
 {
@@ -46,14 +44,23 @@ public:
 
     ~WlTouch();
 
-    void handle_event(MirTouchEvent const* touch_ev, WlSurface* surface);
+    void down(
+        std::chrono::milliseconds const& ms,
+        int32_t touch_id,
+        WlSurface* parent,
+        geometry::Point const& position_on_parent);
+    void motion(
+        std::chrono::milliseconds const& ms,
+        int32_t touch_id,
+        WlSurface* parent,
+        geometry::Point const& position_on_parent);
+    void up(std::chrono::milliseconds const& ms, int32_t touch_id);
+    void frame();
 
 private:
     std::function<void(WlTouch*)> on_destroy;
-    std::map<int32_t, WlSurface*> focused_surface_for_ids;
-
-    void handle_down(mir::geometry::Point position, WlSurface* surface, uint32_t time, int32_t id);
-    void handle_up(uint32_t time, int32_t id);
+    std::unordered_map<int32_t, WlSurface*> focused_surface_for_ids;
+    bool can_send_frame{false};
 
     void release() override;
 };


### PR DESCRIPTION
This probably wasn't really required, but I started fiddling with things and one thing lead to another. This moves all the code to unpack Mir events into `WlSurfaceEventSink` and out of the Wayland objects. It also generally breaks up the code into more logical chunks with better names and more type safety (ints are replaced by geometry types and chrono types where possible). I've tested the keyboard and mouse portions, but not touch. The WLCS touch tests pass even when I know it's broken (I should probably work on them at some point), so manual testing is needed. I'll comment when I've got it done building and tested on my under-powered touch machine.

My next PR will be changing the surface event sink to a surface observer, which cuts out large pieces of the Mir event system from the Wayland code paths. After that *should* be the final PR that ties it all together.