### PR TITLE
SurfaceObserver: split resized_to() into window_resized_to() and content_resized_to()

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -82,7 +82,7 @@ Description: Display server for Ubuntu - RPC definitions
 
 #TODO: Packaging infrastructure for better dependency generation,
 #      ala pkg-xorg's xviddriver:Provides and ABI detection.
-Package: libmirserver51
+Package: libmirserver52
 Section: libs
 Architecture: linux-any
 Multi-Arch: same
@@ -161,7 +161,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirserver51 (= ${binary:Version}),
+Depends: libmirserver52 (= ${binary:Version}),
          libmirplatform-dev (= ${binary:Version}),
          libmircommon-dev (= ${binary:Version}),
          libglm-dev,

--- a/debian/libmirserver51.install
+++ b/debian/libmirserver51.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmirserver.so.51

--- a/debian/libmirserver52.install
+++ b/debian/libmirserver52.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmirserver.so.52

--- a/include/server/mir/scene/null_surface_observer.h
+++ b/include/server/mir/scene/null_surface_observer.h
@@ -32,7 +32,8 @@ public:
     virtual ~NullSurfaceObserver() = default;
 
     void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) override;
-    void resized_to(Surface const* surf, geometry::Size const& size) override;
+    void window_resized_to(Surface const* surf, geometry::Size const& window_size) override;
+    void content_resized_to(Surface const* surf, geometry::Size const& content_size) override;
     void moved_to(Surface const* surf, geometry::Point const& top_left) override;
     void hidden_set_to(Surface const* surf, bool hide) override;
     void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) override;

--- a/include/server/mir/scene/surface_observer.h
+++ b/include/server/mir/scene/surface_observer.h
@@ -49,7 +49,8 @@ class SurfaceObserver
 {
 public:
     virtual void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) = 0;
-    virtual void resized_to(Surface const* surf, geometry::Size const& size) = 0;
+    virtual void window_resized_to(Surface const* surf, geometry::Size const& window_size) = 0;
+    virtual void content_resized_to(Surface const* surf, geometry::Size const& content_size) = 0;
     virtual void moved_to(Surface const* surf, geometry::Point const& top_left) = 0;
     virtual void hidden_set_to(Surface const* surf, bool hide) = 0;
     virtual void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) = 0;

--- a/src/include/server/mir/scene/surface_event_source.h
+++ b/src/include/server/mir/scene/surface_event_source.h
@@ -42,7 +42,7 @@ public:
         std::shared_ptr<frontend::EventSink> const& event_sink);
 
     void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) override;
-    void resized_to(Surface const* surf, geometry::Size const& size) override;
+    void content_resized_to(Surface const* surf, geometry::Size const& content_size) override;
     void moved_to(Surface const* surf, geometry::Point const& top_left) override;
     void orientation_set_to(Surface const* surf, MirOrientation orientation) override;
     void client_surface_close_requested(Surface const* surf) override;

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -35,7 +35,8 @@ public:
     using BasicObservers<SurfaceObserver>::for_each;
 
     void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) override;
-    void resized_to(Surface const* surf, geometry::Size const& size) override;
+    void window_resized_to(Surface const* surf, geometry::Size const& window_size) override;
+    void content_resized_to(Surface const* surf, geometry::Size const& content_size) override;
     void moved_to(Surface const* surf, geometry::Point const& top_left) override;
     void hidden_set_to(Surface const* surf, bool hide) override;
     void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) override;

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -163,7 +163,7 @@ install(DIRECTORY
   ${CMAKE_SOURCE_DIR}/include/server/mir DESTINATION "include/mirserver"
 )
 
