### PR TITLE
Add session property to surfaces

### DIFF
--- a/include/server/mir/scene/null_surface_observer.h
+++ b/include/server/mir/scene/null_surface_observer.h
@@ -56,6 +56,8 @@ public:
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
     void application_id_set_to(Surface const* surf, std::string const& application_id) override;
+    void session_set_to(Surface const* surf, std::shared_ptr<Session> const& session) override;
+    void session_cleared(Surface const* surf) override;
 
 protected:
     NullSurfaceObserver(NullSurfaceObserver const&) = delete;

--- a/include/server/mir/scene/surface.h
+++ b/include/server/mir/scene/surface.h
@@ -44,6 +44,7 @@ struct StreamInfo
 };
 
 class SurfaceObserver;
+class Session;
 
 class Surface :
     public input::Surface,
@@ -135,6 +136,14 @@ public:
     ///@{
     virtual auto application_id() const -> std::string = 0;
     virtual void set_application_id(std::string const& application_id) = 0;
+    ///@}
+
+    /// Defaults to nullopt
+    /// Setting to nullptr is allowed, and will result in getter returning nullopt
+    /// If the getter returns a value, it will never be nullptr
+    ///@{
+    virtual auto session() const -> std::experimental::optional<std::shared_ptr<Session>> = 0;
+    virtual void set_session(std::shared_ptr<Session> const& session) = 0;
     ///@}
 };
 }

--- a/include/server/mir/scene/surface_observer.h
+++ b/include/server/mir/scene/surface_observer.h
@@ -28,6 +28,7 @@
 #include <glm/glm.hpp>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace mir
 {
@@ -44,6 +45,7 @@ class CursorImage;
 namespace scene
 {
 class Surface;
+class Session;
 
 class SurfaceObserver
 {
@@ -73,6 +75,8 @@ public:
     virtual void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) = 0;
     virtual void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) = 0;
     virtual void application_id_set_to(Surface const* surf, std::string const& application_id) = 0;
+    virtual void session_set_to(Surface const* surf, std::shared_ptr<Session> const& session) = 0;
+    virtual void session_cleared(Surface const* surf) = 0;
 
 protected:
     SurfaceObserver() = default;

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -78,6 +78,8 @@ struct StubSurface : scene::Surface
     void set_focus_state(MirWindowFocusState new_state) override;
     std::string application_id() const override;
     void set_application_id(std::string const& application_id) override;
+    std::experimental::optional<std::shared_ptr<scene::Session>> session() const  override;
+    void set_session(std::shared_ptr<scene::Session> const& session) override;
 };
 }
 }

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -59,6 +59,8 @@ public:
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
     void application_id_set_to(Surface const* surf, std::string const& application_id) override;
+    void session_set_to(Surface const* surf, std::shared_ptr<Session> const& session) override;
+    void session_cleared(Surface const* surf) override;
 };
 
 }

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -76,6 +76,7 @@ ms::ApplicationSession::~ApplicationSession()
     for (auto const& surface : surfaces)
     {
         session_listener->destroying_surface(*this, surface);
+        surface->set_session(nullptr);
         surface_stack->remove_surface(surface);
     }
 }
@@ -166,6 +167,7 @@ void ms::ApplicationSession::destroy_surface(std::shared_ptr<Surface> const& sur
         surfaces.erase(surface_iter);
     }
 
+    surface->set_session(nullptr);
     surface_stack->remove_surface(surface);
 }
 

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -1017,3 +1017,18 @@ void mir::scene::BasicSurface::set_application_id(std::string const& application
         observers.application_id_set_to(this, application_id);
     }
 }
+
+auto mir::scene::BasicSurface::session() const -> std::experimental::optional<std::shared_ptr<Session>>
+{
+    std::lock_guard<std::mutex> lock(guard);
+    if (auto const session = session_.lock())
+        return session;
+    else
+        return std::experimental::nullopt;
+}
+
+void mir::scene::BasicSurface::set_session(std::shared_ptr<Session> const& session)
+{
+    std::lock_guard<std::mutex> lock(guard);
+    session_ = session;
+}

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -155,6 +155,9 @@ public:
     auto application_id() const -> std::string override;
     void set_application_id(std::string const& application_id) override;
 
+    auto session() const -> std::experimental::optional<std::shared_ptr<Session>> override;
+    void set_session(std::shared_ptr<Session> const& session) override;
+
 private:
     bool visible(std::lock_guard<std::mutex> const&) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
@@ -195,6 +198,8 @@ private:
     MirDepthLayer depth_layer_ = mir_depth_layer_application;
     std::experimental::optional<geometry::Rectangle> clip_area_;
     std::string application_id_;
