### PR TITLE
Fixes for new Protobuf on Arch

### DIFF
--- a/src/client/display_configuration.h
+++ b/src/client/display_configuration.h
@@ -27,10 +27,53 @@
 #include <vector>
 #include <memory>
 
-struct MirDisplayConfig : mir::protobuf::DisplayConfiguration
+struct MirDisplayConfig
 {
-    explicit MirDisplayConfig(mir::protobuf::DisplayConfiguration& pconfig) :
-        mir::protobuf::DisplayConfiguration::DisplayConfiguration{std::move(pconfig)} {}
+    MirDisplayConfig()
+    {
+    }
+
+    explicit MirDisplayConfig(mir::protobuf::DisplayConfiguration& wrapped) :
+        wrapped{std::move(wrapped)}
+    {
+    }
+
+    operator mir::protobuf::DisplayConfiguration const&() const
+    {
+        return wrapped;
+    }
+
+    int ByteSize() const
+    {
+        return wrapped.ByteSize();
+    }
+
+    uint8_t* SerializeWithCachedSizesToArray(uint8_t* target) const
+    {
+        return wrapped.SerializeWithCachedSizesToArray(target);
+    }
+
+    bool ParseFromArray(const void* data, int size)
+    {
+        return wrapped.ParseFromArray(data, size);
+    }
+
+    int display_output_size() const
+    {
+        return wrapped.display_output_size();
+    }
+
+    mir::protobuf::DisplayOutput const& display_output(int index) const
+    {
+        return wrapped.display_output(index);
+    }
+
+    mir::protobuf::DisplayOutput* mutable_display_output(int index)
+    {
+        return wrapped.mutable_display_output(index);
+    }
+
+    mir::protobuf::DisplayConfiguration wrapped;
 };
 
 namespace mir

--- a/src/client/mir_blob.cpp
+++ b/src/client/mir_blob.cpp
@@ -226,11 +226,11 @@ catch (std::exception const& x)
 MirDisplayConfig* mir_blob_to_display_config(MirBlob* blob)
 try
 {
-    auto config = new mir::protobuf::DisplayConfiguration;
+    auto config = new MirDisplayConfig;
 
     config->ParseFromArray(mir_blob_data(blob), mir_blob_size(blob));
 
-    return static_cast<MirDisplayConfig*>(config);
+    return config;
 }
 catch (std::exception const& x)
 {

--- a/src/client/rpc/mir_basic_rpc_channel.cpp
+++ b/src/client/rpc/mir_basic_rpc_channel.cpp
@@ -26,7 +26,7 @@
 #include "mir/protobuf/protocol_version.h"
 #include "mir/log.h"
 
-#if GOOGLE_PROTOBUF_VERSION >= 3008000
+#if GOOGLE_PROTOBUF_VERSION >= 3007000
 #include <google/protobuf/stubs/callback.h>
 #endif
 

--- a/src/include/common/mir/protobuf/display_server.h
+++ b/src/include/common/mir/protobuf/display_server.h
@@ -20,7 +20,7 @@
 #define MIR_PROTOBUF_DISPLAY_SERVER_H_
 
 #include "mir_protobuf.pb.h"
-#if GOOGLE_PROTOBUF_VERSION >= 3008000
+#if GOOGLE_PROTOBUF_VERSION >= 3007000
 #include <google/protobuf/stubs/callback.h>
 #endif
 

--- a/src/include/common/mir/protobuf/display_server_debug.h
+++ b/src/include/common/mir/protobuf/display_server_debug.h
@@ -20,7 +20,7 @@
 #define MIR_PROTOBUF_DISPLAY_SERVER_DEBUG_H_
 
 #include "mir_protobuf.pb.h"
-#if GOOGLE_PROTOBUF_VERSION >= 3008000
+#if GOOGLE_PROTOBUF_VERSION >= 3007000
 #include <google/protobuf/stubs/callback.h>
 #endif
 


### PR DESCRIPTION
We had a version check, but it appears it wasn't checking the right version. Also, some protobuf types have become `final`, so we can't inherit from them. `MirDisplayConfig` becomes a wrapper struct instead of a child struct, and `MirOutput` becomes an opaque struct that's typedef and casted to but never declared.