### PR TITLE
Bump xdg output to v3

### DIFF
--- a/src/server/frontend_wayland/xdg_output_v1.cpp
+++ b/src/server/frontend_wayland/xdg_output_v1.cpp
@@ -156,10 +156,18 @@ mf::XdgOutputV1::XdgOutputV1(
      */
     if (wl_resource_get_version(resource) >= 3)
     {
-        // TODO: Use wrapper methods once wl_output is is uing a wrapper
+        // TODO: Use wrapper methods once wl_output is is using a wrapper
         if (wl_resource_get_version(wl_output_resource) >= WL_OUTPUT_DONE_SINCE_VERSION)
         {
             wl_output_send_done(wl_output_resource);
+        }
+        else
+        {
+            log_warning(
+                "xdg_output_v1 is v%d (meaning Mir must send wl_output.done), "
+                "but wl_output is only v%d (meaning it can't)",
+                wl_resource_get_version(resource),
+                wl_resource_get_version(wl_output_resource));
         }
     }
     else

--- a/src/server/frontend_wayland/xdg_output_v1.cpp
+++ b/src/server/frontend_wayland/xdg_output_v1.cpp
@@ -134,11 +134,17 @@ mf::XdgOutputV1::XdgOutputV1(
     auto extents = config.extents();
     send_logical_position_event(extents.left().as_int(), extents.top().as_int());
     send_logical_size_event(extents.size.width.as_int(), extents.size.height.as_int());
-    // TODO: Better output names that are consistant between sessions
-    auto output_name = "OUT-" + std::to_string(config.id.as_value());
-    send_name_event(output_name);
+    if (version_supports_name())
+    {
+        // TODO: Better output names that are consistant between sessions
+        auto output_name = "OUT-" + std::to_string(config.id.as_value());
+        send_name_event(output_name);
+    }
     // not sending description is allowed
-    // send_description_event("TODO: set this");
+    // if (version_supports_description())
+    // {
+    //     send_description_event("TODO: set this");
+    // }
     send_done_event();
 }
 

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
@@ -114,9 +114,9 @@ struct mw::XdgOutputManagerV1::Thunks
     static void const* request_vtable[];
 };
 
-int const mw::XdgOutputManagerV1::Thunks::supported_version = 2;
+int const mw::XdgOutputManagerV1::Thunks::supported_version = 3;
 
-mw::XdgOutputManagerV1::XdgOutputManagerV1(struct wl_resource* resource, Version<2>)
+mw::XdgOutputManagerV1::XdgOutputManagerV1(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -137,7 +137,7 @@ void mw::XdgOutputManagerV1::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::XdgOutputManagerV1::Global::Global(wl_display* display, Version<2>)
+mw::XdgOutputManagerV1::Global::Global(wl_display* display, Version<3>)
     : wayland::Global{
           wl_global_create(
               display,
@@ -198,9 +198,9 @@ struct mw::XdgOutputV1::Thunks
     static void const* request_vtable[];
 };
 
-int const mw::XdgOutputV1::Thunks::supported_version = 2;
+int const mw::XdgOutputV1::Thunks::supported_version = 3;
 
-mw::XdgOutputV1::XdgOutputV1(struct wl_resource* resource, Version<2>)
+mw::XdgOutputV1::XdgOutputV1(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
@@ -30,7 +30,7 @@ public:
 
     static XdgOutputManagerV1* from(struct wl_resource*);
 
-    XdgOutputManagerV1(struct wl_resource* resource, Version<2>);
+    XdgOutputManagerV1(struct wl_resource* resource, Version<3>);
     virtual ~XdgOutputManagerV1() = default;
 
     void destroy_wayland_object() const;
@@ -45,7 +45,7 @@ public:
     class Global : public wayland::Global
     {
     public:
-        Global(wl_display* display, Version<2>);
+        Global(wl_display* display, Version<3>);
 
         auto interface_name() const -> char const* override;
 
@@ -66,7 +66,7 @@ public:
 
     static XdgOutputV1* from(struct wl_resource*);
 
-    XdgOutputV1(struct wl_resource* resource, Version<2>);
+    XdgOutputV1(struct wl_resource* resource, Version<3>);
     virtual ~XdgOutputV1() = default;
 
     void send_logical_position_event(int32_t x, int32_t y) const;

--- a/src/wayland/protocol/xdg-output-unstable-v1.xml
+++ b/src/wayland/protocol/xdg-output-unstable-v1.xml
@@ -54,7 +54,7 @@
     reset.
   </description>
 
-  <interface name="zxdg_output_manager_v1" version="2">
+  <interface name="zxdg_output_manager_v1" version="3">
     <description summary="manage xdg_output objects">
       A global factory interface for xdg_output objects.
     </description>
@@ -77,12 +77,17 @@
     </request>
   </interface>
 
-  <interface name="zxdg_output_v1" version="2">
+  <interface name="zxdg_output_v1" version="3">
     <description summary="compositor logical output region">
       An xdg_output describes part of the compositor geometry.
 
       This typically corresponds to a monitor that displays part of the
       compositor space.
+
+      For objects version 3 onwards, after all xdg_output properties have been
+      sent (when the object is created and when properties are updated), a
+      wl_output.done event is sent. This allows changes to the output
+      properties to be seen as atomic, even if they happen via multiple events.
     </description>
 
     <request name="destroy" type="destructor">
@@ -157,6 +162,10 @@
 
 	This allows changes to the xdg_output properties to be seen as
 	atomic, even if they happen via multiple events.
+
+	For objects version 3 onwards, this event is deprecated. Compositors
+	are not required to send it anymore and must send wl_output.done
+	instead.
       </description>
     </event>
 
@@ -197,10 +206,12 @@
 	output via :1'.
 
 	The description event is sent after creating an xdg_output (see
-	xdg_output_manager.get_xdg_output). This event is only sent once per
+	xdg_output_manager.get_xdg_output) and whenever the description
+	changes. The description is optional, and may not be sent at all.
+
+	For objects of version 2 and lower, this event is only sent once per
 	xdg_output, and the description does not change over the lifetime of
-	the wl_output global. The description is optional, and may not be sent
-	at all.
+	the wl_output global.
       </description>
       <arg name="description" type="string" summary="output description"/>
     </event>


### PR DESCRIPTION
Note that this is not a breaking protocol change. I'm bumping the backwards compatible version from 2 to 3. The protocol itself is still `xdg_output_unstable_v1`. No events or requests were added. The only change is that now the `wl_output.done` event is used to commit a change instead of `xdg_output_v1.done`