+
+    std::weak_ptr<Session> session_;
 };
 
 }

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -46,3 +46,5 @@ void ms::NullSurfaceObserver::input_consumed(Surface const*, MirEvent const*) {}
 void ms::NullSurfaceObserver::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&) {}
 void ms::NullSurfaceObserver::depth_layer_set_to(Surface const*, MirDepthLayer) {}
 void ms::NullSurfaceObserver::application_id_set_to(Surface const*, std::string const&) {}
+void ms::NullSurfaceObserver::session_set_to(Surface const*, std::shared_ptr<Session> const&) {}
+void ms::NullSurfaceObserver::session_cleared(Surface const*) {}

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -142,7 +142,9 @@ auto msh::AbstractShell::create_surface(
 {
     auto const build = [observer](std::shared_ptr<ms::Session> const& session, ms::SurfaceCreationParameters const& placed_params)
         {
-            return session->create_surface(placed_params, observer);
+            auto const surface = session->create_surface(placed_params, observer);
+            surface->set_session(session);
+            return surface;
         };
 
     auto const result = window_manager->add_surface(session, params, build);

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -935,3 +935,11 @@ MIR_SERVER_DETAIL_FOR_TESTING_1.4 {
     mir::run_mir*;
   };
 } MIR_SERVER_0.1.5;
+
+MIR_SERVER_0.1.6 {
+ global:
+  extern "C++" {
+    mir::scene::NullSurfaceObserver::session_set_to*;
+    mir::scene::NullSurfaceObserver::session_cleared*;
+  };
+} MIR_SERVER_0.1.5;

--- a/tests/acceptance-tests/test_client_cursor_api.cpp
+++ b/tests/acceptance-tests/test_client_cursor_api.cpp
@@ -89,6 +89,8 @@ public:
     MOCK_METHOD2(start_drag_and_drop, void(msc::Surface const*, std::vector<uint8_t> const& handle));
     MOCK_METHOD2(depth_layer_set_to, void(msc::Surface const*, MirDepthLayer depth_layer));
     MOCK_METHOD2(application_id_set_to, void(msc::Surface const*, std::string const& application_id));
+    MOCK_METHOD2(session_set_to, void(msc::Surface const*, std::shared_ptr<msc::Session> const& session));
+    MOCK_METHOD1(session_cleared, void(msc::Surface const*));
 };
 
 

--- a/tests/include/mir/test/doubles/mock_surface.h
+++ b/tests/include/mir/test/doubles/mock_surface.h
@@ -68,6 +68,9 @@ struct MockSurface : public scene::BasicSurface
     MOCK_CONST_METHOD0(primary_buffer_stream, std::shared_ptr<frontend::BufferStream>());
     MOCK_METHOD1(set_streams, void(std::list<scene::StreamInfo> const&));
 
+    MOCK_CONST_METHOD0(session, std::experimental::optional<std::shared_ptr<scene::Session>>());
+    MOCK_METHOD1(set_session, void(std::shared_ptr<scene::Session> const&));
+
     std::shared_ptr<MockBufferStream> const stream;
 };
 

--- a/tests/include/mir/test/doubles/stub_scene_surface.h
+++ b/tests/include/mir/test/doubles/stub_scene_surface.h
@@ -103,6 +103,9 @@ public:
 
     auto application_id() const -> std::string override { return ""; }
     void set_application_id(std::string const& /*application_id*/) override {}
+
+    auto session() const -> std::experimental::optional<std::shared_ptr<scene::Session>> override { return {}; }
+    void set_session(std::shared_ptr<scene::Session> const& /*session*/) override {}
 };
 
 }

--- a/tests/mir_test_framework/stub_surface.cpp
+++ b/tests/mir_test_framework/stub_surface.cpp
@@ -232,6 +232,15 @@ void mtd::StubSurface::set_application_id(std::string const& /*application_id*/)
 {
 }
 
+std::experimental::optional<std::shared_ptr<mir::scene::Session>> mtd::StubSurface::session() const
+{
+    return {};
+}
+
+void mtd::StubSurface::set_session(std::shared_ptr<scene::Session> const& /*session*/)
+{
+}
+
 namespace
 {
 // Ensure we don't accidentally have an abstract class


### PR DESCRIPTION
Adds and tests a new session property to surfaces. Allows modifying a surface without also storing it's session (will allow the implementation of foreign toplevel control). This could also allow us to reduce the number of places a surface is passed around with its session. Since a surface only ever belongs to a single session, it makes more sense to just pass around the surface and get the session when we need it.