-set(MIRSERVER_ABI 51) # Be sure to increment MIR_VERSION_MINOR at the same time
+set(MIRSERVER_ABI 52) # Be sure to increment MIR_VERSION_MINOR at the same time
 set(symbol_map ${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)
 
 set_target_properties(

--- a/src/server/frontend_wayland/wayland_surface_observer.cpp
+++ b/src/server/frontend_wayland/wayland_surface_observer.cpp
@@ -91,15 +91,15 @@ void mf::WaylandSurfaceObserver::attrib_changed(ms::Surface const*, MirWindowAtt
     }
 }
 
-void mf::WaylandSurfaceObserver::resized_to(ms::Surface const*, geom::Size const& size)
+void mf::WaylandSurfaceObserver::content_resized_to(ms::Surface const*, geom::Size const& content_size)
 {
     run_on_wayland_thread_unless_destroyed(
-        [this, size]()
+        [this, content_size]()
         {
-            if (size != window_size)
+            if (content_size != window_size)
             {
-                requested_size = size;
-                window->handle_resize(std::experimental::nullopt, size);
+                requested_size = content_size;
+                window->handle_resize(std::experimental::nullopt, content_size);
             }
         });
 }

--- a/src/server/frontend_wayland/wayland_surface_observer.h
+++ b/src/server/frontend_wayland/wayland_surface_observer.h
@@ -47,7 +47,7 @@ public:
     /// Overrides from scene::SurfaceObserver
     ///@{
     void attrib_changed(scene::Surface const*, MirWindowAttrib attrib, int value) override;
-    void resized_to(scene::Surface const*, geometry::Size const& size) override;
+    void content_resized_to(scene::Surface const*, geometry::Size const& content_size) override;
     void client_surface_close_requested(scene::Surface const*) override;
     void keymap_changed(
         scene::Surface const*,

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -396,6 +396,6 @@ void mf::WindowWlSurfaceRole::create_mir_window()
     // The shell isn't guaranteed to respect the requested size
     auto const client_size = scene_surface->client_size();
     if (client_size != params->size)
-        observer->resized_to(scene_surface.get(), client_size);
+        observer->content_resized_to(scene_surface.get(), client_size);
 }
 

--- a/src/server/input/cursor_controller.cpp
+++ b/src/server/input/cursor_controller.cpp
@@ -48,7 +48,7 @@ struct UpdateCursorOnSurfaceChanges : ms::NullSurfaceObserver
     {
         // Attribute changing alone wont trigger a cursor update
     }
-    void resized_to(ms::Surface const*, geom::Size const&) override
+    void content_resized_to(ms::Surface const*, geom::Size const&) override
     {
         cursor_controller->update_cursor_image();
     }

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -74,7 +74,7 @@ struct InputDispatcherSceneObserver :
         // TODO: Do we need to listen to visibility events?
     }
 
-    void resized_to(ms::Surface const*, mir::geometry::Size const& /*size*/) override
+    void content_resized_to(ms::Surface const*, mir::geometry::Size const& /*size*/) override
     {
         on_surface_resized();
     }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -53,10 +53,16 @@ void ms::SurfaceObservers::attrib_changed(Surface const* surf, MirWindowAttrib a
         { observer->attrib_changed(surf, attrib, value); });
 }
 
-void ms::SurfaceObservers::resized_to(Surface const* surf, geometry::Size const& size)
+void ms::SurfaceObservers::window_resized_to(Surface const* surf, geometry::Size const& window_size)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->resized_to(surf, size); });
+        { observer->window_resized_to(surf, window_size); });
+}
+
+void ms::SurfaceObservers::content_resized_to(Surface const* surf, geometry::Size const& content_size)
+{
+    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
+        { observer->window_resized_to(surf, content_size); });
 }
 
 void ms::SurfaceObservers::moved_to(Surface const* surf, geometry::Point const& top_left)
@@ -351,7 +357,8 @@ void ms::BasicSurface::resize(geom::Size const& desired_size)
         surface_rect.size = new_size;
 
         lock.unlock();
-        observers.resized_to(this, new_size);
+        observers.window_resized_to(this, new_size);
+        observers.content_resized_to(this, new_size);
     }
 }
 

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -62,7 +62,7 @@ void ms::SurfaceObservers::window_resized_to(Surface const* surf, geometry::Size
 void ms::SurfaceObservers::content_resized_to(Surface const* surf, geometry::Size const& content_size)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->window_resized_to(surf, content_size); });
+        { observer->content_resized_to(surf, content_size); });
 }
 
 void ms::SurfaceObservers::moved_to(Surface const* surf, geometry::Point const& top_left)

--- a/src/server/scene/legacy_surface_change_notification.cpp
+++ b/src/server/scene/legacy_surface_change_notification.cpp
@@ -31,7 +31,7 @@ ms::LegacySurfaceChangeNotification::LegacySurfaceChangeNotification(
 {
 }
 
-void ms::LegacySurfaceChangeNotification::resized_to(Surface const*, geometry::Size const&)
+void ms::LegacySurfaceChangeNotification::content_resized_to(Surface const*, geometry::Size const&)
 {
     notify_scene_change();
 }

--- a/src/server/scene/legacy_surface_change_notification.h
+++ b/src/server/scene/legacy_surface_change_notification.h
@@ -34,7 +34,7 @@ public:
         std::function<void()> const& notify_scene_change,
         std::function<void(int)> const& notify_buffer_change);
 
