### PR TITLE
Convert buffer stream to cursor images in wl_pointer

### DIFF
--- a/include/server/mir/frontend/surface.h
+++ b/include/server/mir/frontend/surface.h
@@ -52,6 +52,7 @@ public:
     virtual auto primary_buffer_stream() const -> std::shared_ptr<frontend::BufferStream> = 0;
 
     virtual void set_cursor_image(std::shared_ptr<graphics::CursorImage> const& image) = 0;
+    /// \deprecated can be removed along with mirclient
     virtual void set_cursor_stream(
         std::shared_ptr<frontend::BufferStream> const& image,
         geometry::Displacement const& hotspot) = 0;

--- a/include/server/mir/shell/surface_specification.h
+++ b/include/server/mir/shell/surface_specification.h
@@ -104,6 +104,7 @@ struct SurfaceSpecification
     optional_value<MirShellChrome> shell_chrome;
     optional_value<MirPointerConfinementState> confine_pointer;
     optional_value<std::shared_ptr<graphics::CursorImage>> cursor_image;
+    /// \deprecated can be removed along with mirclient
     optional_value<StreamCursor> stream_cursor;
 
     /// Child surfaces are by default created on the same layer as their parent, and updating the depth layer of a parent

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -33,6 +33,7 @@
 
 #include <linux/input-event-codes.h>
 #include <boost/throw_exception.hpp>
+#include <string.h> // memcpy
 
 namespace mf = mir::frontend;
 namespace ms = mir::scene;

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -260,6 +260,7 @@ void mf::WlPointer::set_cursor(
         if (!compositor_stream)
             BOOST_THROW_EXCEPTION(std::logic_error("Surface does not have a compositor buffer stream"));
 
+        cursor.reset(); // Destroy the old cursor *before* creating a new one with potentially the same stream
         cursor = std::make_unique<WlStreamCursor>(compositor_stream, cursor_hotspot);
     }
     else

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -118,6 +118,7 @@ public:
     void remove_cursor_image(); // Removes the cursor image without resetting the stream
     std::shared_ptr<graphics::CursorImage> cursor_image() const override;
 
+    /// \deprecated can be removed along with mirclient
     void set_cursor_stream(std::shared_ptr<frontend::BufferStream> const& stream,
                            geometry::Displacement const& hotspot) override;
     void set_cursor_from_buffer(graphics::Buffer& buffer,
@@ -185,6 +186,7 @@ private:
     MirOrientationMode pref_orientation_mode = mir_orientation_mode_any;
     MirPointerConfinementState confine_pointer_state_ = mir_pointer_unconfined;
 
+    /// \deprecated can be removed along with mirclient
     std::unique_ptr<CursorStreamImageAdapter> const cursor_stream_adapter;
 
     MirDepthLayer depth_layer_ = mir_depth_layer_application;


### PR DESCRIPTION
Fixes #1000

Unfortunately, the old paths are still used by mirclient so I can't get rid of them, but once we drop that `basic_surface` should no longer deal with stream cursors.