### PR TITLE
Add application_id surface property

### DIFF
--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -397,6 +397,8 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"miral::WindowInfo::attached_edges(MirPlacementGravity)@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowInfo::exclusive_rect() const@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowInfo::exclusive_rect(mir::optional_value<mir::geometry::Rectangle> const&)@MIRAL_2.7" 2.7.0
+ (c++)"miral::WindowSpecification::application_id[abi:cxx11]() const@MIRAL_2.7" 2.7.0
+ (c++)"miral::WindowSpecification::application_id[abi:cxx11]()@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowSpecification::attached_edges() const@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowSpecification::attached_edges()@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowSpecification::exclusive_rect() const@MIRAL_2.7" 2.7.0

--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -397,13 +397,15 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"miral::WindowInfo::attached_edges(MirPlacementGravity)@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowInfo::exclusive_rect() const@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowInfo::exclusive_rect(mir::optional_value<mir::geometry::Rectangle> const&)@MIRAL_2.7" 2.7.0
- (c++)"miral::WindowSpecification::application_id[abi:cxx11]() const@MIRAL_2.7" 2.7.0
- (c++)"miral::WindowSpecification::application_id[abi:cxx11]()@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowSpecification::attached_edges() const@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowSpecification::attached_edges()@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowSpecification::exclusive_rect() const@MIRAL_2.7" 2.7.0
  (c++)"miral::WindowSpecification::exclusive_rect()@MIRAL_2.7" 2.7.0
  MIRAL_2.8@MIRAL_2.8 2.8.0
+ (c++)"miral::WindowInfo::application_id(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIRAL_2.8" 2.8.0
+ (c++)"miral::WindowInfo::application_id[abi:cxx11]() const@MIRAL_2.8" 2.8.0
  (c++)"miral::WindowInfo::clip_area() const@MIRAL_2.8" 2.8.0
  (c++)"miral::WindowInfo::clip_area(mir::optional_value<mir::geometry::Rectangle> const&)@MIRAL_2.8" 2.8.0
  (c++)"miral::WindowManagementPolicy::ApplicationZoneAddendum::~ApplicationZoneAddendum()@MIRAL_2.6" 2.8.0
+ (c++)"miral::WindowSpecification::application_id[abi:cxx11]() const@MIRAL_2.8" 2.8.0
+ (c++)"miral::WindowSpecification::application_id[abi:cxx11]()@MIRAL_2.8" 2.8.0

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -140,6 +140,7 @@ struct WindowInfo
 
     /// The D-bus service name and basename of the app's .desktop file
     /// See http://standards.freedesktop.org/desktop-entry-spec/
+    /// \remark Since MirAL 2.8
     ///@{
     auto application_id() const -> std::string;
     void application_id(std::string const& application_id);

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -138,6 +138,13 @@ struct WindowInfo
     auto clip_area() const -> mir::optional_value<mir::geometry::Rectangle>;
     void clip_area(mir::optional_value<mir::geometry::Rectangle> const& area);
 
+    /// The D-bus service name and basename of the app's .desktop file
+    /// See http://standards.freedesktop.org/desktop-entry-spec/
+    ///@{
+    auto application_id() const -> std::string;
+    void application_id(std::string const& application_id);
+    ///@}
+
 private:
     struct Self;
     std::unique_ptr<Self> self;

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -149,6 +149,13 @@ public:
     auto exclusive_rect() -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>>&;
     ///@}
 
+    /// The D-bus service name and basename of the app's .desktop file
+    /// See http://standards.freedesktop.org/desktop-entry-spec/
+    ///@{
+    auto application_id() const -> mir::optional_value<std::string> const&;
+    auto application_id() -> mir::optional_value<std::string>&;
+    ///@}
+
 private:
     struct Self;
     std::unique_ptr<Self> self;

--- a/include/server/mir/scene/null_surface_observer.h
+++ b/include/server/mir/scene/null_surface_observer.h
@@ -55,6 +55,7 @@ public:
     void input_consumed(Surface const* surf, MirEvent const* event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
+    void application_id_set_to(Surface const* surf, std::string const& application_id) override;
 
 protected:
     NullSurfaceObserver(NullSurfaceObserver const&) = delete;

--- a/include/server/mir/scene/surface.h
+++ b/include/server/mir/scene/surface.h
@@ -131,9 +131,11 @@ public:
 
     /// Often the same as the session name, but on Wayland can be set on a per-window basis
     /// See xdg_toplevel.set_app_id and http://standards.freedesktop.org/desktop-entry-spec/ for more details
-    /// Empty string if not set
+    /// Defaults to empty string
+    ///@{
     virtual auto application_id() const -> std::string = 0;
     virtual void set_application_id(std::string const& application_id) = 0;
+    ///@}
 };
 }
 }

