### PR TITLE
Split arch-specific part of libmirwayland-dev into a -bin package 

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -586,8 +586,23 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: libmirwayland0 (= ${binary:Version}),
          libmircore-dev (= ${binary:Version}),
          ${misc:Depends},
+         libmirwayland-bin (= ${binary:Version})
 Description: Display server for Ubuntu - generated wrappers for Wayland
  protocol extensions.
  .
  Contains the developer files for using the shared library containing generated
  wrappers for Wayland protocol extensions
+
+Package: libmirwayland-bin
+Section: libdevel
+Architecture: linux-any
+Multi-Arch: foreign
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+Description: Display server for Ubuntu - generator for Wayland protocol extension wrappers.
+ Contains the tool used for generating the Mir-style wrappers for Wayland
+ protocol extensions found in libmirwayland
+ .
+ This can be useful for implementing Wayland protocol extensions not already
+ implemented in Mir.

--- a/debian/control
+++ b/debian/control
@@ -600,6 +600,8 @@ Multi-Arch: foreign
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends},
          ${misc:Depends},
+Breaks: libmirwayland-dev (<< 1.4.0+dev20)
+Replaces: libmirwayland-dev (<< 1.4.0+dev20)
 Description: Display server for Ubuntu - generator for Wayland protocol extension wrappers.
  Contains the tool used for generating the Mir-style wrappers for Wayland
  protocol extensions found in libmirwayland

--- a/debian/libmirwayland-bin.install
+++ b/debian/libmirwayland-bin.install
@@ -1,0 +1,1 @@
+usr/bin/mir_wayland_generator

--- a/debian/libmirwayland-dev.install
+++ b/debian/libmirwayland-dev.install
@@ -1,4 +1,3 @@
 usr/lib/*/pkgconfig/mirwayland.pc
 usr/lib/*/libmirwayland.so
-usr/bin/mir_wayland_generator
 usr/include/mirwayland


### PR DESCRIPTION
This makes the PPA packaging match the Ubuntu archive packaging, and is necessary should anyone actually want to install `libmirwayland-dev` for multiple architectures (eg: using a cross-compiler)