### PR TITLE
Remove false optimization that short-cut assigning a cursor surface for the second and subsequent times

### DIFF
--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -94,11 +94,16 @@ void mf::WlPointer::leave()
 {
     if (!surface_under_cursor)
         return;
-    surface_under_cursor.value()->remove_destroy_listener(this);
+    auto const surface = surface_under_cursor.value();
+    surface->remove_destroy_listener(this);
+    if (auto mir_surface = surface->scene_surface())
+    {
+        // TODO [purge-mirclient] We should clean up once we've got no mirclient to support:
+        // Called for side-effect set_cursor_image() implicitly detatches the cursor stream
+        mir_surface.value()->set_cursor_image({});
+    }
     auto const serial = wl_display_next_serial(display);
-    send_leave_event(
-        serial,
-        surface_under_cursor.value()->raw_resource());
+    send_leave_event(serial, surface->raw_resource());
     can_send_frame = true;
     surface_under_cursor = std::experimental::nullopt;
 }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -182,22 +182,20 @@ struct ms::CursorStreamImageAdapter
 
     void update(std::shared_ptr<mf::BufferStream> const& new_stream, geom::Displacement const& new_hotspot)
     {
-        if (new_stream == stream && new_hotspot == hotspot)
+        if (stream && new_stream != stream)
         {
-            return;
+            stream->set_frame_posted_callback([](auto){});
         }
-        else if (new_stream != stream)
-        {
-            if (stream)
-                stream->set_frame_posted_callback([](auto){});
 
-            stream = std::dynamic_pointer_cast<mc::BufferStream>(new_stream);
-            stream->set_frame_posted_callback(
-                [this](auto)
-                {
-                    this->post_cursor_image_from_current_buffer();
-                });
-        }
+        stream = std::dynamic_pointer_cast<mc::BufferStream>(new_stream);
+
+        if (!stream) mir::fatal_error("Invalid stream used for cursor");
+
+        stream->set_frame_posted_callback(
+            [this](auto)
+            {
+                this->post_cursor_image_from_current_buffer();
+            });
 
         hotspot = new_hotspot;
         post_cursor_image_from_current_buffer();


### PR DESCRIPTION
Remove false optimization that short-cut assigning a cursor surface for the second and subsequent times. (Fixes: #1000)

(This didn't work if it has been assigned to another surface meanwhile.)