--- a/include/server/mir/scene/surface.h
+++ b/include/server/mir/scene/surface.h
@@ -128,6 +128,12 @@ public:
 
     virtual auto focus_state() const -> MirWindowFocusState = 0;
     virtual void set_focus_state(MirWindowFocusState focus_state) = 0;
+
+    /// Often the same as the session name, but on Wayland can be set on a per-window basis
+    /// See xdg_toplevel.set_app_id and http://standards.freedesktop.org/desktop-entry-spec/ for more details
+    /// Empty string if not set
+    virtual auto application_id() const -> std::string = 0;
+    virtual void set_application_id(std::string const& application_id) = 0;
 };
 }
 }

--- a/include/server/mir/scene/surface_creation_parameters.h
+++ b/include/server/mir/scene/surface_creation_parameters.h
@@ -129,6 +129,9 @@ struct SurfaceCreationParameters
     /// The area of this surface that will not be occluded
     /// Only used if surface is in state mir_window_state_attached and is attached to an edge (not a corner)
     optional_value<geometry::Rectangle> exclusive_rect;
+
+    /// See mir::scene::Surface::application_id()
+    optional_value<std::string> application_id;
 };
 
 bool operator==(const SurfaceCreationParameters& lhs, const SurfaceCreationParameters& rhs);

--- a/include/server/mir/scene/surface_observer.h
+++ b/include/server/mir/scene/surface_observer.h
@@ -72,6 +72,7 @@ public:
     virtual void input_consumed(Surface const* surf, MirEvent const* event) = 0;
     virtual void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) = 0;
     virtual void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) = 0;
+    virtual void application_id_set_to(Surface const* surf, std::string const& application_id) = 0;
 
 protected:
     SurfaceObserver() = default;

--- a/include/server/mir/shell/surface_specification.h
+++ b/include/server/mir/shell/surface_specification.h
@@ -112,6 +112,7 @@ struct SurfaceSpecification
 
     optional_value<MirPlacementGravity> attached_edges;
     optional_value<optional_value<geometry::Rectangle>> exclusive_rect;
+    optional_value<std::string> application_id;
 };
 }
 }

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -76,6 +76,8 @@ struct StubSurface : scene::Surface
     void set_clip_area(std::experimental::optional<geometry::Rectangle> const& area) override;
     MirWindowFocusState focus_state() const override;
     void set_focus_state(MirWindowFocusState new_state) override;
+    std::string application_id() const override;
+    void set_application_id(std::string const& application_id) override;
 };
 }
 }

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -58,6 +58,7 @@ public:
     void input_consumed(Surface const* surf, MirEvent const* event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
+    void application_id_set_to(Surface const* surf, std::string const& application_id) override;
 };
 
 }

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -939,6 +939,7 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
     COPY_IF_SET(depth_layer);
     COPY_IF_SET(attached_edges);
     COPY_IF_SET(exclusive_rect);
+    COPY_IF_SET(application_id);
 
 #undef COPY_IF_SET
 

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -486,6 +486,8 @@ global:
   extern "C++" {
     miral::MirRunner::wayland_display*;
     miral::MirRunner::x11_display*;
+    miral::WindowInfo::application_id*;
     miral::WindowInfo::clip_area*;
+    miral::WindowSpecification::application_id*;
   };
 } MIRAL_2.7;

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -672,3 +672,19 @@ void miral::WindowInfo::clip_area(mir::optional_value<mir::geometry::Rectangle> 
     else
         surface->set_clip_area(std::experimental::optional<mir::geometry::Rectangle>());
 }
+
+auto miral::WindowInfo::application_id() const -> std::string
+{
+    std::shared_ptr<mir::scene::Surface> surface = window();
+    if (surface)
+        return surface->application_id();
+    else
+        return "";
+}
+
+void miral::WindowInfo::application_id(std::string const& application_id)
+{
+    std::shared_ptr<mir::scene::Surface> surface = window();
+    if (surface)
+        return surface->set_application_id(application_id);
+}

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -62,6 +62,7 @@ struct miral::WindowSpecification::Self
     mir::optional_value<MirDepthLayer> depth_layer;
     mir::optional_value<MirPlacementGravity> attached_edges;
     mir::optional_value<mir::optional_value<mir::geometry::Rectangle>> exclusive_rect;
+    mir::optional_value<std::string> application_id;
     mir::optional_value<std::shared_ptr<void>> userdata;
 };
 
