### PR TITLE
Add Immutable session property to surfaces

### DIFF
--- a/include/server/mir/scene/session.h
+++ b/include/server/mir/scene/session.h
@@ -83,7 +83,13 @@ public:
     virtual void suspend_prompt_session() = 0;
     virtual void resume_prompt_session() = 0;
 
+    /// \param session can be nullptr (useful for testing). If not nullptr, must be equal to this. Must be passed in
+    ///                because std::enable_shared_from_this causes trouble
+    /// \param params data used to create the surface
+    /// \param observer automatically added to surface after creation
+    /// \return a newly created surface
     virtual auto create_surface(
+        std::shared_ptr<Session> const& session,
         SurfaceCreationParameters const& params,
         std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<Surface> = 0;
     virtual void destroy_surface(std::shared_ptr<Surface> const& surface) = 0;

--- a/include/server/mir/scene/surface.h
+++ b/include/server/mir/scene/surface.h
@@ -44,6 +44,7 @@ struct StreamInfo
 };
 
 class SurfaceObserver;
+class Session;
 
 class Surface :
     public input::Surface,
@@ -136,6 +137,9 @@ public:
     virtual auto application_id() const -> std::string = 0;
     virtual void set_application_id(std::string const& application_id) = 0;
     ///@}
+
+    /// The session this surface was created by
+    virtual auto session() const -> std::weak_ptr<Session> = 0;
 };
 }
 }

