### PR TITLE
SurfaceObserver: refactor resized_to() to supply both a frame and client size

### DIFF
--- a/include/server/mir/scene/null_surface_observer.h
+++ b/include/server/mir/scene/null_surface_observer.h
@@ -32,7 +32,10 @@ public:
     virtual ~NullSurfaceObserver() = default;
 
     void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) override;
-    void resized_to(Surface const* surf, geometry::Size const& size) override;
+    void resized_to(
+        Surface const* surf,
+        geometry::Size const& frame_size,
+        geometry::Size const& client_size) override;
     void moved_to(Surface const* surf, geometry::Point const& top_left) override;
     void hidden_set_to(Surface const* surf, bool hide) override;
     void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) override;

--- a/include/server/mir/scene/surface_observer.h
+++ b/include/server/mir/scene/surface_observer.h
@@ -49,7 +49,10 @@ class SurfaceObserver
 {
 public:
     virtual void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) = 0;
-    virtual void resized_to(Surface const* surf, geometry::Size const& size) = 0;
+    virtual void resized_to(
+        Surface const* surf,
+        geometry::Size const& frame_size,
+        geometry::Size const& client_size) = 0;
     virtual void moved_to(Surface const* surf, geometry::Point const& top_left) = 0;
     virtual void hidden_set_to(Surface const* surf, bool hide) = 0;
     virtual void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) = 0;

--- a/src/include/server/mir/scene/surface_event_source.h
+++ b/src/include/server/mir/scene/surface_event_source.h
@@ -42,7 +42,10 @@ public:
         std::shared_ptr<frontend::EventSink> const& event_sink);
 
     void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) override;
-    void resized_to(Surface const* surf, geometry::Size const& size) override;
+    void resized_to(
+        Surface const* surf,
+        geometry::Size const& frame_size,
+        geometry::Size const& client_size) override;
     void moved_to(Surface const* surf, geometry::Point const& top_left) override;
     void orientation_set_to(Surface const* surf, MirOrientation orientation) override;
     void client_surface_close_requested(Surface const* surf) override;

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -35,7 +35,10 @@ public:
     using BasicObservers<SurfaceObserver>::for_each;
 
     void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) override;
-    void resized_to(Surface const* surf, geometry::Size const& size) override;
+    void resized_to(
+        Surface const* surf,
+        geometry::Size const& frame_size,
+        geometry::Size const& client_size) override;
     void moved_to(Surface const* surf, geometry::Point const& top_left) override;
     void hidden_set_to(Surface const* surf, bool hide) override;
     void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) override;

--- a/src/server/frontend_wayland/wayland_surface_observer.cpp
+++ b/src/server/frontend_wayland/wayland_surface_observer.cpp
@@ -91,15 +91,18 @@ void mf::WaylandSurfaceObserver::attrib_changed(ms::Surface const*, MirWindowAtt
     }
 }
 
-void mf::WaylandSurfaceObserver::resized_to(ms::Surface const*, geom::Size const& size)
+void mf::WaylandSurfaceObserver::resized_to(
+    scene::Surface const*,
+    geometry::Size const& /*frame_size*/,
+    geometry::Size const& client_size)
 {
     run_on_wayland_thread_unless_destroyed(
-        [this, size]()
+        [this, client_size]()
         {
-            if (size != window_size)
+            if (client_size != window_size)
             {
-                requested_size = size;
-                window->handle_resize(std::experimental::nullopt, size);
+                requested_size = client_size;
+                window->handle_resize(std::experimental::nullopt, client_size);
             }
         });
 }

--- a/src/server/frontend_wayland/wayland_surface_observer.h
+++ b/src/server/frontend_wayland/wayland_surface_observer.h
@@ -47,7 +47,10 @@ public:
     /// Overrides from scene::SurfaceObserver
     ///@{
     void attrib_changed(scene::Surface const*, MirWindowAttrib attrib, int value) override;