@@ -95,7 +96,8 @@ miral::WindowSpecification::Self::Self(mir::shell::SurfaceSpecification const& s
     confine_pointer(spec.confine_pointer),
     depth_layer(spec.depth_layer),
     attached_edges(spec.attached_edges),
-    exclusive_rect(spec.exclusive_rect)
+    exclusive_rect(spec.exclusive_rect),
+    application_id(spec.application_id)
 {
     if (spec.aux_rect_placement_offset_x.is_set() && spec.aux_rect_placement_offset_y.is_set())
         aux_rect_placement_offset = Displacement{spec.aux_rect_placement_offset_x.value(), spec.aux_rect_placement_offset_y.value()};
@@ -230,7 +232,8 @@ miral::WindowSpecification::Self::Self(mir::scene::SurfaceCreationParameters con
     confine_pointer(params.confine_pointer),
     depth_layer(params.depth_layer),
     attached_edges(params.attached_edges),
-    exclusive_rect(params.exclusive_rect)
+    exclusive_rect(params.exclusive_rect),
+    application_id(params.application_id)
 {
     if (params.aux_rect_placement_offset_x.is_set() && params.aux_rect_placement_offset_y.is_set())
         aux_rect_placement_offset = Displacement{params.aux_rect_placement_offset_x.value(), params.aux_rect_placement_offset_y.value()};
@@ -299,6 +302,7 @@ void miral::WindowSpecification::Self::update(mir::scene::SurfaceCreationParamet
     copy_if_set(params.depth_layer, depth_layer);
     copy_if_set(params.attached_edges, attached_edges);
     copy_if_set(params.exclusive_rect, exclusive_rect.value());
+    copy_if_set(params.application_id, application_id);
 
     if (aux_rect_placement_offset.is_set())
     {
@@ -626,6 +630,16 @@ auto miral::WindowSpecification::exclusive_rect()
     -> mir::optional_value<mir::optional_value<mir::geometry::Rectangle>>&
 {
     return self->exclusive_rect;
+}
+
+auto miral::WindowSpecification::application_id() const -> mir::optional_value<std::string> const&
+{
+    return self->application_id;
+}
+
+auto miral::WindowSpecification::application_id() -> mir::optional_value<std::string>&
+{
+    return self->application_id;
 }
 
 auto miral::WindowSpecification::userdata() -> mir::optional_value<std::shared_ptr<void>>&

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -141,6 +141,18 @@ void mf::WindowWlSurfaceRole::set_title(std::string const& title)
     }
 }
 
+void mf::WindowWlSurfaceRole::set_application_id(std::string const& application_id)
+{
+    if (weak_scene_surface.lock())
+    {
+        spec().application_id = application_id;
+    }
+    else
+    {
+        params->application_id = application_id;
+    }
+}
+
 void mf::WindowWlSurfaceRole::initiate_interactive_move()
 {
     if (auto const scene_surface = weak_scene_surface.lock())

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -78,6 +78,7 @@ public:
     void set_pending_width(std::experimental::optional<geometry::Width> const& width);
     void set_pending_height(std::experimental::optional<geometry::Height> const& height);
     void set_title(std::string const& title);
+    void set_application_id(std::string const& application_id);
     void initiate_interactive_move();
     void initiate_interactive_resize(MirResizeEdge edge);
     void set_parent(std::experimental::optional<std::shared_ptr<scene::Surface>> const& parent);

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -85,7 +85,7 @@ public:
     void destroy() override;
     void set_parent(std::experimental::optional<struct wl_resource*> const& parent) override;
     void set_title(std::string const& title) override;
-    void set_app_id(std::string const& /*app_id*/) override;
+    void set_app_id(std::string const& app_id) override;
     void show_window_menu(struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y) override;
     void move(struct wl_resource* seat, uint32_t serial) override;
     void resize(struct wl_resource* seat, uint32_t serial, uint32_t edges) override;
@@ -398,10 +398,9 @@ void mf::XdgToplevelStable::set_title(std::string const& title)
     WindowWlSurfaceRole::set_title(title);
 }
 
-void mf::XdgToplevelStable::set_app_id(std::string const& /*app_id*/)
+void mf::XdgToplevelStable::set_app_id(std::string const& app_id)
 {
-    // Logically this sets the session name, but Mir doesn't allow this (currently) and
-    // allowing e.g. "session_for_client(client)->name(app_id);" would break the libmirserver ABI
+    WindowWlSurfaceRole::set_application_id(app_id);
 }
 
 void mf::XdgToplevelStable::show_window_menu(struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y)

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -106,7 +106,7 @@ public:
     void destroy() override;
     void set_parent(std::experimental::optional<struct wl_resource*> const& parent) override;
     void set_title(std::string const& title) override;
-    void set_app_id(std::string const& /*app_id*/) override;
+    void set_app_id(std::string const& app_id) override;
     void show_window_menu(struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y) override;
     void move(struct wl_resource* seat, uint32_t serial) override;
     void resize(struct wl_resource* seat, uint32_t serial, uint32_t edges) override;
@@ -398,10 +398,9 @@ void mf::XdgToplevelV6::set_title(std::string const& title)
     WindowWlSurfaceRole::set_title(title);
 }
 
-void mf::XdgToplevelV6::set_app_id(std::string const& /*app_id*/)
+void mf::XdgToplevelV6::set_app_id(std::string const& app_id)
 {
-    // Logically this sets the session name, but Mir doesn't allow this (currently) and
-    // allowing e.g. "session_for_client(client)->name(app_id);" would break the libmirserver ABI
+    WindowWlSurfaceRole::set_application_id(app_id);
 }
 
 void mf::XdgToplevelV6::show_window_menu(struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y)

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -144,6 +144,8 @@ auto ms::ApplicationSession::create_surface(
         surface->set_input_region(params.input_shape.value());
     if (params.depth_layer.is_set())
         surface->set_depth_layer(params.depth_layer.value());
+    if (params.application_id.is_set())
+        surface->set_application_id(params.application_id.value());
 
     return surface;
 }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -159,6 +159,12 @@ void ms::SurfaceObservers::depth_layer_set_to(Surface const* surf, MirDepthLayer
                  { observer->depth_layer_set_to(surf, depth_layer); });
 }
 
+void ms::SurfaceObservers::application_id_set_to(Surface const* surf, std::string const& application_id)
+{
+    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
+                 { observer->application_id_set_to(surf, application_id); });
+}
+
 struct ms::CursorStreamImageAdapter
 {
     CursorStreamImageAdapter(ms::BasicSurface &surface)
@@ -992,4 +998,19 @@ void mir::scene::BasicSurface::set_focus_state(MirWindowFocusState new_state)
         lock.unlock();
         observers.attrib_changed(this, mir_window_attrib_focus, new_state);
     }
+}
+
+auto mir::scene::BasicSurface::application_id() const -> std::string
+{
+    std::unique_lock<std::mutex> lg(guard);
+    return application_id_;
+}
+
+void mir::scene::BasicSurface::set_application_id(std::string const& application_id)
+{
+    {
+        std::unique_lock<std::mutex> lg(guard);
+        application_id_ = application_id;
+    }
+    observers.application_id_set_to(this, application_id);
 }

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -151,6 +151,9 @@ public:
     auto focus_state() const -> MirWindowFocusState override;
     void set_focus_state(MirWindowFocusState new_state) override;
 
