### PR TITLE
Drop the last uses of deprecated alloc_buffer

### DIFF
--- a/src/server/graphics/software_cursor.cpp
+++ b/src/server/graphics/software_cursor.cpp
@@ -191,7 +191,7 @@ mg::SoftwareCursor::create_renderable_for(CursorImage const& cursor_image, geom:
         BOOST_THROW_EXCEPTION(std::logic_error("zero sized software cursor image is invalid"));
 
     auto new_renderable = std::make_shared<detail::CursorRenderable>(
-        allocator->alloc_buffer({cursor_image.size(), format, mg::BufferUsage::software}),
+        allocator->alloc_software_buffer(cursor_image.size(), format),
         position + hotspot - cursor_image.hotspot());
 
     // TODO: The buffer pixel format may not be argb_8888, leading to

--- a/src/server/input/touchspot_controller.cpp
+++ b/src/server/input/touchspot_controller.cpp
@@ -111,7 +111,7 @@ private:
 
 mi::TouchspotController::TouchspotController(std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
     std::shared_ptr<mi::Scene> const& scene)
-    : touchspot_buffer(allocator->alloc_buffer({touchspot_size, touchspot_pixel_format, mg::BufferUsage::software})),
+    : touchspot_buffer(allocator->alloc_software_buffer(touchspot_size, touchspot_pixel_format)),
       scene(scene),
       enabled(false),
       renderables_in_use(0)

--- a/tests/unit-tests/graphics/test_software_cursor.cpp
+++ b/tests/unit-tests/graphics/test_software_cursor.cpp
@@ -305,7 +305,7 @@ TEST_F(SoftwareCursor, new_buffer_on_each_show)
         std::vector<MirPixelFormat> supported_pixel_formats() { return {mir_pixel_format_abgr_8888}; } 
     } mock_allocator;
 
-    EXPECT_CALL(mock_allocator, alloc_buffer(testing::_))
+    EXPECT_CALL(mock_allocator, alloc_software_buffer(testing::_, testing::_))
         .Times(3)
         .WillRepeatedly(testing::Return(std::make_shared<mtd::StubBuffer>()));;
     mg::SoftwareCursor cursor{

--- a/tests/unit-tests/input/test_touchspot_controller.cpp
+++ b/tests/unit-tests/input/test_touchspot_controller.cpp
@@ -99,21 +99,13 @@ struct TestTouchspotController : public ::testing::Test
     std::shared_ptr<StubScene> const scene;
 };
 
-MATCHER(SoftwareBuffer, "")
-{
-    auto properties = static_cast<mg::BufferProperties const&>(arg);
-    if (properties.usage != mg::BufferUsage::software)
-        return false;
-    return true;
-}
-
 }
 
 TEST_F(TestTouchspotController, allocates_software_buffer_for_touchspots)
 {
     using namespace ::testing;
 
-    EXPECT_CALL(*allocator, alloc_buffer(SoftwareBuffer())).Times(1)
+    EXPECT_CALL(*allocator, alloc_software_buffer(_, _)).Times(1)
         .WillOnce(Return(std::make_shared<mtd::StubBuffer>()));
     mi::TouchspotController controller(allocator, scene);
 }
@@ -121,8 +113,8 @@ TEST_F(TestTouchspotController, allocates_software_buffer_for_touchspots)
 TEST_F(TestTouchspotController, touches_result_in_renderables_in_stack)
 {
     using namespace ::testing;
-    
-    EXPECT_CALL(*allocator, alloc_buffer(SoftwareBuffer())).Times(1)
+
+    EXPECT_CALL(*allocator, alloc_software_buffer(_, _)).Times(1)
         .WillOnce(Return(std::make_shared<mtd::StubBuffer>()));
     mi::TouchspotController controller(allocator, scene);
     controller.enable();
@@ -136,7 +128,7 @@ TEST_F(TestTouchspotController, spots_move)
 {
     using namespace ::testing;
     
-    EXPECT_CALL(*allocator, alloc_buffer(SoftwareBuffer())).Times(1)
+    EXPECT_CALL(*allocator, alloc_software_buffer(_, _)).Times(1)
         .WillOnce(Return(std::make_shared<mtd::StubBuffer>()));
     mi::TouchspotController controller(allocator, scene);
     controller.enable();
@@ -151,7 +143,7 @@ TEST_F(TestTouchspotController, multiple_spots)
 {
     using namespace ::testing;
     
-    EXPECT_CALL(*allocator, alloc_buffer(SoftwareBuffer())).Times(1)
+    EXPECT_CALL(*allocator, alloc_software_buffer(_, _)).Times(1)
         .WillOnce(Return(std::make_shared<mtd::StubBuffer>()));
     mi::TouchspotController controller(allocator, scene);
     controller.enable();
@@ -173,7 +165,7 @@ TEST_F(TestTouchspotController, touches_do_not_result_in_renderables_in_stack_wh
 {
     using namespace ::testing;
     
-    EXPECT_CALL(*allocator, alloc_buffer(SoftwareBuffer())).Times(1)
+    EXPECT_CALL(*allocator, alloc_software_buffer(_, _)).Times(1)
         .WillOnce(Return(std::make_shared<mtd::StubBuffer>()));
     mi::TouchspotController controller(allocator, scene);
     controller.enable();
@@ -202,7 +194,8 @@ struct TestTouchspotControllerSceneUpdates : public TestTouchspotController
     TestTouchspotControllerSceneUpdates()
         : scene(std::make_shared<StubSceneWithMockEmission>())
     {
-        EXPECT_CALL(*allocator, alloc_buffer(SoftwareBuffer())).Times(1)
+        using namespace ::testing;
+        EXPECT_CALL(*allocator, alloc_software_buffer(_, _)).Times(1)
             .WillOnce(testing::Return(std::make_shared<mtd::StubBuffer>()));
     }
 


### PR DESCRIPTION
Platforms which don't support mirclient won't support the
`alloc_buffer(BufferProperties const&)` method; switch the last two
remaining uses to `alloc_software_buffer()`.