--- a/include/server/mir/scene/surface_factory.h
+++ b/include/server/mir/scene/surface_factory.h
@@ -29,6 +29,7 @@ namespace compositor { class BufferStream; }
 namespace scene
 {
 class Surface;
+class Session;
 class StreamInfo;
 
 class SurfaceFactory
@@ -38,6 +39,7 @@ public:
     virtual ~SurfaceFactory() = default;
 
     virtual std::shared_ptr<Surface> create_surface(
+        std::shared_ptr<Session> const& session,
         std::list<scene::StreamInfo> const& streams,
         SurfaceCreationParameters const& params) = 0;
 

--- a/include/test/mir/test/doubles/stub_session.h
+++ b/include/test/mir/test/doubles/stub_session.h
@@ -57,6 +57,7 @@ struct StubSession : scene::Session
     void resume_prompt_session() override;
 
     auto create_surface(
+        std::shared_ptr<Session> const& session,
         scene::SurfaceCreationParameters const& params,
         std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<scene::Surface> override;
 

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -78,6 +78,7 @@ struct StubSurface : scene::Surface
     void set_focus_state(MirWindowFocusState new_state) override;
     std::string application_id() const override;
     void set_application_id(std::string const& application_id) override;
+    std::weak_ptr<scene::Session> session() const  override;
 };
 }
 }

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -86,9 +86,7 @@ auto ms::ApplicationSession::create_surface(
     std::shared_ptr<ms::SurfaceObserver> const& observer) -> std::shared_ptr<Surface>
 {
     if (session && session.get() != this)
-    {
-        BOOST_THROW_EXCEPTION(std::logic_error("Incorrect session"));
-    }
+        fatal_error("Incorrect session");
 
     //TODO: we take either the content or the first stream's content for now.
     //      Once the surface factory interface takes more than one stream,

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -81,9 +81,15 @@ ms::ApplicationSession::~ApplicationSession()
 }
 
 auto ms::ApplicationSession::create_surface(
+    std::shared_ptr<Session> const& session,
     SurfaceCreationParameters const& the_params,
     std::shared_ptr<ms::SurfaceObserver> const& observer) -> std::shared_ptr<Surface>
 {
+    if (session && session.get() != this)
+    {
+        BOOST_THROW_EXCEPTION(std::logic_error("Incorrect session"));
+    }
+
     //TODO: we take either the content or the first stream's content for now.
     //      Once the surface factory interface takes more than one stream,
     //      we can take all the streams as content.
@@ -116,7 +122,7 @@ auto ms::ApplicationSession::create_surface(
             streams.push_back({std::dynamic_pointer_cast<mc::BufferStream>(stream.stream.lock()), stream.displacement, stream.size});
     }
 
-    auto surface = surface_factory->create_surface(streams, params);
+    auto surface = surface_factory->create_surface(session, streams, params);
 
     surface_stack->add_surface(surface, params.input_mode);
 

--- a/src/server/scene/application_session.h
+++ b/src/server/scene/application_session.h
@@ -48,8 +48,7 @@ class SnapshotStrategy;
 class BufferStreamFactory;
 class SurfaceFactory;
 
-class ApplicationSession
-    : public Session
+class ApplicationSession : public Session
 {
 public:
     ApplicationSession(
@@ -66,6 +65,7 @@ public:
     ~ApplicationSession();
 
     auto create_surface(
+        std::shared_ptr<Session> const& session,
         SurfaceCreationParameters const& params,
         std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<Surface> override;
     void destroy_surface(std::shared_ptr<Surface> const& surface) override;

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -243,6 +243,7 @@ std::shared_ptr<mc::BufferStream> default_stream(std::list<ms::StreamInfo> const
 }
 
 ms::BasicSurface::BasicSurface(
+    std::shared_ptr<Session> const& session,
     std::string const& name,
     geometry::Rectangle rect,
     std::weak_ptr<Surface> const& parent,
@@ -263,7 +264,8 @@ ms::BasicSurface::BasicSurface(
     parent_(parent),
     layers(layers),
     confine_pointer_state_(state),
-    cursor_stream_adapter{std::make_unique<ms::CursorStreamImageAdapter>(*this)}
+    cursor_stream_adapter{std::make_unique<ms::CursorStreamImageAdapter>(*this)},
+    session_{session}
 {
     auto callback = [this](auto const& size) { observers.frame_posted(this, 1, size); };
 
@@ -275,13 +277,14 @@ ms::BasicSurface::BasicSurface(
 }
 
 ms::BasicSurface::BasicSurface(
+    std::shared_ptr<Session> const& session,
     std::string const& name,
     geometry::Rectangle rect,
     MirPointerConfinementState state,
     std::list<StreamInfo> const& layers,
     std::shared_ptr<mg::CursorImage> const& cursor_image,
     std::shared_ptr<SceneReport> const& report) :
-    BasicSurface(name, rect, std::shared_ptr<Surface>{nullptr}, state, layers,
+    BasicSurface(session, name, rect, std::shared_ptr<Surface>{nullptr}, state, layers,
                  cursor_image, report)
 {
 }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -1017,3 +1017,9 @@ void mir::scene::BasicSurface::set_application_id(std::string const& application
         observers.application_id_set_to(this, application_id);
     }
 }
+
+auto mir::scene::BasicSurface::session() const -> std::weak_ptr<Session>
+{
+    std::lock_guard<std::mutex> lock(guard);
+    return session_;
+}

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -59,6 +59,7 @@ class BasicSurface : public Surface
 {
 public:
     BasicSurface(
+        std::shared_ptr<Session> const& session,
         std::string const& name,
         geometry::Rectangle rect,
         MirPointerConfinementState state,
@@ -67,6 +68,7 @@ public:
         std::shared_ptr<SceneReport> const& report);
 
     BasicSurface(
+        std::shared_ptr<Session> const& session,
         std::string const& name,
         geometry::Rectangle rect,
         std::weak_ptr<Surface> const& parent,

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -155,6 +155,8 @@ public:
     auto application_id() const -> std::string override;
     void set_application_id(std::string const& application_id) override;
 
+    auto session() const -> std::weak_ptr<Session> override;
+
 private:
     bool visible(std::lock_guard<std::mutex> const&) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
@@ -195,6 +197,8 @@ private:
     MirDepthLayer depth_layer_ = mir_depth_layer_application;
     std::experimental::optional<geometry::Rectangle> clip_area_;
     std::string application_id_;
+
+    std::weak_ptr<Session> session_;
 };
 
 }

--- a/src/server/scene/surface_allocator.cpp
+++ b/src/server/scene/surface_allocator.cpp
@@ -37,11 +37,13 @@ ms::SurfaceAllocator::SurfaceAllocator(
 }
 
 std::shared_ptr<ms::Surface> ms::SurfaceAllocator::create_surface(
+    std::shared_ptr<Session> const& session,
     std::list<ms::StreamInfo> const& streams,
     SurfaceCreationParameters const& params)
 {
     auto confine = params.confine_pointer.is_set() ? params.confine_pointer.value() : mir_pointer_unconfined;
     auto const surface = std::make_shared<BasicSurface>(
+        session,
         params.name,
         geom::Rectangle{params.top_left, params.size},
         params.parent,

--- a/src/server/scene/surface_allocator.h
+++ b/src/server/scene/surface_allocator.h
@@ -40,6 +40,7 @@ public:
          std::shared_ptr<SceneReport> const& report);
 
     std::shared_ptr<Surface> create_surface(
+        std::shared_ptr<Session> const& session,
         std::list<scene::StreamInfo> const& streams,
         SurfaceCreationParameters const& params) override;
 

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -142,7 +142,7 @@ auto msh::AbstractShell::create_surface(
 {
     auto const build = [observer](std::shared_ptr<ms::Session> const& session, ms::SurfaceCreationParameters const& placed_params)
         {
-            return session->create_surface(placed_params, observer);
+            return session->create_surface(session, placed_params, observer);
         };
 
     auto const result = window_manager->add_surface(session, params, build);

--- a/tests/include/mir/test/doubles/mock_scene_session.h
+++ b/tests/include/mir/test/doubles/mock_scene_session.h
@@ -37,8 +37,9 @@ namespace doubles
 
 struct MockSceneSession : public scene::Session
 {
-    MOCK_METHOD2(create_surface,
+    MOCK_METHOD3(create_surface,
         std::shared_ptr<scene::Surface>(
+            std::shared_ptr<Session> const&,
             scene::SurfaceCreationParameters const&,
             std::shared_ptr<scene::SurfaceObserver> const&));
     MOCK_METHOD1(destroy_surface, void(std::shared_ptr<scene::Surface> const&));

--- a/tests/include/mir/test/doubles/mock_surface.h
+++ b/tests/include/mir/test/doubles/mock_surface.h
@@ -37,6 +37,7 @@ struct MockSurface : public scene::BasicSurface
     MockSurface() :
         scene::BasicSurface(
             {},
+            {},
             {{},{}},
             mir_pointer_unconfined,
             { { std::make_shared<testing::NiceMock<MockBufferStream>>(), {0, 0}, {} } },

--- a/tests/include/mir/test/doubles/stub_scene_surface.h
+++ b/tests/include/mir/test/doubles/stub_scene_surface.h
@@ -103,6 +103,8 @@ public:
 
     auto application_id() const -> std::string override { return ""; }
     void set_application_id(std::string const& /*application_id*/) override {}
+
+    auto session() const -> std::weak_ptr<scene::Session> override { return {}; }
 };
 
 }

--- a/tests/include/mir/test/doubles/stub_surface_factory.h
+++ b/tests/include/mir/test/doubles/stub_surface_factory.h
@@ -34,6 +34,7 @@ class StubSurfaceFactory : public scene::SurfaceFactory
 {
 public:
     std::shared_ptr<scene::Surface> create_surface(
+        std::shared_ptr<scene::Session> const&,
         std::list<scene::StreamInfo> const&,
         scene::SurfaceCreationParameters const& params) override
     {

--- a/tests/integration-tests/test_error_reporting.cpp
+++ b/tests/integration-tests/test_error_reporting.cpp
@@ -111,6 +111,7 @@ TEST_F(ErrorReporting, c_api_returns_surface_creation_error)
         {
             std::shared_ptr<mir::scene::Surface>
             create_surface(
+                std::shared_ptr<mir::scene::Session> const&,
                 std::list<mir::scene::StreamInfo> const&,
                 mir::scene::SurfaceCreationParameters const&) override
             {

--- a/tests/integration-tests/test_session.cpp
+++ b/tests/integration-tests/test_session.cpp
@@ -110,6 +110,7 @@ TEST(ApplicationSession, stress_test_take_snapshot)
     mg::BufferProperties properties(geom::Size{1,1}, mir_pixel_format_abgr_8888, mg::BufferUsage::software);
     auto stream = std::dynamic_pointer_cast<mc::BufferStream>(session.create_buffer_stream(properties));
     session.create_surface(
+        nullptr /* session */,
         ms::a_surface().with_buffer_stream(stream),
         std::make_shared<ms::NullSurfaceObserver>());
 

--- a/tests/integration-tests/test_surface_stack_with_compositor.cpp
+++ b/tests/integration-tests/test_surface_stack_with_compositor.cpp
@@ -127,6 +127,7 @@ struct SurfaceStackCompositor : public Test
         mock_buffer_stream(std::make_shared<NiceMock<mtd::MockBufferStream>>()),
         streams({ { stream, {0,0}, {} } }),
         stub_surface{std::make_shared<ms::BasicSurface>(
+            nullptr /* session */,
             std::string("stub"),
             geom::Rectangle{{0,0},{1,1}},
             mir_pointer_unconfined,

--- a/tests/mir_test_framework/stub_session.cpp
+++ b/tests/mir_test_framework/stub_session.cpp
@@ -81,6 +81,7 @@ void mtd::StubSession::resume_prompt_session()
 }
 
 auto mtd::StubSession::create_surface(
+    std::shared_ptr<Session> const& /*session*/,
     mir::scene::SurfaceCreationParameters const& /*params*/,
     std::shared_ptr<scene::SurfaceObserver> const& /*observer*/) -> std::shared_ptr<ms::Surface>
 {

--- a/tests/mir_test_framework/stub_surface.cpp
+++ b/tests/mir_test_framework/stub_surface.cpp
@@ -232,6 +232,11 @@ void mtd::StubSurface::set_application_id(std::string const& /*application_id*/)
 {
 }
 
+std::weak_ptr<mir::scene::Session> mtd::StubSurface::session() const
+{
+    return {};
+}
+
 namespace
 {
 // Ensure we don't accidentally have an abstract class

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -131,6 +131,7 @@ struct StubSurface : mir::test::doubles::StubSurface
 struct StubStubSession : mir::test::doubles::StubSession
 {
     auto create_surface(
+        std::shared_ptr<mir::scene::Session> const& /*session*/,
         mir::scene::SurfaceCreationParameters const& params,
         std::shared_ptr<mir::scene::SurfaceObserver> const& /*observer*/) -> std::shared_ptr<mir::scene::Surface> override
     {
@@ -285,7 +286,7 @@ auto mt::TestWindowManagerTools::create_surface(
 {
     // This type is Mir-internal, I hope we don't need to create it here
     std::shared_ptr<mir::scene::SurfaceObserver> const observer;
-    return session->create_surface(params, observer);
+    return session->create_surface(nullptr, params, observer);
 }
 
 auto mt::TestWindowManagerTools::create_fake_display_configuration(std::vector<miral::Rectangle> outputs)

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -123,8 +123,10 @@ struct MockSessionManager : ms::SessionManager
 
 struct MockSurfaceFactory : public ms::SurfaceFactory
 {
-    MOCK_METHOD2(create_surface, std::shared_ptr<ms::Surface>(
-        std::list<ms::StreamInfo> const&, ms::SurfaceCreationParameters const&));
+    MOCK_METHOD3(create_surface, std::shared_ptr<ms::Surface>(
+        std::shared_ptr<ms::Session> const&,
+        std::list<ms::StreamInfo> const&,
+        ms::SurfaceCreationParameters const&));
 };
 
 using NiceMockWindowManager = NiceMock<mtd::MockWindowManager>;
@@ -164,7 +166,7 @@ struct AbstractShell : Test
             WillByDefault(Invoke(&session_manager, &MockSessionManager::unmocked_set_focus_to));
         ON_CALL(mock_surface, size())
             .WillByDefault(Return(geom::Size{}));
-        ON_CALL(surface_factory, create_surface(_,_))
+        ON_CALL(surface_factory, create_surface(_, _, _))
             .WillByDefault(Return(mt::fake_shared(mock_surface)));
         ON_CALL(seat, create_device_state())
             .WillByDefault(Invoke(
@@ -222,7 +224,7 @@ TEST_F(AbstractShell, close_session_removes_existing_session_surfaces_from_windo
     mtd::StubSurface surface1;
     mtd::StubSurface surface2;
     mtd::StubSurface surface3;
-    EXPECT_CALL(surface_factory, create_surface(_,_)).
+    EXPECT_CALL(surface_factory, create_surface(_, _, _)).
         WillOnce(Return(mt::fake_shared(surface1))).
         WillOnce(Return(mt::fake_shared(surface2))).
         WillOnce(Return(mt::fake_shared(surface3)));
@@ -469,7 +471,7 @@ TEST_F(AbstractShell, as_focus_controller_focused_surface_follows_focus)
     auto const session1 = shell.open_session(__LINE__, "Bla", std::shared_ptr<mf::EventSink>());
     NiceMock<mtd::MockSurface> dummy_surface;
     ON_CALL(dummy_surface, size()).WillByDefault(Return(geom::Size{}));
-    EXPECT_CALL(surface_factory, create_surface(_,_)).Times(AnyNumber())
+    EXPECT_CALL(surface_factory, create_surface(_, _, _)).Times(AnyNumber())
         .WillOnce(Return(mt::fake_shared(dummy_surface)))
         .WillOnce(Return(mt::fake_shared(mock_surface)));
 

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -281,6 +281,22 @@ TEST_F(AbstractShell, create_surface_allows_window_manager_to_set_create_paramet
     shell.create_surface(session, params, nullptr);
 }
 
+TEST_F(AbstractShell, create_surface_sets_surfaces_session)
+{
+    auto const mock_surface = std::make_shared<mtd::MockSurface>();
+
+    std::shared_ptr<ms::Session> session =
+        shell.open_session(__LINE__, "XPlane", std::shared_ptr<mf::EventSink>());
+
+    EXPECT_CALL(surface_factory, create_surface(session, _, _)).
+        WillOnce(Return(mock_surface));
+
+    auto params = ms::a_surface()
+        .with_buffer_stream(session->create_buffer_stream(properties));
+
+    shell.create_surface(session, params, nullptr);
+}
+
 TEST_F(AbstractShell, destroy_surface_removes_surface_from_window_manager)
 {
     std::shared_ptr<ms::Session> const session =

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -88,6 +88,7 @@ struct BasicSurfaceTest : public testing::Test
     std::list<ms::StreamInfo> streams { { mock_buffer_stream, {}, {} } };
 
     ms::BasicSurface surface{
+        nullptr /* session */,
         name,
         rect,
         mir_pointer_unconfined,
@@ -123,10 +124,14 @@ TEST_F(BasicSurfaceTest, buffer_stream_ids_always_unique)
     for (auto& surface : surfaces)
     {
         surface = std::make_unique<ms::BasicSurface>(
-                name, rect, mir_pointer_unconfined,
+                nullptr /* session */,
+                name,
+                rect,
+                mir_pointer_unconfined,
                 std::list<ms::StreamInfo> {
                     { std::make_shared<testing::NiceMock<mtd::MockBufferStream>>(), {}, {} } },
-                std::shared_ptr<mg::CursorImage>(), report);
+                std::shared_ptr<mg::CursorImage>(),
+                report);
         for (auto& renderable : surface->generate_renderables(this))
             ids.insert(renderable->id());
     }
@@ -143,8 +148,13 @@ TEST_F(BasicSurfaceTest, id_never_invalid)
     for (auto& surface : surfaces)
     {
         surface = std::make_unique<ms::BasicSurface>(
-                name, rect, mir_pointer_unconfined, streams,
-                std::shared_ptr<mg::CursorImage>(), report);
+                nullptr /* session */,
+                name,
+                rect,
+                mir_pointer_unconfined,
+                streams,
+                std::shared_ptr<mg::CursorImage>(),
+                report);
 
         for (auto& renderable : surface->generate_renderables(this))
             EXPECT_THAT(renderable->id(), testing::Ne(nullptr));
@@ -249,6 +259,7 @@ TEST_F(BasicSurfaceTest, test_surface_visibility)
 
     // Must be a fresh surface to guarantee no frames posted yet...
     ms::BasicSurface surface{
+        nullptr /* session */,
         name,
         rect,
         mir_pointer_unconfined,
@@ -287,6 +298,7 @@ TEST_F(BasicSurfaceTest, default_region_is_surface_rectangle)
     geom::Point pt(1,1);
     geom::Size one_by_one{geom::Width{1}, geom::Height{1}};
     ms::BasicSurface surface{
+        nullptr /* session */,
         name,
         geom::Rectangle{pt, one_by_one},
         mir_pointer_unconfined,
@@ -322,6 +334,7 @@ TEST_F(BasicSurfaceTest, default_region_is_surface_rectangle)
 TEST_F(BasicSurfaceTest, default_invisible_surface_doesnt_get_input)
 {
     ms::BasicSurface surface{
+        nullptr /* session */,
         name,
         geom::Rectangle{{0,0}, {100,100}},
         mir_pointer_unconfined,
@@ -340,6 +353,7 @@ TEST_F(BasicSurfaceTest, default_invisible_surface_doesnt_get_input)
 TEST_F(BasicSurfaceTest, surface_doesnt_get_input_outside_clip_area)
 {
     ms::BasicSurface surface{
+        nullptr /* session */,
         name,
         geom::Rectangle{{0,0}, {100,100}},
         mir_pointer_unconfined,
@@ -483,6 +497,7 @@ TEST_F(BasicSurfaceTest, stores_parent)
 {
     auto parent = mt::fake_shared(surface);
     ms::BasicSurface child{
+        nullptr /* session */,
         name,
         geom::Rectangle{{0,0}, {100,100}},
         parent,
@@ -1054,6 +1069,7 @@ TEST_F(BasicSurfaceTest, registers_frame_callbacks_on_construction)
     EXPECT_CALL(*buffer_stream1, set_frame_posted_callback(_));
 
     ms::BasicSurface child{
+        nullptr /* session */,
         name,
         geom::Rectangle{{0,0}, {100,100}},
         std::weak_ptr<ms::Surface>{},

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -30,6 +30,7 @@
 #include "mir/test/doubles/stub_cursor_image.h"
 #include "mir/test/doubles/mock_buffer_stream.h"
 #include "mir/test/doubles/stub_buffer.h"
+#include "mir/test/doubles/stub_session.h"
 #include "mir/test/fake_shared.h"
 
 #include "src/server/report/null_report_factory.h"
@@ -113,6 +114,23 @@ TEST_F(BasicSurfaceTest, basics)
     EXPECT_EQ(rect.top_left, surface.top_left());
     for (auto& renderable : surface.generate_renderables(this))
         EXPECT_FALSE(renderable->shaped());
+}
+
+TEST_F(BasicSurfaceTest, can_be_created_with_session)
+{
+    using namespace testing;
+
+    auto const session = std::make_shared<mtd::StubSession>();
+    ms::BasicSurface surface{
+        session,
+        name,
+        geom::Rectangle{{0,0}, {100,100}},
+        mir_pointer_unconfined,
+        streams,
+        std::shared_ptr<mg::CursorImage>(),
+        report};
+
+    EXPECT_THAT(surface.session().lock(), Eq(session));
 }
 
 TEST_F(BasicSurfaceTest, buffer_stream_ids_always_unique)

--- a/tests/unit-tests/scene/test_session_manager.cpp
+++ b/tests/unit-tests/scene/test_session_manager.cpp
@@ -69,6 +69,7 @@ struct MockSessionEventSink : public ms::SessionEventSink
 struct SessionManagerSetup : public testing::Test
 {
     std::shared_ptr<ms::Surface> dummy_surface = std::make_shared<ms::BasicSurface>(
+        nullptr /* session */,
         std::string("stub"),
         geom::Rectangle{{},{}},
         mir_pointer_unconfined,
@@ -178,7 +179,7 @@ TEST_F(SessionManagerSessionListenerSetup, additional_listeners_receive_surface_
     auto session = session_manager.open_session(__LINE__, "XPlane", std::shared_ptr<mf::EventSink>());
     auto bs = std::dynamic_pointer_cast<mc::BufferStream>(session->create_buffer_stream(
         mg::BufferProperties{{640, 480}, mir_pixel_format_abgr_8888, mg::BufferUsage::hardware}));
-    session->create_surface(ms::SurfaceCreationParameters().with_buffer_stream(bs), mt::fake_shared(observer));
+    session->create_surface(nullptr, ms::SurfaceCreationParameters().with_buffer_stream(bs), mt::fake_shared(observer));
 }
 
 namespace

--- a/tests/unit-tests/scene/test_surface.cpp
+++ b/tests/unit-tests/scene/test_surface.cpp
@@ -175,10 +175,14 @@ namespace
 struct SurfaceCreation : public ::testing::Test
 {
     SurfaceCreation()
-        : surface(surface_name,
-            rect, mir_pointer_unconfined,
+        : surface(
+            nullptr /* session */,
+            surface_name,
+            rect,
+            mir_pointer_unconfined,
             streams,
-            nullptr /* cursor_image */, report)
+            nullptr /* cursor_image */,
+            report)
     {
     }
 
@@ -309,6 +313,7 @@ TEST_F(SurfaceCreation, consume_calls_send_event)
 {
     using namespace testing;
     ms::BasicSurface surface(
+        nullptr /* session */,
         surface_name,
         rect,
         mir_pointer_unconfined,

--- a/tests/unit-tests/scene/test_surface_impl.cpp
+++ b/tests/unit-tests/scene/test_surface_impl.cpp
@@ -82,10 +82,13 @@ struct Surface : testing::Test
             .WillByDefault(InvokeArgument<0>(nullptr));
         
         surface = std::make_shared<ms::BasicSurface>(
-            std::string("stub"), geom::Rectangle{{},{}},
+            nullptr /* session */,
+            std::string("stub"),
+            geom::Rectangle{{},{}},
             mir_pointer_unconfined,
             std::list<ms::StreamInfo> { { buffer_stream, {}, {} } },
-            nullptr, report);
+            nullptr,
+            report);
     }
 
     mf::SurfaceId stub_id;
@@ -274,6 +277,7 @@ TEST_F(Surface, preferred_orientation_mode_defaults_to_any)
     using namespace testing;
 
     ms::BasicSurface surf(
+        nullptr /* session */,
         std::string("stub"),
         geom::Rectangle{{},{}},
         mir_pointer_unconfined,

--- a/tests/unit-tests/scene/test_surface_stack.cpp
+++ b/tests/unit-tests/scene/test_surface_stack.cpp
@@ -92,6 +92,7 @@ struct SurfaceStack : public ::testing::Test
         default_params = ms::a_surface().of_size(geom::Size{geom::Width{1024}, geom::Height{768}});
 
         stub_surface1 = std::make_shared<ms::BasicSurface>(
+            nullptr /* session */,
             std::string("stub"),
             geom::Rectangle{{},{}},
             mir_pointer_unconfined,
@@ -100,6 +101,7 @@ struct SurfaceStack : public ::testing::Test
             report);
 
         stub_surface2 = std::make_shared<ms::BasicSurface>(
+            nullptr /* session */,
             std::string("stub"),
             geom::Rectangle{{},{}},
             mir_pointer_unconfined,
@@ -109,6 +111,7 @@ struct SurfaceStack : public ::testing::Test
 
         
         stub_surface3 = std::make_shared<ms::BasicSurface>(
+            nullptr /* session */,
             std::string("stub"),
             geom::Rectangle{{},{}},
             mir_pointer_unconfined,
@@ -118,6 +121,7 @@ struct SurfaceStack : public ::testing::Test
 
         
         invisible_stub_surface = std::make_shared<ms::BasicSurface>(
+            nullptr /* session */,
             std::string("stub"),
             geom::Rectangle{{},{}},
             mir_pointer_unconfined,
@@ -234,6 +238,7 @@ TEST_F(SurfaceStack, scene_counts_pending_accurately)
     auto stream = std::make_shared<mc::Stream>(geom::Size{ 1, 1 }, mir_pixel_format_abgr_8888);
 
     auto surface = std::make_shared<ms::BasicSurface>(
+        nullptr /* session */,
         std::string("stub"),
         geom::Rectangle{{},{}},
         mir_pointer_unconfined,
@@ -267,6 +272,7 @@ TEST_F(SurfaceStack, scene_doesnt_count_pending_frames_from_occluded_surfaces)
     stack.register_compositor(this);
     auto stream = std::make_shared<mtd::StubBufferStream>();
     auto surface = std::make_shared<ms::BasicSurface>(
+        nullptr /* session */,
         std::string("stub"),
         geom::Rectangle{{},{}},
         mir_pointer_unconfined,
@@ -299,6 +305,7 @@ TEST_F(SurfaceStack, scene_doesnt_count_pending_frames_from_partially_exposed_su
     stack.register_compositor(comp2);
     auto stream = std::make_shared<mtd::StubBufferStream>();
     auto surface = std::make_shared<ms::BasicSurface>(
+        nullptr /* session */,
         std::string("stub"),
         geom::Rectangle{{},{}},
         mir_pointer_unconfined,
@@ -411,6 +418,7 @@ TEST_F(SurfaceStack, generate_elementelements)
     for(auto i = 0u; i < num_surfaces; i++)
     {
         auto const surface = std::make_shared<ms::BasicSurface>(
+            nullptr /* session */,
             std::string("stub"),
             geom::Rectangle{geom::Point{3 * i, 4 * i},geom::Size{1 * i, 2 * i}},
             mir_pointer_unconfined,
@@ -594,6 +602,7 @@ TEST_F(SurfaceStack, scene_elements_hold_snapshot_of_positioning_info)
     for(auto i = 0u; i < num_surfaces; i++)
     {
         auto const surface = std::make_shared<ms::BasicSurface>(
+            nullptr /* session */,
             std::string("stub"),
             geom::Rectangle{geom::Point{3 * i, 4 * i},geom::Size{1 * i, 2 * i}},
             mir_pointer_unconfined,
@@ -625,6 +634,7 @@ TEST_F(SurfaceStack, generates_scene_elements_that_delay_buffer_acquisition)
         .Times(0);
 
     auto const surface = std::make_shared<ms::BasicSurface>(
+        nullptr /* session */,
         std::string("stub"),
         geom::Rectangle{geom::Point{3, 4},geom::Size{1, 2}},
         mir_pointer_unconfined,
@@ -653,6 +663,7 @@ TEST_F(SurfaceStack, generates_scene_elements_that_allow_only_one_buffer_acquisi
         .WillOnce(Return(std::make_shared<mtd::StubBuffer>()));
 
     auto const surface = std::make_shared<ms::BasicSurface>(
+        nullptr /* session */,
         std::string("stub"),
         geom::Rectangle{geom::Point{3, 4},geom::Size{1, 2}},
         mir_pointer_unconfined,
@@ -674,6 +685,7 @@ struct MockConfigureSurface : public ms::BasicSurface
 {
     MockConfigureSurface() :
         ms::BasicSurface(
+            {},
             {},
             {{},{}},
             mir_pointer_unconfined,


### PR DESCRIPTION
Adds and tests an immutable session property to surfaces. Alternative to #1041 