+    auto application_id() const -> std::string override;
+    void set_application_id(std::string const& application_id) override;
+
 private:
     bool visible(std::lock_guard<std::mutex> const&) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
@@ -189,6 +192,7 @@ private:
 
     MirDepthLayer depth_layer_ = mir_depth_layer_application;
     std::experimental::optional<geometry::Rectangle> clip_area_;
+    std::string application_id_;
 };
 
 }

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -45,3 +45,4 @@ void ms::NullSurfaceObserver::placed_relative(Surface const*, geometry::Rectangl
 void ms::NullSurfaceObserver::input_consumed(Surface const*, MirEvent const*) {}
 void ms::NullSurfaceObserver::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&) {}
 void ms::NullSurfaceObserver::depth_layer_set_to(Surface const*, MirDepthLayer) {}
+void ms::NullSurfaceObserver::application_id_set_to(Surface const*, std::string const&) {}

--- a/src/server/scene/surface_creation_parameters.cpp
+++ b/src/server/scene/surface_creation_parameters.cpp
@@ -253,9 +253,6 @@ bool ms::operator==(
         lhs.depth_layer == rhs.depth_layer &&
         lhs.attached_edges == rhs.attached_edges &&
         lhs.exclusive_rect == rhs.exclusive_rect &&
-        lhs.depth_layer == rhs.depth_layer &&
-        lhs.attached_edges == rhs.attached_edges &&
-        lhs.exclusive_rect == rhs.exclusive_rect &&
         lhs.application_id == rhs.application_id;
 }
 

