### PR TITLE
Revert "Merge #1010"

### DIFF
--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -208,10 +208,7 @@ private:
     {
         if (stream->has_submitted_buffer())
         {
-            if (stream->buffers_ready_for_compositor(this))
-            {
-                surface.set_cursor_from_buffer(*stream->lock_compositor_buffer(this), hotspot);
-            }
+            surface.set_cursor_from_buffer(*stream->lock_compositor_buffer(this), hotspot);
         }
         else
         {

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -681,29 +681,9 @@ TEST_F(BasicSurfaceTest, notifies_when_cursor_stream_set)
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
     auto stub_buffer = std::make_shared<mtd::StubBuffer>();
 
-    ON_CALL(*buffer_stream, buffers_ready_for_compositor(_))
-        .WillByDefault(Return(1));
     ON_CALL(*buffer_stream, lock_compositor_buffer(_))
         .WillByDefault(Return(stub_buffer));
     EXPECT_CALL(mock_surface_observer, cursor_image_set_to(_, _));
-
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
-    surface.set_cursor_stream(buffer_stream, {});
-}
-
-TEST_F(BasicSurfaceTest, does_not_notify_when_cursor_stream_set_has_no_buffers_ready)
-{
-    using namespace testing;
-
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
-    auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
-    auto stub_buffer = std::make_shared<mtd::StubBuffer>();
-
-    ON_CALL(*buffer_stream, buffers_ready_for_compositor(_))
-        .WillByDefault(Return(0));
-    ON_CALL(*buffer_stream, lock_compositor_buffer(_))
-        .WillByDefault(Return(stub_buffer));
-    EXPECT_CALL(mock_surface_observer, cursor_image_set_to(_, _)).Times(0);
 
     surface.add_observer(mt::fake_shared(mock_surface_observer));
     surface.set_cursor_stream(buffer_stream, {});
@@ -738,11 +718,6 @@ TEST_F(BasicSurfaceTest, cursor_can_be_set_from_stream_that_started_empty)
             FAIL() << "frame_posted_callback should have been set by the surface";
         });
 
-    ON_CALL(*buffer_stream, buffers_ready_for_compositor(_))
-        .WillByDefault(Invoke([&](auto)
-            {
-                return stub_buffer != nullptr;
-            }));
     ON_CALL(*buffer_stream, has_submitted_buffer())
         .WillByDefault(Invoke([&]
             {


### PR DESCRIPTION
This reverts commit 391da119d1e0965f1b7c59b1a3cfbb64701332fa, reversing
changes made to d965d6af1afed7251ec3ef77b6a4d9aa52819dba.

The logic here is wrong - we want to draw the cursor even if this
particular cursor image has already been displayed on the current output
(ie: buffers_ready_for_compositor(this) == 0)