### PR TITLE
ApplicationSession: use a display config observer

### DIFF
--- a/include/server/mir/graphics/display_configuration_observer.h
+++ b/include/server/mir/graphics/display_configuration_observer.h
@@ -115,9 +115,9 @@ public:
     /**
      * Notification that the session should send the given display configuration
      *
-     * It may or may not be a session configuration
+     * It may or may not be a session configuration. Used only to implement the mirclient API
      */
-    virtual void session_should_send_display_configuration(
+    virtual void configuration_updated_for_session(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<DisplayConfiguration const> const& config) = 0;
 

--- a/include/server/mir/graphics/display_configuration_observer.h
+++ b/include/server/mir/graphics/display_configuration_observer.h
@@ -112,6 +112,15 @@ public:
         std::shared_ptr<DisplayConfiguration const> const& failed_fallback,
         std::exception const& error) = 0;
 
+    /**
+     * Notification that the session should send the given display configuration
+     *
+     * It may or may not be a session configuration
+     */
+    virtual void session_should_send_display_configuration(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<DisplayConfiguration const> const& config) = 0;
+
 protected:
     DisplayConfigurationObserver() = default;
     virtual ~DisplayConfigurationObserver() = default;

--- a/include/server/mir/scene/session.h
+++ b/include/server/mir/scene/session.h
@@ -66,7 +66,6 @@ public:
     virtual auto process_id() const -> pid_t = 0;
     virtual auto name() const -> std::string = 0;
 
-    virtual void send_display_config(graphics::DisplayConfiguration const&) = 0;
     virtual void send_error(ClientVisibleError const&) = 0;
     virtual void send_input_config(MirInputConfig const& config) = 0;
 

--- a/include/test/mir/test/display_config_matchers.h
+++ b/include/test/mir/test/display_config_matchers.h
@@ -93,6 +93,11 @@ bool compare_display_configurations(
 
 bool compare_display_configurations(
     testing::MatchResultListener* listener,
+    std::shared_ptr<graphics::DisplayConfiguration const> const& display_config1,
+    graphics::DisplayConfiguration const& display_config2);
+
+bool compare_display_configurations(
+    testing::MatchResultListener* listener,
     MirDisplayConfiguration const* display_config2,
     graphics::DisplayConfiguration const& display_config1);
 

--- a/include/test/mir/test/doubles/mock_display_configuration_observer.h
+++ b/include/test/mir/test/doubles/mock_display_configuration_observer.h
@@ -60,7 +60,7 @@ public:
             std::exception const& error));
 
     MOCK_METHOD2(
-        session_should_send_display_configuration,
+        configuration_updated_for_session,
         void(
             std::shared_ptr<scene::Session> const&,
             std::shared_ptr<graphics::DisplayConfiguration const> const&));

--- a/include/test/mir/test/doubles/mock_display_configuration_observer.h
+++ b/include/test/mir/test/doubles/mock_display_configuration_observer.h
@@ -58,6 +58,12 @@ public:
         void(
             std::shared_ptr<graphics::DisplayConfiguration const> const& failed_fallback,
             std::exception const& error));
+
+    MOCK_METHOD2(
+        session_should_send_display_configuration,
+        void(
+            std::shared_ptr<scene::Session> const&,
+            std::shared_ptr<graphics::DisplayConfiguration const> const&));
 };
 
 }

--- a/include/test/mir/test/doubles/stub_session.h
+++ b/include/test/mir/test/doubles/stub_session.h
@@ -42,8 +42,6 @@ struct StubSession : scene::Session
 
     void set_lifecycle_state(MirLifecycleState state) override;
 
-    void send_display_config(graphics::DisplayConfiguration const&) override;
-
     void send_error(ClientVisibleError const&) override;
 
     void hide() override;