-    void resized_to(scene::Surface const*, geometry::Size const& size) override;
+    void resized_to(
+        scene::Surface const*,
+        geometry::Size const& frame_size,
+        geometry::Size const& client_size) override;
     void client_surface_close_requested(scene::Surface const*) override;
     void keymap_changed(
         scene::Surface const*,

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -396,6 +396,6 @@ void mf::WindowWlSurfaceRole::create_mir_window()
     // The shell isn't guaranteed to respect the requested size
     auto const client_size = scene_surface->client_size();
     if (client_size != params->size)
-        observer->resized_to(scene_surface.get(), client_size);
+        observer->resized_to(scene_surface.get(), scene_surface->size(), client_size);
 }
 

--- a/src/server/input/cursor_controller.cpp
+++ b/src/server/input/cursor_controller.cpp
@@ -48,7 +48,7 @@ struct UpdateCursorOnSurfaceChanges : ms::NullSurfaceObserver
     {
         // Attribute changing alone wont trigger a cursor update
     }
-    void resized_to(ms::Surface const*, geom::Size const&) override
+    void resized_to(ms::Surface const*, geom::Size const&, geom::Size const&) override
     {
         cursor_controller->update_cursor_image();
     }

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -74,7 +74,7 @@ struct InputDispatcherSceneObserver :
         // TODO: Do we need to listen to visibility events?
     }
 
-    void resized_to(ms::Surface const*, mir::geometry::Size const& /*size*/) override
+    void resized_to(ms::Surface const*, mir::geometry::Size const& /*frame_size*/, mir::geometry::Size const& /*client_size*/) override
     {
         on_surface_resized();
     }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -53,10 +53,13 @@ void ms::SurfaceObservers::attrib_changed(Surface const* surf, MirWindowAttrib a
         { observer->attrib_changed(surf, attrib, value); });
 }
 
-void ms::SurfaceObservers::resized_to(Surface const* surf, geometry::Size const& size)
+void ms::SurfaceObservers::resized_to(
+    Surface const* surf,
+    geometry::Size const& frame_size,
+    geometry::Size const& client_size)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->resized_to(surf, size); });
+        { observer->resized_to(surf, frame_size, client_size); });
 }
 
 void ms::SurfaceObservers::moved_to(Surface const* surf, geometry::Point const& top_left)
@@ -351,7 +354,8 @@ void ms::BasicSurface::resize(geom::Size const& desired_size)
         surface_rect.size = new_size;
 
         lock.unlock();
-        observers.resized_to(this, new_size);
+        // TODO: subtract the frame from the client size
+        observers.resized_to(this, new_size, new_size);
     }
 }
 

--- a/src/server/scene/legacy_surface_change_notification.cpp
+++ b/src/server/scene/legacy_surface_change_notification.cpp
@@ -31,7 +31,7 @@ ms::LegacySurfaceChangeNotification::LegacySurfaceChangeNotification(
 {
 }
 
-void ms::LegacySurfaceChangeNotification::resized_to(Surface const*, geometry::Size const&)
+void ms::LegacySurfaceChangeNotification::resized_to(Surface const*, geometry::Size const&, geometry::Size const&)
 {
     notify_scene_change();
 }

--- a/src/server/scene/legacy_surface_change_notification.h
+++ b/src/server/scene/legacy_surface_change_notification.h
@@ -34,7 +34,10 @@ public:
         std::function<void()> const& notify_scene_change,
         std::function<void(int)> const& notify_buffer_change);
 
-    void resized_to(Surface const* surf, geometry::Size const&) override;
+    void resized_to(
+        Surface const* surf,
+        geometry::Size const& frame_size,
+        geometry::Size const& client_size) override;
     void moved_to(Surface const* surf, geometry::Point const&) override;
     void hidden_set_to(Surface const* surf, bool) override;
     void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) override;

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -22,7 +22,10 @@ namespace ms = mir::scene;
 namespace mg = mir::graphics;
 
 void ms::NullSurfaceObserver::attrib_changed(Surface const*, MirWindowAttrib, int) {}
