### PR TITLE
Don't call modify_window if size bounds have been set to the same value

### DIFF
--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -49,14 +49,14 @@ geom::Size const max_possible_size{
 /// Clears pending if it holds a value different than cache
 /// sets cache to pending and leaves pending alone if it holds a different value
 template<typename T>
-inline void clear_pending_if_unchanged(mir::optional_value<T>* pending, T* cache)
+inline void clear_pending_if_unchanged(mir::optional_value<T>& pending, T& cache)
 {
-    if (*pending)
+    if (pending)
     {
-        if (pending->value() == *cache)
-            pending->consume();
+        if (pending.value() == cache)
+            pending.consume();
         else
-            *cache = pending->value();
+            cache = pending.value();
     }
 }
 }
@@ -360,10 +360,10 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
 
         if (pending_changes)
         {
-            clear_pending_if_unchanged(&pending_changes->min_width,  &committed_min_size.width);
-            clear_pending_if_unchanged(&pending_changes->min_height, &committed_min_size.height);
-            clear_pending_if_unchanged(&pending_changes->max_width,  &committed_max_size.width);
-            clear_pending_if_unchanged(&pending_changes->max_height, &committed_max_size.height);
+            clear_pending_if_unchanged(pending_changes->min_width,  committed_min_size.width);
+            clear_pending_if_unchanged(pending_changes->min_height, committed_min_size.height);
+            clear_pending_if_unchanged(pending_changes->max_width,  committed_max_size.width);
+            clear_pending_if_unchanged(pending_changes->max_height, committed_max_size.height);
         }
 
         if (pending_changes && !pending_changes->is_empty())

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -335,7 +335,7 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
             populate_spec_with_surface_data(spec());
         }
 
-        if (pending_changes)
+        if (pending_changes && !pending_changes->is_empty())
             shell->modify_surface(session, scene_surface, *pending_changes);
 
         pending_changes.reset();

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -419,13 +419,6 @@ void mf::WindowWlSurfaceRole::apply_pending_size_bounds()
 
         }
     }
-    else
-    {
-        if (params->min_width)  committed_min_size.width  = params->min_width.value();
-        if (params->min_height) committed_min_size.height = params->min_height.value();
-        if (params->max_width)  committed_max_size.width  = params->max_width.value();
-        if (params->max_height) committed_max_size.height = params->max_height.value();
-    }
 }
 
 void mf::WindowWlSurfaceRole::create_mir_window()
@@ -434,10 +427,14 @@ void mf::WindowWlSurfaceRole::create_mir_window()
     params->streams = std::vector<shell::StreamSpecification>{};
     params->input_shape = std::vector<geom::Rectangle>{};
     surface->populate_surface_data(params->streams.value(), params->input_shape.value(), {});
-    apply_pending_size_bounds();
 
     auto const scene_surface = shell->create_surface(session, *params, observer);
     weak_scene_surface = scene_surface;
+
+    if (params->min_width)  committed_min_size.width  = params->min_width.value();
+    if (params->min_height) committed_min_size.height = params->min_height.value();
+    if (params->max_width)  committed_max_size.width  = params->max_width.value();
+    if (params->max_height) committed_max_size.height = params->max_height.value();
 
     // The shell isn't guaranteed to respect the requested size
     auto const client_size = scene_surface->client_size();

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -42,7 +42,7 @@ namespace geom = mir::geometry;
 
 namespace
 {
-static geom::Size const max_possible_size{
+geom::Size const max_possible_size{
     std::numeric_limits<int>::max(),
     std::numeric_limits<int>::max()};
 }

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -61,7 +61,9 @@ mf::WindowWlSurfaceRole::WindowWlSurfaceRole(
       output_manager{output_manager},
       observer{std::make_shared<WaylandSurfaceObserver>(seat, client, surface, this)},
       params{std::make_unique<scene::SurfaceCreationParameters>(
-          scene::SurfaceCreationParameters().of_type(mir_window_type_freestyle))}
+          scene::SurfaceCreationParameters().of_type(mir_window_type_freestyle))},
+      committed_min_size{0, 0},
+      committed_max_size{max_possible_size}
 {
     surface->set_role(this);
 }

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -40,6 +40,13 @@ namespace ms = mir::scene;
 namespace msh = mir::shell;
 namespace geom = mir::geometry;
 
+namespace
+{
+static geom::Size const max_possible_size{
+    std::numeric_limits<int>::max(),
+    std::numeric_limits<int>::max()};
+}
+
 mf::WindowWlSurfaceRole::WindowWlSurfaceRole(
     WlSeat* seat,
     wl_client* client,
@@ -191,8 +198,8 @@ void mf::WindowWlSurfaceRole::set_max_size(int32_t width, int32_t height)
 {
     if (weak_scene_surface.lock())
     {
-        if (width == 0) width = std::numeric_limits<int>::max();
-        if (height == 0) height = std::numeric_limits<int>::max();
+        if (width == 0) width = max_possible_size.width.as_int();
+        if (height == 0) height = max_possible_size.height.as_int();
 
         auto& mods = spec();
         mods.max_width = geom::Width{width};

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -152,9 +152,6 @@ private:
     void visiblity(bool visible) override;
 
     shell::SurfaceSpecification& spec();
-    /// Sets committed_max_size and committed_min_size from the current pending size bounds
-    /// clears pending if its value is the same as currently committed
-    void apply_pending_size_bounds();
     void create_mir_window();
 };
 

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -152,6 +152,9 @@ private:
     void visiblity(bool visible) override;
 
     shell::SurfaceSpecification& spec();
+    /// Sets committed_max_size and committed_min_size from the current pending size bounds
+    /// clears pending if its value is the same as currently committed
+    void apply_pending_size_bounds();
     void create_mir_window();
 };
 

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -141,6 +141,12 @@ private:
     /// The last committed window size (either explicitly set or taken from the surface buffer size)
     std::experimental::optional<geometry::Size> committed_size;
 
+    /// The min and max size of the window as of last commit
+    /// @{
+    geometry::Size committed_min_size;
+    geometry::Size committed_max_size;
+    /// @}
+
     std::unique_ptr<shell::SurfaceSpecification> pending_changes;
 
     void visiblity(bool visible) override;


### PR DESCRIPTION
GTK loves to set max and min win size. Previously we were calling all the way through to the window management policy every time this was set (even if there was no change). This PR prevents that