### PR TITLE
Remove frontend types from Wayland

### DIFF
--- a/include/server/mir/frontend/basic_mir_client_session.h
+++ b/include/server/mir/frontend/basic_mir_client_session.h
@@ -45,6 +45,12 @@ public:
     auto name() const -> std::string override;
     auto get_surface(SurfaceId surface) const -> std::shared_ptr<Surface> override;
 
+    auto create_surface(
+        std::shared_ptr<shell::Shell> const& shell,
+        scene::SurfaceCreationParameters const& params,
+        std::shared_ptr<EventSink> const& sink) -> SurfaceId override;
+    void destroy_surface(std::shared_ptr<shell::Shell> const& shell, SurfaceId surface) override;
+
     auto create_buffer_stream(graphics::BufferProperties const& props) -> BufferStreamId override;
     auto get_buffer_stream(BufferStreamId stream) const -> std::shared_ptr<BufferStream> override;
     void destroy_buffer_stream(BufferStreamId stream) override;

--- a/include/server/mir/frontend/mir_client_session.h
+++ b/include/server/mir/frontend/mir_client_session.h
@@ -27,9 +27,14 @@
 
 namespace mir
 {
+namespace shell
+{
+class Shell;
+}
 namespace scene
 {
 class Session;
+struct SurfaceCreationParameters;
 }
 namespace graphics
 {
@@ -39,6 +44,7 @@ namespace frontend
 {
 class Surface;
 class BufferStream;
+class EventSink;
 
 /// Session interface specific to applications using the deprecated mirclient protocol
 class MirClientSession
@@ -48,6 +54,12 @@ public:
 
     virtual auto name() const -> std::string = 0;
     virtual auto get_surface(SurfaceId surface) const -> std::shared_ptr<Surface> = 0;
+
+    virtual auto create_surface(
+        std::shared_ptr<shell::Shell> const& shell,
+        scene::SurfaceCreationParameters const& params,
+        std::shared_ptr<EventSink> const& sink) -> SurfaceId = 0;
+    virtual void destroy_surface(std::shared_ptr<shell::Shell> const& shell, SurfaceId surface) = 0;
 
     virtual auto create_buffer_stream(graphics::BufferProperties const& props) -> BufferStreamId = 0;
     virtual auto get_buffer_stream(BufferStreamId stream) const -> std::shared_ptr<BufferStream> = 0;

--- a/include/server/mir/frontend/wayland.h
+++ b/include/server/mir/frontend/wayland.h
@@ -31,10 +31,10 @@ namespace mir
 namespace scene
 {
 class Session;
+class Surface;
 }
 namespace frontend
 {
-class Surface;
 
 /// Utility function to recover the session associated with a wl_client
 auto get_session(wl_client* client) -> std::shared_ptr<scene::Session>;
@@ -43,7 +43,7 @@ auto get_session(wl_client* client) -> std::shared_ptr<scene::Session>;
 auto get_session(wl_resource* resource) -> std::shared_ptr<scene::Session>;
 
 /// Utility function to recover the window associated with a wl_client
-auto get_window(wl_resource* surface) -> std::shared_ptr<Surface>;
+auto get_window(wl_resource* surface) -> std::shared_ptr<scene::Surface>;
 
 /// Returns the "standard" extensions Mir recomends enabling (a subset of supported extensions)
 auto get_standard_extensions() -> std::vector<std::string>;

--- a/include/server/mir/scene/session.h
+++ b/include/server/mir/scene/session.h
@@ -84,9 +84,10 @@ public:
 
     virtual auto create_surface(
         SurfaceCreationParameters const& params,
-        std::shared_ptr<frontend::EventSink> const& sink) -> frontend::SurfaceId = 0;
+        std::shared_ptr<frontend::EventSink> const& sink) -> std::shared_ptr<scene::Surface> = 0;
     virtual void destroy_surface(frontend::SurfaceId surface) = 0;
     virtual auto surface(frontend::SurfaceId surface) const -> std::shared_ptr<Surface> = 0;
+    virtual auto surface_id(std::shared_ptr<scene::Surface> const& surface) const -> frontend::SurfaceId = 0;
     virtual void destroy_surface(std::weak_ptr<Surface> const& surface) = 0;
     virtual auto surface_after(std::shared_ptr<Surface> const& surface) const -> std::shared_ptr<Surface> = 0;
 

--- a/include/server/mir/scene/session.h
+++ b/include/server/mir/scene/session.h
@@ -84,10 +84,10 @@ public:
 
     virtual auto create_surface(
         SurfaceCreationParameters const& params,
-        std::shared_ptr<frontend::EventSink> const& sink) -> std::shared_ptr<scene::Surface> = 0;
+        std::shared_ptr<frontend::EventSink> const& sink) -> std::shared_ptr<Surface> = 0;
     virtual void destroy_surface(frontend::SurfaceId surface) = 0;
     virtual auto surface(frontend::SurfaceId surface) const -> std::shared_ptr<Surface> = 0;
-    virtual auto surface_id(std::shared_ptr<scene::Surface> const& surface) const -> frontend::SurfaceId = 0;
+    virtual auto surface_id(std::shared_ptr<Surface> const& surface) const -> frontend::SurfaceId = 0;
     virtual void destroy_surface(std::weak_ptr<Surface> const& surface) = 0;
     virtual auto surface_after(std::shared_ptr<Surface> const& surface) const -> std::shared_ptr<Surface> = 0;
 

--- a/include/server/mir/shell/abstract_shell.h
+++ b/include/server/mir/shell/abstract_shell.h
@@ -51,21 +51,26 @@ public:
 
     ~AbstractShell() noexcept;
 
-    std::shared_ptr<scene::Session> open_session(
+    auto open_session(
         pid_t client_pid,
         std::string const& name,
-        std::shared_ptr<frontend::EventSink> const& sink) override;
+        std::shared_ptr<frontend::EventSink> const& sink) -> std::shared_ptr<scene::Session> override;
 
     void close_session(std::shared_ptr<scene::Session> const& session) override;
 
-    frontend::SurfaceId create_surface(
+    auto create_surface(
         std::shared_ptr<scene::Session> const& session,
         scene::SurfaceCreationParameters const& params,
-        std::shared_ptr<frontend::EventSink> const& sink) override;
+        std::shared_ptr<frontend::EventSink> const& sink) -> std::shared_ptr<scene::Surface> override;
 
-    void modify_surface(std::shared_ptr<scene::Session> const& session, std::shared_ptr<scene::Surface> const& surface, SurfaceSpecification const& modifications) override;
+    void modify_surface(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<scene::Surface> const& surface,
+        SurfaceSpecification const& modifications) override;
 
-    void destroy_surface(std::shared_ptr<scene::Session> const& session, frontend::SurfaceId surface) override;
+    void destroy_surface(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<scene::Surface> const& surface) override;
 
     int set_surface_attribute(
         std::shared_ptr<scene::Session> const& session,

--- a/include/server/mir/shell/shell.h
+++ b/include/server/mir/shell/shell.h
@@ -21,7 +21,6 @@
 
 #include "mir/shell/focus_controller.h"
 #include "mir/input/event_filter.h"
-#include "mir/frontend/surface_id.h"
 #include "mir/compositor/display_listener.h"
 
 #include "mir_toolkit/common.h"
@@ -56,10 +55,10 @@ class Shell :
 public:
 /** @name these functions support frontend requests
  *  @{ */
-    virtual std::shared_ptr<scene::Session> open_session(
+    virtual auto open_session(
         pid_t client_pid,
         std::string const& name,
-        std::shared_ptr<frontend::EventSink> const& sink) = 0;
+        std::shared_ptr<frontend::EventSink> const& sink) -> std::shared_ptr<scene::Session> = 0;
 
     virtual void close_session(std::shared_ptr<scene::Session> const& session) = 0;
 
@@ -73,17 +72,19 @@ public:
 
     virtual void stop_prompt_session(std::shared_ptr<scene::PromptSession> const& prompt_session) = 0;
 
-    virtual frontend::SurfaceId create_surface(
+    virtual auto create_surface(
         std::shared_ptr<scene::Session> const& session,
         scene::SurfaceCreationParameters const& params,
-        std::shared_ptr<frontend::EventSink> const& sink) = 0;
+        std::shared_ptr<frontend::EventSink> const& sink) -> std::shared_ptr<scene::Surface> = 0;
 
     virtual void modify_surface(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
         shell::SurfaceSpecification  const& modifications) = 0;
 
-    virtual void destroy_surface(std::shared_ptr<scene::Session> const& session, frontend::SurfaceId surface) = 0;
+    virtual void destroy_surface(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<scene::Surface> const& surface) = 0;
 
     virtual int set_surface_attribute(
         std::shared_ptr<scene::Session> const& session,

--- a/include/server/mir/shell/shell_report.h
+++ b/include/server/mir/shell/shell_report.h
@@ -46,10 +46,12 @@ public:
     virtual void closing_session(scene::Session const& session) = 0;
 
     virtual void created_surface(
-        scene::Session const& session, frontend::SurfaceId surface_id) = 0;
+        scene::Session const& session,
+        scene::Surface const& surface) = 0;
 
     virtual void update_surface(
-        scene::Session const& session, scene::Surface const& surface,
+        scene::Session const& session,
+        scene::Surface const& surface,
         SurfaceSpecification const& modifications) = 0;
 
     virtual void update_surface(
@@ -57,7 +59,8 @@ public:
         MirWindowAttrib attrib, int value) = 0;
 
     virtual void destroying_surface(
-        scene::Session const& session, frontend::SurfaceId surface) = 0;
+        scene::Session const& session,
+        scene::Surface const& surface) = 0;
 
     virtual void started_prompt_session(
         scene::PromptSession const& prompt_session,

--- a/include/server/mir/shell/shell_wrapper.h
+++ b/include/server/mir/shell/shell_wrapper.h
@@ -33,28 +33,28 @@ public:
     void focus_next_session() override;
     void focus_prev_session() override;
 
-    std::shared_ptr<scene::Session> focused_session() const override;
+    auto focused_session() const -> std::shared_ptr<scene::Session> override;
 
     void set_focus_to(
         std::shared_ptr<scene::Session> const& focus_session,
         std::shared_ptr<scene::Surface> const& focus_surface) override;
 
-    std::shared_ptr<scene::Surface> focused_surface() const override;
+    auto focused_surface() const -> std::shared_ptr<scene::Surface> override;
 
     auto surface_at(geometry::Point cursor) const -> std::shared_ptr<scene::Surface> override;
 
     void raise(SurfaceSet const& surfaces) override;
 
-    std::shared_ptr<scene::Session> open_session(
+    auto open_session(
         pid_t client_pid,
         std::string const& name,
-        std::shared_ptr<frontend::EventSink> const& sink) override;
+        std::shared_ptr<frontend::EventSink> const& sink) -> std::shared_ptr<scene::Session> override;
 
     void close_session(std::shared_ptr<scene::Session> const& session) override;
 
-    std::shared_ptr<scene::PromptSession> start_prompt_session_for(
+    auto start_prompt_session_for(
         std::shared_ptr<scene::Session> const& session,
-        scene::PromptSessionCreationParameters const& params) override;
+        scene::PromptSessionCreationParameters const& params) -> std::shared_ptr<scene::PromptSession> override;
 
     void add_prompt_provider_for(
         std::shared_ptr<scene::PromptSession> const& prompt_session,
@@ -62,14 +62,19 @@ public:
 
     void stop_prompt_session(std::shared_ptr<scene::PromptSession> const& prompt_session) override;
 
-    frontend::SurfaceId create_surface(
+    auto create_surface(
         std::shared_ptr<scene::Session> const& session,
         scene::SurfaceCreationParameters const& params,
-        std::shared_ptr<frontend::EventSink> const& sink) override;
+        std::shared_ptr<frontend::EventSink> const& sink) -> std::shared_ptr<scene::Surface> override;
 
-    void modify_surface(std::shared_ptr<scene::Session> const& session, std::shared_ptr<scene::Surface> const& surface, SurfaceSpecification const& modifications) override;
+    void modify_surface(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<scene::Surface> const& surface,
+        SurfaceSpecification const& modifications) override;
 
-    void destroy_surface(std::shared_ptr<scene::Session> const& session, frontend::SurfaceId surface) override;
+    void destroy_surface(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<scene::Surface> const& surface) override;
 
     int set_surface_attribute(
         std::shared_ptr<scene::Session> const& session,

--- a/include/server/mir/shell/system_compositor_window_manager.h
+++ b/include/server/mir/shell/system_compositor_window_manager.h
@@ -66,10 +66,12 @@ private:
 
     void remove_session(std::shared_ptr<scene::Session> const& session) override;
 
-    frontend::SurfaceId add_surface(
+    auto add_surface(
         std::shared_ptr<scene::Session> const& session,
         scene::SurfaceCreationParameters const& params,
-        std::function<frontend::SurfaceId(std::shared_ptr<scene::Session> const& session, scene::SurfaceCreationParameters const& params)> const& build) override;
+        std::function<std::shared_ptr<scene::Surface>(
+            std::shared_ptr<scene::Session> const& session,
+            scene::SurfaceCreationParameters const& params)> const& build) -> std::shared_ptr<scene::Surface> override;
 
     void modify_surface(
         std::shared_ptr<scene::Session> const& session,

--- a/include/server/mir/shell/window_manager.h
+++ b/include/server/mir/shell/window_manager.h
@@ -41,10 +41,12 @@ public:
 
     virtual void remove_session(std::shared_ptr<scene::Session> const& session) = 0;
 
-    virtual frontend::SurfaceId add_surface(
+    virtual auto add_surface(
         std::shared_ptr<scene::Session> const& session,
         scene::SurfaceCreationParameters const& params,
-        std::function<frontend::SurfaceId(std::shared_ptr<scene::Session> const& session, scene::SurfaceCreationParameters const& params)> const& build) = 0;
+        std::function<std::shared_ptr<scene::Surface>(
+            std::shared_ptr<scene::Session> const& session,
+            scene::SurfaceCreationParameters const& params)> const& build) -> std::shared_ptr<scene::Surface> = 0;
 
     virtual void modify_surface(
         std::shared_ptr<scene::Session> const& session,

--- a/include/test/mir/test/doubles/mock_window_manager.h
+++ b/include/test/mir/test/doubles/mock_window_manager.h
@@ -42,10 +42,12 @@ struct MockWindowManager : shell::WindowManager
     MOCK_METHOD1(add_session, void (std::shared_ptr<scene::Session> const&));
     MOCK_METHOD1(remove_session, void (std::shared_ptr<scene::Session> const&));
 
-    MOCK_METHOD3(add_surface, frontend::SurfaceId(
+    MOCK_METHOD3(add_surface, std::shared_ptr<scene::Surface>(
         std::shared_ptr<scene::Session> const& session,
         scene::SurfaceCreationParameters const& params,
-        std::function<frontend::SurfaceId(std::shared_ptr<scene::Session> const& session, scene::SurfaceCreationParameters const& params)> const& build));
+        std::function<std::shared_ptr<scene::Surface>(
+            std::shared_ptr<scene::Session> const& session,
+            scene::SurfaceCreationParameters const& params)> const& build));
 
     MOCK_METHOD3(modify_surface, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, shell::SurfaceSpecification const&));
     MOCK_METHOD2(remove_surface, void(std::shared_ptr<scene::Session> const&, std::weak_ptr<scene::Surface> const&));
@@ -68,10 +70,12 @@ struct MockWindowManager : shell::WindowManager
             MirWindowAttrib attrib,
             int value));
 
-    static frontend::SurfaceId add_surface_default(
+    static auto add_surface_default(
         std::shared_ptr<scene::Session> const& session,
         scene::SurfaceCreationParameters const& params,
-        std::function<frontend::SurfaceId(std::shared_ptr<scene::Session> const& session, scene::SurfaceCreationParameters const& params)> const& build)
+        std::function<std::shared_ptr<scene::Surface>(
+            std::shared_ptr<scene::Session> const& session,
+            scene::SurfaceCreationParameters const& params)> const& build) -> std::shared_ptr<scene::Surface>
         { return build(session, params); }
 };
 

--- a/include/test/mir/test/doubles/stub_session.h
+++ b/include/test/mir/test/doubles/stub_session.h
@@ -58,14 +58,17 @@ struct StubSession : scene::Session
 
     void resume_prompt_session() override;
 
-    frontend::SurfaceId create_surface(
+    auto create_surface(
         scene::SurfaceCreationParameters const& params,
-        std::shared_ptr<frontend::EventSink> const& sink) override;
+        std::shared_ptr<frontend::EventSink> const& sink) -> std::shared_ptr<scene::Surface> override;
 
     void destroy_surface(frontend::SurfaceId surface) override;
 
-    std::shared_ptr<scene::Surface> surface(
-        frontend::SurfaceId surface) const override;
+    auto surface(
+        frontend::SurfaceId surface) const -> std::shared_ptr<scene::Surface> override;
+
+    auto surface_id(
+        std::shared_ptr<scene::Surface> const& surface) const -> frontend::SurfaceId override;
 
     std::shared_ptr<scene::Surface> surface_after(
         std::shared_ptr<scene::Surface> const&) const override;

--- a/include/test/mir/test/doubles/wrap_shell_to_track_latest_surface.h
+++ b/include/test/mir/test/doubles/wrap_shell_to_track_latest_surface.h
@@ -32,13 +32,13 @@ struct WrapShellToTrackLatestSurface : mir::shell::ShellWrapper
 {
     using mir::shell::ShellWrapper::ShellWrapper;
 
-    mir::frontend::SurfaceId create_surface(
+    auto create_surface(
         std::shared_ptr <mir::scene::Session> const& session,
         mir::scene::SurfaceCreationParameters const& params,
-        std::shared_ptr<mir::frontend::EventSink> const& sink) override
+        std::shared_ptr<mir::frontend::EventSink> const& sink) -> std::shared_ptr<scene::Surface> override
     {
         auto const surface = mir::shell::ShellWrapper::create_surface(session, params, sink);
-        latest_surface = session->surface(surface);
+        latest_surface = surface;
         return surface;
     }
 

--- a/include/test/mir_test_framework/observant_shell.h
+++ b/include/test/mir_test_framework/observant_shell.h
@@ -31,10 +31,10 @@ struct ObservantShell : mir::shell::ShellWrapper
         std::shared_ptr<mir::shell::Shell> const& wrapped,
         std::shared_ptr<mir::scene::SurfaceObserver> const& surface_observer);
 
-    mir::frontend::SurfaceId create_surface(
+    auto create_surface(
         std::shared_ptr<mir::scene::Session> const& session,
         mir::scene::SurfaceCreationParameters const& params,
-        std::shared_ptr<mir::frontend::EventSink> const& sink) override;
+        std::shared_ptr<mir::frontend::EventSink> const& sink) -> std::shared_ptr<mir::scene::Surface> override;
 
 private:
     std::shared_ptr<mir::scene::SurfaceObserver> const surface_observer;

--- a/include/test/mir_test_framework/placement_applying_shell.h
+++ b/include/test/mir_test_framework/placement_applying_shell.h
@@ -45,10 +45,10 @@ struct PlacementApplyingShell : mir::shell::ShellWrapper
         ClientPositions const& client_positions);
 
     ~PlacementApplyingShell();
-    mir::frontend::SurfaceId create_surface(
+    auto create_surface(
         std::shared_ptr<mir::scene::Session> const& session,
         mir::scene::SurfaceCreationParameters const& params,
-        std::shared_ptr<mir::frontend::EventSink> const& sink) override;
+        std::shared_ptr<mir::frontend::EventSink> const& sink) -> std::shared_ptr<mir::scene::Surface> override;
 
     void modify_surface(
         std::shared_ptr<mir::scene::Session> const& session,

--- a/src/include/server/mir/server_configuration.h
+++ b/src/include/server/mir/server_configuration.h
@@ -37,12 +37,11 @@ class Compositor;
 namespace frontend
 {
 class Connector;
-class Shell;
-class MirClientSession;
 }
 namespace shell
 {
 class SessionContainer;
+class Shell;
 }
 namespace graphics
 {

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -103,8 +103,10 @@ void miral::BasicWindowManager::remove_session(std::shared_ptr<scene::Session> c
 auto miral::BasicWindowManager::add_surface(
     std::shared_ptr<scene::Session> const& session,
     scene::SurfaceCreationParameters const& params,
-    std::function<frontend::SurfaceId(std::shared_ptr<scene::Session> const& session, scene::SurfaceCreationParameters const& params)> const& build)
--> frontend::SurfaceId
+    std::function<std::shared_ptr<scene::Surface>(
+        std::shared_ptr<scene::Session> const& session,
+        scene::SurfaceCreationParameters const& params)> const& build)
+-> std::shared_ptr<scene::Surface>
 {
     Locker lock{this};
 
@@ -118,8 +120,8 @@ auto miral::BasicWindowManager::add_surface(
 
     scene::SurfaceCreationParameters parameters;
     spec.update(parameters);
-    auto const surface_id = build(session, parameters);
-    Window const window{session, session->surface(surface_id)};
+    auto const surface = build(session, parameters);
+    Window const window{session, surface};
     auto& window_info = this->window_info.emplace(window, WindowInfo{window, spec}).first->second;
 
     if (spec.parent().is_set() && spec.parent().value().lock())
@@ -159,7 +161,7 @@ auto miral::BasicWindowManager::add_surface(
         mir_surface->placed_relative(relative_placement);
     }
 
-    return surface_id;
+    return surface;
 }
 
 void miral::BasicWindowManager::modify_surface(

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -78,8 +78,10 @@ public:
     auto add_surface(
         std::shared_ptr<mir::scene::Session> const& session,
         mir::scene::SurfaceCreationParameters const& params,
-        std::function<mir::frontend::SurfaceId(std::shared_ptr<mir::scene::Session> const& session, mir::scene::SurfaceCreationParameters const& params)> const& build)
-    -> mir::frontend::SurfaceId override;
+        std::function<std::shared_ptr<mir::scene::Surface>(
+            std::shared_ptr<mir::scene::Session> const& session,
+            mir::scene::SurfaceCreationParameters const& params)> const& build)
+    -> std::shared_ptr<mir::scene::Surface> override;
 
     void modify_surface(
         std::shared_ptr<mir::scene::Session> const& session,

--- a/src/server/frontend/basic_mir_client_session.cpp
+++ b/src/server/frontend/basic_mir_client_session.cpp
@@ -40,6 +40,20 @@ auto mf::BasicMirClientSession::get_surface(SurfaceId surface) const -> std::sha
     return session_->surface(surface);
 }
 
+auto mf::BasicMirClientSession::create_surface(
+    std::shared_ptr<shell::Shell> const& shell,
+    scene::SurfaceCreationParameters const& params,
+    std::shared_ptr<EventSink> const& sink) -> SurfaceId
+{
+    auto surface = shell->create_surface(session_, params, sink);
+    return session_->surface_id(surface);
+}
+
+void mf::BasicMirClientSession::destroy_surface(std::shared_ptr<shell::Shell> const& shell, SurfaceId surface)
+{
+    shell->destroy_surface(session_, session_->surface(surface));
+}
+
 auto mf::BasicMirClientSession::create_buffer_stream(graphics::BufferProperties const& props) -> BufferStreamId
 {
     return session_->create_buffer_stream(props);

--- a/src/server/frontend_wayland/layer_shell_v1.h
+++ b/src/server/frontend_wayland/layer_shell_v1.h
@@ -23,21 +23,32 @@
 
 namespace mir
 {
-namespace frontend
+namespace scene
 {
-
+class Surface;
+}
+namespace shell
+{
 class Shell;
 class Surface;
+}
+namespace frontend
+{
 class WlSeat;
 class OutputManager;
 
 class LayerShellV1 : public wayland::LayerShellV1::Global
 {
 public:
-    LayerShellV1(wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
-    static auto get_window(wl_resource* surface) -> std::shared_ptr<Surface>;
+    LayerShellV1(
+        wl_display* display,
+        std::shared_ptr<shell::Shell> shell,
+        WlSeat& seat,
+        OutputManager* output_manager);
 
-    std::shared_ptr<Shell> const shell;
+    static auto get_window(wl_resource* surface) -> std::shared_ptr<scene::Surface>;
+
+    std::shared_ptr<shell::Shell> const shell;
     WlSeat& seat;
     OutputManager* const output_manager;
 

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -626,7 +626,7 @@ mf::WaylandConnector::WaylandConnector(
       pause_signal{eventfd(0, EFD_CLOEXEC | EFD_SEMAPHORE)},
       executor{std::make_shared<WaylandExecutor>(wl_display_get_event_loop(display.get()))},
       allocator{allocator_for_display(allocator, display.get(), executor)},
-      weak_shell{shell},
+      shell{shell},
       extensions{std::move(extensions_)},
       extension_filter{extension_filter}
 {
@@ -851,9 +851,6 @@ bool mf::WaylandConnector::wl_display_global_filter_func(wl_client const* client
 {
 #ifndef MIR_NO_WAYLAND_FILTER
     auto const* const interface = wl_global_get_interface(global);
-    auto const shell = weak_shell.lock();
-    if (!shell)
-        BOOST_THROW_EXCEPTION(std::logic_error("Invalid shell"));
     auto const session = get_session(const_cast<wl_client*>(client));
     return extension_filter(session, interface->name);
 #else

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -47,6 +47,14 @@ namespace geometry
 {
 struct Size;
 }
+namespace shell
+{
+class Shell;
+}
+namespace scene
+{
+class Surface;
+}
 namespace frontend
 {
 class WlCompositor;
@@ -54,9 +62,6 @@ class WlSubcompositor;
 class WlApplication;
 class WlSeat;
 class OutputManager;
-class MirClientSession;
-class Shell;
-class Surface;
 class MirDisplay;
 class SessionAuthorizer;
 class DataDeviceManager;
@@ -71,14 +76,14 @@ public:
 
     virtual void run_builders(wl_display* display, std::function<void(std::function<void()>&& work)> const& run_on_wayland_mainloop);
 
-    void init(wl_display* display, std::shared_ptr<Shell> const& shell, WlSeat* seat, OutputManager* const output_manager);
+    void init(wl_display* display, std::shared_ptr<shell::Shell> const& shell, WlSeat* seat, OutputManager* const output_manager);
 
     auto get_extension(std::string const& name) const -> std::shared_ptr<void>;
 
 protected:
 
     void add_extension(std::string const name, std::shared_ptr<void> implementation);
-    virtual void custom_extensions(wl_display* display, std::shared_ptr<Shell> const& shell, WlSeat* seat, OutputManager* const output_manager);
+    virtual void custom_extensions(wl_display* display, std::shared_ptr<shell::Shell> const& shell, WlSeat* seat, OutputManager* const output_manager);
 
 private:
     std::unordered_map<std::string, std::shared_ptr<void>> extension_protocols;
@@ -91,7 +96,7 @@ public:
 
     WaylandConnector(
         optional_value<std::string> const& display_name,
-        std::shared_ptr<Shell> const& shell,
+        std::shared_ptr<shell::Shell> const& shell,
         std::shared_ptr<MirDisplay> const& display_config,
         std::shared_ptr<input::InputDeviceHub> const& input_hub,
         std::shared_ptr<input::Seat> const& seat,
@@ -131,7 +136,7 @@ private:
     std::unique_ptr<DataDeviceManager> data_device_manager_global;
     std::shared_ptr<Executor> const executor;
     std::shared_ptr<graphics::WaylandAllocator> const allocator;
-    std::weak_ptr<frontend::Shell> const weak_shell;
+    std::weak_ptr<shell::Shell> const weak_shell;
     std::unique_ptr<WaylandExtensions> const extensions;
     std::thread dispatch_thread;
     wl_event_source* pause_source;
@@ -143,10 +148,13 @@ private:
     std::unordered_map<int, std::function<void(std::shared_ptr<scene::Session> const& session)>> mutable connect_handlers;
 };
 
-auto create_wl_shell(wl_display* display, std::shared_ptr<Shell> const& shell, WlSeat* seat, OutputManager* const output_manager)
-    -> std::shared_ptr<void>;
+auto create_wl_shell(
+    wl_display* display,
+    std::shared_ptr<shell::Shell> const& shell,
+    WlSeat* seat,
+    OutputManager* const output_manager) -> std::shared_ptr<void>;
 
-auto get_wl_shell_window(wl_resource* surface) -> std::shared_ptr<Surface>;
+auto get_wl_shell_window(wl_resource* surface) -> std::shared_ptr<scene::Surface>;
 }
 }
 

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -136,7 +136,7 @@ private:
     std::unique_ptr<DataDeviceManager> data_device_manager_global;
     std::shared_ptr<Executor> const executor;
     std::shared_ptr<graphics::WaylandAllocator> const allocator;
-    std::weak_ptr<shell::Shell> const weak_shell;
+    std::shared_ptr<shell::Shell> const shell;
     std::unique_ptr<WaylandExtensions> const extensions;
     std::thread dispatch_thread;
     wl_event_source* pause_source;

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -35,6 +35,7 @@
 
 namespace mf = mir::frontend;
 namespace ms = mir::scene;
+namespace msh = mir::shell;
 namespace mo = mir::options;
 namespace mw = mir::wayland;
 
@@ -80,7 +81,7 @@ auto configure_wayland_extensions(
     protected:
         void custom_extensions(
             wl_display* display,
-            std::shared_ptr<mf::Shell> const& shell,
+            std::shared_ptr<msh::Shell> const& shell,
             mf::WlSeat* seat,
             mf::OutputManager* const output_manager) override
         {
@@ -157,7 +158,7 @@ std::shared_ptr<mf::Connector>
 
             return std::make_shared<mf::WaylandConnector>(
                 display_name,
-                the_frontend_shell(),
+                the_shell(),
                 display_config,
                 the_input_device_hub(),
                 the_seat(),
@@ -188,7 +189,7 @@ void mir::DefaultServerConfiguration::set_enabled_wayland_extensions(std::vector
     enabled_wayland_extensions = extensions;
 }
 
-auto mir::frontend::get_window(wl_resource* surface) -> std::shared_ptr<Surface>
+auto mir::frontend::get_window(wl_resource* surface) -> std::shared_ptr<ms::Surface>
 {
     if (auto result = get_wl_shell_window(surface))
         return result;

--- a/src/server/frontend_wayland/wayland_utils.h
+++ b/src/server/frontend_wayland/wayland_utils.h
@@ -45,7 +45,6 @@ namespace mir
 {
 namespace frontend
 {
-class MirClientSession;
 
 template<typename Callable>
 inline auto run_unless(std::shared_ptr<bool> const& condition, Callable&& callable)
@@ -58,7 +57,6 @@ inline auto run_unless(std::shared_ptr<bool> const& condition, Callable&& callab
         };
 }
 
-auto get_mir_client_session(wl_client* client) -> std::shared_ptr<MirClientSession>;
 }
 }
 

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -25,37 +25,36 @@
 #include "wl_seat.h"
 
 #include "mir/shell/surface_specification.h"
+#include "mir/shell/shell.h"
 
-#include "mir/frontend/shell.h"
 #include "mir/frontend/wayland.h"
-#include "mir/frontend/mir_client_session.h"
 #include "null_event_sink.h"
 
 #include "mir/scene/surface.h"
 #include "mir/scene/surface_creation_parameters.h"
 
+#include <boost/throw_exception.hpp>
+
 namespace mf = mir::frontend;
 namespace ms = mir::scene;
+namespace msh = mir::shell;
 namespace geom = mir::geometry;
 
-namespace
-{
-std::shared_ptr<ms::Surface> scene_surface_from(std::shared_ptr<mf::MirClientSession> const& session, mf::SurfaceId surface_id)
-{
-    return std::dynamic_pointer_cast<ms::Surface>(session->get_surface(surface_id));
-}
-}
-
-mf::WindowWlSurfaceRole::WindowWlSurfaceRole(WlSeat* seat, wl_client* client, WlSurface* surface,
-                                             std::shared_ptr<Shell> const& shell, OutputManager* output_manager)
-        : destroyed{std::make_shared<bool>(false)},
-          client{client},
-          surface{surface},
-          shell{shell},
-          output_manager{output_manager},
-          observer{std::make_shared<WaylandSurfaceObserver>(seat, client, surface, this)},
-          params{std::make_unique<scene::SurfaceCreationParameters>(
-                 scene::SurfaceCreationParameters().of_type(mir_window_type_freestyle))}
+mf::WindowWlSurfaceRole::WindowWlSurfaceRole(
+    WlSeat* seat,
+    wl_client* client,
+    WlSurface* surface,
+    std::shared_ptr<msh::Shell> const& shell,
+    OutputManager* output_manager)
+    : destroyed{std::make_shared<bool>(false)},
+      surface{surface},
+      client{client},
+      weak_shell{shell},
+      weak_session{get_session(client)},
+      output_manager{output_manager},
+      observer{std::make_shared<WaylandSurfaceObserver>(seat, client, surface, this)},
+      params{std::make_unique<scene::SurfaceCreationParameters>(
+          scene::SurfaceCreationParameters().of_type(mir_window_type_freestyle))}
 {
     surface->set_role(this);
 }
@@ -65,15 +64,22 @@ mf::WindowWlSurfaceRole::~WindowWlSurfaceRole()
     surface->clear_role();
     observer->disconnect();
     *destroyed = true;
-    if (surface_id_.as_value())
+    if (auto const scene_surface = weak_scene_surface.lock())
     {
-        if (auto session = get_mir_client_session(client))
-        {
-            shell->destroy_surface(session, surface_id_);
-        }
-
-        surface_id_ = {};
+        auto const shell = shell_checked();
+        auto const session = session_checked();
+        shell->destroy_surface(session, scene_surface);
+        weak_scene_surface.reset();
     }
+}
+
+auto mf::WindowWlSurfaceRole::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>
+{
+    auto shared = weak_scene_surface.lock();
+    if (shared)
+        return shared;
+    else
+        return std::experimental::nullopt;
 }
 
 void mf::WindowWlSurfaceRole::populate_spec_with_surface_data(shell::SurfaceSpecification& spec)
@@ -85,9 +91,14 @@ void mf::WindowWlSurfaceRole::populate_spec_with_surface_data(shell::SurfaceSpec
 
 void mf::WindowWlSurfaceRole::refresh_surface_data_now()
 {
-    shell::SurfaceSpecification surface_data_spec;
-    populate_spec_with_surface_data(surface_data_spec);
-    shell->modify_surface(get_mir_client_session(client), surface_id_, surface_data_spec);
+    if (auto const scene_surface = weak_scene_surface.lock())
+    {
+        shell::SurfaceSpecification surface_data_spec;
+        populate_spec_with_surface_data(surface_data_spec);
+        auto const shell = shell_checked();
+        auto const session = session_checked();
+        shell->modify_surface(session, scene_surface, surface_data_spec);
+    }
 }
 
 void mf::WindowWlSurfaceRole::apply_spec(mir::shell::SurfaceSpecification const& new_spec)
@@ -97,7 +108,7 @@ void mf::WindowWlSurfaceRole::apply_spec(mir::shell::SurfaceSpecification const&
     if (new_spec.height.is_set())
         pending_explicit_height = new_spec.height.value();
 
-    if (surface_id().as_value())
+    if (weak_scene_surface.lock())
     {
         spec().update_from(new_spec);
     }
@@ -124,7 +135,7 @@ void mf::WindowWlSurfaceRole::set_pending_height(std::experimental::optional<geo
 
 void mf::WindowWlSurfaceRole::set_title(std::string const& title)
 {
-    if (surface_id().as_value())
+    if (weak_scene_surface.lock())
     {
         spec().name = title;
     }
@@ -136,46 +147,45 @@ void mf::WindowWlSurfaceRole::set_title(std::string const& title)
 
 void mf::WindowWlSurfaceRole::initiate_interactive_move()
 {
-    if (surface_id().as_value())
+    if (auto const scene_surface = weak_scene_surface.lock())
     {
-        if (auto session = get_mir_client_session(client))
-        {
-            shell->request_operation(session, surface_id(), observer->latest_timestamp().count(), Shell::UserRequest::move);
-        }
+        auto const shell = shell_checked();
+        auto const session = session_checked();
+        shell->request_move(session, scene_surface, observer->latest_timestamp().count());
     }
 }
 
 void mf::WindowWlSurfaceRole::initiate_interactive_resize(MirResizeEdge edge)
 {
-    if (surface_id().as_value())
+    if (auto const scene_surface = weak_scene_surface.lock())
     {
-        if (auto session = get_mir_client_session(client))
-        {
-            shell->request_operation(
-                session,
-                surface_id(),
-                observer->latest_timestamp().count(),
-                Shell::UserRequest::resize,
-                edge);
-        }
+        auto const shell = shell_checked();
+        auto const session = session_checked();
+        shell->request_resize(session, scene_surface, observer->latest_timestamp().count(), edge);
     }
 }
 
-void mf::WindowWlSurfaceRole::set_parent(optional_value<SurfaceId> parent_id)
+void mf::WindowWlSurfaceRole::set_parent(std::experimental::optional<std::weak_ptr<scene::Surface>> const& parent)
 {
-    if (surface_id().as_value())
+    if (weak_scene_surface.lock())
     {
-        spec().parent_id = parent_id;
+        if (parent)
+            spec().parent = parent.value();
+        else
+            spec().parent.consume();
     }
     else
     {
-        params->parent_id = parent_id;
+        if (parent)
+            params->parent = parent.value();
+        else
+            params->parent = {};
     }
 }
 
 void mf::WindowWlSurfaceRole::set_max_size(int32_t width, int32_t height)
 {
-    if (surface_id().as_value())
+    if (weak_scene_surface.lock())
     {
         if (width == 0) width = std::numeric_limits<int>::max();
         if (height == 0) height = std::numeric_limits<int>::max();
@@ -206,7 +216,7 @@ void mf::WindowWlSurfaceRole::set_max_size(int32_t width, int32_t height)
 
 void mf::WindowWlSurfaceRole::set_min_size(int32_t width, int32_t height)
 {
-    if (surface_id().as_value())
+    if (weak_scene_surface.lock())
     {
         auto& mods = spec();
         mods.min_width = geom::Width{width};
@@ -222,13 +232,14 @@ void mf::WindowWlSurfaceRole::set_min_size(int32_t width, int32_t height)
 void mf::WindowWlSurfaceRole::set_fullscreen(std::experimental::optional<struct wl_resource*> const& output)
 {
     // We must process this request immediately (i.e. don't defer until commit())
-    if (surface_id_.as_value())
+    if (auto const scene_surface = weak_scene_surface.lock())
     {
         shell::SurfaceSpecification mods;
         mods.state = mir_window_state_fullscreen;
         mods.output_id = output_manager->output_id_for(client, output);
-        auto const session = get_mir_client_session(client);
-        shell->modify_surface(session, surface_id_, mods);
+        auto const shell = shell_checked();
+        auto const session = session_checked();
+        shell->modify_surface(session, scene_surface, mods);
     }
     else
     {
@@ -241,12 +252,13 @@ void mf::WindowWlSurfaceRole::set_fullscreen(std::experimental::optional<struct 
 
 void mf::WindowWlSurfaceRole::set_state_now(MirWindowState state)
 {
-    if (surface_id_.as_value())
+    if (auto const scene_surface = weak_scene_surface.lock())
     {
         shell::SurfaceSpecification mods;
         mods.state = state;
-        auto const session = get_mir_client_session(client);
-        shell->modify_surface(session, surface_id_, mods);
+        auto const shell = shell_checked();
+        auto const session = session_checked();
+        shell->modify_surface(session, scene_surface, mods);
     }
     else
     {
@@ -304,14 +316,11 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
 
     handle_commit();
 
-    auto const session = get_mir_client_session(client);
     auto size = pending_size();
     observer->latest_client_size(size);
 
-    if (surface_id_.as_value())
+    if (auto const scene_surface = weak_scene_surface.lock())
     {
-        auto const scene_surface = scene_surface_from(session, surface_id_);
-
         if (!committed_size || size != committed_size.value())
         {
             spec().width = size.width;
@@ -323,8 +332,11 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
             populate_spec_with_surface_data(spec());
         }
 
+        auto const shell = shell_checked();
+        auto const session = session_checked();
+
         if (pending_changes)
-            shell->modify_surface(session, surface_id_, *pending_changes);
+            shell->modify_surface(session, scene_surface, *pending_changes);
 
         pending_changes.reset();
     }
@@ -342,26 +354,41 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
     pending_explicit_height = std::experimental::nullopt;
 }
 
+auto mf::WindowWlSurfaceRole::shell_checked() -> std::shared_ptr<msh::Shell>
+{
+    auto locked = weak_shell.lock();
+    if (locked)
+        return locked;
+    else
+        BOOST_THROW_EXCEPTION(std::logic_error("weak_shell is null"));
+}
+
+auto mf::WindowWlSurfaceRole::session_checked() -> std::shared_ptr<ms::Session>
+{
+    auto locked = weak_session.lock();
+    if (locked)
+        return locked;
+    else
+        BOOST_THROW_EXCEPTION(std::logic_error("weak_session is null"));
+}
+
 void mf::WindowWlSurfaceRole::visiblity(bool visible)
 {
-    if (!surface_id_.as_value())
+    auto const scene_surface = weak_scene_surface.lock();
+    if (!scene_surface)
         return;
 
-    auto const session = get_mir_client_session(client);
-
-    auto mir_surface = scene_surface_from(session, surface_id_);
-
-    if (mir_surface->visible() == visible)
+    if (scene_surface->visible() == visible)
         return;
 
     if (visible)
     {
-        if (mir_surface->state() == mir_window_state_hidden)
+        if (scene_surface->state() == mir_window_state_hidden)
             spec().state = mir_window_state_restored;
     }
     else
     {
-        if (mir_surface->state() != mir_window_state_hidden)
+        if (scene_surface->state() != mir_window_state_hidden)
             spec().state = mir_window_state_hidden;
     }
 }
@@ -376,18 +403,16 @@ mir::shell::SurfaceSpecification& mf::WindowWlSurfaceRole::spec()
 
 void mf::WindowWlSurfaceRole::create_mir_window()
 {
-    auto const session = get_mir_client_session(client);
-
     params->size = pending_size();
     params->streams = std::vector<shell::StreamSpecification>{};
     params->input_shape = std::vector<geom::Rectangle>{};
     surface->populate_surface_data(params->streams.value(), params->input_shape.value(), {});
 
-    surface_id_ = shell->create_surface(session, *params, std::make_shared<NullEventSink>());
+    auto const shell = shell_checked();
+    auto const session = session_checked();
 
-    // The shell isn't guaranteed to respect the requested size
-    std::shared_ptr<mf::Surface> const frontend_surface = session->get_surface(surface_id_);
-    std::shared_ptr<ms::Surface> const scene_surface = std::dynamic_pointer_cast<ms::Surface>(frontend_surface);
+    auto const scene_surface = shell->create_surface(session, *params, std::make_shared<NullEventSink>());
+    weak_scene_surface = scene_surface;
 
     scene_surface->add_observer(observer);
 
@@ -401,9 +426,10 @@ void mf::WindowWlSurfaceRole::create_mir_window()
         mods.placement_hints = params->placement_hints;
         mods.surface_placement_gravity = params->surface_placement_gravity;
         mods.aux_rect_placement_gravity = params->aux_rect_placement_gravity;
-        shell->modify_surface(session, surface_id_, mods);
+        shell->modify_surface(session, scene_surface, mods);
     }
 
+    // The shell isn't guaranteed to respect the requested size
     auto const client_size = scene_surface->client_size();
     if (client_size != params->size)
         observer->resized_to(scene_surface.get(), client_size);

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -165,7 +165,7 @@ void mf::WindowWlSurfaceRole::initiate_interactive_resize(MirResizeEdge edge)
     }
 }
 
-void mf::WindowWlSurfaceRole::set_parent(std::experimental::optional<std::weak_ptr<scene::Surface>> const& parent)
+void mf::WindowWlSurfaceRole::set_parent(std::experimental::optional<std::shared_ptr<scene::Surface>> const& parent)
 {
     if (weak_scene_surface.lock())
     {

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -115,10 +115,6 @@ protected:
 
     void commit(WlSurfaceState const& state) override;
 
-    /// Locks and returns weak_shell
-    /// Throws std::logic_error if the shell is null
-    auto shell_checked() -> std::shared_ptr<shell::Shell>;
-
     /// Locks and returns weak_session
     /// Throws std::logic_error if the session is null
     auto session_checked() -> std::shared_ptr<scene::Session>;
@@ -126,7 +122,7 @@ protected:
 private:
     WlSurface* const surface;
     wl_client* client;
-    std::weak_ptr<shell::Shell> const weak_shell;
+    std::shared_ptr<shell::Shell> const shell;
     std::weak_ptr<scene::Session> const weak_session;
     OutputManager* output_manager;
     std::shared_ptr<WaylandSurfaceObserver> const observer;

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -80,7 +80,7 @@ public:
     void set_title(std::string const& title);
     void initiate_interactive_move();
     void initiate_interactive_resize(MirResizeEdge edge);
-    void set_parent(std::experimental::optional<std::weak_ptr<scene::Surface>> const& parent);
+    void set_parent(std::experimental::optional<std::shared_ptr<scene::Surface>> const& parent);
     void set_max_size(int32_t width, int32_t height);
     void set_min_size(int32_t width, int32_t height);
     void set_fullscreen(std::experimental::optional<wl_resource*> const& output);

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -115,15 +115,11 @@ protected:
 
     void commit(WlSurfaceState const& state) override;
 
-    /// Locks and returns weak_session
-    /// Throws std::logic_error if the session is null
-    auto session_checked() -> std::shared_ptr<scene::Session>;
-
 private:
     WlSurface* const surface;
     wl_client* client;
     std::shared_ptr<shell::Shell> const shell;
-    std::weak_ptr<scene::Session> const weak_session;
+    std::shared_ptr<scene::Session> const session;
     OutputManager* output_manager;
     std::shared_ptr<WaylandSurfaceObserver> const observer;
     std::unique_ptr<scene::SurfaceCreationParameters> const params;

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -102,9 +102,9 @@ bool mf::WlSubsurface::synchronized() const
     return synchronized_ || parent->synchronized();
 }
 
-mf::SurfaceId mf::WlSubsurface::surface_id() const
+auto mf::WlSubsurface::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>
 {
-    return parent->surface_id();
+    return parent->scene_surface();
 }
 
 void mf::WlSubsurface::parent_has_committed()

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -60,7 +60,7 @@ public:
 
     geometry::Displacement total_offset() const override { return parent->total_offset(); }
     bool synchronized() const override;
-    SurfaceId surface_id() const override;
+    auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
 
     void parent_has_committed();
 

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -30,7 +30,7 @@
 #include "wayland_frontend.tp.h"
 
 #include "mir/graphics/buffer_properties.h"
-#include "mir/frontend/mir_client_session.h"
+#include "mir/scene/session.h"
 #include "mir/frontend/wayland.h"
 #include "mir/compositor/buffer_stream.h"
 #include "mir/executor.h"
@@ -81,7 +81,7 @@ mf::WlSurface::WlSurface(
     std::shared_ptr<Executor> const& executor,
     std::shared_ptr<graphics::WaylandAllocator> const& allocator)
     : Surface(new_resource, Version<4>()),
-        session{mf::get_mir_client_session(client)},
+        session{get_session(client)},
         stream_id{session->create_buffer_stream({{}, mir_pixel_format_invalid, graphics::BufferUsage::undefined})},
         stream{session->get_buffer_stream(stream_id)},
         allocator{allocator},
@@ -134,9 +134,9 @@ mf::WlSurface::Position mf::WlSurface::transform_point(geom::Point point)
     return {point, this, false};
 }
 
-mf::SurfaceId mf::WlSurface::surface_id() const
+auto mf::WlSurface::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>
 {
-    return role->surface_id();
+    return role->scene_surface();
 }
 
 void mf::WlSurface::set_role(WlSurfaceRole* role_)
@@ -412,7 +412,10 @@ mf::NullWlSurfaceRole::NullWlSurfaceRole(WlSurface* surface) :
 {
 }
 
-mf::SurfaceId mf::NullWlSurfaceRole::surface_id() const { return {}; }
+auto mf::NullWlSurfaceRole::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>
+{
+    return std::experimental::nullopt;
+}
 void mf::NullWlSurfaceRole::refresh_surface_data_now() {}
 void mf::NullWlSurfaceRole::commit(WlSurfaceState const& state) { surface->commit(state); }
 void mf::NullWlSurfaceRole::visiblity(bool /*visible*/) {}

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -41,6 +41,10 @@ namespace graphics
 {
 class WaylandAllocator;
 }
+namespace scene
+{
+class Session;
+}
 namespace shell
 {
 struct StreamSpecification;
@@ -53,7 +57,6 @@ class Rectangle;
 namespace frontend
 {
 class BufferStream;
-class MirClientSession;
 class WlSurface;
 class WlSubsurface;
 
@@ -94,7 +97,7 @@ class NullWlSurfaceRole : public WlSurfaceRole
 {
 public:
     NullWlSurfaceRole(WlSurface* surface);
-    SurfaceId surface_id() const override;
+    auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
     void refresh_surface_data_now() override;
     void commit(WlSurfaceState const& state) override;
     void visiblity(bool /*visible*/) override;
@@ -127,7 +130,7 @@ public:
     bool synchronized() const;
     Position transform_point(geometry::Point point);
     wl_resource* raw_resource() const { return resource; }
-    mir::frontend::SurfaceId surface_id() const;
+    auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>;
 
     void set_role(WlSurfaceRole* role_);
     void clear_role();
@@ -142,7 +145,7 @@ public:
     void add_destroy_listener(void const* key, std::function<void()> listener);
     void remove_destroy_listener(void const* key);
 
-    std::shared_ptr<MirClientSession> const session;
+    std::shared_ptr<scene::Session> const session;
     mir::frontend::BufferStreamId const stream_id;
     std::shared_ptr<mir::frontend::BufferStream> const stream;
 

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -25,9 +25,14 @@
 #include <mir_toolkit/common.h>
 
 #include <memory>
+#include <experimental/optional>
 
 namespace mir
 {
+namespace scene
+{
+class Surface;
+}
 namespace frontend
 {
 struct WlSurfaceState;
@@ -36,8 +41,8 @@ class WlSurfaceRole
 {
 public:
     virtual bool synchronized() const { return false; }
-    virtual geometry::Displacement total_offset() const { return {}; }
-    virtual SurfaceId surface_id() const = 0;
+    virtual auto total_offset() const -> geometry::Displacement { return {}; }
+    virtual auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> = 0;
     virtual void refresh_surface_data_now() = 0;
     virtual void commit(WlSurfaceState const& state) = 0;
     virtual void visiblity(bool visible) = 0;

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -24,10 +24,13 @@
 
 namespace mir
 {
-namespace frontend
+namespace scene
 {
 class Shell;
 class Surface;
+}
+namespace frontend
+{
 class WlSeat;
 class OutputManager;
 class WlSurface;
@@ -36,10 +39,14 @@ class XdgSurfaceStable;
 class XdgShellStable : public wayland::XdgWmBase::Global
 {
 public:
-    XdgShellStable(wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
+    XdgShellStable(
+        wl_display* display,
+        std::shared_ptr<shell::Shell> shell,
+        WlSeat& seat,
+        OutputManager* output_manager);
 
-    static auto get_window(wl_resource* surface) -> std::shared_ptr<Surface>;
-    std::shared_ptr<Shell> const shell;
+    static auto get_window(wl_resource* surface) -> std::shared_ptr<scene::Surface>;
+    std::shared_ptr<shell::Shell> const shell;
     WlSeat& seat;
     OutputManager* const output_manager;
 

--- a/src/server/frontend_wayland/xdg_shell_v6.h
+++ b/src/server/frontend_wayland/xdg_shell_v6.h
@@ -23,25 +23,30 @@
 
 namespace mir
 {
+namespace scene
+{
+class Surface;
+}
+namespace shell
+{
+class Shell;
+}
 namespace frontend
 {
-
-class Shell;
-class Surface;
 class WlSeat;
 class OutputManager;
 
 class XdgShellV6 : public wayland::XdgShellV6::Global
 {
 public:
-    XdgShellV6(wl_display* display, std::shared_ptr<Shell> const shell, WlSeat& seat, OutputManager* output_manager);
+    XdgShellV6(wl_display* display, std::shared_ptr<shell::Shell> shell, WlSeat& seat, OutputManager* output_manager);
 
-    std::shared_ptr<Shell> const shell;
+    std::shared_ptr<shell::Shell> const shell;
     WlSeat& seat;
     OutputManager* const output_manager;
 
     // Returns the Mir surface if the window is recognised by XdgShellV6
-    static auto get_window(wl_resource* surface) -> std::shared_ptr<Surface>;
+    static auto get_window(wl_resource* surface) -> std::shared_ptr<scene::Surface>;
 
 private:
     class Instance;

--- a/src/server/frontend_xwayland/xwayland_wm_shell.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_shell.cpp
@@ -26,11 +26,16 @@
 #include "xwayland_wm_shellsurface.h"
 
 namespace mf = mir::frontend;
+namespace ms = mir::scene;
+namespace msh = mir::shell;
 
-mf::XWaylandWMShell::XWaylandWMShell(std::shared_ptr<mf::Shell> const& shell,
-                                     mf::WlSeat& seat,
-                                     OutputManager* const output_manager)
-    : shell{shell}, seat{seat}, output_manager{output_manager}
+mf::XWaylandWMShell::XWaylandWMShell(
+    std::shared_ptr<msh::Shell> const& shell,
+    mf::WlSeat& seat,
+    OutputManager* const output_manager)
+    : shell{shell},
+      seat{seat},
+      output_manager{output_manager}
 {
 }
 

--- a/src/server/frontend_xwayland/xwayland_wm_shell.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shell.h
@@ -23,24 +23,27 @@
 
 namespace mir
 {
+namespace shell
+{
+class Shell;
+}
 namespace frontend
 {
 class OutputManager;
 class WlSeat;
 class WlSurface;
-class Shell;
 class XWaylandWMShellSurface;
 class XWaylandWMShell
 {
 public:
-    XWaylandWMShell(std::shared_ptr<Shell> const& shell, WlSeat& seat,
+    XWaylandWMShell(std::shared_ptr<shell::Shell> const& shell, WlSeat& seat,
                     OutputManager* const output_manager);
 
     std::shared_ptr<XWaylandWMShellSurface> get_shell_surface(wl_client* client,
                                                               WlSurface* surface);
 
 private:
-    std::shared_ptr<Shell> const shell;
+    std::shared_ptr<shell::Shell> const shell;
     WlSeat& seat;
     OutputManager* const output_manager;
 };

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.cpp
@@ -29,12 +29,15 @@
 #include "wayland_utils.h"
 
 namespace mf = mir::frontend;
+namespace ms = mir::scene;
+namespace msh = mir::shell;
 
-mf::XWaylandWMShellSurface::XWaylandWMShellSurface(wl_client* client,
-                                                   WlSurface* surface,
-                                                   std::shared_ptr<mf::Shell> const& shell,
-                                                   WlSeat& seat,
-                                                   OutputManager* const output_manager)
+mf::XWaylandWMShellSurface::XWaylandWMShellSurface(
+    wl_client* client,
+    WlSurface* surface,
+    std::shared_ptr<msh::Shell> const& shell,
+    WlSeat& seat,
+    OutputManager* const output_manager)
     : WindowWlSurfaceRole{&seat, client, surface, shell, output_manager}
 {
 //    params->type = mir_window_type_normal;

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
@@ -29,13 +29,15 @@ namespace frontend
 {
 class OutputManager;
 class XWaylandWMSurface;
-class Shell;
 class XWaylandWMShellSurface : public WindowWlSurfaceRole
 {
 public:
-    XWaylandWMShellSurface(wl_client* client, WlSurface* surface,
-                           std::shared_ptr<Shell> const& shell, WlSeat& seat,
-                           OutputManager* const output_manager);
+    XWaylandWMShellSurface(
+        wl_client* client,
+        WlSurface* surface,
+        std::shared_ptr<shell::Shell> const& shell,
+        WlSeat& seat,
+        OutputManager* const output_manager);
     ~XWaylandWMShellSurface();
 
     void move();
@@ -61,8 +63,6 @@ protected:
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left, geometry::Size const& new_size) override;
     void handle_close_request() override;
-
-    using WindowWlSurfaceRole::surface_id;
 
 private:
     XWaylandWMSurface *surface;

--- a/src/server/report/logging/shell_report.cpp
+++ b/src/server/report/logging/shell_report.cpp
@@ -60,14 +60,13 @@ void mrl::ShellReport::closing_session(Session const& session)
 
 void mrl::ShellReport::created_surface(
     Session const& session,
-    frontend::SurfaceId surface_id)
+    scene::Surface const& surface)
 {
-    auto const surface = session.surface(surface_id);
     std::ostringstream out;
 
-    log_basics(out, session, *surface, "created");
+    log_basics(out, session, surface, "created");
 
-    if (auto const parent = surface->parent())
+    if (auto const parent = surface.parent())
         out << ", parent=\"" << parent->name() << "\"";
 
     log->log(Severity::informational, out.str(), component);
@@ -95,10 +94,10 @@ void mrl::ShellReport::update_surface(
 
 void mrl::ShellReport::destroying_surface(
     Session const& session,
-    frontend::SurfaceId surface_id)
+    scene::Surface const& surface)
 {
     std::ostringstream out;
-    log_basics(out, session, *session.surface(surface_id), "destroying");
+    log_basics(out, session, surface, "destroying");
     log->log(Severity::informational, out.str(), component);
 }
 

--- a/src/server/report/logging/shell_report.h
+++ b/src/server/report/logging/shell_report.h
@@ -38,7 +38,7 @@ public:
 
     void created_surface(
         scene::Session const& session,
-        frontend::SurfaceId surface_id) override;
+        scene::Surface const& surface) override;
 
     void update_surface(
         scene::Session const& session,
@@ -52,7 +52,7 @@ public:
 
     void destroying_surface(
         scene::Session const& session,
-        frontend::SurfaceId surface) override;
+        scene::Surface const& surface) override;
 
     void started_prompt_session(
         scene::PromptSession const& prompt_session,

--- a/src/server/report/null/shell_report.cpp
+++ b/src/server/report/null/shell_report.cpp
@@ -30,7 +30,7 @@ void mrn::ShellReport::closing_session(scene::Session const& /*session*/)
 
 void mrn::ShellReport::created_surface(
     scene::Session const& /*session*/,
-    frontend::SurfaceId /*surface_id*/)
+    scene::Surface const& /*surface_id*/)
 {
 }
 
@@ -50,7 +50,7 @@ void mrn::ShellReport::update_surface(
 
 void mrn::ShellReport::destroying_surface(
     scene::Session const& /*session*/,
-    frontend::SurfaceId /*surface*/)
+    scene::Surface const& /*surface*/)
 {
 }
 

--- a/src/server/report/null/shell_report.h
+++ b/src/server/report/null/shell_report.h
@@ -35,7 +35,7 @@ class ShellReport : public shell::ShellReport
 
     void created_surface(
         scene::Session const& /*session*/,
-        frontend::SurfaceId /*surface_id*/) override;
+        scene::Surface const& /*surface_id*/) override;
 
     void update_surface(
         scene::Session const& /*session*/,
@@ -49,7 +49,7 @@ class ShellReport : public shell::ShellReport
 
     void destroying_surface(
         scene::Session const& /*session*/,
-        frontend::SurfaceId /*surface*/) override;
+        scene::Surface const& /*surface*/) override;
 
     void started_prompt_session(
         scene::PromptSession const& /*prompt_session*/,

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -89,9 +89,9 @@ mf::SurfaceId ms::ApplicationSession::next_id()
     return mf::SurfaceId(next_surface_id.fetch_add(1));
 }
 
-mf::SurfaceId ms::ApplicationSession::create_surface(
+auto ms::ApplicationSession::create_surface(
     SurfaceCreationParameters const& the_params,
-    std::shared_ptr<mf::EventSink> const& surface_sink)
+    std::shared_ptr<mf::EventSink> const& surface_sink) -> std::shared_ptr<scene::Surface>
 {
     auto const id = next_id();
 
@@ -165,10 +165,11 @@ mf::SurfaceId ms::ApplicationSession::create_surface(
     if (params.depth_layer.is_set())
         surface->set_depth_layer(params.depth_layer.value());
 
-    return id;
+    return surface;
 }
 
-ms::ApplicationSession::Surfaces::const_iterator ms::ApplicationSession::checked_find(mf::SurfaceId id) const
+auto ms::ApplicationSession::checked_find(
+    mf::SurfaceId id) const -> ms::ApplicationSession::Surfaces::const_iterator
 {
     auto p = surfaces.find(id);
     if (p == surfaces.end())
@@ -176,7 +177,20 @@ ms::ApplicationSession::Surfaces::const_iterator ms::ApplicationSession::checked
     return p;
 }
 
-ms::ApplicationSession::Streams::const_iterator ms::ApplicationSession::checked_find(mf::BufferStreamId id) const
+auto ms::ApplicationSession::checked_find(
+    std::shared_ptr<ms::Surface> const& surface) const -> ms::ApplicationSession::Surfaces::const_iterator
+{
+    auto p = std::find_if(surfaces.begin(), surfaces.end(), [&](auto iter)
+        {
+            return iter.second == surface;
+        });
+    if (p == surfaces.end())
+        BOOST_THROW_EXCEPTION(std::runtime_error("Invalid Surface"));
+    return p;
+}
+
+auto ms::ApplicationSession::checked_find(
+    mf::BufferStreamId id) const -> ms::ApplicationSession::Streams::const_iterator
 {
     auto p = streams.find(id);
     if (p == streams.end())
@@ -184,10 +198,16 @@ ms::ApplicationSession::Streams::const_iterator ms::ApplicationSession::checked_
     return p;
 }
 
-std::shared_ptr<ms::Surface> ms::ApplicationSession::surface(mf::SurfaceId id) const
+auto ms::ApplicationSession::surface(mf::SurfaceId id) const -> std::shared_ptr<ms::Surface>
 {
     std::unique_lock<std::mutex> lock(surfaces_and_streams_mutex);
     return checked_find(id)->second;
+}
+
+auto ms::ApplicationSession::surface_id(std::shared_ptr<ms::Surface> const& surface) const -> mf::SurfaceId
+{
+    std::unique_lock<std::mutex> lock(surfaces_and_streams_mutex);
+    return checked_find(surface)->first;
 }
 
 std::shared_ptr<ms::Surface> ms::ApplicationSession::surface_after(std::shared_ptr<ms::Surface> const& before) const

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -91,7 +91,7 @@ mf::SurfaceId ms::ApplicationSession::next_id()
 
 auto ms::ApplicationSession::create_surface(
     SurfaceCreationParameters const& the_params,
-    std::shared_ptr<mf::EventSink> const& surface_sink) -> std::shared_ptr<scene::Surface>
+    std::shared_ptr<mf::EventSink> const& surface_sink) -> std::shared_ptr<Surface>
 {
     auto const id = next_id();
 

--- a/src/server/scene/application_session.h
+++ b/src/server/scene/application_session.h
@@ -70,10 +70,10 @@ public:
 
     auto create_surface(
         SurfaceCreationParameters const& params,
-        std::shared_ptr<frontend::EventSink> const& surface_sink) -> std::shared_ptr<scene::Surface> override;
+        std::shared_ptr<frontend::EventSink> const& surface_sink) -> std::shared_ptr<Surface> override;
     void destroy_surface(frontend::SurfaceId surface) override;
     auto surface(frontend::SurfaceId surface) const -> std::shared_ptr<Surface> override;
-    auto surface_id(std::shared_ptr<scene::Surface> const& surface) const -> frontend::SurfaceId override;
+    auto surface_id(std::shared_ptr<Surface> const& surface) const -> frontend::SurfaceId override;
     std::shared_ptr<Surface> surface_after(std::shared_ptr<Surface> const&) const override;
 
     void take_snapshot(SnapshotCallback const& snapshot_taken) override;
@@ -125,7 +125,7 @@ private:
     typedef std::map<frontend::SurfaceId, std::shared_ptr<Surface>> Surfaces;
     typedef std::map<frontend::BufferStreamId, std::shared_ptr<compositor::BufferStream>> Streams;
     auto checked_find(frontend::SurfaceId id) const -> Surfaces::const_iterator;
-    auto checked_find(std::shared_ptr<scene::Surface> const& surface) const -> Surfaces::const_iterator;
+    auto checked_find(std::shared_ptr<Surface> const& surface) const -> Surfaces::const_iterator;
     auto checked_find(frontend::BufferStreamId id) const -> Streams::const_iterator;
     std::mutex mutable surfaces_and_streams_mutex;
     Surfaces surfaces;

--- a/src/server/scene/application_session.h
+++ b/src/server/scene/application_session.h
@@ -68,11 +68,12 @@ public:
 
     ~ApplicationSession();
 
-    frontend::SurfaceId create_surface(
+    auto create_surface(
         SurfaceCreationParameters const& params,
-        std::shared_ptr<frontend::EventSink> const& surface_sink) override;
+        std::shared_ptr<frontend::EventSink> const& surface_sink) -> std::shared_ptr<scene::Surface> override;
     void destroy_surface(frontend::SurfaceId surface) override;
-    std::shared_ptr<Surface> surface(frontend::SurfaceId surface) const override;
+    auto surface(frontend::SurfaceId surface) const -> std::shared_ptr<Surface> override;
+    auto surface_id(std::shared_ptr<scene::Surface> const& surface) const -> frontend::SurfaceId override;
     std::shared_ptr<Surface> surface_after(std::shared_ptr<Surface> const&) const override;
 
     void take_snapshot(SnapshotCallback const& snapshot_taken) override;
@@ -123,8 +124,9 @@ private:
 
     typedef std::map<frontend::SurfaceId, std::shared_ptr<Surface>> Surfaces;
     typedef std::map<frontend::BufferStreamId, std::shared_ptr<compositor::BufferStream>> Streams;
-    Surfaces::const_iterator checked_find(frontend::SurfaceId id) const;
-    Streams::const_iterator checked_find(frontend::BufferStreamId id) const;
+    auto checked_find(frontend::SurfaceId id) const -> Surfaces::const_iterator;
+    auto checked_find(std::shared_ptr<scene::Surface> const& surface) const -> Surfaces::const_iterator;
+    auto checked_find(frontend::BufferStreamId id) const -> Streams::const_iterator;
     std::mutex mutable surfaces_and_streams_mutex;
     Surfaces surfaces;
     Streams streams;

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -135,10 +135,10 @@ void msh::AbstractShell::close_session(
     window_manager->remove_session(session);
 }
 
-mf::SurfaceId msh::AbstractShell::create_surface(
+auto msh::AbstractShell::create_surface(
     std::shared_ptr<ms::Session> const& session,
     ms::SurfaceCreationParameters const& params,
-    std::shared_ptr<mf::EventSink> const& sink)
+    std::shared_ptr<mf::EventSink> const& sink) -> std::shared_ptr<ms::Surface>
 {
     auto const build = [sink](std::shared_ptr<ms::Session> const& session, ms::SurfaceCreationParameters const& placed_params)
         {
@@ -146,7 +146,7 @@ mf::SurfaceId msh::AbstractShell::create_surface(
         };
 
     auto const result = window_manager->add_surface(session, params, build);
-    report->created_surface(*session, result);
+    report->created_surface(*session, *result);
     return result;
 }
 
@@ -206,10 +206,10 @@ void msh::AbstractShell::modify_surface(std::shared_ptr<scene::Session> const& s
 
 void msh::AbstractShell::destroy_surface(
     std::shared_ptr<ms::Session> const& session,
-    mf::SurfaceId surface)
+    std::shared_ptr<scene::Surface> const& surface)
 {
-    report->destroying_surface(*session, surface);
-    window_manager->remove_surface(session, session->surface(surface));
+    report->destroying_surface(*session, *surface);
+    window_manager->remove_surface(session, surface);
 }
 
 std::shared_ptr<ms::PromptSession> msh::AbstractShell::start_prompt_session_for(

--- a/src/server/shell/frontend_shell.cpp
+++ b/src/server/shell/frontend_shell.cpp
@@ -106,7 +106,7 @@ mf::SurfaceId msh::FrontendShell::create_surface(
     if (populated_params.parent_id.is_set())
         populated_params.parent = scene_session->surface(populated_params.parent_id.value());
 
-    return wrapped->create_surface(scene_session, populated_params, sink);
+    return session->create_surface(wrapped, populated_params, sink);
 }
 
 void msh::FrontendShell::modify_surface(std::shared_ptr<mf::MirClientSession> const& session, mf::SurfaceId surface_id, SurfaceSpecification const& modifications)
@@ -124,8 +124,7 @@ void msh::FrontendShell::modify_surface(std::shared_ptr<mf::MirClientSession> co
 
 void msh::FrontendShell::destroy_surface(std::shared_ptr<mf::MirClientSession> const& session, mf::SurfaceId surface)
 {
-    auto const scene_session = scene_session_for(session);
-    wrapped->destroy_surface(scene_session, surface);
+    session->destroy_surface(wrapped, surface);
 }
 
 std::string msh::FrontendShell::persistent_id_for(std::shared_ptr<mf::MirClientSession> const& session, mf::SurfaceId surface_id)

--- a/src/server/shell/shell_wrapper.cpp
+++ b/src/server/shell/shell_wrapper.cpp
@@ -28,10 +28,10 @@ msh::ShellWrapper::ShellWrapper(std::shared_ptr<Shell> const& wrapped) :
 {
 }
 
-std::shared_ptr<ms::Session> msh::ShellWrapper::open_session(
+auto msh::ShellWrapper::open_session(
     pid_t client_pid,
     std::string const& name,
-    std::shared_ptr<mf::EventSink> const& sink)
+    std::shared_ptr<mf::EventSink> const& sink) -> std::shared_ptr<ms::Session>
 {
     return wrapped->open_session(client_pid, name, sink);
 }
@@ -51,7 +51,7 @@ void msh::ShellWrapper::focus_prev_session()
     wrapped->focus_prev_session();
 }
 
-std::shared_ptr<ms::Session> msh::ShellWrapper::focused_session() const
+auto msh::ShellWrapper::focused_session() const -> std::shared_ptr<ms::Session>
 {
     return wrapped->focused_session();
 }
@@ -83,20 +83,25 @@ void msh::ShellWrapper::stop_prompt_session(std::shared_ptr<ms::PromptSession> c
     wrapped->stop_prompt_session(prompt_session);
 }
 
-mf::SurfaceId msh::ShellWrapper::create_surface(
+auto msh::ShellWrapper::create_surface(
     std::shared_ptr<ms::Session> const& session,
     ms::SurfaceCreationParameters const& params,
-    std::shared_ptr<mf::EventSink> const& sink)
+    std::shared_ptr<mf::EventSink> const& sink) -> std::shared_ptr<ms::Surface>
 {
     return wrapped->create_surface(session, params, sink);
 }
 
-void msh::ShellWrapper::modify_surface(std::shared_ptr<scene::Session> const& session, std::shared_ptr<scene::Surface> const& surface, SurfaceSpecification const& modifications)
+void msh::ShellWrapper::modify_surface(
+    std::shared_ptr<scene::Session> const& session,
+    std::shared_ptr<scene::Surface> const& surface,
+    SurfaceSpecification const& modifications)
 {
     wrapped->modify_surface(session, surface, modifications);
 }
 
-void msh::ShellWrapper::destroy_surface(std::shared_ptr<ms::Session> const& session, mf::SurfaceId surface)
+void msh::ShellWrapper::destroy_surface(
+    std::shared_ptr<ms::Session> const& session,
+    std::shared_ptr<ms::Surface> const& surface)
 {
     wrapped->destroy_surface(session, surface);
 }

--- a/src/server/shell/shell_wrapper.cpp
+++ b/src/server/shell/shell_wrapper.cpp
@@ -51,7 +51,7 @@ void msh::ShellWrapper::focus_prev_session()
     wrapped->focus_prev_session();
 }
 
-auto msh::ShellWrapper::focused_session() const -> std::shared_ptr<ms::Session>
+std::shared_ptr<ms::Session> msh::ShellWrapper::focused_session() const
 {
     return wrapped->focused_session();
 }

--- a/src/server/shell/system_compositor_window_manager.cpp
+++ b/src/server/shell/system_compositor_window_manager.cpp
@@ -57,8 +57,10 @@ void msh::SystemCompositorWindowManager::remove_session(std::shared_ptr<ms::Sess
 auto msh::SystemCompositorWindowManager::add_surface(
     std::shared_ptr<ms::Session> const& session,
     ms::SurfaceCreationParameters const& params,
-    std::function<mf::SurfaceId(std::shared_ptr<ms::Session> const& session, ms::SurfaceCreationParameters const& params)> const& build)
--> mf::SurfaceId
+    std::function<std::shared_ptr<scene::Surface>(
+        std::shared_ptr<ms::Session> const& session,
+        ms::SurfaceCreationParameters const& params)> const& build)
+-> std::shared_ptr<scene::Surface>
 {
     mir::geometry::Rectangle rect{params.top_left, params.size};
 
@@ -71,8 +73,7 @@ auto msh::SystemCompositorWindowManager::add_surface(
     placed_parameters.top_left = rect.top_left;
     placed_parameters.size = rect.size;
 
-    auto const result = build(session, placed_parameters);
-    auto const surface = session->surface(result);
+    auto const surface = build(session, placed_parameters);
 
     auto const session_ready_observer = std::make_shared<SurfaceReadyObserver>(
         [this](std::shared_ptr<ms::Session> const& session, std::shared_ptr<ms::Surface> const& /*surface*/)
@@ -87,7 +88,7 @@ auto msh::SystemCompositorWindowManager::add_surface(
     std::lock_guard<decltype(mutex)> lock{mutex};
     output_map[surface] = params.output_id;
 
-    return result;
+    return surface;
 }
 
 void msh::SystemCompositorWindowManager::modify_surface(

--- a/tests/acceptance-tests/test_client_input.cpp
+++ b/tests/acceptance-tests/test_client_input.cpp
@@ -127,16 +127,16 @@ struct SurfaceTrackingShell : mir::shell::ShellWrapper
         : ShellWrapper{wrapped_shell}, wrapped_shell{wrapped_shell}
     {}
 
-    mir::frontend::SurfaceId create_surface(
+    auto create_surface(
         std::shared_ptr<mir::scene::Session> const& session,
         mir::scene::SurfaceCreationParameters const& params,
-        std::shared_ptr<mir::frontend::EventSink> const& sink) override
+        std::shared_ptr<mir::frontend::EventSink> const& sink) -> std::shared_ptr<mir::scene::Surface> override
     {
-        auto surface_id = wrapped_shell->create_surface(session, params, sink);
+        auto const surface = wrapped_shell->create_surface(session, params, sink);
 
-        tracked_surfaces[session->name()] =  TrackedSurface{session, surface_id};
+        tracked_surfaces[session->name()] =  {session, surface};
 
-        return surface_id;
+        return surface;
     }
 
     std::shared_ptr<mir::scene::Surface> get_surface(std::string const& session_name)
@@ -147,13 +147,13 @@ struct SurfaceTrackingShell : mir::shell::ShellWrapper
         auto session = tracked_surface.session.lock();
         if (!session)
             return nullptr;
-        return session->surface(tracked_surface.surface);
+        return tracked_surface.surface;
     }
 
     struct TrackedSurface
     {
         std::weak_ptr<mir::scene::Session> session;
-        mir::frontend::SurfaceId surface;
+        std::shared_ptr<mir::scene::Surface> surface;
     };
     std::unordered_map<std::string, TrackedSurface> tracked_surfaces;
     std::shared_ptr<mir::shell::Shell> wrapped_shell;

--- a/tests/acceptance-tests/test_client_surface_events.cpp
+++ b/tests/acceptance-tests/test_client_surface_events.cpp
@@ -512,13 +512,13 @@ class WrapShellGeneratingCloseEvent : public mir::shell::ShellWrapper
 {
     using mir::shell::ShellWrapper::ShellWrapper;
 
-    mir::frontend::SurfaceId create_surface(
+    auto create_surface(
         std::shared_ptr <mir::scene::Session> const& session,
         mir::scene::SurfaceCreationParameters const& params,
-        std::shared_ptr<mir::frontend::EventSink> const& sink) override
+        std::shared_ptr<mir::frontend::EventSink> const& sink) -> std::shared_ptr<mir::scene::Surface> override
     {
         auto const window = mir::shell::ShellWrapper::create_surface(session, params, sink);
-        session->surface(window)->request_client_surface_close();
+        window->request_client_surface_close();
         return window;
     }
 };
@@ -681,10 +681,10 @@ struct WrapShellCreatingFixedSizeSurfaces : public mir::shell::ShellWrapper
     {
     }
 
-    mir::frontend::SurfaceId create_surface(
+    auto create_surface(
         std::shared_ptr <mir::scene::Session> const& session,
         mir::scene::SurfaceCreationParameters const& orig_params,
-        std::shared_ptr<mir::frontend::EventSink> const& sink) override
+        std::shared_ptr<mir::frontend::EventSink> const& sink) -> std::shared_ptr<mir::scene::Surface> override
     {
         auto params = orig_params;
         params.size = {surface_width, surface_height};

--- a/tests/acceptance-tests/test_client_surface_visibility.cpp
+++ b/tests/acceptance-tests/test_client_surface_visibility.cpp
@@ -50,16 +50,15 @@ public:
         msh::ShellWrapper{wrapped}
     {}
 
-    mf::SurfaceId create_surface(
+    auto create_surface(
         std::shared_ptr<ms::Session> const& session,
         ms::SurfaceCreationParameters const& params,
-        std::shared_ptr<mf::EventSink> const& sink) override
+        std::shared_ptr<mf::EventSink> const& sink) -> std::shared_ptr<ms::Surface> override
     {
-        auto const result = msh::ShellWrapper::create_surface(session, params, sink);
-        auto const window = session->surface(result);
+        auto const window = msh::ShellWrapper::create_surface(session, params, sink);
         window->move_to({0, 0});
         surfaces.push_back(window);
-        return result;
+        return window;
     }
 
     using msh::ShellWrapper::raise;

--- a/tests/acceptance-tests/test_custom_window_management.cpp
+++ b/tests/acceptance-tests/test_custom_window_management.cpp
@@ -263,10 +263,13 @@ TEST_F(CustomWindowManagement, state_change_requests_are_associated_with_correct
         auto const grab_server_surface = [i, &server_surface](
             std::shared_ptr<ms::Session> const& session,
             ms::SurfaceCreationParameters const& params,
-            std::function<mf::SurfaceId(std::shared_ptr<ms::Session> const& session, ms::SurfaceCreationParameters const& params)> const& build)
+            std::function<std::shared_ptr<ms::Surface>(
+                std::shared_ptr<ms::Session> const& session,
+                ms::SurfaceCreationParameters const& params)> const& build)
+            -> std::shared_ptr<ms::Surface>
             {
                 auto const result = build(session, params);
-                server_surface[i] = session->surface(result);
+                server_surface[i] = result;
                 return result;
             };
 
@@ -314,7 +317,10 @@ TEST_F(CustomWindowManagement, create_low_chrome_surface_from_spec)
     auto const check_add_surface = [](
         std::shared_ptr<ms::Session> const& session,
         ms::SurfaceCreationParameters const& params,
-        std::function<mf::SurfaceId(std::shared_ptr<ms::Session> const& session, ms::SurfaceCreationParameters const& params)> const& build)
+        std::function<std::shared_ptr<ms::Surface>(
+            std::shared_ptr<ms::Session> const& session,
+            ms::SurfaceCreationParameters const& params)> const& build)
+        -> std::shared_ptr<ms::Surface>
             {
                 EXPECT_TRUE(params.shell_chrome.is_set());
                 return build(session, params);
@@ -458,7 +464,10 @@ TEST_F(CustomWindowManagement, when_the_client_places_a_new_surface_the_request_
     auto const check_placement = [&](
         std::shared_ptr<ms::Session> const& session,
         ms::SurfaceCreationParameters const& params,
-        std::function<mf::SurfaceId(std::shared_ptr<ms::Session> const& session, ms::SurfaceCreationParameters const& params)> const& build)
+        std::function<std::shared_ptr<ms::Surface>(
+            std::shared_ptr<ms::Session> const& session,
+            ms::SurfaceCreationParameters const& params)> const& build)
+        -> std::shared_ptr<ms::Surface>
         {
             EXPECT_TRUE(params.aux_rect.is_set());
             if (params.aux_rect.is_set())
@@ -662,12 +671,13 @@ TEST_F(CustomWindowManagement, when_the_window_manager_places_a_surface_the_noti
     auto capture_scene_surface = [&](
         std::shared_ptr<ms::Session> const& session,
         ms::SurfaceCreationParameters const& params,
-        std::function<mf::SurfaceId(std::shared_ptr<ms::Session> const& session, ms::SurfaceCreationParameters const& params)> const& build)
-        ->  mf::SurfaceId
+        std::function<std::shared_ptr<mir::scene::Surface>(
+            std::shared_ptr<ms::Session> const& session,
+            ms::SurfaceCreationParameters const& params)> const& build)
+        ->  std::shared_ptr<mir::scene::Surface>
         {
-            auto const result = build(session, params);
-            scene_surface = session->surface(result);
-            return result;
+            scene_surface = build(session, params);
+            return scene_surface;
         };
 
     EXPECT_CALL(window_manager, add_surface(_,_,_)).WillOnce(Invoke(capture_scene_surface));

--- a/tests/acceptance-tests/test_debug_api.cpp
+++ b/tests/acceptance-tests/test_debug_api.cpp
@@ -46,18 +46,15 @@ class SimpleConfigurablePlacementShell : public msh::ShellWrapper
 public:
     using msh::ShellWrapper::ShellWrapper;
 
-    mir::frontend::SurfaceId create_surface(
+    auto create_surface(
         std::shared_ptr<ms::Session> const& session,
         ms::SurfaceCreationParameters const& params,
-        std::shared_ptr<mf::EventSink> const& sink) override
+        std::shared_ptr<mf::EventSink> const& sink) -> std::shared_ptr<ms::Surface> override
     {
-        auto const result = msh::ShellWrapper::create_surface(session, params, sink);
-        auto const window = session->surface(result);
-
+        auto const window = msh::ShellWrapper::create_surface(session, params, sink);
         window->move_to(placement.top_left);
         window->resize(placement.size);
-
-        return result;
+        return window;
     }
 
     mir::geometry::Rectangle placement{{0, 0}, {100, 100}};

--- a/tests/acceptance-tests/test_nested_input.cpp
+++ b/tests/acceptance-tests/test_nested_input.cpp
@@ -55,6 +55,7 @@ namespace mis = mi::synthesis;
 
 namespace mt = mir::test;
 namespace mg = mir::graphics;
+namespace ms  = mir::scene;
 namespace mtd = mt::doubles;
 namespace mtf = mir_test_framework;
 
@@ -71,16 +72,16 @@ struct SurfaceTrackingShell : mir::shell::ShellWrapper
         : ShellWrapper{wrapped_shell}, wrapped_shell{wrapped_shell}
     {}
 
-    mir::frontend::SurfaceId create_surface(
+    auto create_surface(
         std::shared_ptr<mir::scene::Session> const& session,
         mir::scene::SurfaceCreationParameters const& params,
-        std::shared_ptr<mir::frontend::EventSink> const& sink) override
+        std::shared_ptr<mir::frontend::EventSink> const& sink) -> std::shared_ptr<ms::Surface> override
     {
-        auto surface_id = wrapped_shell->create_surface(session, params, sink);
+        auto surface = wrapped_shell->create_surface(session, params, sink);
 
-        tracked_surfaces[session->name()] =  TrackedSurface{session, surface_id};
+        tracked_surfaces[session->name()] =  TrackedSurface{surface};
 
-        return surface_id;
+        return surface;
     }
 
     std::shared_ptr<mir::scene::Surface> get_surface(std::string const& session_name)
@@ -88,16 +89,12 @@ struct SurfaceTrackingShell : mir::shell::ShellWrapper
         if (end(tracked_surfaces) == tracked_surfaces.find(session_name))
             return nullptr;
         TrackedSurface & tracked_surface = tracked_surfaces[session_name];
-        auto session = tracked_surface.session.lock();
-        if (!session)
-            return nullptr;
-        return session->surface(tracked_surface.surface);
+        return tracked_surface.surface;
     }
 
     struct TrackedSurface
     {
-        std::weak_ptr<mir::scene::Session> session;
-        mir::frontend::SurfaceId surface;
+        std::shared_ptr<mir::scene::Surface> surface;
     };
     std::unordered_map<std::string, TrackedSurface> tracked_surfaces;
     std::shared_ptr<mir::shell::Shell> wrapped_shell;

--- a/tests/acceptance-tests/test_surfaces_with_output_id.cpp
+++ b/tests/acceptance-tests/test_surfaces_with_output_id.cpp
@@ -67,13 +67,13 @@ class TrackingShell : public msh::ShellWrapper
 public:
     using msh::ShellWrapper::ShellWrapper;
 
-    mf::SurfaceId create_surface(
+    auto create_surface(
         std::shared_ptr<ms::Session> const& session,
         ms::SurfaceCreationParameters const& params,
-        std::shared_ptr<mf::EventSink> const& sink) override
+        std::shared_ptr<mf::EventSink> const& sink) -> std::shared_ptr<ms::Surface> override
     {
         auto const surface = msh::ShellWrapper::create_surface(session, params, sink);
-        surfaces.push_back(session->surface(surface));
+        surfaces.push_back(surface);
         return surface;
     }
 

--- a/tests/include/mir/shell/basic_window_manager.h
+++ b/tests/include/mir/shell/basic_window_manager.h
@@ -143,8 +143,10 @@ public:
     auto add_surface(
         std::shared_ptr<scene::Session> const& session,
         scene::SurfaceCreationParameters const& params,
-        std::function<frontend::SurfaceId(std::shared_ptr<scene::Session> const& session, scene::SurfaceCreationParameters const& params)> const& build)
-    -> frontend::SurfaceId override;
+        std::function<std::shared_ptr<scene::Surface>(
+            std::shared_ptr<scene::Session> const& session,
+            scene::SurfaceCreationParameters const& params)> const& build)
+    -> std::shared_ptr<scene::Surface> override;
 
     void modify_surface(
         std::shared_ptr<scene::Session> const& session,

--- a/tests/include/mir/test/doubles/mock_scene_session.h
+++ b/tests/include/mir/test/doubles/mock_scene_session.h
@@ -38,12 +38,13 @@ namespace doubles
 struct MockSceneSession : public scene::Session
 {
     MOCK_METHOD2(create_surface,
-        frontend::SurfaceId(
+        std::shared_ptr<scene::Surface>(
             scene::SurfaceCreationParameters const&,
             std::shared_ptr<frontend::EventSink> const&));
     MOCK_METHOD1(destroy_surface, void(frontend::SurfaceId));
     MOCK_CONST_METHOD1(get_surface, std::shared_ptr<frontend::Surface>(frontend::SurfaceId));
     MOCK_CONST_METHOD1(surface, std::shared_ptr<scene::Surface>(frontend::SurfaceId));
+    MOCK_CONST_METHOD1(surface_id, frontend::SurfaceId(std::shared_ptr<scene::Surface> const&));
     MOCK_CONST_METHOD1(surface_after, std::shared_ptr<scene::Surface>(std::shared_ptr<scene::Surface> const&));
 
     MOCK_METHOD1(take_snapshot, void(scene::SnapshotCallback const&));

--- a/tests/include/mir/test/doubles/stub_mir_client_session.h
+++ b/tests/include/mir/test/doubles/stub_mir_client_session.h
@@ -40,6 +40,18 @@ struct StubMirClientSession : public frontend::MirClientSession
         return nullptr;
     }
 
+    auto create_surface(
+        std::shared_ptr<shell::Shell> const& /* shell */,
+        scene::SurfaceCreationParameters const& /* params */,
+        std::shared_ptr<frontend::EventSink> const& /* sink */) -> frontend::SurfaceId override
+    {
+        return {};
+    }
+
+    void destroy_surface(std::shared_ptr<shell::Shell> const& /* shell */, frontend::SurfaceId /* surface */) override
+    {
+    }
+
     auto create_buffer_stream(graphics::BufferProperties const& /* props */)
         -> frontend::BufferStreamId override
     {

--- a/tests/integration-tests/client/test_mirsurface.cpp
+++ b/tests/integration-tests/client/test_mirsurface.cpp
@@ -45,7 +45,7 @@ struct MockShell : msh::ShellWrapper
 {
     using msh::ShellWrapper::ShellWrapper;
     MOCK_METHOD3(create_surface,
-        mf::SurfaceId(
+        std::shared_ptr<ms::Surface>(
             std::shared_ptr<ms::Session> const&,
             ms::SurfaceCreationParameters const&,
             std::shared_ptr<mf::EventSink> const&));

--- a/tests/mir_test_framework/basic_window_manager.cpp
+++ b/tests/mir_test_framework/basic_window_manager.cpp
@@ -55,16 +55,17 @@ void msh::BasicWindowManager::remove_session(std::shared_ptr<scene::Session> con
 auto msh::BasicWindowManager::add_surface(
     std::shared_ptr<scene::Session> const& session,
     scene::SurfaceCreationParameters const& params,
-    std::function<frontend::SurfaceId(std::shared_ptr<scene::Session> const& session, scene::SurfaceCreationParameters const& params)> const& build)
--> frontend::SurfaceId
+    std::function<std::shared_ptr<scene::Surface>(
+        std::shared_ptr<scene::Session> const& session,
+        scene::SurfaceCreationParameters const& params)> const& build)
+-> std::shared_ptr<scene::Surface>
 {
     std::lock_guard<decltype(mutex)> lock(mutex);
     scene::SurfaceCreationParameters const placed_params = policy->handle_place_new_surface(session, params);
-    auto const result = build(session, placed_params);
-    auto const surface = session->surface(result);
+    auto const surface = build(session, placed_params);
     surface_info.emplace(surface, SurfaceInfo{session, surface, placed_params});
     policy->handle_new_surface(session, surface);
-    return result;
+    return surface;
 }
 
 void msh::BasicWindowManager::modify_surface(

--- a/tests/mir_test_framework/observant_shell.cpp
+++ b/tests/mir_test_framework/observant_shell.cpp
@@ -22,6 +22,7 @@
 #include "mir/scene/surface.h"
 
 namespace msh = mir::shell;
+namespace ms = mir::scene;
 namespace msc = mir::scene;
 namespace mf = mir::frontend;
 namespace mtf = mir_test_framework;
@@ -33,13 +34,13 @@ mtf::ObservantShell::ObservantShell(
     surface_observer(surface_observer)
 {
 }
-mf::SurfaceId mtf::ObservantShell::create_surface(
+
+auto mtf::ObservantShell::create_surface(
     std::shared_ptr<msc::Session> const& session,
     msc::SurfaceCreationParameters const& params,
-    std::shared_ptr<mf::EventSink> const& sink) 
+    std::shared_ptr<mf::EventSink> const& sink) -> std::shared_ptr<ms::Surface>
 {
-    auto id = msh::ShellWrapper::create_surface(session, params, sink);
-    auto window = session->surface(id);
+    auto window = msh::ShellWrapper::create_surface(session, params, sink);
     window->add_observer(surface_observer);
-    return id;
+    return window;
 }

--- a/tests/mir_test_framework/placement_applying_shell.cpp
+++ b/tests/mir_test_framework/placement_applying_shell.cpp
@@ -32,15 +32,14 @@ mtf::PlacementApplyingShell::PlacementApplyingShell(
 
 mtf::PlacementApplyingShell::~PlacementApplyingShell() = default;
 
-mir::frontend::SurfaceId mtf::PlacementApplyingShell::create_surface(
+auto mtf::PlacementApplyingShell::create_surface(
     std::shared_ptr<mir::scene::Session> const& session,
     mir::scene::SurfaceCreationParameters const& params,
-    std::shared_ptr<mir::frontend::EventSink> const& sink)
+    std::shared_ptr<mir::frontend::EventSink> const& sink) -> std::shared_ptr<mir::scene::Surface>
 {
     auto creation_parameters = params;
 
-    auto const id = wrapped->create_surface(session, creation_parameters, sink);
-    auto const surface = session->surface(id);
+    auto const surface = wrapped->create_surface(session, creation_parameters, sink);
     latest_surface = surface;
 
     auto position= client_positions.find(params.name);
@@ -54,7 +53,7 @@ mir::frontend::SurfaceId mtf::PlacementApplyingShell::create_surface(
     if (regions != client_input_regions.end())
         surface->set_input_region(regions->second);
 
-    return id;
+    return surface;
 }
     
 void mtf::PlacementApplyingShell::modify_surface(

--- a/tests/mir_test_framework/stub_session.cpp
+++ b/tests/mir_test_framework/stub_session.cpp
@@ -21,6 +21,7 @@
 #include "mir_test_framework/stub_platform_native_buffer.h"
 
 namespace mtd = mir::test::doubles;
+namespace ms = mir::scene;
 
 mtd::StubSession::StubSession(pid_t pid)
     : pid(pid)
@@ -84,19 +85,25 @@ void mtd::StubSession::resume_prompt_session()
 {
 }
 
-mir::frontend::SurfaceId mtd::StubSession::create_surface(
+auto mtd::StubSession::create_surface(
     mir::scene::SurfaceCreationParameters const& /*params*/,
-    std::shared_ptr<frontend::EventSink> const& /*sink*/)
+    std::shared_ptr<frontend::EventSink> const& /*sink*/) -> std::shared_ptr<ms::Surface>
 {
-    return mir::frontend::SurfaceId{0};
+    return nullptr;
 }
 
 void mtd::StubSession::destroy_surface(mir::frontend::SurfaceId /*surface*/)
 {
 }
 
-std::shared_ptr<mir::scene::Surface> mtd::StubSession::surface(
-    mir::frontend::SurfaceId /*surface*/) const
+auto mtd::StubSession::surface(
+    frontend::SurfaceId /*surface*/) const -> std::shared_ptr<scene::Surface>
+{
+    return {};
+}
+
+auto mtd::StubSession::surface_id(
+    std::shared_ptr<scene::Surface> const& /*surface*/) const -> frontend::SurfaceId
 {
     return {};
 }

--- a/tests/miral/generated/server-decoration_wrapper.h
+++ b/tests/miral/generated/server-decoration_wrapper.h
@@ -20,6 +20,9 @@ namespace mir
 namespace wayland
 {
 
+class ServerDecorationManager;
+class ServerDecoration;
+
 class ServerDecorationManager : public Resource
 {
 public:

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -130,9 +130,9 @@ struct StubSurface : mir::test::doubles::StubSurface
 
 struct StubStubSession : mir::test::doubles::StubSession
 {
-    mir::frontend::SurfaceId create_surface(
+    auto create_surface(
         mir::scene::SurfaceCreationParameters const& params,
-        std::shared_ptr<mir::frontend::EventSink> const& /*sink*/) override
+        std::shared_ptr<mir::frontend::EventSink> const& /*sink*/) -> std::shared_ptr<mir::scene::Surface> override
     {
         auto id = mir::frontend::SurfaceId{next_surface_id.fetch_add(1)};
         auto surface = std::make_shared<StubSurface>(
@@ -144,7 +144,7 @@ struct StubStubSession : mir::test::doubles::StubSession
                 params.depth_layer.value()
                 : mir_depth_layer_application);
         surfaces[id] = surface;
-        return id;
+        return surface;
     }
 
     std::shared_ptr<mir::scene::Surface> surface(mir::frontend::SurfaceId surface) const override
@@ -286,7 +286,7 @@ mt::TestWindowManagerTools::~TestWindowManagerTools() = default;
 
 auto mt::TestWindowManagerTools::create_surface(
     std::shared_ptr<mir::scene::Session> const& session,
-    mir::scene::SurfaceCreationParameters const& params) -> mir::frontend::SurfaceId
+    mir::scene::SurfaceCreationParameters const& params) -> std::shared_ptr<mir::scene::Surface>
 {
     // This type is Mir-internal, I hope we don't need to create it here
     std::shared_ptr<mir::frontend::EventSink> const sink;

--- a/tests/miral/test_window_manager_tools.h
+++ b/tests/miral/test_window_manager_tools.h
@@ -87,7 +87,7 @@ public:
 
     static auto create_surface(
         std::shared_ptr<mir::scene::Session> const& session,
-        mir::scene::SurfaceCreationParameters const& params) -> mir::frontend::SurfaceId;
+        mir::scene::SurfaceCreationParameters const& params) -> std::shared_ptr<mir::scene::Surface>;
 
     auto static create_fake_display_configuration(std::vector<miral::Rectangle> outputs)
         -> std::shared_ptr<graphics::DisplayConfiguration const>;

--- a/tests/unit-tests/frontend/test_session_mediator.cpp
+++ b/tests/unit-tests/frontend/test_session_mediator.cpp
@@ -54,6 +54,7 @@
 #include "mir/test/doubles/mock_buffer.h"
 #include "mir/test/doubles/stub_session.h"
 #include "mir/test/doubles/stub_mir_client_session.h"
+#include "mir/test/doubles/stub_session.h"
 #include "mir/test/doubles/stub_display_configuration.h"
 #include "mir/test/doubles/stub_buffer_allocator.h"
 #include "mir/test/doubles/null_screencast.h"
@@ -214,6 +215,11 @@ public:
     int buffer_count = 0;
     int native_buffer_count = 0;
     int destroy_buffers = 0;
+};
+
+class StubbedSceneSession : public mtd::StubSession
+{
+public:
 };
 
 struct StubScreencast : mtd::NullScreencast

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -209,19 +209,19 @@ TEST_F(AbstractShell, close_session_removes_existing_session_surfaces_from_windo
         WillOnce(Return(mt::fake_shared(surface3)));
 
     auto const session = shell.open_session(__LINE__, "XPlane", std::shared_ptr<mf::EventSink>());
-    auto const surface_id1 = shell.create_surface(session,
+    auto const created_surface1 = shell.create_surface(session,
         ms::a_surface().with_buffer_stream(session->create_buffer_stream(properties)), nullptr);
-    auto const surface_id2 = shell.create_surface(session,
+    auto const created_surface2 = shell.create_surface(session,
         ms::a_surface().with_buffer_stream(session->create_buffer_stream(properties)), nullptr);
-    auto const surface_id3 = shell.create_surface(session,
+    auto const created_surface3 = shell.create_surface(session,
         ms::a_surface().with_buffer_stream(session->create_buffer_stream(properties)), nullptr);
 
-    session->destroy_surface(surface_id2);
+    session->destroy_surface(created_surface2);
 
     Expectation remove1 = EXPECT_CALL(
-        *wm, remove_surface(session, WeakPtrTo(session->surface(surface_id1))));
+        *wm, remove_surface(session, WeakPtrTo(created_surface1)));
     Expectation remove3 = EXPECT_CALL(
-        *wm, remove_surface(session, WeakPtrTo(session->surface(surface_id3))));
+        *wm, remove_surface(session, WeakPtrTo(created_surface3)));
     EXPECT_CALL(*wm, remove_session(session)).After(remove1, remove3);
 
     shell.close_session(session);
@@ -254,7 +254,7 @@ TEST_F(AbstractShell, create_surface_allows_window_manager_to_set_create_paramet
     EXPECT_CALL(*wm, add_surface(session, Ref(params), _)).WillOnce(Invoke(
         [&](std::shared_ptr<ms::Session> const& session,
             ms::SurfaceCreationParameters const&,
-            std::function<mf::SurfaceId(std::shared_ptr<ms::Session> const& session, ms::SurfaceCreationParameters const&)> const& build)
+            std::function<std::shared_ptr<ms::Surface>(std::shared_ptr<ms::Session> const& session, ms::SurfaceCreationParameters const&)> const& build)
             { return build(session, placed_params); }));
 
     shell.create_surface(session, params, nullptr);
@@ -267,12 +267,11 @@ TEST_F(AbstractShell, destroy_surface_removes_surface_from_window_manager)
     auto const params = ms::a_surface()
         .with_buffer_stream(session->create_buffer_stream(properties));
 
-    auto const surface_id = shell.create_surface(session, params, nullptr);
-    auto const surface = session->surface(surface_id);
+    auto const surface = shell.create_surface(session, params, nullptr);
 
     EXPECT_CALL(*wm, remove_surface(session, WeakPtrTo(surface)));
 
-    shell.destroy_surface(session, surface_id);
+    shell.destroy_surface(session, surface);
 }
 
 TEST_F(AbstractShell, add_display_adds_display_to_window_manager)
@@ -376,8 +375,7 @@ TEST_F(AbstractShell, setting_surface_state_is_handled_by_window_manager)
 
     auto const params = ms::a_surface()
         .with_buffer_stream(session->create_buffer_stream(properties));
-    auto const surface_id = shell.create_surface(session, params, nullptr);
-    auto const surface = session->surface(surface_id);
+    auto const surface = shell.create_surface(session, params, nullptr);
 
     MirWindowState const state{mir_window_state_fullscreen};
 
@@ -460,10 +458,8 @@ TEST_F(AbstractShell, as_focus_controller_focused_surface_follows_focus)
         .with_buffer_stream(session0->create_buffer_stream(properties));
     auto const params2 = ms::a_surface()
         .with_buffer_stream(session1->create_buffer_stream(properties));
-    auto const surface0_id = shell.create_surface(session0, params, nullptr);
-    auto const surface0 = session0->surface(surface0_id);
-    auto const surface1_id = shell.create_surface(session1, params2, nullptr);
-    auto const surface1 = session1->surface(surface1_id);
+    auto const surface0 = shell.create_surface(session0, params, nullptr);
+    auto const surface1 = shell.create_surface(session1, params2, nullptr);
 
     msh::FocusController& focus_controller = shell;
 
@@ -474,8 +470,8 @@ TEST_F(AbstractShell, as_focus_controller_focused_surface_follows_focus)
     focus_controller.focus_next_session();
     EXPECT_THAT(focus_controller.focused_surface(), Eq(surface0));
 
-    shell.destroy_surface(session0, surface0_id);
-    shell.destroy_surface(session1, surface1_id);
+    shell.destroy_surface(session0, surface0);
+    shell.destroy_surface(session1, surface1);
     shell.close_session(session1);
     shell.close_session(session0);
 }
@@ -501,12 +497,12 @@ TEST_F(AbstractShell, as_focus_controller_focus_next_session_skips_surfaceless_s
     auto session2 = shell.open_session(__LINE__, "Bla", std::shared_ptr<mf::EventSink>());
     auto const params = ms::a_surface()
         .with_buffer_stream(session->create_buffer_stream(properties));
-    auto surface_id = shell.create_surface(session, params, nullptr);
+    auto created_surface = shell.create_surface(session, params, nullptr);
     auto const params2 = ms::a_surface()
         .with_buffer_stream(session2->create_buffer_stream(properties));
     shell.create_surface(session2, params2, nullptr);
 
-    focus_controller.set_focus_to(session, session->surface(surface_id));
+    focus_controller.set_focus_to(session, created_surface);
 
     EXPECT_CALL(session_event_sink, handle_focus_change(session2));
 
@@ -521,11 +517,11 @@ TEST_F(AbstractShell,
     auto session1 = shell.open_session(__LINE__, "Surfaceless", std::shared_ptr<mf::EventSink>());
     auto creation_params = ms::a_surface()
         .with_buffer_stream(session->create_buffer_stream(properties));
-    auto surface_id = shell.create_surface(session, creation_params, nullptr);
+    auto surface = shell.create_surface(session, creation_params, nullptr);
 
-    focus_controller.set_focus_to(session, session->surface(surface_id));
+    focus_controller.set_focus_to(session, surface);
 
-    session->destroy_surface(surface_id);
+    session->destroy_surface(surface);
 
     EXPECT_CALL(session_event_sink, handle_no_focus());
 
@@ -539,8 +535,7 @@ TEST_F(AbstractShell, modify_surface_with_only_streams_doesnt_call_into_wm)
 
     auto creation_params = ms::a_surface()
         .with_buffer_stream(session->create_buffer_stream(properties));
-    auto surface_id = shell.create_surface(session, creation_params, nullptr);
-    auto surface = session->surface(surface_id);
+    auto surface = shell.create_surface(session, creation_params, nullptr);
 
     msh::SurfaceSpecification stream_modification;
     stream_modification.streams = std::vector<msh::StreamSpecification>{};
@@ -558,8 +553,7 @@ TEST_F(AbstractShell, modify_surface_does_not_call_wm_for_empty_changes)
     auto creation_params = ms::a_surface()
         .with_buffer_stream(session->create_buffer_stream(properties));
 
-    auto surface_id = shell.create_surface(session, creation_params, nullptr);
-    auto surface = session->surface(surface_id);
+    auto surface = shell.create_surface(session, creation_params, nullptr);
 
     msh::SurfaceSpecification stream_modification;
 
@@ -580,9 +574,9 @@ TEST_F(AbstractShell, when_remaining_session_has_no_surface_focus_next_session_d
 
         auto creation_params = ms::a_surface()
             .with_buffer_stream(another_session->create_buffer_stream(properties));
-        auto surface_id = shell.create_surface(another_session, creation_params, nullptr);
+        auto surface = shell.create_surface(another_session, creation_params, nullptr);
 
-        shell.set_focus_to(another_session, another_session->surface(surface_id));
+        shell.set_focus_to(another_session, surface);
 
         shell.close_session(another_session);
     }
@@ -622,8 +616,7 @@ TEST_F(AbstractShell, as_focus_controller_emits_input_device_state_event_on_focu
     auto session = shell.open_session(__LINE__, "some", std::shared_ptr<mf::EventSink>());
     auto creation_params = ms::a_surface()
         .with_buffer_stream(session->create_buffer_stream(properties));
-    auto surface_id = shell.create_surface(session, creation_params, nullptr);
-    auto surface = session->surface(surface_id);
+    auto surface = shell.create_surface(session, creation_params, nullptr);
 
     msh::FocusController& focus_controller = shell;
     focus_controller.set_focus_to(session, surface);

--- a/tests/unit-tests/scene/test_application_session.cpp
+++ b/tests/unit-tests/scene/test_application_session.cpp
@@ -367,21 +367,21 @@ TEST_F(ApplicationSession, default_surface_is_first_surface)
 
     ms::SurfaceCreationParameters params = ms::a_surface()
         .with_buffer_stream(app_session->create_buffer_stream(properties));
-    auto id1 = app_session->create_surface(params, nullptr);
-    auto id2 = app_session->create_surface(params, nullptr);
-    auto id3 = app_session->create_surface(params, nullptr);
+    auto surface1 = app_session->create_surface(params, nullptr);
+    auto surface2 = app_session->create_surface(params, nullptr);
+    auto surface3 = app_session->create_surface(params, nullptr);
 
     auto default_surf = app_session->default_surface();
-    EXPECT_EQ(app_session->surface(id1), default_surf);
-    app_session->destroy_surface(id1);
+    EXPECT_EQ(surface1, default_surf);
+    app_session->destroy_surface(surface1);
 
     default_surf = app_session->default_surface();
-    EXPECT_EQ(app_session->surface(id2), default_surf);
-    app_session->destroy_surface(id2);
+    EXPECT_EQ(surface2, default_surf);
+    app_session->destroy_surface(surface2);
 
     default_surf = app_session->default_surface();
-    EXPECT_EQ(app_session->surface(id3), default_surf);
-    app_session->destroy_surface(id3);
+    EXPECT_EQ(surface3, default_surf);
+    app_session->destroy_surface(surface3);
 }
 
 TEST_F(ApplicationSession, foreign_surface_has_no_successor)
@@ -389,17 +389,16 @@ TEST_F(ApplicationSession, foreign_surface_has_no_successor)
     auto session1 = make_application_session_with_stubs();
     ms::SurfaceCreationParameters params = ms::a_surface()
         .with_buffer_stream(session1->create_buffer_stream(properties));
-    auto id1 = session1->create_surface(params, nullptr);
-    auto surf1 = session1->surface(id1);
-    auto id2 = session1->create_surface(params, nullptr);
+    auto surf1 = session1->create_surface(params, nullptr);
+    auto surf2 = session1->create_surface(params, nullptr);
 
     auto session2 = make_application_session_with_stubs();
 
     EXPECT_THROW({session2->surface_after(surf1);},
                  std::runtime_error);
 
-    session1->destroy_surface(id1);
-    session1->destroy_surface(id2);
+    session1->destroy_surface(surf1);
+    session1->destroy_surface(surf2);
 }
 
 TEST_F(ApplicationSession, surface_after_one_is_self)
@@ -407,12 +406,11 @@ TEST_F(ApplicationSession, surface_after_one_is_self)
     auto session = make_application_session_with_stubs();
     ms::SurfaceCreationParameters params = ms::a_surface()
         .with_buffer_stream(session->create_buffer_stream(properties));
-    auto id = session->create_surface(params, nullptr);
-    auto surf = session->surface(id);
+    auto surf = session->create_surface(params, nullptr);
 
     EXPECT_EQ(surf, session->surface_after(surf));
 
-    session->destroy_surface(id);
+    session->destroy_surface(surf);
 }
 
 TEST_F(ApplicationSession, surface_after_cycles_through_all)
@@ -424,12 +422,10 @@ TEST_F(ApplicationSession, surface_after_cycles_through_all)
 
     int const N = 3;
     std::shared_ptr<ms::Surface> surf[N];
-    mf::SurfaceId id[N];
 
     for (int i = 0; i < N; ++i)
     {
-        id[i] = app_session->create_surface(params, nullptr);
-        surf[i] = app_session->surface(id[i]);
+        surf[i] = app_session->create_surface(params, nullptr);
 
         if (i > 0)
         {
@@ -443,7 +439,7 @@ TEST_F(ApplicationSession, surface_after_cycles_through_all)
     EXPECT_EQ(surf[0], app_session->surface_after(surf[N-1]));
 
     for (int i = 0; i < N; ++i)
-        app_session->destroy_surface(id[i]);
+        app_session->destroy_surface(surf[i]);
 }
 
 TEST_F(ApplicationSession, session_visbility_propagates_to_surfaces)
@@ -954,8 +950,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_surface_output_events_to_surfaces)
     ms::SurfaceCreationParameters params = ms::SurfaceCreationParameters{}
         .of_size({100, 100})
         .with_buffer_stream(app_session.create_buffer_stream(properties));
-    auto surf_id = app_session.create_surface(params, sender);
-    auto surface = app_session.surface(surf_id);
+    auto surface = app_session.create_surface(params, sender);
 
     ASSERT_TRUE(event_received);
     EXPECT_THAT(&event, SurfaceOutputEventFor(high_dpi));
@@ -984,14 +979,10 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_correct_surface_details_to_surface
         .of_size({100, 100})
         .with_buffer_stream(app_session.create_buffer_stream(properties));
 
-    mf::SurfaceId ids[2];
     std::shared_ptr<ms::Surface> surfaces[2];
 
-    ids[0] = app_session.create_surface(params, sender);
-    ids[1] = app_session.create_surface(params, sender);
-
-    surfaces[0] = app_session.surface(ids[0]);
-    surfaces[1] = app_session.surface(ids[1]);
+    surfaces[0] = app_session.create_surface(params, sender);
+    surfaces[1] = app_session.create_surface(params, sender);
 
     surfaces[0]->move_to({0 + 100, 100});
     surfaces[1]->move_to({outputs[0]->width + 100, 100});
@@ -1013,7 +1004,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_correct_surface_details_to_surface
 
     for (int i = 0; i < 2 ; ++i)
     {
-        EXPECT_THAT(event[i].to_window_output()->surface_id(), Eq(ids[i].as_value()));
+        EXPECT_THAT(app_session.surface(mf::SurfaceId{event[i].to_window_output()->surface_id()}), Eq(surfaces[i]));
         EXPECT_THAT(&event[i], SurfaceOutputEventFor(*outputs[i]));
     }
 }
@@ -1041,8 +1032,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_details_of_the_hightest_scale_fact
         .of_size({100, 100})
         .with_buffer_stream(app_session.create_buffer_stream(properties));
 
-    auto id = app_session.create_surface(params, sender);
-    auto surface = app_session.surface(id);
+    auto surface = app_session.create_surface(params, sender);
 
     // This should overlap both outputs
     surface->move_to({outputs[0]->width - 50, 100});
@@ -1062,7 +1052,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_details_of_the_hightest_scale_fact
 
     ASSERT_TRUE(event_received);
 
-    EXPECT_THAT(event.to_window_output()->surface_id(), Eq(id.as_value()));
+    EXPECT_THAT(app_session.surface(mf::SurfaceId{event.to_window_output()->surface_id()}), Eq(surface));
     EXPECT_THAT(&event, SurfaceOutputEventFor(high_dpi));
 }
 
@@ -1102,8 +1092,7 @@ TEST_F(ApplicationSessionSurfaceOutput, surfaces_on_edges_get_correct_values)
         .of_size({640, 480})
         .with_buffer_stream(app_session.create_buffer_stream(properties));
 
-    auto id = app_session.create_surface(params, sender);
-    auto surface = app_session.surface(id);
+    auto surface = app_session.create_surface(params, sender);
 
     // This should solidly overlap both outputs
     surface->move_to({outputs[0]->width - ((surface->size().width.as_uint32_t()) / 2), 100});
@@ -1163,8 +1152,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_surface_output_event_on_move)
         .of_size({100, 100})
         .with_buffer_stream(app_session.create_buffer_stream(properties));
 
-    auto id = app_session.create_surface(params, sender);
-    auto surface = app_session.surface(id);
+    auto surface = app_session.create_surface(params, sender);
 
     // This should overlap both outputs
     surface->move_to({outputs[0]->width - 50, 100});
@@ -1173,7 +1161,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_surface_output_event_on_move)
     ASSERT_THAT(events_received, Ge(1));
     auto events_expected = events_received + 1;
 
-    EXPECT_THAT(event.to_window_output()->surface_id(), Eq(id.as_value()));
+    EXPECT_THAT(app_session.surface(mf::SurfaceId{event.to_window_output()->surface_id()}), Eq(surface));
     EXPECT_THAT(&event, SurfaceOutputEventFor(high_dpi));
 
     // Now solely on the left output
@@ -1182,7 +1170,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_surface_output_event_on_move)
     ASSERT_THAT(events_received, Eq(events_expected));
     events_expected++;
 
-    EXPECT_THAT(event.to_window_output()->surface_id(), Eq(id.as_value()));
+    EXPECT_THAT(app_session.surface(mf::SurfaceId{event.to_window_output()->surface_id()}), Eq(surface));
     EXPECT_THAT(&event, SurfaceOutputEventFor(projector));
 
     // Now solely on the right output
@@ -1191,7 +1179,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_surface_output_event_on_move)
     ASSERT_THAT(events_received, Eq(events_expected));
     events_expected++;
 
-    EXPECT_THAT(event.to_window_output()->surface_id(), Eq(id.as_value()));
+    EXPECT_THAT(app_session.surface(mf::SurfaceId{event.to_window_output()->surface_id()}), Eq(surface));
     EXPECT_THAT(&event, SurfaceOutputEventFor(high_dpi));
 }
 
@@ -1226,8 +1214,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_surface_output_event_on_move_only_
         .of_size({100, 100})
         .with_buffer_stream(app_session.create_buffer_stream(properties));
 
-    auto id = app_session.create_surface(params, sender);
-    auto surface = app_session.surface(id);
+    auto surface = app_session.create_surface(params, sender);
 
     // We get an event on surface creation.
     EXPECT_THAT(events_received, Eq(1));

--- a/tests/unit-tests/scene/test_application_session.cpp
+++ b/tests/unit-tests/scene/test_application_session.cpp
@@ -872,6 +872,11 @@ struct ApplicationSessionSurfaceOutput : public ApplicationSession
         uint32_t id;
     };
 
+    auto get_surface(MirWindowOutputEvent const& event) -> std::shared_ptr<ms::Surface>
+    {
+        return app_session.surface(mf::SurfaceId{event.to_window_output()->surface_id()});
+    }
+
     TestOutput const high_dpi;
     TestOutput const projector;
     std::shared_ptr<ms::SurfaceFactory> const stub_surface_factory;
@@ -1004,7 +1009,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_correct_surface_details_to_surface
 
     for (int i = 0; i < 2 ; ++i)
     {
-        EXPECT_THAT(app_session.surface(mf::SurfaceId{event[i].to_window_output()->surface_id()}), Eq(surfaces[i]));
+        EXPECT_THAT(get_surface(event[i]), Eq(surfaces[i]));
         EXPECT_THAT(&event[i], SurfaceOutputEventFor(*outputs[i]));
     }
 }
@@ -1052,7 +1057,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_details_of_the_hightest_scale_fact
 
     ASSERT_TRUE(event_received);
 
-    EXPECT_THAT(app_session.surface(mf::SurfaceId{event.to_window_output()->surface_id()}), Eq(surface));
+    EXPECT_THAT(get_surface(event), Eq(surface));
     EXPECT_THAT(&event, SurfaceOutputEventFor(high_dpi));
 }
 
@@ -1161,7 +1166,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_surface_output_event_on_move)
     ASSERT_THAT(events_received, Ge(1));
     auto events_expected = events_received + 1;
 
-    EXPECT_THAT(app_session.surface(mf::SurfaceId{event.to_window_output()->surface_id()}), Eq(surface));
+    EXPECT_THAT(get_surface(event), Eq(surface));
     EXPECT_THAT(&event, SurfaceOutputEventFor(high_dpi));
 
     // Now solely on the left output
@@ -1170,7 +1175,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_surface_output_event_on_move)
     ASSERT_THAT(events_received, Eq(events_expected));
     events_expected++;
 
-    EXPECT_THAT(app_session.surface(mf::SurfaceId{event.to_window_output()->surface_id()}), Eq(surface));
+    EXPECT_THAT(get_surface(event), Eq(surface));
     EXPECT_THAT(&event, SurfaceOutputEventFor(projector));
 
     // Now solely on the right output
@@ -1179,7 +1184,7 @@ TEST_F(ApplicationSessionSurfaceOutput, sends_surface_output_event_on_move)
     ASSERT_THAT(events_received, Eq(events_expected));
     events_expected++;
 
-    EXPECT_THAT(app_session.surface(mf::SurfaceId{event.to_window_output()->surface_id()}), Eq(surface));
+    EXPECT_THAT(get_surface(event), Eq(surface));
     EXPECT_THAT(&event, SurfaceOutputEventFor(high_dpi));
 }
 


### PR DESCRIPTION
Moves the Wayland frontend away from using mirclient specific types
`frontend::Shell` -> `shell::Shell`
`frontend::MirClientSession` -> `scene::Session`
`frontend::SurfaceId` -> `scene::Surface`