### PR TITLE
Add missing throw_exception.hpp include

### DIFF
--- a/src/server/report/lttng/lttng_report_factory.cpp
+++ b/src/server/report/lttng/lttng_report_factory.cpp
@@ -26,6 +26,7 @@
 #include "scene_report.h"
 #include "session_mediator_report.h"
 #include "shared_library_prober_report.h"
+#include <boost/throw_exception.hpp>
 
 std::shared_ptr<mir::compositor::CompositorReport> mir::report::LttngReportFactory::create_compositor_report()
 {


### PR DESCRIPTION
```
Fix these errors with boost 1.71.0:

/home/pmos/build/src/mir-1.1.2/src/server/report/lttng/lttng_report_factory.cpp:67:5:
error: use of undeclared identifier 'BOOST_THROW_EXCEPTION'
    BOOST_THROW_EXCEPTION(std::logic_error("Not implemented"));
    ^
/home/pmos/build/src/mir-1.1.2/src/server/report/lttng/lttng_report_factory.cpp:77:5:
error: use of undeclared identifier 'BOOST_THROW_EXCEPTION'
    BOOST_THROW_EXCEPTION(std::logic_error("Not implemented"));
```
This patch was written against mir-1.1.2 (as one can see in the commit message). However, the header is still missing in master.