### PR TITLE
Don't try to draw cursor buffers that are not ready

### DIFF
--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -200,7 +200,8 @@ struct ms::CursorStreamImageAdapter
         }
 
         hotspot = new_hotspot;
-        post_cursor_image_from_current_buffer();
+        if (stream->buffers_ready_for_compositor(this))
+            post_cursor_image_from_current_buffer();
     }
 
 private:

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -200,8 +200,7 @@ struct ms::CursorStreamImageAdapter
         }
 
         hotspot = new_hotspot;
-        if (stream->buffers_ready_for_compositor(this))
-            post_cursor_image_from_current_buffer();
+        post_cursor_image_from_current_buffer();
     }
 
 private:
@@ -209,7 +208,10 @@ private:
     {
         if (stream->has_submitted_buffer())
         {
-            surface.set_cursor_from_buffer(*stream->lock_compositor_buffer(this), hotspot);
+            if (stream->buffers_ready_for_compositor(this))
+            {
+                surface.set_cursor_from_buffer(*stream->lock_compositor_buffer(this), hotspot);
+            }
         }
         else
         {

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -681,6 +681,8 @@ TEST_F(BasicSurfaceTest, notifies_when_cursor_stream_set)
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
     auto stub_buffer = std::make_shared<mtd::StubBuffer>();
 
+    ON_CALL(*buffer_stream, buffers_ready_for_compositor(_))
+        .WillByDefault(Return(1));
     ON_CALL(*buffer_stream, lock_compositor_buffer(_))
         .WillByDefault(Return(stub_buffer));
     EXPECT_CALL(mock_surface_observer, cursor_image_set_to(_, _));
@@ -718,6 +720,11 @@ TEST_F(BasicSurfaceTest, cursor_can_be_set_from_stream_that_started_empty)
             FAIL() << "frame_posted_callback should have been set by the surface";
         });
 
+    ON_CALL(*buffer_stream, buffers_ready_for_compositor(_))
+        .WillByDefault(Invoke([&](auto)
+            {
+                return stub_buffer != nullptr;
+            }));
     ON_CALL(*buffer_stream, has_submitted_buffer())
         .WillByDefault(Invoke([&]
             {

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -691,6 +691,24 @@ TEST_F(BasicSurfaceTest, notifies_when_cursor_stream_set)
     surface.set_cursor_stream(buffer_stream, {});
 }
 
+TEST_F(BasicSurfaceTest, does_not_notify_when_cursor_stream_set_has_no_buffers_ready)
+{
+    using namespace testing;
+
+    NiceMock<MockSurfaceObserver> mock_surface_observer;
+    auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
+    auto stub_buffer = std::make_shared<mtd::StubBuffer>();
+
+    ON_CALL(*buffer_stream, buffers_ready_for_compositor(_))
+        .WillByDefault(Return(0));
+    ON_CALL(*buffer_stream, lock_compositor_buffer(_))
+        .WillByDefault(Return(stub_buffer));
+    EXPECT_CALL(mock_surface_observer, cursor_image_set_to(_, _)).Times(0);
+
+    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.set_cursor_stream(buffer_stream, {});
+}
+
 TEST_F(BasicSurfaceTest, notifies_about_cursor_removal_when_empty_stream_set)
 {
     using namespace testing;


### PR DESCRIPTION
Don't try to draw cursor buffers that are not ready. (Fixes #1009)

This results from the MultiMonitorArbiter state machine being in a condition that was not anticipated for streams passed to `set_cursor_stream()`. (I don't think it was possible with the mirclient API.)

Specifically, although the stream has buffers posted, they have been consumed and the `current_buffer` is no longer ready.