### PR TITLE
PixelSource::read() should execute the supplied block

### DIFF
--- a/src/server/frontend_wayland/wlshmbuffer.cpp
+++ b/src/server/frontend_wayland/wlshmbuffer.cpp
@@ -257,12 +257,8 @@ void mf::WlShmBuffer::write(unsigned char const *pixels, size_t size)
 void mf::WlShmBuffer::read(std::function<void(unsigned char const *)> const &do_with_pixels)
 {
     std::lock_guard <std::mutex> lock{wayland->mutex};
-    if (!wayland->buffer) {
-        log_warning("Attempt to read from WlShmBuffer after the wl_buffer has been destroyed");
-        return;
-    }
-
-    if (!consumed) {
+    if (!consumed)
+    {
         on_consumed();
         consumed = true;
     }


### PR DESCRIPTION
PixelSource::read() should execute the supplied block. (Fixes: #1009)

The WlShmBuffer::read() implementation failed to execute the do_with_pixels block when the underlying wl_buffer has been destroyed.

As the most recent buffer remains in the bufferstream until another buffer is submitted client code (e.g. CursorImageFromBuffer) cannot know that the PixelSource is no longer supported by an underlying wl_buffer.

I've removed the log that this is a logic_error as I don't see how the calling code can know.