--- a/src/miral/display_configuration_listeners.cpp
+++ b/src/miral/display_configuration_listeners.cpp
@@ -69,7 +69,7 @@ void miral::DisplayConfigurationListeners::session_configuration_applied(std::sh
 
 void miral::DisplayConfigurationListeners::session_configuration_removed(std::shared_ptr<mir::scene::Session> const&) {}
 
-void miral::DisplayConfigurationListeners::session_should_send_display_configuration(
+void miral::DisplayConfigurationListeners::configuration_updated_for_session(
     std::shared_ptr<mir::scene::Session> const&,
     std::shared_ptr<mir::graphics::DisplayConfiguration const> const&) {}
 

--- a/src/miral/display_configuration_listeners.cpp
+++ b/src/miral/display_configuration_listeners.cpp
@@ -69,6 +69,10 @@ void miral::DisplayConfigurationListeners::session_configuration_applied(std::sh
 
 void miral::DisplayConfigurationListeners::session_configuration_removed(std::shared_ptr<mir::scene::Session> const&) {}
 
+void miral::DisplayConfigurationListeners::session_should_send_display_configuration(
+    std::shared_ptr<mir::scene::Session> const&,
+    std::shared_ptr<mir::graphics::DisplayConfiguration const> const&) {}
+
 void miral::DisplayConfigurationListeners::configuration_applied(std::shared_ptr<mir::graphics::DisplayConfiguration const> const& config)
 {
     std::lock_guard<decltype(mutex)> lock{mutex};

--- a/src/miral/display_configuration_listeners.h
+++ b/src/miral/display_configuration_listeners.h
@@ -58,6 +58,10 @@ private:
 
     void session_configuration_removed(std::shared_ptr<mir::scene::Session> const&) override;
 
+    void session_should_send_display_configuration(
+        std::shared_ptr<mir::scene::Session> const& session,
+        std::shared_ptr<mir::graphics::DisplayConfiguration const> const& config) override;
+
     std::mutex mutable mutex;
     std::vector<ActiveOutputsListener*> active_output_listeners;
     std::vector<Output> active_outputs;

--- a/src/miral/display_configuration_listeners.h
+++ b/src/miral/display_configuration_listeners.h
@@ -58,7 +58,7 @@ private:
 
     void session_configuration_removed(std::shared_ptr<mir::scene::Session> const&) override;
 
-    void session_should_send_display_configuration(
+    void configuration_updated_for_session(
         std::shared_ptr<mir::scene::Session> const& session,
         std::shared_ptr<mir::graphics::DisplayConfiguration const> const& config) override;
 

--- a/src/server/frontend_wayland/mir_display.cpp
+++ b/src/server/frontend_wayland/mir_display.cpp
@@ -76,7 +76,7 @@ struct DisplayConfigurationObserverAdapter : mg::DisplayConfigurationObserver
     {
     }
 
-    void session_should_send_display_configuration(
+    void configuration_updated_for_session(
         std::shared_ptr<ms::Session> const&,
         std::shared_ptr<mg::DisplayConfiguration const> const&) override
     {

--- a/src/server/frontend_wayland/mir_display.cpp
+++ b/src/server/frontend_wayland/mir_display.cpp
@@ -75,6 +75,12 @@ struct DisplayConfigurationObserverAdapter : mg::DisplayConfigurationObserver
         std::exception const&) override
     {
     }
+
+    void session_should_send_display_configuration(
+        std::shared_ptr<ms::Session> const&,
+        std::shared_ptr<mg::DisplayConfiguration const> const&) override
+    {
+    }
 };
 }
 

--- a/src/server/graphics/display_configuration_observer_multiplexer.cpp
+++ b/src/server/graphics/display_configuration_observer_multiplexer.cpp
@@ -66,11 +66,11 @@ void mg::DisplayConfigurationObserverMultiplexer::catastrophic_configuration_err
     for_each_observer(&mg::DisplayConfigurationObserver::catastrophic_configuration_error, failed_fallback, error);
 }
 
-void mg::DisplayConfigurationObserverMultiplexer::session_should_send_display_configuration(
+void mg::DisplayConfigurationObserverMultiplexer::configuration_updated_for_session(
     std::shared_ptr<scene::Session> const& session,
     std::shared_ptr<DisplayConfiguration const> const& config)
 {
-    for_each_observer(&mg::DisplayConfigurationObserver::session_should_send_display_configuration, session, config);
+    for_each_observer(&mg::DisplayConfigurationObserver::configuration_updated_for_session, session, config);
 }
 
 mg::DisplayConfigurationObserverMultiplexer::DisplayConfigurationObserverMultiplexer(

--- a/src/server/graphics/display_configuration_observer_multiplexer.cpp
+++ b/src/server/graphics/display_configuration_observer_multiplexer.cpp
@@ -66,6 +66,13 @@ void mg::DisplayConfigurationObserverMultiplexer::catastrophic_configuration_err
     for_each_observer(&mg::DisplayConfigurationObserver::catastrophic_configuration_error, failed_fallback, error);
 }
 
+void mg::DisplayConfigurationObserverMultiplexer::session_should_send_display_configuration(
+    std::shared_ptr<scene::Session> const& session,
+    std::shared_ptr<DisplayConfiguration const> const& config)
+{
+    for_each_observer(&mg::DisplayConfigurationObserver::session_should_send_display_configuration, session, config);
+}
+
 mg::DisplayConfigurationObserverMultiplexer::DisplayConfigurationObserverMultiplexer(
     std::shared_ptr<Executor> const& default_executor)
     : ObserverMultiplexer(*default_executor),

--- a/src/server/graphics/display_configuration_observer_multiplexer.h
+++ b/src/server/graphics/display_configuration_observer_multiplexer.h
@@ -55,7 +55,7 @@ public:
         std::shared_ptr<DisplayConfiguration const> const& failed_fallback,
         std::exception const& error) override;
 
-    void session_should_send_display_configuration(
+    void configuration_updated_for_session(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<DisplayConfiguration const> const& config) override;
 

--- a/src/server/graphics/display_configuration_observer_multiplexer.h
+++ b/src/server/graphics/display_configuration_observer_multiplexer.h
@@ -55,6 +55,10 @@ public:
         std::shared_ptr<DisplayConfiguration const> const& failed_fallback,
         std::exception const& error) override;
 
+    void session_should_send_display_configuration(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<DisplayConfiguration const> const& config) override;
+
 private:
     std::shared_ptr<Executor> const executor;
 };

--- a/src/server/input/basic_seat.cpp
+++ b/src/server/input/basic_seat.cpp
@@ -131,6 +131,11 @@ struct mi::BasicSeat::OutputTracker : mg::DisplayConfigurationObserver
         std::exception const&) override
     {}
 
+    void session_should_send_display_configuration(
+        std::shared_ptr<ms::Session> const&,
+        std::shared_ptr<mg::DisplayConfiguration const> const&) override
+    {}
+
     geom::Rectangle get_bounding_rectangle() const
     {
         std::lock_guard<std::mutex> lock(output_mutex);

--- a/src/server/input/basic_seat.cpp
+++ b/src/server/input/basic_seat.cpp
@@ -131,7 +131,7 @@ struct mi::BasicSeat::OutputTracker : mg::DisplayConfigurationObserver
         std::exception const&) override
     {}
 
-    void session_should_send_display_configuration(
+    void configuration_updated_for_session(
         std::shared_ptr<ms::Session> const&,
         std::shared_ptr<mg::DisplayConfiguration const> const&) override
     {}

--- a/src/server/report/logging/display_configuration_report.cpp
+++ b/src/server/report/logging/display_configuration_report.cpp
@@ -202,3 +202,11 @@ void mrl::DisplayConfigurationReport::catastrophic_configuration_error(
     logger->log(component, ml::Severity::critical, "Error details:");
     logger->log(component, ml::Severity::critical, "%s", boost::diagnostic_information(error).c_str());
 }
+
+void mrl::DisplayConfigurationReport::session_should_send_display_configuration(
+    std::shared_ptr<scene::Session> const& session,
+    std::shared_ptr<graphics::DisplayConfiguration const> const& config)
+{
+    logger->log(component, severity, "Sending display configuration to session %s:", session->name().c_str());
+    log_configuration(severity, *config);
+}

--- a/src/server/report/logging/display_configuration_report.cpp
+++ b/src/server/report/logging/display_configuration_report.cpp
@@ -203,7 +203,7 @@ void mrl::DisplayConfigurationReport::catastrophic_configuration_error(
     logger->log(component, ml::Severity::critical, "%s", boost::diagnostic_information(error).c_str());
 }
 
-void mrl::DisplayConfigurationReport::session_should_send_display_configuration(
+void mrl::DisplayConfigurationReport::configuration_updated_for_session(
     std::shared_ptr<scene::Session> const& session,
     std::shared_ptr<graphics::DisplayConfiguration const> const& config)
 {

--- a/src/server/report/logging/display_configuration_report.h
+++ b/src/server/report/logging/display_configuration_report.h
@@ -62,7 +62,7 @@ public:
         std::shared_ptr<graphics::DisplayConfiguration const> const& failed_fallback,
         std::exception const& error) override;
 
-    void session_should_send_display_configuration(
+    void configuration_updated_for_session(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<graphics::DisplayConfiguration const> const& config) override;
 

--- a/src/server/report/logging/display_configuration_report.h
+++ b/src/server/report/logging/display_configuration_report.h
@@ -62,6 +62,10 @@ public:
         std::shared_ptr<graphics::DisplayConfiguration const> const& failed_fallback,
         std::exception const& error) override;
 
+    void session_should_send_display_configuration(
+        std::shared_ptr<scene::Session> const& session,
+        std::shared_ptr<graphics::DisplayConfiguration const> const& config) override;
+
 private:
     void log_configuration(
         mir::logging::Severity severity,

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -92,6 +92,14 @@ public:
     {
     }
 
+    void session_should_send_display_configuration(
+        std::shared_ptr<ms::Session> const& session,
+        std::shared_ptr<mg::DisplayConfiguration const> const& config)
+    {
+        if (session.get() == this->session)
+            this->session->send_display_config(*config);
+    }
+
 private:
     ApplicationSession* const session;
 };

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -92,7 +92,7 @@ public:
     {
     }
 
-    void session_should_send_display_configuration(
+    void configuration_updated_for_session(
         std::shared_ptr<ms::Session> const& session,
         std::shared_ptr<mg::DisplayConfiguration const> const& config) override
     {

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -32,6 +32,7 @@
 #include "mir/events/event_builders.h"
 #include "mir/frontend/event_sink.h"
 #include "mir/graphics/graphic_buffer_allocator.h"
+#include "mir/graphics/display_configuration_observer.h"
 
 #include <boost/throw_exception.hpp>
 
@@ -48,6 +49,53 @@ namespace mg = mir::graphics;
 namespace mev = mir::events;
 namespace mc = mir::compositor;
 
+class mir::scene::ApplicationSession::DisplayConfigurationObserver
+    : public graphics::DisplayConfigurationObserver
+{
+public:
+    DisplayConfigurationObserver(ApplicationSession* session)
+        : session{session}
+    {
+    }
+
+    void initial_configuration(std::shared_ptr<mg::DisplayConfiguration const> const&) override
+    {
+    }
+
+    void configuration_applied(std::shared_ptr<mg::DisplayConfiguration const> const&) override
+    {
+    }
+
+    void base_configuration_updated(std::shared_ptr<mg::DisplayConfiguration const> const&) override
+    {
+    }
+
+    void session_configuration_applied(
+        std::shared_ptr<scene::Session> const&,
+        std::shared_ptr<mg::DisplayConfiguration> const&) override
+    {
+    }
+
+    void session_configuration_removed(std::shared_ptr<scene::Session> const&) override
+    {
+    }
+
+    void configuration_failed(
+        std::shared_ptr<mg::DisplayConfiguration const> const&,
+        std::exception const&) override
+    {
+    }
+
+    void catastrophic_configuration_error(
+        std::shared_ptr<mg::DisplayConfiguration const> const&,
+        std::exception const&) override
+    {
+    }
+
+private:
+    ApplicationSession* const session;
+};
+
 ms::ApplicationSession::ApplicationSession(
     std::shared_ptr<msh::SurfaceStack> const& surface_stack,
     std::shared_ptr<SurfaceFactory> const& surface_factory,
@@ -58,7 +106,8 @@ ms::ApplicationSession::ApplicationSession(
     std::shared_ptr<SessionListener> const& session_listener,
     mg::DisplayConfiguration const& initial_config,
     std::shared_ptr<mf::EventSink> const& sink,
-    std::shared_ptr<graphics::GraphicBufferAllocator> const& gralloc) : 
+    std::shared_ptr<graphics::GraphicBufferAllocator> const& gralloc,
+    std::shared_ptr<ObserverRegistrar<graphics::DisplayConfigurationObserver>> const& display_config_registrar) :
     surface_stack(surface_stack),
     surface_factory(surface_factory),
     buffer_stream_factory(buffer_stream_factory),
@@ -68,14 +117,20 @@ ms::ApplicationSession::ApplicationSession(
     session_listener(session_listener),
     event_sink(sink),
     gralloc(gralloc),
+    display_config_registrar{display_config_registrar},
+    display_config_observer{std::make_shared<DisplayConfigurationObserver>(this)},
     next_surface_id(0)
 {
     assert(surface_stack);
     output_cache.update_from(initial_config);
+    display_config_registrar->register_interest(display_config_observer);
 }
 
 ms::ApplicationSession::~ApplicationSession()
 {
+    if (auto const registrar = display_config_registrar.lock())
+        registrar->unregister_interest(*display_config_observer);
+
     std::unique_lock<std::mutex> lock(surfaces_and_streams_mutex);
     for (auto const& pair_id_surface : surfaces)
     {

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -94,7 +94,7 @@ public:
 
     void session_should_send_display_configuration(
         std::shared_ptr<ms::Session> const& session,
-        std::shared_ptr<mg::DisplayConfiguration const> const& config)
+        std::shared_ptr<mg::DisplayConfiguration const> const& config) override
     {
         if (session.get() == this->session)
             this->session->send_display_config(*config);

--- a/src/server/scene/application_session.h
+++ b/src/server/scene/application_session.h
@@ -22,6 +22,7 @@
 #include "mir/scene/session.h"
 
 #include "output_properties_cache.h"
+#include "mir/observer_registrar.h"
 
 #include <atomic>
 #include <map>
@@ -40,6 +41,7 @@ namespace graphics
 class DisplayConfiguration;
 class GraphicBufferAllocator;
 class BufferAttribute;
+class DisplayConfigurationObserver;
 }
 namespace shell { class SurfaceStack; }
 namespace scene
@@ -64,7 +66,8 @@ public:
         std::shared_ptr<SessionListener> const& session_listener,
         graphics::DisplayConfiguration const& initial_config,
         std::shared_ptr<frontend::EventSink> const& sink,
-        std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator);
+        std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
+        std::shared_ptr<ObserverRegistrar<graphics::DisplayConfigurationObserver>> const& display_config_registrar);
 
     ~ApplicationSession();
 
@@ -105,6 +108,8 @@ protected:
     ApplicationSession& operator=(ApplicationSession const&) = delete;
 
 private:
+    class DisplayConfigurationObserver;
+
     std::shared_ptr<shell::SurfaceStack> const surface_stack;
     std::shared_ptr<SurfaceFactory> const surface_factory;
     std::shared_ptr<BufferStreamFactory> const buffer_stream_factory;
@@ -114,6 +119,8 @@ private:
     std::shared_ptr<SessionListener> const session_listener;
     std::shared_ptr<frontend::EventSink> const event_sink;
     std::shared_ptr<graphics::GraphicBufferAllocator> const gralloc;
+    std::weak_ptr<ObserverRegistrar<graphics::DisplayConfigurationObserver>> const display_config_registrar;
+    std::shared_ptr<DisplayConfigurationObserver> const display_config_observer;
 
     frontend::SurfaceId next_id();
 

--- a/src/server/scene/application_session.h
+++ b/src/server/scene/application_session.h
@@ -87,7 +87,7 @@ public:
     void hide() override;
     void show() override;
 
-    void send_display_config(graphics::DisplayConfiguration const& info) override;
+    void send_display_config(graphics::DisplayConfiguration const& info);
     void send_error(ClientVisibleError const& error) override;
     void send_input_config(MirInputConfig const& devices) override;
 

--- a/src/server/scene/default_configuration.cpp
+++ b/src/server/scene/default_configuration.cpp
@@ -172,7 +172,8 @@ mir::DefaultServerConfiguration::the_session_coordinator()
                 the_session_listener(),
                 the_display(),
                 the_application_not_responding_detector(),
-                the_buffer_allocator());
+                the_buffer_allocator(),
+                the_display_configuration_observer_registrar());
         });
 }
 

