### PR TITLE
renderer: Also log supported EGL and GL extensions

### DIFF
--- a/src/renderers/gl/renderer.cpp
+++ b/src/renderers/gl/renderer.cpp
@@ -352,6 +352,7 @@ mrg::Renderer::Renderer(graphics::DisplayBuffer& display_buffer)
             {EGL_VENDOR,      "EGL vendor"},
             {EGL_VERSION,     "EGL version"},
             {EGL_CLIENT_APIS, "EGL client APIs"},
+            {EGL_EXTENSIONS,  "EGL extensions"},
         };
         for (auto& s : eglstrings)
         {
@@ -366,6 +367,7 @@ mrg::Renderer::Renderer(graphics::DisplayBuffer& display_buffer)
         {GL_RENDERER, "GL renderer"},
         {GL_VERSION,  "GL version"},
         {GL_SHADING_LANGUAGE_VERSION,  "GLSL version"},
+        {GL_EXTENSIONS, "GL extensions"},
     };
 
     for (auto& s : glstrings)


### PR DESCRIPTION
This is handy for checking that the platform really does support
the things that you think it does.