### PR TITLE
BasicSurface: add ProofOfMutexLock

### DIFF
--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -168,7 +168,7 @@ void ms::SurfaceObservers::application_id_set_to(Surface const* surf, std::strin
 ms::BasicSurface::ProofOfMutexLock::ProofOfMutexLock(std::unique_lock<std::mutex> const& lock)
 {
     if (!lock.owns_lock())
-        BOOST_THROW_EXCEPTION(std::logic_error("ProofOfMutexLock created with unlocked unique_lock"));
+        fatal_error("ProofOfMutexLock created with unlocked unique_lock");
 }
 
 struct ms::CursorStreamImageAdapter

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -165,6 +165,12 @@ void ms::SurfaceObservers::application_id_set_to(Surface const* surf, std::strin
                  { observer->application_id_set_to(surf, application_id); });
 }
 
+ms::BasicSurface::ProofOfMutexLock::ProofOfMutexLock(std::unique_lock<std::mutex> const& lock)
+{
+    if (!lock.owns_lock())
+        BOOST_THROW_EXCEPTION(std::logic_error("ProofOfMutexLock created with unlocked unique_lock"));
+}
+
 struct ms::CursorStreamImageAdapter
 {
     CursorStreamImageAdapter(ms::BasicSurface &surface)

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -427,7 +427,7 @@ bool ms::BasicSurface::visible() const
     return visible(lock);
 }
 
-bool ms::BasicSurface::visible(std::lock_guard<std::mutex> const&) const
+bool ms::BasicSurface::visible(ProofOfMutexLock const&) const
 {
     bool visible{false};
     for (auto const& info : layers)

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -159,7 +159,7 @@ private:
     struct ProofOfMutexLock
     {
         ProofOfMutexLock(std::lock_guard<std::mutex> const&) {}
-        ProofOfMutexLock(std::unique_lock<std::mutex> const&) {}
+        ProofOfMutexLock(std::unique_lock<std::mutex> const& lock);
         ProofOfMutexLock(ProofOfMutexLock const&) = delete;
         ProofOfMutexLock operator=(ProofOfMutexLock const&) = delete;
     };

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -156,7 +156,15 @@ public:
     void set_application_id(std::string const& application_id) override;
 
 private:
-    bool visible(std::lock_guard<std::mutex> const&) const;
+    struct ProofOfMutexLock
+    {
+        ProofOfMutexLock(std::lock_guard<std::mutex> const&) {}
+        ProofOfMutexLock(std::unique_lock<std::mutex> const&) {}
+        ProofOfMutexLock(ProofOfMutexLock const&) = delete;
+        ProofOfMutexLock operator=(ProofOfMutexLock const&) = delete;
+    };
+
+    bool visible(ProofOfMutexLock const&) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
     MirWindowState set_state(MirWindowState s);
     int set_dpi(int);


### PR DESCRIPTION
It just so happens that the private version of `BasicSurface::visible()` only needs to be called from functions that hold a `std::lock_guard` and not a `std::unique_lock`. However, another private function will need to be called when both types of locks are held, so I'm introducing `BasicSurface::ProofOfMutexLock` which can be created from either. The system isn't full proof, but it does give a clear indication that functions that take it are intended to be called when the mutex is locked, and gives some level of compile-time checking.