--- a/src/server/scene/mediating_display_changer.cpp
+++ b/src/server/scene/mediating_display_changer.cpp
@@ -301,7 +301,7 @@ ms::MediatingDisplayChanger::preview_base_configuration(
                     if (auto live_session = session.lock())
                     {
                         apply_base_config();
-                        observer->session_should_send_display_configuration(live_session, base_configuration());
+                        observer->configuration_updated_for_session(live_session, base_configuration());
                     }
                 });
         preview_configuration_timeout->reschedule_in(timeout);
@@ -317,7 +317,7 @@ ms::MediatingDisplayChanger::preview_base_configuration(
                 try
                 {
                     apply_config(conf);
-                    observer->session_should_send_display_configuration(live_session, conf);
+                    observer->configuration_updated_for_session(live_session, conf);
                 }
                 catch (std::runtime_error const&)
                 {
@@ -375,7 +375,7 @@ ms::MediatingDisplayChanger::cancel_base_configuration_preview(
                 if (auto live_session = weak_session.lock())
                 {
                     apply_base_config();
-                    observer->session_should_send_display_configuration(live_session, base_configuration());
+                    observer->configuration_updated_for_session(live_session, base_configuration());
                 }
             });
     }
@@ -521,7 +521,7 @@ void ms::MediatingDisplayChanger::send_config_to_all_sessions(
     session_container->for_each(
         [this, &conf](std::shared_ptr<Session> const& session)
         {
-            observer->session_should_send_display_configuration(session, conf);
+            observer->configuration_updated_for_session(session, conf);
         });
 }
 

