### PR TITLE
[miral] Make it possible for servers to set up the environment for launching clients

### DIFF
--- a/include/miral/miral/runner.h
+++ b/include/miral/miral/runner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Canonical Ltd.
+ * Copyright © 2016-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -18,6 +18,8 @@
 
 #ifndef MIRAL_RUNNER_H
 #define MIRAL_RUNNER_H
+
+#include "mir/optional_value.h"
 
 #include <functional>
 #include <initializer_list>
@@ -76,6 +78,14 @@ public:
     /// Config file entries are long form (e.g. "x11-output=1200x720")
     /// \remark Since MirAL 2.4
     auto display_config_file() const -> std::string;
+
+    /// Get the Wayland endpoint name (if any) usable as a $WAYLAND_DISPLAY value
+    /// \remark Since MirAL 2.8
+    auto wayland_display() const -> mir::optional_value<std::string>;
+
+    /// Get the X11 socket name (if any) usable as a $DISPLAY value
+    /// \remark Since MirAL 2.8
+    auto x11_display() const -> mir::optional_value<std::string>;
 
 private:
     MirRunner(MirRunner const&) = delete;

--- a/include/test/miral/test_display_server.h
+++ b/include/test/miral/test_display_server.h
@@ -94,6 +94,7 @@ struct TestDisplayServer : private TestRuntimeEnvironment
     build_window_manager_policy(WindowManagerTools const& tools) -> std::unique_ptr<WindowManagementPolicy>;
 
     /// Wrapper to gain access to the MirRunner
+    /// \note call after start_server()
     void invoke_runner(std::function<void(MirRunner& runner)> const& f);
 
 private:

--- a/include/test/miral/test_display_server.h
+++ b/include/test/miral/test_display_server.h
@@ -84,7 +84,7 @@ struct TestDisplayServer : private TestRuntimeEnvironment
 
     /// Wrapper to gain access to WindowManagerTools API (with correct locking in place)
     /// \note call after start_server()
-    void invoke_tools(std::function<void(WindowManagerTools & tools)> const& f);
+    void invoke_tools(std::function<void(WindowManagerTools& tools)> const& f);
 
     /// Stop the server
     /// \note Typically called by TestServer::TearDown()
@@ -92,6 +92,9 @@ struct TestDisplayServer : private TestRuntimeEnvironment
 
     virtual auto
     build_window_manager_policy(WindowManagerTools const& tools) -> std::unique_ptr<WindowManagementPolicy>;
+
+    /// Wrapper to gain access to the MirRunner
+    void invoke_runner(std::function<void(MirRunner& runner)> const& f);
 
 private:
     MirRunner runner;

--- a/src/miral/runner.cpp
+++ b/src/miral/runner.cpp
@@ -276,3 +276,28 @@ auto miral::MirRunner::display_config_file() const -> std::string
     return self->display_config_file;
 }
 
+auto miral::MirRunner::wayland_display() const -> mir::optional_value<std::string>
+{
+    std::lock_guard<decltype(self->mutex)> lock{self->mutex};
+
+    if (auto const server = self->weak_server.lock())
+    {
+        return server->wayland_display();
+    }
+
+    return {};
+}
+
+auto miral::MirRunner::x11_display() const -> mir::optional_value<std::string>
+{
+    std::lock_guard<decltype(self->mutex)> lock{self->mutex};
+
+    if (auto const server = self->weak_server.lock())
+    {
+        auto const options = server->get_options();
+        if (options->is_set(mo::x11_display_opt))
+            return std::string(":") + std::to_string(options->get<int>(mo::x11_display_opt));
+    }
+
+    return {};
+}

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -484,6 +484,8 @@ global:
 MIRAL_2.8 {
 global:
   extern "C++" {
+    miral::MirRunner::wayland_display*;
+    miral::MirRunner::x11_display*;
     miral::WindowInfo::clip_area*;
   };
 } MIRAL_2.7;

--- a/tests/mir_test_framework/test_display_server.cpp
+++ b/tests/mir_test_framework/test_display_server.cpp
@@ -203,3 +203,8 @@ void miral::TestRuntimeEnvironment::add_to_environment(char const* key, char con
 {
     env.emplace_back(key, value);
 }
+
+void TestDisplayServer::invoke_runner(std::function<void(MirRunner& runner)> const& f)
+{
+    f(runner);
+}

--- a/tests/miral/runner.cpp
+++ b/tests/miral/runner.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Canonical Ltd.
+ * Copyright © 2016-2019 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -17,6 +17,7 @@
  */
 
 #include <miral/test_server.h>
+#include <miral/x11_support.h>
 
 #include <mir/test/signal.h>
 
@@ -58,4 +59,33 @@ TEST_F(Runner, start_callback_is_called)
 
     signal.wait_for(a_long_time);
     testing::Mock::VerifyAndClearExpectations(this);
+}
+
+TEST_F(Runner, wayland_socket_is_returned_by_default)
+{
+    miral::TestServer::SetUp();
+
+    miral::TestServer::invoke_runner([](auto& runner){ EXPECT_TRUE(runner.wayland_display().is_set()); });
+}
+
+TEST_F(Runner, x11_socket_is_not_returned_by_default)
+{
+    miral::TestServer::SetUp();
+
+    miral::TestServer::invoke_runner([](auto& runner){ EXPECT_FALSE(runner.x11_display().is_set()); });
+}
+
+TEST_F(Runner, x11_socket_is_returned_if_configured)
+{
+    miral::X11Support x11support;
+    add_server_init(x11support);
+    add_to_environment("MIR_SERVER_x11_DISPLAY_EXPERIMENTAL", "666");
+
+    miral::TestServer::SetUp();
+
+    miral::TestServer::invoke_runner([](auto& runner)
+    {
+        EXPECT_TRUE(runner.x11_display().is_set());
+        EXPECT_THAT(runner.x11_display().value(), Eq(":666"));
+    });
 }


### PR DESCRIPTION
[miral] Make it possible for servers to set up the environment for launching clients

Add MirRunner properties to retrieve the WAYLAND_DISPLAY and DISPLAY supported by the server.