### PR TITLE
WindowWlSurfaceRole: don't consume optional if empty

### DIFF
--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -175,7 +175,7 @@ void mf::WindowWlSurfaceRole::set_parent(std::experimental::optional<std::shared
     {
         if (parent)
             spec().parent = parent.value();
-        else
+        else if (spec().parent)
             spec().parent.consume();
     }
     else


### PR DESCRIPTION
fixes #1053. Tested by https://github.com/MirServer/wlcs/pull/146