--- a/src/server/scene/mediating_display_changer.cpp
+++ b/src/server/scene/mediating_display_changer.cpp
@@ -301,7 +301,7 @@ ms::MediatingDisplayChanger::preview_base_configuration(
                     if (auto live_session = session.lock())
                     {
                         apply_base_config();
-                        live_session->send_display_config(*base_configuration());
+                        observer->session_should_send_display_configuration(live_session, base_configuration());
                     }
                 });
         preview_configuration_timeout->reschedule_in(timeout);
@@ -317,7 +317,7 @@ ms::MediatingDisplayChanger::preview_base_configuration(
                 try
                 {
                     apply_config(conf);
-                    live_session->send_display_config(*conf);
+                    observer->session_should_send_display_configuration(live_session, conf);
                 }
                 catch (std::runtime_error const&)
                 {
@@ -375,7 +375,7 @@ ms::MediatingDisplayChanger::cancel_base_configuration_preview(
                 if (auto live_session = weak_session.lock())
                 {
                     apply_base_config();
-                    live_session->send_display_config(*base_configuration());
+                    observer->session_should_send_display_configuration(live_session, base_configuration());
                 }
             });
     }
@@ -519,9 +519,9 @@ void ms::MediatingDisplayChanger::send_config_to_all_sessions(
     std::shared_ptr<mg::DisplayConfiguration> const& conf)
 {
     session_container->for_each(
-        [&conf](std::shared_ptr<Session> const& session)
+        [this, &conf](std::shared_ptr<Session> const& session)
         {
-            session->send_display_config(*conf);
+            observer->session_should_send_display_configuration(session, conf);
         });
 }
 

--- a/src/server/scene/session_manager.cpp
+++ b/src/server/scene/session_manager.cpp
@@ -98,7 +98,8 @@ ms::SessionManager::SessionManager(
     std::shared_ptr<SessionListener> const& session_listener,
     std::shared_ptr<graphics::Display const> const& display,
     std::shared_ptr<ApplicationNotRespondingDetector> const& anr_detector,
-    std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator) :
+    std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
+    std::shared_ptr<ObserverRegistrar<graphics::DisplayConfigurationObserver>> display_config_registrar) :
     observers(std::make_shared<SessionObservers>()),
     surface_stack(surface_stack),
     surface_factory(surface_factory),
@@ -109,7 +110,8 @@ ms::SessionManager::SessionManager(
     session_listener(session_listener),
     display{display},
     anr_detector{anr_detector},
-    allocator(allocator)
+    allocator{allocator},
+    display_config_registrar{display_config_registrar}
 {
     observers->register_interest(session_listener);
 }
@@ -149,7 +151,8 @@ std::shared_ptr<ms::Session> ms::SessionManager::open_session(
             observers,
             *display->configuration(),
             sender,
-            allocator);
+            allocator,
+            display_config_registrar);
 
     app_container->insert_session(new_session);
 

--- a/src/server/scene/session_manager.h
+++ b/src/server/scene/session_manager.h
@@ -21,6 +21,7 @@
 
 #include "mir/scene/session_coordinator.h"
 #include "mir/scene/session_listener.h"
+#include "mir/observer_registrar.h"
 
 #include <memory>
 #include <vector>
@@ -32,6 +33,7 @@ namespace graphics
 class DisplayConfiguration;
 class Display;
 class GraphicBufferAllocator;
+class DisplayConfigurationObserver;
 }
 
 namespace shell { class SurfaceStack; }
@@ -61,7 +63,8 @@ public:
         std::shared_ptr<SessionListener> const& session_listener,
         std::shared_ptr<graphics::Display const> const& display,
         std::shared_ptr<ApplicationNotRespondingDetector> const& anr_detector,
-        std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator); 
+        std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
+        std::shared_ptr<ObserverRegistrar<graphics::DisplayConfigurationObserver>> display_config_registrar);
 
     virtual ~SessionManager() noexcept;
 
@@ -98,6 +101,7 @@ private:
     std::shared_ptr<graphics::Display const> const display;
     std::shared_ptr<ApplicationNotRespondingDetector> const anr_detector;
     std::shared_ptr<graphics::GraphicBufferAllocator> const allocator;
+    std::shared_ptr<ObserverRegistrar<graphics::DisplayConfigurationObserver>> display_config_registrar;
 };
 
 }

--- a/tests/acceptance-tests/test_new_display_configuration.cpp
+++ b/tests/acceptance-tests/test_new_display_configuration.cpp
@@ -158,7 +158,7 @@ struct DisplayConfigurationTest : mtf::ConnectedClientWithAWindow
         {
         }
 
