### PR TITLE
Drop workaround for broken std::uncaught_exception()

### DIFF
--- a/src/include/common/mir/unwind_helpers.h
+++ b/src/include/common/mir/unwind_helpers.h
@@ -30,25 +30,28 @@ class RevertIfUnwinding
 public:
     template<typename Apply>
     RevertIfUnwinding(Apply && apply, Unwind&& unwind)
-        : unwind{std::move(unwind)}
+        : unwind{std::move(unwind)},
+          initial_exception_count{std::uncaught_exceptions()}
     {
         apply();
     }
 
     RevertIfUnwinding(Unwind&& unwind)
-        : unwind{std::move(unwind)}
+        : unwind{std::move(unwind)},
+          initial_exception_count{std::uncaught_exceptions()}
     {
     }
 
     RevertIfUnwinding(RevertIfUnwinding<Unwind>&& rhs)
-        : unwind{std::move(rhs.unwind)}
+        : unwind{std::move(rhs.unwind)},
+          initial_exception_count{std::uncaught_exceptions()}
     {
         rhs.unwind = nullptr;
     }
 
     ~RevertIfUnwinding()
     {
-        if (std::uncaught_exceptions())
+        if (std::uncaught_exceptions() > initial_exception_count)
             unwind();
     }
 
@@ -57,6 +60,7 @@ private:
     RevertIfUnwinding& operator=(RevertIfUnwinding const&) = delete;
 
     Unwind unwind;
+    int const initial_exception_count;
 };
 
 template<typename Apply, typename Revert>

--- a/src/include/common/mir/unwind_helpers.h
+++ b/src/include/common/mir/unwind_helpers.h
@@ -40,9 +40,10 @@ public:
     {
     }
 
-    RevertIfUnwinding(RevertIfUnwinding<Unwind> && rhs)
+    RevertIfUnwinding(RevertIfUnwinding<Unwind>&& rhs)
         : unwind{std::move(rhs.unwind)}
     {
+        rhs.unwind = nullptr;
     }
 
     ~RevertIfUnwinding()

--- a/src/server/compositor/multi_threaded_compositor.cpp
+++ b/src/server/compositor/multi_threaded_compositor.cpp
@@ -309,12 +309,8 @@ void mc::MultiThreadedCompositor::start()
     /* To cleanup state if any code below throws */
     auto cleanup_if_unwinding = on_unwind([this]
         {
-            // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=62258
-            // After using rethrow_exception() (and catching the exception),
-            // all subsequent calls to uncaught_exception() return `true'.
-            if (state == CompositorState::started) return;
-
-            destroy_compositing_threads(); state = CompositorState::stopped;
+            destroy_compositing_threads();
+            state = CompositorState::stopped;
         });
 
     create_compositing_threads();
@@ -339,11 +335,6 @@ void mc::MultiThreadedCompositor::stop()
     /* To cleanup state if any code below throws */
     auto cleanup_if_unwinding = on_unwind([this]
         {
-            // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=62258
-            // After using rethrow_exception() (and catching the exception),
-            // all subsequent calls to uncaught_exception() return `true'.
-            if (state == CompositorState::stopped) return;
-
             state = CompositorState::started;
         });
 


### PR DESCRIPTION
This was fixed in GCC/libstdc++ v5.3. Ubuntu 16.04 has v5.4 in -updates,
so none of our currently supported platforms suffer from this bug.