-void ms::NullSurfaceObserver::resized_to(Surface const*, geometry::Size const&) {}
+void ms::NullSurfaceObserver::resized_to(
+    Surface const*,
+    geometry::Size const&,
+    geometry::Size const&) {}
 void ms::NullSurfaceObserver::moved_to(Surface const*, geometry::Point const&) {}
 void ms::NullSurfaceObserver::hidden_set_to(Surface const*, bool) {}
 void ms::NullSurfaceObserver::frame_posted(Surface const*, int, geometry::Size const&) {}

--- a/src/server/scene/surface_event_source.cpp
+++ b/src/server/scene/surface_event_source.cpp
@@ -41,9 +41,12 @@ ms::SurfaceEventSource::SurfaceEventSource(
 {
 }
 
-void ms::SurfaceEventSource::resized_to(Surface const*, geometry::Size const& size)
+void ms::SurfaceEventSource::resized_to(
+    Surface const*,
+    geometry::Size const& /*frame_size*/,
+    geometry::Size const& client_size)
 {
-    event_sink->handle_event(mev::make_event(id, size));
+    event_sink->handle_event(mev::make_event(id, client_size));
 }
 
 void ms::SurfaceEventSource::moved_to(Surface const* surface, geometry::Point const& top_left)

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -49,7 +49,7 @@ struct UpdateConfinementOnSurfaceChanges : ms::NullSurfaceObserver
     {
     }
 
-    void resized_to(ms::Surface const*, geom::Size const& /*size*/) override
+    void resized_to(ms::Surface const*, geom::Size const& /*frame_size*/, geom::Size const& /*client_size*/) override
     {
         update_confinement_region();
     }

--- a/tests/acceptance-tests/test_client_cursor_api.cpp
+++ b/tests/acceptance-tests/test_client_cursor_api.cpp
@@ -65,7 +65,7 @@ class MockSurfaceObserver : public msc::SurfaceObserver
 {
 public:
     MOCK_METHOD3(attrib_changed, void(msc::Surface const*, MirWindowAttrib attrib, int value));
-    MOCK_METHOD2(resized_to, void(msc::Surface const*, geom::Size const& size));
+    MOCK_METHOD3(resized_to, void(msc::Surface const*, geom::Size const& frame_size, geom::Size const& client_size));
     MOCK_METHOD2(moved_to, void(msc::Surface const*, geom::Point const& top_left));
     MOCK_METHOD2(hidden_set_to, void(msc::Surface const*, bool hide));
     MOCK_METHOD3(frame_posted, void(msc::Surface const*, int frames_available, geom::Size const& size));

--- a/tests/acceptance-tests/test_confined_pointer.cpp
+++ b/tests/acceptance-tests/test_confined_pointer.cpp
@@ -55,7 +55,7 @@ int const surface_height = 100;
 
 struct MockSurfaceObserver : public ms::NullSurfaceObserver
 {
-    MOCK_METHOD2(resized_to, void(ms::Surface const*, geom::Size const&));
+    MOCK_METHOD3(resized_to, void(ms::Surface const*, geom::Size const&, geom::Size const&));
 };
 }
 
@@ -263,7 +263,7 @@ TEST_F(PointerConfinement, test_we_update_our_confined_region_on_a_resize)
     latest_shell_surface()->add_observer(fake);
 
     geom::Size new_size = {surface_width * 2, surface_height};
-    EXPECT_CALL(surface_observer, resized_to(_, new_size)).Times(1);
+    EXPECT_CALL(surface_observer, resized_to(_, _, new_size)).Times(1);
 
     geom::Rectangles confinement_region{{{0, 0}, new_size}};
     EXPECT_CALL(*mock_seat_observer, seat_set_confinement_region_called(mt::RectanglesMatches(confinement_region)))

--- a/tests/acceptance-tests/test_surface_modifications.cpp
+++ b/tests/acceptance-tests/test_surface_modifications.cpp
@@ -47,7 +47,7 @@ class MockSurfaceObserver : public ms::NullSurfaceObserver
 {
 public:
     MOCK_METHOD2(renamed, void(ms::Surface const*, char const*));
-    MOCK_METHOD2(resized_to, void(ms::Surface const*, Size const& size));
+    MOCK_METHOD3(resized_to, void(ms::Surface const*, Size const& frame_size, Size const& client_size));
     MOCK_METHOD2(hidden_set_to, void(ms::Surface const*, bool));
 };
 
@@ -205,7 +205,7 @@ TEST_F(SurfaceModifications, surface_spec_resize_is_notified)
     auto const new_width = 5;
     auto const new_height = 7;
 
-    EXPECT_CALL(surface_observer, resized_to(_, Size{new_width, new_height}));
+    EXPECT_CALL(surface_observer, resized_to(_, _, Size{new_width, new_height}));
 
     apply_changes([&](MirWindowSpec* spec)
         {
@@ -218,7 +218,7 @@ TEST_F(SurfaceModifications, surface_spec_change_width_is_notified)
 {
     auto const new_width = 11;
 
-    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(new_width)));
+    EXPECT_CALL(surface_observer, resized_to(_, _, WidthEq(new_width)));
 
     apply_changes([&](MirWindowSpec* spec)
         {
@@ -230,7 +230,7 @@ TEST_F(SurfaceModifications, surface_spec_change_height_is_notified)
 {
     auto const new_height = 13;
 
-    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(new_height)));
+    EXPECT_CALL(surface_observer, resized_to(_, _, HeightEq(new_height)));
 
     apply_changes([&](MirWindowSpec* spec)
         {
@@ -252,7 +252,7 @@ TEST_F(SurfaceModifications, surface_spec_min_width_is_respected)
     auto const shell_surface = this->shell_surface.lock();
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(min_width)));
+    EXPECT_CALL(surface_observer, resized_to(_, _, WidthEq(min_width)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(shell_surface->top_left());
@@ -272,7 +272,7 @@ TEST_F(SurfaceModifications, surface_spec_min_height_is_respected)
     auto const shell_surface = this->shell_surface.lock();
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(min_height)));
+    EXPECT_CALL(surface_observer, resized_to(_, _, HeightEq(min_height)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(shell_surface->top_left());
@@ -292,7 +292,7 @@ TEST_F(SurfaceModifications, surface_spec_max_width_is_respected)
     auto const shell_surface = this->shell_surface.lock();
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(max_width)));
+    EXPECT_CALL(surface_observer, resized_to(_, _, WidthEq(max_width)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(max_width));
@@ -312,7 +312,7 @@ TEST_F(SurfaceModifications, surface_spec_max_height_is_respected)
     auto const shell_surface = this->shell_surface.lock();
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(max_height)));
+    EXPECT_CALL(surface_observer, resized_to(_, _, HeightEq(max_height)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(max_height));
@@ -333,7 +333,7 @@ TEST_F(SurfaceModifications, surface_spec_width_inc_is_respected)
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).WillOnce(SaveArg<2>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(16));
@@ -358,7 +358,7 @@ TEST_F(SurfaceModifications, surface_spec_with_min_width_and_width_inc_is_respec
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).WillOnce(SaveArg<2>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(16));
@@ -381,7 +381,7 @@ TEST_F(SurfaceModifications, surface_spec_height_inc_is_respected)
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).WillOnce(SaveArg<2>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(16));
@@ -406,7 +406,7 @@ TEST_F(SurfaceModifications, surface_spec_with_min_height_and_height_inc_is_resp
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).WillOnce(SaveArg<2>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(16));
@@ -431,7 +431,7 @@ TEST_F(SurfaceModifications, surface_spec_with_min_aspect_ratio_is_respected)
     auto const bottom_left = shell_surface->input_bounds().bottom_left() + Displacement{1,-1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).WillOnce(SaveArg<2>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_left);
@@ -456,7 +456,7 @@ TEST_F(SurfaceModifications, surface_spec_with_max_aspect_ratio_is_respected)
     auto const top_right = shell_surface->input_bounds().top_right() - Displacement{1,-1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).WillOnce(SaveArg<2>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(top_right);
@@ -476,7 +476,7 @@ TEST_F(SurfaceModifications, surface_spec_with_fixed_aspect_ratio_and_size_range
     auto const height_inc = 7;
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).Times(AnyNumber()).WillRepeatedly(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).Times(AnyNumber()).WillRepeatedly(SaveArg<2>(&actual));
 
     apply_changes([&](MirWindowSpec* spec)
           {

--- a/tests/acceptance-tests/test_surface_specification.cpp
+++ b/tests/acceptance-tests/test_surface_specification.cpp
@@ -49,7 +49,7 @@ namespace
     public:
         MOCK_METHOD2(renamed, void(ms::Surface const*, char const*));
         MOCK_METHOD3(attrib_changed, void(ms::Surface const*, MirWindowAttrib attrib, int value));
-        MOCK_METHOD2(resized_to, void(ms::Surface const*, Size const& size));
+        MOCK_METHOD3(resized_to, void(ms::Surface const*, Size const& frame_size, Size const& client_size));
     };
 
     struct SurfaceSpecification : mtf::ConnectedClientHeadlessServer
@@ -226,7 +226,7 @@ TEST_F(SurfaceSpecification, surface_spec_min_width_is_respected)
 
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(min_width)));
+    EXPECT_CALL(surface_observer, resized_to(_, _, WidthEq(min_width)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(shell_surface->top_left());
@@ -254,7 +254,7 @@ TEST_F(SurfaceSpecification, surface_spec_min_height_is_respected)
 
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(min_height)));
+    EXPECT_CALL(surface_observer, resized_to(_, _, HeightEq(min_height)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(shell_surface->top_left());
@@ -282,7 +282,7 @@ TEST_F(SurfaceSpecification, surface_spec_max_width_is_respected)
 
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(max_width)));
+    EXPECT_CALL(surface_observer, resized_to(_, _, WidthEq(max_width)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(max_width));
@@ -310,7 +310,7 @@ TEST_F(SurfaceSpecification, surface_spec_max_height_is_respected)
 
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(max_height)));
+    EXPECT_CALL(surface_observer, resized_to(_, _, HeightEq(max_height)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(max_height));
@@ -339,7 +339,7 @@ TEST_F(SurfaceSpecification, surface_spec_width_inc_is_respected)
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).WillOnce(SaveArg<2>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(16));
@@ -372,7 +372,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_min_width_and_width_inc_is_respec
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).WillOnce(SaveArg<2>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(16));
@@ -403,7 +403,7 @@ TEST_F(SurfaceSpecification, surface_spec_height_inc_is_respected)
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).WillOnce(SaveArg<2>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(16));
@@ -436,7 +436,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_min_height_and_height_inc_is_resp
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).WillOnce(SaveArg<2>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(16));
@@ -469,7 +469,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_min_aspect_ratio_is_respected)
     auto const bottom_left = shell_surface->input_bounds().bottom_left() + Displacement{1,-1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).WillOnce(SaveArg<2>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_left);
@@ -502,7 +502,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_max_aspect_ratio_is_respected)
     auto const top_right = shell_surface->input_bounds().top_right() - Displacement{1,-1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).WillOnce(SaveArg<2>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(top_right);
@@ -553,7 +553,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_fixed_aspect_ratio_and_size_range
     shell_surface->add_observer(mt::fake_shared(surface_observer));
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).Times(AnyNumber()).WillRepeatedly(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, resized_to(_, _, _)).Times(AnyNumber()).WillRepeatedly(SaveArg<2>(&actual));
 
     for (int delta = 1; delta != 20; ++delta)
     {


### PR DESCRIPTION
Companion PR to #1057 