### PR TITLE
Add ImmediateExecutor

### DIFF
--- a/include/platform/mir/executor.h
+++ b/include/platform/mir/executor.h
@@ -48,7 +48,6 @@ public:
      */
     virtual void spawn(std::function<void()>&& work) = 0;
 
-protected:
     virtual ~Executor() = default;
 };
 

--- a/include/platform/mir/immediate_executor.h
+++ b/include/platform/mir/immediate_executor.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_IMMEDIATE_EXECUTOR_H_
+#define MIR_IMMEDIATE_EXECUTOR_H_
+
+#include "executor.h"
+
+namespace mir
+{
+
+/**
+ * Executes the given function synchronously on the current thread
+ * Used when an executor is required by an interface, but no special behavior is desired
+ */
+class ImmediateExecutor
+    : public Executor
+{
+public:
+    void spawn(std::function<void()>&& work) override;
+};
+
+}
+
+#endif // MIR_IMMEDIATE_EXECUTOR_H_

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -31,9 +31,11 @@ set(MIR_PLATFORM_REFERENCES ${MIR_PLATFORM_REFERENCES} PARENT_SCOPE)
 add_library(mirplatform SHARED
   ${MIR_PLATFORM_OBJECTS}
 
+  immediate_executor.cpp
   ${PROJECT_SOURCE_DIR}/include/platform/mir/input/input_sink.h
   ${PROJECT_SOURCE_DIR}/include/platform/mir/console_services.h
   ${PROJECT_SOURCE_DIR}/include/platform/mir/executor.h
+  ${PROJECT_SOURCE_DIR}/include/platform/mir/immediate_executor.h
 )
 
 target_link_libraries(mirplatform

--- a/src/platform/immediate_executor.cpp
+++ b/src/platform/immediate_executor.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "mir/immediate_executor.h"
+
+void mir::ImmediateExecutor::spawn(std::function<void()>&& work)
+{
+    work();
+}

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -241,3 +241,12 @@ MIR_PLATFORM_1.4.0 {
     mir::options::enable_mirclient_opt;
   };
 } MIR_PLATFORM_1.1.1;
+
+MIR_PLATFORM_1.4.1 {
+ global:
+  extern "C++" {
+    typeinfo?for?mir::ImmediateExecutor;
+    vtable?for?mir::ImmediateExecutor;
+    mir::ImmediateExecutor::spawn*;
+  };
+} MIR_PLATFORM_1.4.0;


### PR DESCRIPTION
Adds an executor that just runs the function synchronously, in the current thread. In a branch I'm working on I pass one of these to `registrar->register_interest()`.

The default executor throws the call on the main loop, which allows it to get called after `unregister_interest()` has been called, and the observer has been destroyed. This race condition foot-gun results in an intermittent crash that is difficult to diagnose. Perhaps we should rethink how the observer system works, and how we can prevent this sort of thing. As far as I can tell, the only way to safely register an observer with the default executor is to make sure that it stays alive for as long as messages are being sent, or it stays alive for at lase one main loop iteration after it is unregistered.