### PR TITLE
More wl_pointer improvements

### DIFF
--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -299,14 +299,11 @@ void mf::WlPointer::release()
 WlSurfaceCursor::WlSurfaceCursor(mf::WlSurface* surface, geom::Displacement hotspot)
     : surface{surface},
       surface_destroyed{surface->destroyed_flag()},
-      stream{std::dynamic_pointer_cast<mc::BufferStream>(surface->stream)},
+      stream{surface->stream},
       surface_role{surface},
       hotspot{hotspot}
 {
     surface->set_role(&surface_role);
-
-    if (!stream)
-        BOOST_THROW_EXCEPTION(std::logic_error("Surface does not have a compositor buffer stream"));
 
     stream->set_frame_posted_callback(
         [this](auto)

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -143,7 +143,7 @@ auto mf::WlSurface::scene_surface() const -> std::experimental::optional<std::sh
 void mf::WlSurface::set_role(WlSurfaceRole* role_)
 {
     if (role != &null_role)
-        BOOST_THROW_EXCEPTION(std::logic_error("Surface already has a role"));
+        BOOST_THROW_EXCEPTION(std::runtime_error("Surface already has a role"));
     role = role_;
 }
 

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -39,6 +39,7 @@
 #include "mir/log.h"
 
 #include <algorithm>
+#include <boost/throw_exception.hpp>
 
 namespace mf = mir::frontend;
 namespace geom = mir::geometry;
@@ -141,6 +142,8 @@ auto mf::WlSurface::scene_surface() const -> std::experimental::optional<std::sh
 
 void mf::WlSurface::set_role(WlSurfaceRole* role_)
 {
+    if (role != &null_role)
+        BOOST_THROW_EXCEPTION(std::logic_error("Surface already has a role"));
     role = role_;
 }
 

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -50,10 +50,12 @@ namespace geometry
 {
 class Rectangle;
 }
-
-namespace frontend
+namespace compositor
 {
 class BufferStream;
+}
+namespace frontend
+{
 class WlSurface;
 class WlSubsurface;
 
@@ -143,7 +145,7 @@ public:
     void remove_destroy_listener(void const* key);
 
     std::shared_ptr<scene::Session> const session;
-    std::shared_ptr<mir::frontend::BufferStream> const stream;
+    std::shared_ptr<compositor::BufferStream> const stream;
 
     static WlSurface* from(wl_resource* resource);
 


### PR DESCRIPTION
Stacked on #1033

Makes `WlSurface` throw if a surface role is set without the previous one being cleared (not sure why it didn't already). This allows a surface to loose one role and gain a different one, which isn't *technically* allowed by Wayland, but it's an improvement.

 Makes the wl_pointer cursor set a null surface role, so the surface can't be given a different role or be used by a different wl_pointer (this would have exposed the bug in #1033).