### PR TITLE
Allow Fedora rawhides builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ env:
 
 matrix:
   allow_failures:
-#    - env: SYSTEM=google:fedora-rawhide-64 VARIANT=amd64
+    - env: SYSTEM=google:fedora-rawhide-64 VARIANT=amd64
   fast_finish: true
 
 before_install:


### PR DESCRIPTION
We're seeing "GPG check FAILED" errors in CI.

Temporarily ignore the failing builds.