-        void session_should_send_display_configuration(
+        void configuration_updated_for_session(
             std::shared_ptr<ms::Session> const&,
             std::shared_ptr<mg::DisplayConfiguration const> const&) override
         {

--- a/tests/acceptance-tests/test_new_display_configuration.cpp
+++ b/tests/acceptance-tests/test_new_display_configuration.cpp
@@ -158,6 +158,12 @@ struct DisplayConfigurationTest : mtf::ConnectedClientWithAWindow
         {
         }
 
+        void session_should_send_display_configuration(
+            std::shared_ptr<ms::Session> const&,
+            std::shared_ptr<mg::DisplayConfiguration const> const&) override
+        {
+        }
+
     private:
         struct Expectation
         {

--- a/tests/include/mir/test/doubles/mock_display_configuration_observer.h
+++ b/tests/include/mir/test/doubles/mock_display_configuration_observer.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com
+ */
+
+#ifndef MIR_TEST_DOUBLES_MOCK_DISPLAY_CONFIGURATION_OBSERVER_H_
+#define MIR_TEST_DOUBLES_MOCK_DISPLAY_CONFIGURATION_OBSERVER_H_
+
+#include "mir/graphics/display_configuration_observer.h"
+
+#include <gmock/gmock.h>
+
+namespace mir
+{
+namespace test
+{
+namespace doubles
+{
+
+class MockDisplayConfigurationObserver : public graphics::DisplayConfigurationObserver
+{
+public:
+    MOCK_METHOD1(initial_configuration, void(std::shared_ptr<graphics::DisplayConfiguration const> const& config));
+
+    MOCK_METHOD1(configuration_applied, void(std::shared_ptr<graphics::DisplayConfiguration const> const& config));
+
+    MOCK_METHOD1(
+        base_configuration_updated,
+        void(std::shared_ptr<graphics::DisplayConfiguration const> const& base_config));
+
+    MOCK_METHOD2(
+        session_configuration_applied,
+        void(
+            std::shared_ptr<scene::Session> const& session,
+            std::shared_ptr<graphics::DisplayConfiguration> const& config));
+
+    MOCK_METHOD1(session_configuration_removed, void(std::shared_ptr<scene::Session> const& session));
+
+    MOCK_METHOD2(
+        configuration_failed,
+        void(std::shared_ptr<graphics::DisplayConfiguration const> const& attempted, std::exception const& error));
+
+    MOCK_METHOD2(
+        catastrophic_configuration_error,
+        void(
+            std::shared_ptr<graphics::DisplayConfiguration const> const& failed_fallback,
+            std::exception const& error));
+};
+
+}
+}
+}
+
+#endif /* MIR_TEST_DOUBLES_MOCK_DISPLAY_CONFIGURATION_OBSERVER_H_ */
+

--- a/tests/include/mir/test/doubles/mock_display_configuration_observer.h
+++ b/tests/include/mir/test/doubles/mock_display_configuration_observer.h
@@ -58,6 +58,12 @@ public:
         void(
             std::shared_ptr<graphics::DisplayConfiguration const> const& failed_fallback,
             std::exception const& error));
+
+    MOCK_METHOD2(
+        session_should_send_display_configuration,
+        void(
+            std::shared_ptr<scene::Session> const&,
+            std::shared_ptr<graphics::DisplayConfiguration const> const&));
 };
 
 }

--- a/tests/include/mir/test/doubles/mock_scene_session.h
+++ b/tests/include/mir/test/doubles/mock_scene_session.h
@@ -55,7 +55,6 @@ struct MockSceneSession : public scene::Session
     MOCK_METHOD0(hide, void());
     MOCK_METHOD0(show, void());
 
-    MOCK_METHOD1(send_display_config, void(graphics::DisplayConfiguration const&));
     MOCK_METHOD1(send_error, void(ClientVisibleError const&));
     MOCK_METHOD1(send_input_config, void(MirInputConfig const&));
     MOCK_METHOD3(configure_surface, int(frontend::SurfaceId, MirWindowAttrib, int));

--- a/tests/include/mir/test/doubles/stub_observer_registrar.h
+++ b/tests/include/mir/test/doubles/stub_observer_registrar.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_TEST_DOUBLES_STUB_OBSERVER_REGISTRAR_H_
+#define MIR_TEST_DOUBLES_STUB_OBSERVER_REGISTRAR_H_
+
+#include "mir/observer_registrar.h"
+
+namespace mir
+{
+namespace test
+{
+namespace doubles
+{
+
+template<class Observer>
+class StubObserverRegistrar
+    : public ObserverRegistrar<Observer>
+{
+public:
+    void register_interest(std::weak_ptr<Observer> const&) override
+    {
+    }
+
+    void register_interest(
+        std::weak_ptr<Observer> const&,
+        mir::Executor&) override
+    {
+    }
+
+    void unregister_interest(Observer const&) override
+    {
+    }
+};
+
+}
+}
+}
+
+#endif // MIR_TEST_DOUBLES_STUB_OBSERVER_REGISTRAR_H_

--- a/tests/integration-tests/test_session.cpp
+++ b/tests/integration-tests/test_session.cpp
@@ -105,7 +105,8 @@ TEST(ApplicationSession, stress_test_take_snapshot)
         std::make_shared<ms::NullSessionListener>(),
         mtd::StubDisplayConfig{},
         std::make_shared<mtd::NullEventSink>(),
-        conf.the_buffer_allocator()
+        conf.the_buffer_allocator(),
+        conf.the_display_configuration_observer_registrar()
     };
 
     mg::BufferProperties properties(geom::Size{1,1}, mir_pixel_format_abgr_8888, mg::BufferUsage::software);

