### PR TITLE
Clean up and test attached windows on outputs

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1091,6 +1091,11 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
     {
         set_state(window_info, modifications.state().value());
     }
+    else if (modifications.output_id().is_set())
+    {
+        update_attached_and_fullscreen_sets(window_info, window_info.state());
+        application_zones_need_update = true;
+    }
 
     if (application_zones_need_update)
     {

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1650,7 +1650,21 @@ auto miral::BasicWindowManager::place_new_surface(WindowSpecification parameters
     if (!parameters.state().is_set())
         parameters.state() = mir_window_state_restored;
 
-    auto const display_area = active_display_area();
+    std::shared_ptr<DisplayArea> display_area;
+    if (parameters.output_id().is_set())
+    {
+        for (auto const& area : display_areas)
+        {
+            if (area->output && area->output->id() == parameters.output_id())
+            {
+                display_area = area;
+                break;
+            }
+        }
+    }
+    if (!display_area)
+        display_area = active_display_area();
+
     auto const application_zone = display_area->application_zone.extents();;
     auto const height = parameters.size().value().height.as_int();
 

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1671,17 +1671,6 @@ auto miral::BasicWindowManager::place_new_surface(WindowSpecification parameters
 
     bool const has_parent{parameters.parent().is_set() && parameters.parent().value().lock()};
 
-    if (parameters.output_id().is_set() && parameters.output_id().value() != 0)
-    {
-        Rectangle rect{parameters.top_left().value(), parameters.size().value()};
-        graphics::DisplayConfigurationOutputId id{parameters.output_id().value()};
-        display_layout->place_in_output(id, rect);
-        parameters.top_left() = rect.top_left;
-        parameters.size() = rect.size;
-        parameters.state() = mir_window_state_fullscreen;
-        positioned = true;
-    }
-
     if (has_parent)
     {
         auto const parent = info_for(parameters.parent().value()).window();

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -2353,15 +2353,6 @@ void miral::BasicWindowManager::for_each_window_in_workspace(
         callback(kv->second);
 }
 
-void miral::BasicWindowManager::add_display_for_testing(mir::geometry::Rectangle const& area)
-{
-    Locker lock{this};
-    outputs.add(area);
-    display_areas.push_back(std::make_shared<DisplayArea>(area));
-
-    update_windows_for_outputs();
-}
-
 auto miral::BasicWindowManager::apply_exclusive_rect_to_application_zone(
     Rectangle const& original_zone,
     Rectangle const& exclusive_rect,

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -281,13 +281,12 @@ private:
         mir::geometry::Rectangle const& application_zone,
         mir::geometry::Rectangle const& output_area);
     void set_state(miral::WindowInfo& window_info, MirWindowState value);
-    auto fullscreen_rect_for(WindowInfo const& window_info) const -> Rectangle;
     void remove_window(Application const& application, miral::WindowInfo const& info);
     void refocus(Application const& application, Window const& parent,
                  std::vector<std::shared_ptr<Workspace>> const& workspaces_containing_window);
     auto workspaces_containing(Window const& window) const -> std::vector<std::shared_ptr<Workspace>>;
     auto active_display_area() const -> std::shared_ptr<DisplayArea>;
-    auto display_area_for(Window const& window) const -> std::shared_ptr<DisplayArea>;
+    auto display_area_for(WindowInfo const& info) const -> std::shared_ptr<DisplayArea>;
     /// Returns the application zone area after shrinking it for the exclusive zone if needed
     static auto apply_exclusive_rect_to_application_zone(
         mir::geometry::Rectangle const& original_zone,

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -93,8 +93,6 @@ public:
     void add_display(mir::geometry::Rectangle const& area) override
     __attribute__((deprecated("Mir doesn't reliably call this: it is ignored. Use add_display_for_testing() instead")));
 
-    void add_display_for_testing(mir::geometry::Rectangle const& area);
-
     void remove_display(mir::geometry::Rectangle const& area) override;
 
     bool handle_keyboard_event(MirKeyboardEvent const* event) override;

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -280,6 +280,7 @@ private:
         WindowInfo& info,
         mir::geometry::Rectangle const& application_zone,
         mir::geometry::Rectangle const& output_area);
+    void update_attached_and_fullscreen_sets(WindowInfo& window_info, MirWindowState state);
     void set_state(miral::WindowInfo& window_info, MirWindowState value);
     void remove_window(Application const& application, miral::WindowInfo const& info);
     void refocus(Application const& application, Window const& parent,

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -42,6 +42,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     application_zone.cpp
     initial_window_placement.cpp
     window_placement_attached.cpp
+    window_placement_fullscreen.cpp
     ${MIRAL_TEST_SOURCES}
 )
 

--- a/tests/miral/depth_layer.cpp
+++ b/tests/miral/depth_layer.cpp
@@ -36,7 +36,7 @@ struct DepthLayer : mt::TestWindowManagerTools, WithParamInterface<MirDepthLayer
 {
     void SetUp() override
     {
-        basic_window_manager.add_display_for_testing(display_area);
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
         basic_window_manager.add_session(session);
     }
 

--- a/tests/miral/display_reconfiguration.cpp
+++ b/tests/miral/display_reconfiguration.cpp
@@ -42,7 +42,7 @@ struct DisplayConfiguration : mt::TestWindowManagerTools
 
     void SetUp() override
     {
-        basic_window_manager.add_display_for_testing(display_area);
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
         basic_window_manager.add_session(session);
     }
 
@@ -83,6 +83,6 @@ TEST_F(DisplayConfiguration, given_fullscreen_windows_reconfiguring_displays_doe
     Rectangle const new_display{
         display_area.top_left + Displacement{as_delta(display_width), 0}, display_area.size};
 
-    basic_window_manager.add_display_for_testing(new_display);
+    notify_configuration_applied(create_fake_display_configuration({display_area}));
     basic_window_manager.remove_display(new_display);
 }

--- a/tests/miral/drag_active_window.cpp
+++ b/tests/miral/drag_active_window.cpp
@@ -42,7 +42,7 @@ struct DragActiveWindow : mt::TestWindowManagerTools, WithParamInterface<MirWind
 
     void SetUp() override
     {
-        basic_window_manager.add_display_for_testing(display_area);
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
         basic_window_manager.add_session(session);
     }
 

--- a/tests/miral/initial_window_placement.cpp
+++ b/tests/miral/initial_window_placement.cpp
@@ -30,7 +30,7 @@ struct InitialWindowPlacement : mt::TestWindowManagerTools
 {
     void SetUp() override
     {
-        basic_window_manager.add_display_for_testing(display_area);
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
         basic_window_manager.add_session(session);
     }
 

--- a/tests/miral/modify_window_specification.cpp
+++ b/tests/miral/modify_window_specification.cpp
@@ -40,7 +40,7 @@ struct ModifyWindowState : mt::TestWindowManagerTools, WithParamInterface<MirWin
 
     void SetUp() override
     {
-        basic_window_manager.add_display_for_testing(display_area);
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
         basic_window_manager.add_session(session);
     }
 

--- a/tests/miral/modify_window_state.cpp
+++ b/tests/miral/modify_window_state.cpp
@@ -42,7 +42,7 @@ struct ModifyWindowState : mt::TestWindowManagerTools, WithParamInterface<MirWin
 
     void SetUp() override
     {
-        basic_window_manager.add_display_for_testing(display_area);
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
         basic_window_manager.add_session(session);
     }
 

--- a/tests/miral/popup_window_placement.cpp
+++ b/tests/miral/popup_window_placement.cpp
@@ -61,7 +61,7 @@ struct PopupWindowPlacement : mt::TestWindowManagerTools
 
     void SetUp() override
     {
-        basic_window_manager.add_display_for_testing(display_area);
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
 
         mir::scene::SurfaceCreationParameters creation_parameters;
         basic_window_manager.add_session(session);

--- a/tests/miral/raise_tree.cpp
+++ b/tests/miral/raise_tree.cpp
@@ -42,7 +42,7 @@ struct RaiseTree : mt::TestWindowManagerTools
 
     void SetUp() override
     {
-        basic_window_manager.add_display_for_testing(display_area);
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
 
         mir::scene::SurfaceCreationParameters creation_parameters;
         basic_window_manager.add_session(session);

--- a/tests/miral/select_active_window.cpp
+++ b/tests/miral/select_active_window.cpp
@@ -37,7 +37,7 @@ struct SelectActiveWindow : mt::TestWindowManagerTools
 
     void SetUp() override
     {
-        basic_window_manager.add_display_for_testing(display_area);
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
         basic_window_manager.add_session(session);
     }
 

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -301,7 +301,7 @@ auto mt::TestWindowManagerTools::create_fake_display_configuration(std::vector<m
     {
         auto const& rect = outputs[i];
         config_outputs.push_back(mir::graphics::DisplayConfigurationOutput{
-            mir::graphics::DisplayConfigurationOutputId{(int)i}, // id
+            mir::graphics::DisplayConfigurationOutputId{(int)(i + 1)}, // id
             mir::graphics::DisplayConfigurationCardId{1}, // card_id
             mir::graphics::DisplayConfigurationOutputType::unknown, // type
             {mir_pixel_format_abgr_8888}, // pixel_formats

--- a/tests/miral/window_placement_anchors_to_parent.cpp
+++ b/tests/miral/window_placement_anchors_to_parent.cpp
@@ -59,7 +59,7 @@ struct WindowPlacementAnchorsToParent : mt::TestWindowManagerTools
     {
         TestWindowManagerTools::SetUp();
 
-        basic_window_manager.add_display_for_testing(display_area);
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
 
         mir::scene::SurfaceCreationParameters creation_parameters;
         basic_window_manager.add_session(session);

--- a/tests/miral/window_placement_fullscreen.cpp
+++ b/tests/miral/window_placement_fullscreen.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "test_window_manager_tools.h"
+
+using namespace miral;
+using namespace testing;
+namespace mt = mir::test;
+namespace mg = mir::graphics;
+
+namespace
+{
+X const display_left{30};
+Y const display_top{40};
+Width const display_width{1280};
+Height const display_height{720};
+
+Rectangle const display_area{{display_left,  display_top},
+                             {display_width, display_height}};
+
+struct WindowPlacementFullscreen : mt::TestWindowManagerTools
+{
+    void SetUp() override
+    {
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
+        basic_window_manager.add_session(session);
+    }
+
+    auto create_window(mir::scene::SurfaceCreationParameters creation_parameters) -> Window
+    {
+        Window result;
+
+        EXPECT_CALL(*window_manager_policy, advise_new_window(_))
+            .WillOnce(
+                Invoke(
+                    [&result](WindowInfo const& window_info)
+                        { result = window_info.window(); }));
+
+        basic_window_manager.add_surface(session, creation_parameters, &create_surface);
+        basic_window_manager.select_active_window(result);
+
+        // Clear the expectations used to capture the window
+        Mock::VerifyAndClearExpectations(window_manager_policy);
+
+        return result;
+    }
+};
+
+}
+
+TEST_F(WindowPlacementFullscreen, window_is_initially_placed_correctly)
+{
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_fullscreen;
+        window = create_window(params);
+    }
+    auto const& info = basic_window_manager.info_for(window);
+
+    EXPECT_THAT(info.state(), Eq(mir_window_state_fullscreen));
+    EXPECT_THAT(window.top_left(), Eq(display_area.top_left));
+    EXPECT_THAT(window.size(), Eq(display_area.size));
+}
+
+TEST_F(WindowPlacementFullscreen, window_is_placed_correctly_when_fullscreened)
+{
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_maximized;
+        window = create_window(params);
+    }
+    auto const& info = basic_window_manager.info_for(window);
+
+    {
+        WindowSpecification spec;
+        spec.state() = mir_window_state_fullscreen;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(info.state(), Eq(mir_window_state_fullscreen));
+    EXPECT_THAT(window.top_left(), Eq(display_area.top_left));
+    EXPECT_THAT(window.size(), Eq(display_area.size));
+}
+
+TEST_F(WindowPlacementFullscreen, window_can_be_unfullscreened)
+{
+    Size window_size{100, 200};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_restored;
+        params.size = window_size;
+        window = create_window(params);
+    }
+    auto const& info = basic_window_manager.info_for(window);
+
+    {
+        WindowSpecification spec;
+        spec.state() = mir_window_state_fullscreen;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.state() = mir_window_state_restored;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(info.state(), Eq(mir_window_state_restored));
+    EXPECT_THAT(window.size(), Eq(window_size));
+}
+
+TEST_F(WindowPlacementFullscreen, window_initially_placed_correctly_when_output_id_set)
+{
+    Rectangle const other_display_area = {{1400, 10}, {960, 720}};
+    mg::DisplayConfigurationOutputId output_id{2};
+
+    auto const display_config = create_fake_display_configuration({display_area, other_display_area});
+    notify_configuration_applied(display_config);
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_fullscreen;
+        params.output_id = output_id;
+        window = create_window(params);
+    }
+    auto const& info = basic_window_manager.info_for(window);
+
+    EXPECT_THAT(info.state(), Eq(mir_window_state_fullscreen));
+    EXPECT_THAT(window.top_left(), Eq(other_display_area.top_left));
+    EXPECT_THAT(window.size(), Eq(other_display_area.size));
+}
+
+TEST_F(WindowPlacementFullscreen, window_placed_correctly_when_output_id_changes)
+{
+    Rectangle const other_display_area = {{1400, 10}, {960, 720}};
+    mg::DisplayConfigurationOutputId output_id_a{1};
+    mg::DisplayConfigurationOutputId output_id_b{2};
+
+    auto const display_config = create_fake_display_configuration({display_area, other_display_area});
+    notify_configuration_applied(display_config);
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.state = mir_window_state_fullscreen;
+        params.output_id = output_id_b;
+        window = create_window(params);
+    }
+    auto const& info = basic_window_manager.info_for(window);
+
+    {
+        WindowSpecification spec;
+        spec.output_id() = output_id_a.as_value();
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(info.state(), Eq(mir_window_state_fullscreen));
+    EXPECT_THAT(window.top_left(), Eq(display_area.top_left));
+    EXPECT_THAT(window.size(), Eq(display_area.size));
+}


### PR DESCRIPTION
This fixes and tests a bunch of subtle bugs related to attached and fullscreen windows on specific outputs. Fixes problems with #982.