### PR TITLE
miral: Fix glob syntax in symbols.map

### DIFF
--- a/src/miral/regenerate-miral-symbols-map.py
+++ b/src/miral/regenerate-miral-symbols-map.py
@@ -516,9 +516,9 @@ global:
     miral::WaylandExtensions::disable*;
     miral::WaylandExtensions::enable*;
 #    miral::WaylandExtensions::recommended*;
-    miral::WaylandExtensions::recommended[*;
+    miral::WaylandExtensions::recommended[[]*;
 #    miral::WaylandExtensions::supported*;
-    miral::WaylandExtensions::supported[*;
+    miral::WaylandExtensions::supported[[]*;
     miral::WaylandExtensions::zwlr_layer_shell_v1*;
     miral::WaylandExtensions::zxdg_output_manager_v1*;
     miral::WindowInfo::depth_layer*;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -433,9 +433,9 @@ global:
     miral::WaylandExtensions::disable*;
     miral::WaylandExtensions::enable*;
 #    miral::WaylandExtensions::recommended*;
-    miral::WaylandExtensions::recommended[*;
+    miral::WaylandExtensions::recommended[[]*;
 #    miral::WaylandExtensions::supported*;
-    miral::WaylandExtensions::supported[*;
+    miral::WaylandExtensions::supported[[]*;
     miral::WaylandExtensions::zwlr_layer_shell_v1*;
     miral::WaylandExtensions::zxdg_output_manager_v1*;
     miral::WindowInfo::depth_layer*;


### PR DESCRIPTION
The glob syntax treats '[' as the start of a character range, so lld is
pretty reasonable in rejecting a single '[' in the symbol name.

'[[]' (a character range containing only '[') is the correct way to match
a '[' in glob syntax.

Closes: #990