--- a/tests/mir_test/display_config_matchers.cpp
+++ b/tests/mir_test/display_config_matchers.cpp
@@ -360,6 +360,14 @@ bool mt::compare_display_configurations(
 
 bool mt::compare_display_configurations(
     testing::MatchResultListener* listener,
+    std::shared_ptr<mg::DisplayConfiguration const> const& display_config1,
+    mg::DisplayConfiguration const& display_config2)
+{
+    return compare_display_configurations(listener, *display_config1, display_config2);
+}
+
+bool mt::compare_display_configurations(
+    testing::MatchResultListener* listener,
     MirDisplayConfiguration const* display_config2,
     graphics::DisplayConfiguration const& display_config1)
 {

--- a/tests/mir_test_framework/stub_session.cpp
+++ b/tests/mir_test_framework/stub_session.cpp
@@ -50,11 +50,6 @@ void mtd::StubSession::set_lifecycle_state(MirLifecycleState /*state*/)
 {
 }
 
-void mtd::StubSession::send_display_config(
-    mir::graphics::DisplayConfiguration const& /*configuration*/)
-{
-}
-
 void mtd::StubSession::send_error(
     mir::ClientVisibleError const& /*error*/)
 {

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -93,6 +93,28 @@ struct MockSessionManager : ms::SessionManager
 {
     using ms::SessionManager::SessionManager;
 
+    // Must wrap the constructor as the NiceMock<> constructor can only take 10 arguments on older platforms
+    MockSessionManager(
+        std::shared_ptr<msh::SurfaceStack> const& surface_stack,
+        std::shared_ptr<ms::SurfaceFactory> const& surface_factory,
+        std::shared_ptr<ms::SessionContainer> const& app_container,
+        std::shared_ptr<ms::SessionEventSink> const& session_event_sink,
+        std::shared_ptr<mg::Display const> const& display)
+        : ms::SessionManager{
+              surface_stack,
+              surface_factory,
+              std::make_shared<mtd::StubBufferStreamFactory>(),
+              app_container,
+              std::make_shared<mtd::NullSnapshotStrategy>(),
+              session_event_sink,
+              std::make_shared<ms::NullSessionListener>(),
+              display,
+              std::make_shared<mtd::NullANRDetector>(),
+              std::make_shared<mtd::StubBufferAllocator>(),
+              std::make_shared<mtd::StubObserverRegistrar<mir::graphics::DisplayConfigurationObserver>>()}
+    {
+    }
+
     MOCK_METHOD1(set_focus_to, void (std::shared_ptr<ms::Session> const& focus));
 
     void unmocked_set_focus_to(std::shared_ptr<ms::Session> const& focus)
@@ -120,15 +142,9 @@ struct AbstractShell : Test
     NiceMock<MockSessionManager> session_manager{
         mt::fake_shared(surface_stack),
         mt::fake_shared(surface_factory),
-        std::make_shared<mtd::StubBufferStreamFactory>(),
         mt::fake_shared(session_container),
-        std::make_shared<mtd::NullSnapshotStrategy>(),
         mt::fake_shared(session_event_sink),
-        std::make_shared<ms::NullSessionListener>(),
-        mt::fake_shared(display),
-        std::make_shared<mtd::NullANRDetector>(),
-        std::make_shared<mtd::StubBufferAllocator>(),
-        std::make_shared<mtd::StubObserverRegistrar<mir::graphics::DisplayConfigurationObserver>>()};
+        mt::fake_shared(display)};
 
     mtd::StubInputTargeter input_targeter;
     std::shared_ptr<NiceMockWindowManager> wm;

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -24,6 +24,7 @@
 #include "mir/scene/session_container.h"
 #include "mir/scene/surface_creation_parameters.h"
 #include "mir/scene/surface_factory.h"
+#include "mir/graphics/display_configuration_observer.h"
 
 #include "src/server/report/null/shell_report.h"
 #include "src/include/server/mir/scene/session_event_sink.h"
@@ -42,6 +43,7 @@
 #include "mir/test/doubles/null_application_not_responding_detector.h"
 #include "mir/test/doubles/stub_display.h"
 #include "mir/test/doubles/mock_input_seat.h"
+#include "mir/test/doubles/stub_observer_registrar.h"
 
 #include "mir/test/fake_shared.h"
 #include "mir/test/event_matchers.h"
@@ -125,7 +127,8 @@ struct AbstractShell : Test
         std::make_shared<ms::NullSessionListener>(),
         mt::fake_shared(display),
         std::make_shared<mtd::NullANRDetector>(),
-        std::make_shared<mtd::StubBufferAllocator>()};
+        std::make_shared<mtd::StubBufferAllocator>(),
+        std::make_shared<mtd::StubObserverRegistrar<mir::graphics::DisplayConfigurationObserver>>()};
 
     mtd::StubInputTargeter input_targeter;
     std::shared_ptr<NiceMockWindowManager> wm;

--- a/tests/unit-tests/scene/test_mediating_display_changer.cpp
+++ b/tests/unit-tests/scene/test_mediating_display_changer.cpp
@@ -366,8 +366,8 @@ TEST_F(MediatingDisplayChangerTest, notifies_all_sessions_on_hardware_config_cha
     session_container.insert_session(mt::fake_shared(mock_session1));
     session_container.insert_session(mt::fake_shared(mock_session2));
 
-    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mt::fake_shared(mock_session1)), _));
-    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mt::fake_shared(mock_session2)), _));
+    EXPECT_CALL(display_configuration_observer, configuration_updated_for_session(Eq(mt::fake_shared(mock_session1)), _));
+    EXPECT_CALL(display_configuration_observer, configuration_updated_for_session(Eq(mt::fake_shared(mock_session2)), _));
 
     changer->configure_for_hardware_change(mt::fake_shared(conf));
 }
@@ -393,13 +393,13 @@ TEST_F(MediatingDisplayChangerTest, notifies_all_sessions_when_hardware_config_c
 
     EXPECT_CALL(
         display_configuration_observer,
-        session_should_send_display_configuration(
+        configuration_updated_for_session(
             Eq(mt::fake_shared(mock_session1)),
             mt::DisplayConfigMatches(std::cref(*previous_base_config))));
 
     EXPECT_CALL(
         display_configuration_observer,
-        session_should_send_display_configuration(
+        configuration_updated_for_session(
             Eq(mt::fake_shared(mock_session2)),
             mt::DisplayConfigMatches(std::cref(*previous_base_config))));
 
@@ -838,8 +838,8 @@ TEST_F(MediatingDisplayChangerTest, notifies_all_sessions_on_set_base_configurat
     session_container.insert_session(mt::fake_shared(mock_session1));
     session_container.insert_session(mt::fake_shared(mock_session2));
 
-    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mt::fake_shared(mock_session1)), _));
-    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mt::fake_shared(mock_session2)), _));
+    EXPECT_CALL(display_configuration_observer, configuration_updated_for_session(Eq(mt::fake_shared(mock_session1)), _));
+    EXPECT_CALL(display_configuration_observer, configuration_updated_for_session(Eq(mt::fake_shared(mock_session2)), _));
 
     changer->set_base_configuration(mt::fake_shared(conf));
 }
@@ -876,7 +876,7 @@ TEST_F(MediatingDisplayChangerTest, notifies_session_on_preview_base_configurati
 
     session_container.insert_session(mock_session);
 
-    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mock_session), _));
+    EXPECT_CALL(display_configuration_observer, configuration_updated_for_session(Eq(mock_session), _));
 
     changer->preview_base_configuration(
         mock_session,
@@ -931,9 +931,9 @@ TEST_F(MediatingDisplayChangerTest, only_configuring_client_receives_preview_not
     session_container.insert_session(mock_session1);
     session_container.insert_session(mock_session2);
 
-    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mock_session1), _))
+    EXPECT_CALL(display_configuration_observer, configuration_updated_for_session(Eq(mock_session1), _))
         .Times(AtLeast(1));