--- a/src/server/scene/surface_creation_parameters.cpp
+++ b/src/server/scene/surface_creation_parameters.cpp
@@ -204,6 +204,8 @@ void ms::SurfaceCreationParameters::update_from(msh::SurfaceSpecification const&
         attached_edges = that.attached_edges;
     if (that.exclusive_rect.is_set())
         exclusive_rect = that.exclusive_rect.value();
+    if (that.application_id.is_set())
+        application_id = that.application_id.value();
     // TODO: should SurfaceCreationParameters support cursors?
 //     if (that.cursor_image.is_set())
 //         cursor_image = that.cursor_image;
@@ -250,7 +252,11 @@ bool ms::operator==(
         lhs.confine_pointer == rhs.confine_pointer &&
         lhs.depth_layer == rhs.depth_layer &&
         lhs.attached_edges == rhs.attached_edges &&
-        lhs.exclusive_rect == rhs.exclusive_rect;
+        lhs.exclusive_rect == rhs.exclusive_rect &&
+        lhs.depth_layer == rhs.depth_layer &&
+        lhs.attached_edges == rhs.attached_edges &&
+        lhs.exclusive_rect == rhs.exclusive_rect &&
+        lhs.application_id == rhs.application_id;
 }
 
 bool ms::operator!=(

--- a/src/server/shell/surface_specification.cpp
+++ b/src/server/shell/surface_specification.cpp
@@ -65,7 +65,8 @@ bool msh::SurfaceSpecification::is_empty() const
         !shell_chrome.is_set() &&
         !depth_layer.is_set() &&
         !attached_edges.is_set() &&
-        !exclusive_rect.is_set();
+        !exclusive_rect.is_set() &&
+        !application_id.is_set();
 }
 
 void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
@@ -140,4 +141,6 @@ void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
         attached_edges = that.attached_edges;
     if (that.exclusive_rect.is_set())
         exclusive_rect = that.exclusive_rect;
+    if (that.application_id.is_set())
+        application_id = that.application_id;
 }

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -941,3 +941,10 @@ MIR_SERVER_0.1.5 {
     mir::frontend::MirClientSession::*
   };
 } MIR_SERVER_0.1.4;
+
+MIR_SERVER_0.1.6 {
+ global:
+  extern "C++" {
+    mir::scene::NullSurfaceObserver::application_id_set_to*;
+  };
+} MIR_SERVER_0.1.5;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -938,13 +938,7 @@ MIR_SERVER_0.1.5 {
  global:
   extern "C++" {
     non-virtual?thunk?to?mir::scene::NullSurfaceObserver::depth_layer_set_to*;
-    mir::frontend::MirClientSession::*
-  };
-} MIR_SERVER_0.1.4;
-
-MIR_SERVER_0.1.6 {
- global:
-  extern "C++" {
+    mir::frontend::MirClientSession::*;
     mir::scene::NullSurfaceObserver::application_id_set_to*;
   };
-} MIR_SERVER_0.1.5;
+} MIR_SERVER_0.1.4;

--- a/tests/acceptance-tests/test_client_cursor_api.cpp
+++ b/tests/acceptance-tests/test_client_cursor_api.cpp
@@ -88,6 +88,7 @@ public:
     MOCK_METHOD2(input_consumed, void(msc::Surface const*, MirEvent const*));
     MOCK_METHOD2(start_drag_and_drop, void(msc::Surface const*, std::vector<uint8_t> const& handle));
     MOCK_METHOD2(depth_layer_set_to, void(msc::Surface const*, MirDepthLayer depth_layer));
+    MOCK_METHOD2(application_id_set_to, void(msc::Surface const*, std::string const& application_id));
 };
 
 

--- a/tests/include/mir/test/doubles/stub_scene_surface.h
+++ b/tests/include/mir/test/doubles/stub_scene_surface.h
@@ -100,6 +100,9 @@ public:
 
     auto focus_state() const -> MirWindowFocusState override { return mir_window_focus_state_unfocused; }
     void set_focus_state(MirWindowFocusState /*focus_state*/) override {}
+
+    auto application_id() const -> std::string override { return ""; }
+    void set_application_id(std::string const& /*application_id*/) override {}
 };
 
 }

--- a/tests/mir_test_framework/stub_surface.cpp
+++ b/tests/mir_test_framework/stub_surface.cpp
@@ -223,6 +223,15 @@ void mtd::StubSurface::set_focus_state(MirWindowFocusState /*new_state*/)
 {
 }
 
+std::string mtd::StubSurface::application_id() const
+{
+    return "";
+}
+
+void mtd::StubSurface::set_application_id(std::string const& /*application_id*/)
+{
+}
+
 namespace
 {
 // Ensure we don't accidentally have an abstract class


### PR DESCRIPTION
This will be something like `org.gnome.gedit`. Generally the same for all toplevels of a given application, but XDG shell allows setting it on a per-surface bases so so do we. It will be needed for foreign toplevel control, but also I though would be useful to MirAL.