### PR TITLE
scene::Surface: Add setters and getters for focus state

### DIFF
--- a/include/server/mir/scene/surface.h
+++ b/include/server/mir/scene/surface.h
@@ -117,13 +117,17 @@ public:
     virtual void placed_relative(geometry::Rectangle const& placement) = 0;
     virtual void start_drag_and_drop(std::vector<uint8_t> const& handle) = 0;
 
+    /// The depth layer the surface is on
+    /// It will be kept above all surfaces on lower layers, and below surfaces on higher layers
     virtual auto depth_layer() const -> MirDepthLayer = 0;
-    /**
-     * When the depth layer is changed, the surface becomes the top surface on that layer
-     */
+    /// When the depth layer is changed, the surface becomes the top surface on that layer
     virtual void set_depth_layer(MirDepthLayer depth_layer) = 0;
+
     virtual std::experimental::optional<geometry::Rectangle> clip_area() const = 0;
     virtual void set_clip_area(std::experimental::optional<geometry::Rectangle> const& area) = 0;
+
+    virtual auto focus_state() const -> MirWindowFocusState = 0;
+    virtual void set_focus_state(MirWindowFocusState focus_state) = 0;
 };
 }
 }

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -74,6 +74,8 @@ struct StubSurface : scene::Surface
     void set_depth_layer(MirDepthLayer depth_layer) override;
     std::experimental::optional<geometry::Rectangle> clip_area() const override;
     void set_clip_area(std::experimental::optional<geometry::Rectangle> const& area) override;
+    MirWindowFocusState focus_state() const override;
+    void set_focus_state(MirWindowFocusState new_state) override;
 };
 }
 }

--- a/src/server/frontend_wayland/wayland_surface_observer.cpp
+++ b/src/server/frontend_wayland/wayland_surface_observer.cpp
@@ -68,7 +68,7 @@ void mf::WaylandSurfaceObserver::attrib_changed(ms::Surface const*, MirWindowAtt
     case mir_window_attrib_focus:
         run_on_wayland_thread_unless_destroyed([this, value]()
             {
-                has_focus = static_cast<bool>(value);
+                auto has_focus = static_cast<bool>(value);
                 if (has_focus)
                     seat->notify_focus(client);
                 window->handle_active_change(has_focus);

--- a/src/server/frontend_wayland/wayland_surface_observer.h
+++ b/src/server/frontend_wayland/wayland_surface_observer.h
@@ -75,11 +75,6 @@ public:
         return timestamp;
     }
 
-    auto is_active() const -> bool
-    {
-        return has_focus;
-    }
-
     auto state() const -> MirWindowState
     {
         return current_state;
@@ -95,7 +90,6 @@ private:
     geometry::Size window_size;
     std::chrono::nanoseconds timestamp{0};
     std::experimental::optional<geometry::Size> requested_size;
-    bool has_focus{false};
     MirWindowState current_state{mir_window_state_unknown};
     MirPointerButtons last_pointer_buttons{0};
     std::experimental::optional<mir::geometry::Point> last_pointer_position;

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -290,7 +290,10 @@ auto mf::WindowWlSurfaceRole::window_state() -> MirWindowState
 
 auto mf::WindowWlSurfaceRole::is_active() -> bool
 {
-    return observer->is_active();
+    if (auto const scene_surface = weak_scene_surface.lock())
+        return scene_surface->focus_state() == mir_window_focus_state_focused;
+    else
+        return false;
 }
 
 std::chrono::nanoseconds mf::WindowWlSurfaceRole::latest_timestamp()

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -148,6 +148,9 @@ public:
     std::experimental::optional<geometry::Rectangle> clip_area() const override;
     void set_clip_area(std::experimental::optional<geometry::Rectangle> const& area) override;
 
+    auto focus_state() const -> MirWindowFocusState override;
+    void set_focus_state(MirWindowFocusState new_state) override;
+
 private:
     bool visible(std::lock_guard<std::mutex> const&) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
@@ -155,7 +158,6 @@ private:
     int set_dpi(int);
     MirWindowVisibility set_visibility(MirWindowVisibility v);
     int set_swap_interval(int);
-    MirWindowFocusState set_focus_state(MirWindowFocusState f);
     MirOrientationMode set_preferred_orientation(MirOrientationMode mode);
 
     SurfaceObservers observers;

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -387,7 +387,7 @@ void msh::AbstractShell::notify_focus_locked(
             if (find(begin(new_focus_tree), end(new_focus_tree), item) == end(new_focus_tree) ||
                 item == surface)
             {
-                item->configure(mir_window_attrib_focus, mir_window_focus_state_unfocused);
+                item->set_focus_state(mir_window_focus_state_unfocused);
             }
         }
 
@@ -413,7 +413,7 @@ void msh::AbstractShell::notify_focus_locked(
                 if (find(begin(current_focus_tree), end(current_focus_tree), item) == end(current_focus_tree) ||
                     item == surface)
                 {
-                    item->configure(mir_window_attrib_focus, mir_window_focus_state_focused);
+                    item->set_focus_state(mir_window_focus_state_focused);
                 }
             }
         }

--- a/tests/include/mir/test/doubles/stub_scene_surface.h
+++ b/tests/include/mir/test/doubles/stub_scene_surface.h
@@ -97,6 +97,9 @@ public:
 
     auto depth_layer() const -> MirDepthLayer override { return mir_depth_layer_application; }
     void set_depth_layer(MirDepthLayer /*depth_layer*/) override {}
+
+    auto focus_state() const -> MirWindowFocusState override { return mir_window_focus_state_unfocused; }
+    void set_focus_state(MirWindowFocusState /*focus_state*/) override {}
 };
 
 }

--- a/tests/mir_test_framework/stub_surface.cpp
+++ b/tests/mir_test_framework/stub_surface.cpp
@@ -214,6 +214,15 @@ void mtd::StubSurface::set_clip_area(std::experimental::optional<mir::geometry::
 {
 }
 
+MirWindowFocusState mtd::StubSurface::focus_state() const
+{
+    return mir_window_focus_state_unfocused;
+}
+
+void mtd::StubSurface::set_focus_state(MirWindowFocusState /*new_state*/)
+{
+}
+
 namespace
 {
 // Ensure we don't accidentally have an abstract class


### PR DESCRIPTION
The focus state property is currently only exposed by the old attribute system via `mir_window_attrib_focus`. This PR exposes it with a setter/getter (like other properties). The observer does not need to be changed since for better or for worse, that still uses attributes. This removes the need to cache the current focus state in `WindowWlSurfaceRole`s observer, and is required for the implementation of `wlr-foreign-toplevel-management`.