-    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mock_session2), _))
+    EXPECT_CALL(display_configuration_observer, configuration_updated_for_session(Eq(mock_session2), _))
         .Times(0);
 
     std::chrono::seconds const timeout{30};
@@ -1024,7 +1024,7 @@ TEST_F(MediatingDisplayChangerTest, all_sessions_get_notified_on_configuration_c
 
     std::unique_ptr<mg::DisplayConfiguration> received_configuration;
 
-    ON_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mock_session2), _))
+    ON_CALL(display_configuration_observer, configuration_updated_for_session(Eq(mock_session2), _))
         .WillByDefault(Invoke([&received_configuration](auto const&, auto const& config)
             {
                 received_configuration = config->clone();

--- a/tests/unit-tests/scene/test_mediating_display_changer.cpp
+++ b/tests/unit-tests/scene/test_mediating_display_changer.cpp
@@ -366,8 +366,8 @@ TEST_F(MediatingDisplayChangerTest, notifies_all_sessions_on_hardware_config_cha
     session_container.insert_session(mt::fake_shared(mock_session1));
     session_container.insert_session(mt::fake_shared(mock_session2));
 
-    EXPECT_CALL(mock_session1, send_display_config(_));
-    EXPECT_CALL(mock_session2, send_display_config(_));
+    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mt::fake_shared(mock_session1)), _));
+    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mt::fake_shared(mock_session2)), _));
 
     changer->configure_for_hardware_change(mt::fake_shared(conf));
 }
@@ -387,10 +387,21 @@ TEST_F(MediatingDisplayChangerTest, notifies_all_sessions_when_hardware_config_c
 
     EXPECT_CALL(mock_display, configure(Ref(conf)))
         .WillOnce(InvokeWithoutArgs([]() { BOOST_THROW_EXCEPTION(std::runtime_error{"Avocado!"}); }));
+
     EXPECT_CALL(mock_display, configure(Not(Ref(conf))))
         .Times(AnyNumber());
-    EXPECT_CALL(mock_session1, send_display_config(mt::DisplayConfigMatches(std::cref(*previous_base_config))));
-    EXPECT_CALL(mock_session2, send_display_config(mt::DisplayConfigMatches(std::cref(*previous_base_config))));
+
+    EXPECT_CALL(
+        display_configuration_observer,
+        session_should_send_display_configuration(
+            Eq(mt::fake_shared(mock_session1)),
+            mt::DisplayConfigMatches(std::cref(*previous_base_config))));
+
+    EXPECT_CALL(
+        display_configuration_observer,
+        session_should_send_display_configuration(
+            Eq(mt::fake_shared(mock_session2)),
+            mt::DisplayConfigMatches(std::cref(*previous_base_config))));
 
     changer->configure_for_hardware_change(mt::fake_shared(conf));
 }
@@ -827,8 +838,8 @@ TEST_F(MediatingDisplayChangerTest, notifies_all_sessions_on_set_base_configurat
     session_container.insert_session(mt::fake_shared(mock_session1));
     session_container.insert_session(mt::fake_shared(mock_session2));
 
-    EXPECT_CALL(mock_session1, send_display_config(_));
-    EXPECT_CALL(mock_session2, send_display_config(_));
+    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mt::fake_shared(mock_session1)), _));
+    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mt::fake_shared(mock_session2)), _));
 
     changer->set_base_configuration(mt::fake_shared(conf));
 }
@@ -865,7 +876,7 @@ TEST_F(MediatingDisplayChangerTest, notifies_session_on_preview_base_configurati
 
     session_container.insert_session(mock_session);
 
-    EXPECT_CALL(*mock_session, send_display_config(_));
+    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mock_session), _));
 
     changer->preview_base_configuration(
         mock_session,
@@ -920,7 +931,10 @@ TEST_F(MediatingDisplayChangerTest, only_configuring_client_receives_preview_not
     session_container.insert_session(mock_session1);
     session_container.insert_session(mock_session2);
 
-    EXPECT_CALL(*mock_session2, send_display_config(_)).Times(0);
+    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mock_session1), _))
+        .Times(AtLeast(1));
+    EXPECT_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mock_session2), _))
+        .Times(0);
 
     std::chrono::seconds const timeout{30};
 
@@ -1010,8 +1024,11 @@ TEST_F(MediatingDisplayChangerTest, all_sessions_get_notified_on_configuration_c
 
     std::unique_ptr<mg::DisplayConfiguration> received_configuration;
 
-    ON_CALL(*mock_session2, send_display_config(_))
-        .WillByDefault(Invoke([&received_configuration](auto& conf) { received_configuration = conf.clone(); }));
+    ON_CALL(display_configuration_observer, session_should_send_display_configuration(Eq(mock_session2), _))
+        .WillByDefault(Invoke([&received_configuration](auto const&, auto const& config)
+            {
+                received_configuration = config->clone();
+            }));
 
     changer->preview_base_configuration(
         mock_session1,

--- a/tests/unit-tests/scene/test_mediating_display_changer.cpp
+++ b/tests/unit-tests/scene/test_mediating_display_changer.cpp
@@ -19,7 +19,6 @@
 #include "src/server/scene/mediating_display_changer.h"
 #include "mir/scene/session_container.h"
 #include "mir/graphics/display_configuration_policy.h"
-#include "mir/graphics/display_configuration_observer.h"
 #include "mir/geometry/rectangles.h"
 #include "src/server/scene/broadcasting_session_event_sink.h"
 #include "mir/server_action_queue.h"
@@ -33,6 +32,7 @@
 #include "mir/test/fake_shared.h"
 #include "mir/test/display_config_matchers.h"
 #include "mir/test/doubles/fake_alarm_factory.h"
+#include "mir/test/doubles/mock_display_configuration_observer.h"
 
 #include <mutex>
 #include <boost/throw_exception.hpp>
@@ -105,24 +105,6 @@ struct MockServerActionQueue : mir::ServerActionQueue
     MOCK_METHOD1(resume_processing_for, void(void const*));
 };
 
-struct StubDisplayConfigurationObserver : mg::DisplayConfigurationObserver
-{
-    void initial_configuration(std::shared_ptr<mg::DisplayConfiguration const> const&) override {}
-    void configuration_applied(std::shared_ptr<mg::DisplayConfiguration const> const&) override {}
-    void base_configuration_updated(std::shared_ptr<mg::DisplayConfiguration const> const&) override {}
-    void session_configuration_applied(
-        std::shared_ptr<ms::Session> const&,
-        std::shared_ptr<mg::DisplayConfiguration> const&) override {};
-    void session_configuration_removed(std::shared_ptr<ms::Session> const&) override {};
-    void configuration_failed(
-        std::shared_ptr<mg::DisplayConfiguration const> const&,
-        std::exception const&) override {}
-    void catastrophic_configuration_error(
-        std::shared_ptr<mg::DisplayConfiguration const> const&,
-        std::exception const&) override { }
-};
-
-
 struct MediatingDisplayChangerTest : public ::testing::Test
 {
     MediatingDisplayChangerTest()
@@ -136,7 +118,7 @@ struct MediatingDisplayChangerTest : public ::testing::Test
                       mt::fake_shared(session_container),
                       mt::fake_shared(session_event_sink),
                       mt::fake_shared(server_action_queue),
-                      mt::fake_shared(display_configuration_report),
+                      mt::fake_shared(display_configuration_observer),
                       mt::fake_shared(alarm_factory));
     }
 