-    void resized_to(Surface const* surf, geometry::Size const&) override;
+    void content_resized_to(Surface const* surf, geometry::Size const&) override;
     void moved_to(Surface const* surf, geometry::Point const&) override;
     void hidden_set_to(Surface const* surf, bool) override;
     void frame_posted(Surface const* surf, int frames_available, geometry::Size const& size) override;

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -22,7 +22,8 @@ namespace ms = mir::scene;
 namespace mg = mir::graphics;
 
 void ms::NullSurfaceObserver::attrib_changed(Surface const*, MirWindowAttrib, int) {}
-void ms::NullSurfaceObserver::resized_to(Surface const*, geometry::Size const&) {}
+void ms::NullSurfaceObserver::window_resized_to(Surface const*, geometry::Size const&) {}
+void ms::NullSurfaceObserver::content_resized_to(Surface const*, geometry::Size const&) {}
 void ms::NullSurfaceObserver::moved_to(Surface const*, geometry::Point const&) {}
 void ms::NullSurfaceObserver::hidden_set_to(Surface const*, bool) {}
 void ms::NullSurfaceObserver::frame_posted(Surface const*, int, geometry::Size const&) {}

--- a/src/server/scene/surface_event_source.cpp
+++ b/src/server/scene/surface_event_source.cpp
@@ -41,9 +41,9 @@ ms::SurfaceEventSource::SurfaceEventSource(
 {
 }
 
-void ms::SurfaceEventSource::resized_to(Surface const*, geometry::Size const& size)
+void ms::SurfaceEventSource::content_resized_to(Surface const*, geometry::Size const& content_size)
 {
-    event_sink->handle_event(mev::make_event(id, size));
+    event_sink->handle_event(mev::make_event(id, content_size));
 }
 
 void ms::SurfaceEventSource::moved_to(Surface const* surface, geometry::Point const& top_left)

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -49,7 +49,7 @@ struct UpdateConfinementOnSurfaceChanges : ms::NullSurfaceObserver
     {
     }
 
-    void resized_to(ms::Surface const*, geom::Size const& /*size*/) override
+    void content_resized_to(ms::Surface const*, geom::Size const& /*content_size*/) override
     {
         update_confinement_region();
     }

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1,4 +1,4 @@
-MIR_SERVER_0.1.5 {
+MIR_SERVER_0.1.6 {
  global:
   extern "C++" {
     mir::check_for_termination_exception*;
@@ -129,7 +129,8 @@ MIR_SERVER_0.1.5 {
     mir::scene::NullSurfaceObserver::placed_relative*;
     mir::scene::NullSurfaceObserver::reception_mode_set_to*;
     mir::scene::NullSurfaceObserver::renamed*;
-    mir::scene::NullSurfaceObserver::resized_to*;
+    mir::scene::NullSurfaceObserver::window_resized_to*;
+    mir::scene::NullSurfaceObserver::content_resized_to*;
     mir::scene::NullSurfaceObserver::start_drag_and_drop*;
     mir::scene::NullSurfaceObserver::transformation_set_to*;
     mir::scene::Observer::?Observer*;
@@ -934,4 +935,4 @@ MIR_SERVER_DETAIL_FOR_TESTING_1.4 {
 
     mir::run_mir*;
   };
-} MIR_SERVER_0.1.5;
+} MIR_SERVER_0.1.6;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -1,4 +1,4 @@
-MIR_SERVER_0.1.6 {
+MIR_SERVER_1.6.0 {
  global:
   extern "C++" {
     mir::check_for_termination_exception*;
@@ -935,4 +935,4 @@ MIR_SERVER_DETAIL_FOR_TESTING_1.4 {
 
     mir::run_mir*;
   };
-} MIR_SERVER_0.1.6;
+} MIR_SERVER_1.6.0;

--- a/tests/acceptance-tests/test_client_cursor_api.cpp
+++ b/tests/acceptance-tests/test_client_cursor_api.cpp
@@ -65,7 +65,8 @@ class MockSurfaceObserver : public msc::SurfaceObserver
 {
 public:
     MOCK_METHOD3(attrib_changed, void(msc::Surface const*, MirWindowAttrib attrib, int value));
-    MOCK_METHOD2(resized_to, void(msc::Surface const*, geom::Size const& size));
+    MOCK_METHOD2(window_resized_to, void(msc::Surface const*, geom::Size const& window_size));
+    MOCK_METHOD2(content_resized_to, void(msc::Surface const*, geom::Size const& content_size));
     MOCK_METHOD2(moved_to, void(msc::Surface const*, geom::Point const& top_left));
     MOCK_METHOD2(hidden_set_to, void(msc::Surface const*, bool hide));
     MOCK_METHOD3(frame_posted, void(msc::Surface const*, int frames_available, geom::Size const& size));

--- a/tests/acceptance-tests/test_confined_pointer.cpp
+++ b/tests/acceptance-tests/test_confined_pointer.cpp
@@ -55,7 +55,7 @@ int const surface_height = 100;
 
 struct MockSurfaceObserver : public ms::NullSurfaceObserver
 {
-    MOCK_METHOD2(resized_to, void(ms::Surface const*, geom::Size const&));
+    MOCK_METHOD2(content_resized_to, void(ms::Surface const*, geom::Size const&));
 };
 }
 
@@ -263,7 +263,7 @@ TEST_F(PointerConfinement, test_we_update_our_confined_region_on_a_resize)
     latest_shell_surface()->add_observer(fake);
 
     geom::Size new_size = {surface_width * 2, surface_height};
-    EXPECT_CALL(surface_observer, resized_to(_, new_size)).Times(1);
+    EXPECT_CALL(surface_observer, content_resized_to(_, new_size)).Times(1);
 
     geom::Rectangles confinement_region{{{0, 0}, new_size}};
     EXPECT_CALL(*mock_seat_observer, seat_set_confinement_region_called(mt::RectanglesMatches(confinement_region)))

--- a/tests/acceptance-tests/test_surface_modifications.cpp
+++ b/tests/acceptance-tests/test_surface_modifications.cpp
@@ -47,7 +47,7 @@ class MockSurfaceObserver : public ms::NullSurfaceObserver
 {
 public:
     MOCK_METHOD2(renamed, void(ms::Surface const*, char const*));
-    MOCK_METHOD2(resized_to, void(ms::Surface const*, Size const& size));
+    MOCK_METHOD2(content_resized_to, void(ms::Surface const*, Size const& size));
     MOCK_METHOD2(hidden_set_to, void(ms::Surface const*, bool));
 };
 
@@ -205,7 +205,7 @@ TEST_F(SurfaceModifications, surface_spec_resize_is_notified)
     auto const new_width = 5;
     auto const new_height = 7;
 
-    EXPECT_CALL(surface_observer, resized_to(_, Size{new_width, new_height}));
+    EXPECT_CALL(surface_observer, content_resized_to(_, Size{new_width, new_height}));
 
     apply_changes([&](MirWindowSpec* spec)
         {
@@ -218,7 +218,7 @@ TEST_F(SurfaceModifications, surface_spec_change_width_is_notified)
 {
     auto const new_width = 11;
 
-    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(new_width)));
+    EXPECT_CALL(surface_observer, content_resized_to(_, WidthEq(new_width)));
 
     apply_changes([&](MirWindowSpec* spec)
         {
@@ -230,7 +230,7 @@ TEST_F(SurfaceModifications, surface_spec_change_height_is_notified)
 {
     auto const new_height = 13;
 
-    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(new_height)));
+    EXPECT_CALL(surface_observer, content_resized_to(_, HeightEq(new_height)));
 
     apply_changes([&](MirWindowSpec* spec)
         {
@@ -252,7 +252,7 @@ TEST_F(SurfaceModifications, surface_spec_min_width_is_respected)
     auto const shell_surface = this->shell_surface.lock();
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(min_width)));
+    EXPECT_CALL(surface_observer, content_resized_to(_, WidthEq(min_width)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(shell_surface->top_left());
@@ -272,7 +272,7 @@ TEST_F(SurfaceModifications, surface_spec_min_height_is_respected)
     auto const shell_surface = this->shell_surface.lock();
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(min_height)));
+    EXPECT_CALL(surface_observer, content_resized_to(_, HeightEq(min_height)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(shell_surface->top_left());
@@ -292,7 +292,7 @@ TEST_F(SurfaceModifications, surface_spec_max_width_is_respected)
     auto const shell_surface = this->shell_surface.lock();
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(max_width)));
+    EXPECT_CALL(surface_observer, content_resized_to(_, WidthEq(max_width)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(max_width));
@@ -312,7 +312,7 @@ TEST_F(SurfaceModifications, surface_spec_max_height_is_respected)
     auto const shell_surface = this->shell_surface.lock();
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(max_height)));
+    EXPECT_CALL(surface_observer, content_resized_to(_, HeightEq(max_height)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(max_height));
@@ -333,7 +333,7 @@ TEST_F(SurfaceModifications, surface_spec_width_inc_is_respected)
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(16));
@@ -358,7 +358,7 @@ TEST_F(SurfaceModifications, surface_spec_with_min_width_and_width_inc_is_respec
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(16));
@@ -381,7 +381,7 @@ TEST_F(SurfaceModifications, surface_spec_height_inc_is_respected)
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(16));
@@ -406,7 +406,7 @@ TEST_F(SurfaceModifications, surface_spec_with_min_height_and_height_inc_is_resp
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(16));
@@ -431,7 +431,7 @@ TEST_F(SurfaceModifications, surface_spec_with_min_aspect_ratio_is_respected)
     auto const bottom_left = shell_surface->input_bounds().bottom_left() + Displacement{1,-1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_left);
@@ -456,7 +456,7 @@ TEST_F(SurfaceModifications, surface_spec_with_max_aspect_ratio_is_respected)
     auto const top_right = shell_surface->input_bounds().top_right() - Displacement{1,-1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(top_right);
@@ -476,7 +476,7 @@ TEST_F(SurfaceModifications, surface_spec_with_fixed_aspect_ratio_and_size_range
     auto const height_inc = 7;
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).Times(AnyNumber()).WillRepeatedly(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).Times(AnyNumber()).WillRepeatedly(SaveArg<1>(&actual));
 
     apply_changes([&](MirWindowSpec* spec)
           {

--- a/tests/acceptance-tests/test_surface_specification.cpp
+++ b/tests/acceptance-tests/test_surface_specification.cpp
@@ -49,7 +49,7 @@ namespace
     public:
         MOCK_METHOD2(renamed, void(ms::Surface const*, char const*));
         MOCK_METHOD3(attrib_changed, void(ms::Surface const*, MirWindowAttrib attrib, int value));
-        MOCK_METHOD2(resized_to, void(ms::Surface const*, Size const& size));
+        MOCK_METHOD2(content_resized_to, void(ms::Surface const*, Size const& size));
     };
 
     struct SurfaceSpecification : mtf::ConnectedClientHeadlessServer
@@ -226,7 +226,7 @@ TEST_F(SurfaceSpecification, surface_spec_min_width_is_respected)
 
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(min_width)));
+    EXPECT_CALL(surface_observer, content_resized_to(_, WidthEq(min_width)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(shell_surface->top_left());
@@ -254,7 +254,7 @@ TEST_F(SurfaceSpecification, surface_spec_min_height_is_respected)
 
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(min_height)));
+    EXPECT_CALL(surface_observer, content_resized_to(_, HeightEq(min_height)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(shell_surface->top_left());
@@ -282,7 +282,7 @@ TEST_F(SurfaceSpecification, surface_spec_max_width_is_respected)
 
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, WidthEq(max_width)));
+    EXPECT_CALL(surface_observer, content_resized_to(_, WidthEq(max_width)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(max_width));
@@ -310,7 +310,7 @@ TEST_F(SurfaceSpecification, surface_spec_max_height_is_respected)
 
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
-    EXPECT_CALL(surface_observer, resized_to(_, HeightEq(max_height)));
+    EXPECT_CALL(surface_observer, content_resized_to(_, HeightEq(max_height)));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(max_height));
@@ -339,7 +339,7 @@ TEST_F(SurfaceSpecification, surface_spec_width_inc_is_respected)
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(16));
@@ -372,7 +372,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_min_width_and_width_inc_is_respec
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaX(16));
@@ -403,7 +403,7 @@ TEST_F(SurfaceSpecification, surface_spec_height_inc_is_respected)
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(16));
@@ -436,7 +436,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_min_height_and_height_inc_is_resp
     auto const bottom_right = shell_surface->input_bounds().bottom_right() - Displacement{1,1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_right + DeltaY(16));
@@ -469,7 +469,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_min_aspect_ratio_is_respected)
     auto const bottom_left = shell_surface->input_bounds().bottom_left() + Displacement{1,-1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(bottom_left);
@@ -502,7 +502,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_max_aspect_ratio_is_respected)
     auto const top_right = shell_surface->input_bounds().top_right() - Displacement{1,-1};
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).WillOnce(SaveArg<1>(&actual));
 
     generate_alt_click_at(bottom_right);
     generate_alt_move_to(top_right);
@@ -553,7 +553,7 @@ TEST_F(SurfaceSpecification, surface_spec_with_fixed_aspect_ratio_and_size_range
     shell_surface->add_observer(mt::fake_shared(surface_observer));
 
     Size actual;
-    EXPECT_CALL(surface_observer, resized_to(_, _)).Times(AnyNumber()).WillRepeatedly(SaveArg<1>(&actual));
+    EXPECT_CALL(surface_observer, content_resized_to(_, _)).Times(AnyNumber()).WillRepeatedly(SaveArg<1>(&actual));
 
     for (int delta = 1; delta != 20; ++delta)
     {


### PR DESCRIPTION
Alternative to #1060 