@@ -147,7 +129,7 @@ struct MediatingDisplayChangerTest : public ::testing::Test
     ms::BroadcastingSessionEventSink session_event_sink;
     mtd::StubDisplayConfig base_config;
     StubServerActionQueue server_action_queue;
-    StubDisplayConfigurationObserver display_configuration_report;
+    mtd::MockDisplayConfigurationObserver display_configuration_observer;
     mtd::FakeAlarmFactory alarm_factory;
     std::shared_ptr<ms::MediatingDisplayChanger> changer;
 };
@@ -684,7 +666,7 @@ TEST_F(MediatingDisplayChangerTest, uses_server_action_queue_for_configuration_a
       mt::fake_shared(session_container),
       mt::fake_shared(session_event_sink),
       mt::fake_shared(mock_server_action_queue),
-      mt::fake_shared(display_configuration_report),
+      mt::fake_shared(display_configuration_observer),
       mt::fake_shared(alarm_factory));
 
     void const* owner{nullptr};
@@ -738,7 +720,7 @@ TEST_F(MediatingDisplayChangerTest, does_not_block_IPC_thread_for_inactive_sessi
         mt::fake_shared(session_container),
         mt::fake_shared(session_event_sink),
         mt::fake_shared(mock_server_action_queue),
-        mt::fake_shared(display_configuration_report),
+        mt::fake_shared(display_configuration_observer),
         mt::fake_shared(alarm_factory));
 
     EXPECT_CALL(mock_server_action_queue, enqueue(_, _));
@@ -855,10 +837,7 @@ TEST_F(MediatingDisplayChangerTest, notifies_observer_on_set_base_configuration)
 {
     using namespace testing;
 
-    struct MockDisplayConfigurationObserver : StubDisplayConfigurationObserver
-    {
-        MOCK_METHOD1(base_configuration_updated, void (std::shared_ptr<mg::DisplayConfiguration const> const& base_config));
-    } display_configuration_observer;
+    mtd::MockDisplayConfigurationObserver display_configuration_observer;
 
     changer = std::make_shared<ms::MediatingDisplayChanger>(
         mt::fake_shared(mock_display),

--- a/tests/unit-tests/scene/test_session_manager.cpp
+++ b/tests/unit-tests/scene/test_session_manager.cpp
@@ -22,6 +22,7 @@
 #include "mir/scene/session_container.h"
 #include "mir/scene/session_listener.h"
 #include "mir/scene/null_session_listener.h"
+#include "mir/graphics/display_configuration_observer.h"
 
 #include "src/server/scene/basic_surface.h"
 #include "src/include/server/mir/scene/session_event_sink.h"
@@ -38,6 +39,7 @@
 #include "mir/test/doubles/null_application_not_responding_detector.h"
 #include "mir/test/doubles/stub_display.h"
 #include "mir/test/doubles/stub_buffer_allocator.h"
+#include "mir/test/doubles/stub_observer_registrar.h"
 
 #include "mir/test/fake_shared.h"
 
@@ -78,6 +80,7 @@ struct SessionManagerSetup : public testing::Test
     mtd::StubDisplay display{2};
     mtd::NullEventSink event_sink;
     mtd::StubBufferAllocator allocator;
+    mtd::StubObserverRegistrar<mir::graphics::DisplayConfigurationObserver> display_config_registrar;
 
     ms::SessionManager session_manager{mt::fake_shared(surface_stack),
         mt::fake_shared(stub_surface_factory),
@@ -88,7 +91,8 @@ struct SessionManagerSetup : public testing::Test
         mt::fake_shared(session_listener),
         mt::fake_shared(display),
         std::make_shared<mtd::NullANRDetector>(),
-        mt::fake_shared(allocator)};
+        mt::fake_shared(allocator),
+        mt::fake_shared(display_config_registrar)};
 };
 
 }
@@ -103,6 +107,7 @@ struct SessionManagerSessionListenerSetup : public testing::Test
     mtd::StubSurfaceFactory stub_surface_factory;
     mtd::StubDisplay display{2};
     mtd::StubBufferAllocator allocator;
+    mtd::StubObserverRegistrar<mir::graphics::DisplayConfigurationObserver> display_config_registrar;
 
     ms::SessionManager session_manager{
         mt::fake_shared(surface_stack),
@@ -114,7 +119,8 @@ struct SessionManagerSessionListenerSetup : public testing::Test
         mt::fake_shared(session_listener),
         mt::fake_shared(display),
         std::make_shared<mtd::NullANRDetector>(),
-        mt::fake_shared(allocator)};
+        mt::fake_shared(allocator),
+        mt::fake_shared(display_config_registrar)};
 };
 }
 
@@ -183,6 +189,7 @@ struct SessionManagerSessionEventsSetup : public testing::Test
     mtd::StubSurfaceFactory stub_surface_factory;
     mtd::StubDisplay display{3};
     mtd::StubBufferAllocator allocator;
+    mtd::StubObserverRegistrar<mir::graphics::DisplayConfigurationObserver> display_config_registrar;
 
     ms::SessionManager session_manager{
         mt::fake_shared(surface_stack),
@@ -194,7 +201,8 @@ struct SessionManagerSessionEventsSetup : public testing::Test
         mt::fake_shared(session_listener),
         mt::fake_shared(display),
         std::make_shared<mtd::NullANRDetector>(),
-        mt::fake_shared(allocator)};
+        mt::fake_shared(allocator),
+        mt::fake_shared(display_config_registrar)};
 };
 }
 


### PR DESCRIPTION
Currently, the session has a `send_display_config()` function. This PR makes the session use a `DisplayConfigurationObserver` to get that notification. In a coming PR, this will allow `BasicMirClientSession` to get that notification without having to pass the `MirClientSession` around. Wayland already uses a similar method. Stacked on top of #987