### PR TITLE
Wayland platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,7 @@ pkg_check_modules(WAYLAND_EGLSTREAM wayland-eglstream)
 if (WAYLAND_EGLSTREAM_FOUND)
   set(
     MIR_PLATFORM
-    mesa-kms;mesa-x11;eglstream-kms
+    mesa-kms;mesa-x11;eglstream-kms;wayland
     CACHE
     STRING
     "a list of graphics backends to build (options are 'mesa-kms', 'mesa-x11', or 'eglstream-kms')"
@@ -260,6 +260,9 @@ foreach(platform IN LISTS MIR_PLATFORM)
         message(FATAL_ERROR "EGLStream platform requested, but required NVIDIA external EGL platform nvidia-egl-wayland not found")
      endif()
      set(MIR_BUILD_PLATFORM_EGLSTREAM_KMS TRUE)
+  endif()
+  if (platform STREQUAL "wayland")
+     set(MIR_BUILD_PLATFORM_WAYLAND TRUE)
   endif()
 endforeach(platform)
 
@@ -364,6 +367,10 @@ if (MIR_EGL_SUPPORTED_OUT STREQUAL "")
   option(MIR_EGL_SUPPORTED "Build examples that depend on Mir EGL." OFF)
 else()
   option(MIR_EGL_SUPPORTED "Build examples that depend on Mir EGL." ON)
+endif()
+
+if (MIR_BUILD_PLATFORM_WAYLAND)
+  pkg_check_modules(EPOXY REQUIRED epoxy)
 endif()
 
 set(MIR_TRACEPOINT_LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/mir/tools)

--- a/debian/control
+++ b/debian/control
@@ -343,6 +343,20 @@ Description: Display server for Ubuntu - platform library for NVIDIA
  the hardware platform using the EGLStream EGL extensions, such as the
  NVIDIA binary driver.
 
+Package: mir-platform-graphics-wayland16
+Section: libs
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${misc:Depends},
+         ${shlibs:Depends},
+Description: Display server for Ubuntu - platform library for Wayland
+ Mir is a display server running on linux systems, with a focus on efficiency,
+ robust operation and a well-defined driver model.
+ .
+ Contains the shared libraries required for the Mir server to interact with
+ a "host" Wayland display server.
+
 Package: mir-graphics-drivers-nvidia
 Section: libs
 Architecture: amd64 i386
@@ -408,6 +422,7 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends},
          mir-platform-graphics-mesa-kms16,
          mir-platform-graphics-mesa-x16,
+         mir-platform-graphics-wayland16,
          mir-client-platform-mesa5,
          mir-platform-input-evdev7,
 Description: Display server for Ubuntu - desktop driver metapackage

--- a/debian/mir-platform-graphics-wayland16.install
+++ b/debian/mir-platform-graphics-wayland16.install
@@ -1,0 +1,1 @@
+usr/lib/*/mir/server-platform/graphics-wayland.so.16

--- a/examples/miral-shell/CMakeLists.txt
+++ b/examples/miral-shell/CMakeLists.txt
@@ -49,3 +49,11 @@ target_link_libraries(miral-shell
     example-shell-lib
     miral-spinner
 )
+
+mir_add_wrapped_executable(spinner
+    spinner.cpp
+)
+
+target_link_libraries(spinner
+    miral-spinner
+)

--- a/examples/miral-shell/spinner.cpp
+++ b/examples/miral-shell/spinner.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "spinner/splash.h"
+#include <wayland-client.h>
+
+int main()
+{
+    SpinnerSplash spinner;
+
+    auto const display = wl_display_connect(nullptr);
+
+    spinner(display);
+
+    wl_display_disconnect(display);
+}

--- a/src/platforms/CMakeLists.txt
+++ b/src/platforms/CMakeLists.txt
@@ -72,4 +72,8 @@ if (MIR_BUILD_PLATFORM_EGLSTREAM_KMS)
   add_subdirectory(eglstream-kms)
 endif()
 
+if (MIR_BUILD_PLATFORM_WAYLAND)
+  add_subdirectory(wayland)
+endif()
+
 add_subdirectory(evdev/)

--- a/src/platforms/wayland/CMakeLists.txt
+++ b/src/platforms/wayland/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(mirplatformwayland-graphics STATIC
 target_include_directories(mirplatformwayland-graphics
 PUBLIC
     ${server_common_include_dirs}
+    ${PROJECT_SOURCE_DIR}/include/common
+    ${PROJECT_SOURCE_DIR}/include/client
     ${GBM_INCLUDE_DIRS}
     ${DRM_INCLUDE_DIRS}
     ${EGL_INCLUDE_DIRS}
@@ -50,6 +52,7 @@ add_library(mirplatformwayland-input STATIC
 target_include_directories(mirplatformwayland-input
 PUBLIC
     ${server_common_include_dirs}
+    ${PROJECT_SOURCE_DIR}/include/common
     ${PROJECT_SOURCE_DIR}/include/client
 )
 

--- a/src/platforms/wayland/CMakeLists.txt
+++ b/src/platforms/wayland/CMakeLists.txt
@@ -1,0 +1,83 @@
+find_package(PkgConfig)
+pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
+pkg_check_modules(WAYLAND_EGL REQUIRED wayland-egl)
+pkg_check_modules(XKBCOMMON xkbcommon REQUIRED)
+
+add_definitions(-DMIR_LOG_COMPONENT_FALLBACK="wayland")
+
+add_library(mirplatformwayland-graphics STATIC
+    platform.cpp                platform.h
+    display.cpp                 display.h
+    buffer_allocator.cpp        buffer_allocator.h
+        displayclient.cpp displayclient.h
+    wayland_display.cpp         wayland_display.h
+    cursor.cpp                  cursor.h
+)
+
+target_include_directories(mirplatformwayland-graphics
+PUBLIC
+    ${server_common_include_dirs}
+    ${GBM_INCLUDE_DIRS}
+    ${DRM_INCLUDE_DIRS}
+    ${EGL_INCLUDE_DIRS}
+    ${GLESv2_INCLUDE_DIRS}
+    ${EPOXY_INCLUDE_DIRS}
+    ${WAYLAND_CLIENT_INCLUDE_DIRS}
+    ${WAYLAND_EGL_INCLUDE_DIRS}
+)
+
+target_link_libraries(mirplatformwayland-graphics
+PUBLIC
+    mirplatform
+    server_platform_common
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${EGL_LIBRARIES}
+    ${GLESv2_LIBRARIES}
+    ${EPOXY_LIBRARIES}
+    ${WAYLAND_LIBRARIES}
+    ${WAYLAND_CLIENT_LIBRARIES}
+    ${WAYLAND_EGL_LIBRARIES}
+    ${DRM_LIBRARIES}
+    ${GBM_LIBRARIES}
+    ${XKBCOMMON_LIBRARIES}
+)
+
+add_library(mirplatformwayland-input STATIC
+  input_platform.cpp    input_platform.h
+  input_device.cpp      input_device.h
+)
+
+target_include_directories(mirplatformwayland-input
+PUBLIC
+    ${server_common_include_dirs}
+    ${PROJECT_SOURCE_DIR}/include/client
+)
+
+add_library(mirplatformwayland MODULE
+    input.cpp
+    platform_symbols.cpp
+)
+
+target_link_libraries(mirplatformwayland
+    PRIVATE
+        mirplatformwayland-graphics
+        mirplatformwayland-input
+)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/symbols.map.in
+    ${CMAKE_CURRENT_BINARY_DIR}/symbols.map
+)
+set(symbol_map ${CMAKE_CURRENT_BINARY_DIR}/symbols.map)
+
+set_target_properties(
+    mirplatformwayland PROPERTIES
+    OUTPUT_NAME graphics-wayland
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/server-modules
+    PREFIX ""
+    SUFFIX ".so.${MIR_SERVER_GRAPHICS_PLATFORM_ABI}"
+    LINK_FLAGS "-Wl,--exclude-libs=ALL -Wl,--version-script,${symbol_map}"
+    LINK_DEPENDS ${symbol_map}
+)
+
+install(TARGETS mirplatformwayland LIBRARY DESTINATION ${MIR_SERVER_PLATFORM_PATH})

--- a/src/platforms/wayland/buffer_allocator.cpp
+++ b/src/platforms/wayland/buffer_allocator.cpp
@@ -18,21 +18,58 @@
 
 #include "buffer_allocator.h"
 #include "shm_buffer.h"
+#include "display.h"
 
-#include "mir/anonymous_shm_file.h"
-#include "mir/graphics/buffer_properties.h"
+#include <mir/anonymous_shm_file.h>
+#include <mir/fatal.h>
+#include <mir/graphics/buffer_properties.h>
+#include <mir/graphics/egl_wayland_allocator.h>
+#include <mir/raii.h>
 
 #include <boost/throw_exception.hpp>
+#include <boost/exception/errinfo_errno.hpp>
 
 #include <system_error>
-#include <mir/fatal.h>
 
 namespace mg  = mir::graphics;
 namespace mgw = mg::wayland;
 namespace mgc = mg::common;
 namespace geom = mir::geometry;
 
-mgw::BufferAllocator::BufferAllocator()
+namespace
+{
+std::unique_ptr<mir::renderer::gl::Context> context_for_output(mg::Display const& output)
+{
+    try
+    {
+        auto& context_source = dynamic_cast<mir::renderer::gl::ContextSource const&>(output);
+
+        /*
+         * We care about no part of this context's config; we will do no rendering with it.
+         * All we care is that we can allocate texture IDs and bind a texture, which is
+         * config independent.
+         *
+         * That's not *entirely* true; we also need it to be on the same device as we want
+         * to do the rendering on, and that GL must support all the extensions we care about,
+         * but since we don't yet support heterogeneous hybrid and implementing that will require
+         * broader interface changes it's a safe enough requirement for now.
+         */
+        return context_source.create_gl_context();
+    }
+    catch (std::bad_cast const& err)
+    {
+        std::throw_with_nested(
+            boost::enable_error_info(std::runtime_error{"Output platform cannot provide a GL context"})
+                    << boost::throw_function(__PRETTY_FUNCTION__)
+                    << boost::throw_line(__LINE__)
+                    << boost::throw_file(__FILE__));
+    }
+}
+}
+
+mgw::BufferAllocator::BufferAllocator(graphics::Display const& output) :
+    egl_extensions(std::make_shared<mg::EGLExtensions>()),
+    ctx{context_for_output(output)}
 {
 }
 
@@ -85,4 +122,36 @@ std::vector<MirPixelFormat> mgw::BufferAllocator::supported_pixel_formats()
 std::shared_ptr<mg::Buffer> mgw::BufferAllocator::alloc_buffer(geometry::Size, uint32_t, uint32_t)
 {
     BOOST_THROW_EXCEPTION(std::runtime_error("platform incapable of creating buffers"));
+}
+
+void mgw::BufferAllocator::bind_display(wl_display* display, std::shared_ptr<Executor> wayland_executor)
+{
+    puts(__PRETTY_FUNCTION__);
+    auto context_guard = mir::raii::paired_calls(
+        [this]() { ctx->make_current(); },
+        [this]() { ctx->release_current(); });
+    auto dpy = eglGetCurrentDisplay();
+
+    mg::wayland::bind_display(dpy, display, *egl_extensions);
+
+    this->wayland_executor = std::move(wayland_executor);
+}
+
+auto mgw::BufferAllocator::buffer_from_resource(
+    wl_resource* buffer,
+    std::function<void()>&& on_consumed,
+    std::function<void()>&& on_release) -> std::shared_ptr<Buffer>
+{
+    puts(__PRETTY_FUNCTION__);
+    auto context_guard = mir::raii::paired_calls(
+        [this]() { ctx->make_current(); },
+        [this]() { ctx->release_current(); });
+
+    return mg::wayland::buffer_from_resource(
+        buffer,
+        std::move(on_consumed),
+        std::move(on_release),
+        ctx,
+        *egl_extensions,
+        wayland_executor);
 }

--- a/src/platforms/wayland/buffer_allocator.cpp
+++ b/src/platforms/wayland/buffer_allocator.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "buffer_allocator.h"
+#include "shm_buffer.h"
+
+#include "mir/anonymous_shm_file.h"
+#include "mir/graphics/buffer_properties.h"
+
+#include <boost/throw_exception.hpp>
+
+#include <system_error>
+#include <mir/fatal.h>
+
+namespace mg  = mir::graphics;
+namespace mgw = mg::wayland;
+namespace mgc = mg::common;
+namespace geom = mir::geometry;
+
+mgw::BufferAllocator::BufferAllocator()
+{
+}
+
+std::shared_ptr<mg::Buffer> mgw::BufferAllocator::alloc_buffer(
+    BufferProperties const& buffer_properties)
+{
+    if (buffer_properties.usage == mg::BufferUsage::software)
+        return alloc_software_buffer(buffer_properties.size, buffer_properties.format);
+    BOOST_THROW_EXCEPTION(std::runtime_error("platform incapable of creating hardware buffers"));
+}
+
+std::shared_ptr<mg::Buffer> mgw::BufferAllocator::alloc_software_buffer(geom::Size size, MirPixelFormat format)
+{
+    class SoftwareBuffer: public common::ShmBuffer
+    {
+    public:
+        SoftwareBuffer(
+            std::unique_ptr<ShmFile> shm_file,
+            geometry::Size const& size,
+            MirPixelFormat const& pixel_format) :
+            ShmBuffer(std::move(shm_file), size, pixel_format)
+        {
+        }
+
+        auto native_buffer_handle() const -> std::shared_ptr<NativeBuffer> override
+        {
+            fatal_error("wayland platform does not support mirclient");
+            return {};
+        }
+    };
+
+    if (!mgc::ShmBuffer::supports(format))
+    {
+        BOOST_THROW_EXCEPTION(
+            std::runtime_error(
+                "Trying to create SHM buffer with unsupported pixel format"));
+    }
+
+    auto const stride = geom::Stride{ MIR_BYTES_PER_PIXEL(format) * size.width.as_uint32_t() };
+    size_t const size_in_bytes = stride.as_int() * size.height.as_int();
+    return std::make_shared<SoftwareBuffer>(
+        std::make_unique<AnonymousShmFile>(size_in_bytes), size, format);
+}
+
+std::vector<MirPixelFormat> mgw::BufferAllocator::supported_pixel_formats()
+{
+    return {mir_pixel_format_argb_8888, mir_pixel_format_xrgb_8888};
+}
+
+std::shared_ptr<mg::Buffer> mgw::BufferAllocator::alloc_buffer(geometry::Size, uint32_t, uint32_t)
+{
+    BOOST_THROW_EXCEPTION(std::runtime_error("platform incapable of creating buffers"));
+}

--- a/src/platforms/wayland/buffer_allocator.cpp
+++ b/src/platforms/wayland/buffer_allocator.cpp
@@ -121,7 +121,7 @@ std::vector<MirPixelFormat> mgw::BufferAllocator::supported_pixel_formats()
 
 std::shared_ptr<mg::Buffer> mgw::BufferAllocator::alloc_buffer(geometry::Size, uint32_t, uint32_t)
 {
-    BOOST_THROW_EXCEPTION(std::runtime_error("platform incapable of creating buffers"));
+    BOOST_THROW_EXCEPTION(std::runtime_error("platform incapable of creating native buffers"));
 }
 
 void mgw::BufferAllocator::bind_display(wl_display* display, std::shared_ptr<Executor> wayland_executor)

--- a/src/platforms/wayland/buffer_allocator.cpp
+++ b/src/platforms/wayland/buffer_allocator.cpp
@@ -126,7 +126,6 @@ std::shared_ptr<mg::Buffer> mgw::BufferAllocator::alloc_buffer(geometry::Size, u
 
 void mgw::BufferAllocator::bind_display(wl_display* display, std::shared_ptr<Executor> wayland_executor)
 {
-    puts(__PRETTY_FUNCTION__);
     auto context_guard = mir::raii::paired_calls(
         [this]() { ctx->make_current(); },
         [this]() { ctx->release_current(); });
@@ -142,7 +141,6 @@ auto mgw::BufferAllocator::buffer_from_resource(
     std::function<void()>&& on_consumed,
     std::function<void()>&& on_release) -> std::shared_ptr<Buffer>
 {
-    puts(__PRETTY_FUNCTION__);
     auto context_guard = mir::raii::paired_calls(
         [this]() { ctx->make_current(); },
         [this]() { ctx->release_current(); });

--- a/src/platforms/wayland/buffer_allocator.h
+++ b/src/platforms/wayland/buffer_allocator.h
@@ -19,7 +19,10 @@
 #ifndef  MIR_GRAPHICS_WAYLAND_BUFFER_ALLOCATOR_
 #define  MIR_GRAPHICS_WAYLAND_BUFFER_ALLOCATOR_
 
-#include "mir/graphics/graphic_buffer_allocator.h"
+#include <mir/graphics/egl_extensions.h>
+#include <mir/graphics/graphic_buffer_allocator.h>
+#include <mir/graphics/wayland_allocator.h>
+#include <mir/renderer/gl/context.h>
 
 #include <memory>
 
@@ -27,19 +30,34 @@ namespace mir
 {
 namespace graphics
 {
+class Display;
+
 namespace wayland
 {
-class BufferAllocator: public graphics::GraphicBufferAllocator
+class BufferAllocator: public GraphicBufferAllocator,
+                       public WaylandAllocator
 {
 public:
-    BufferAllocator();
+    BufferAllocator(graphics::Display const& output);
 
-    std::shared_ptr<Buffer> alloc_buffer(graphics::BufferProperties const& buffer_properties) override;
+    std::shared_ptr<Buffer> alloc_buffer(BufferProperties const& buffer_properties) override;
 
     std::shared_ptr<Buffer> alloc_software_buffer(geometry::Size size, MirPixelFormat format) override;
     std::shared_ptr<Buffer> alloc_buffer(geometry::Size size, uint32_t native_format, uint32_t native_flags) override;
 
+    void bind_display(wl_display* display, std::shared_ptr<Executor> wayland_executor) override;
+
+    auto buffer_from_resource(
+        wl_resource* buffer,
+        std::function<void()>&& on_consumed,
+        std::function<void()>&& on_release) -> std::shared_ptr<Buffer> override;
+
     std::vector<MirPixelFormat> supported_pixel_formats() override;
+
+private:
+    std::shared_ptr<Executor> wayland_executor;
+    std::shared_ptr<EGLExtensions> const egl_extensions;
+    std::shared_ptr<renderer::gl::Context> const ctx;
 };
 }
 }

--- a/src/platforms/wayland/buffer_allocator.h
+++ b/src/platforms/wayland/buffer_allocator.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#ifndef  MIR_GRAPHICS_WAYLAND_BUFFER_ALLOCATOR_
+#define  MIR_GRAPHICS_WAYLAND_BUFFER_ALLOCATOR_
+
+#include "mir/graphics/graphic_buffer_allocator.h"
+
+#include <memory>
+
+namespace mir
+{
+namespace graphics
+{
+namespace wayland
+{
+class BufferAllocator: public graphics::GraphicBufferAllocator
+{
+public:
+    BufferAllocator();
+
+    std::shared_ptr<Buffer> alloc_buffer(graphics::BufferProperties const& buffer_properties) override;
+
+    std::shared_ptr<Buffer> alloc_software_buffer(geometry::Size size, MirPixelFormat format) override;
+    std::shared_ptr<Buffer> alloc_buffer(geometry::Size size, uint32_t native_format, uint32_t native_flags) override;
+
+    std::vector<MirPixelFormat> supported_pixel_formats() override;
+};
+}
+}
+}
+
+#endif //  MIR_GRAPHICS_WAYLAND_BUFFER_ALLOCATOR_

--- a/src/platforms/wayland/cursor.cpp
+++ b/src/platforms/wayland/cursor.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "cursor.h"
+
+namespace mpw = mir::platform::wayland;
+
+mpw::Cursor::Cursor(wl_display* display, std::shared_ptr<graphics::CursorImage> const& default_image) :
+    display(display),
+    default_image(default_image)
+{
+    puts(__PRETTY_FUNCTION__);
+}
+
+mpw::Cursor::~Cursor() = default;
+
+void mpw::Cursor::move_to(geometry::Point)
+{
+}
+
+void mpw::Cursor::show(graphics::CursorImage const& /*cursor_image*/)
+{
+    puts(__PRETTY_FUNCTION__);
+}
+
+void mpw::Cursor::show()
+{
+    puts(__PRETTY_FUNCTION__);
+}
+
+void mpw::Cursor::hide()
+{
+    puts(__PRETTY_FUNCTION__);
+}

--- a/src/platforms/wayland/cursor.cpp
+++ b/src/platforms/wayland/cursor.cpp
@@ -31,6 +31,7 @@ mpw::Cursor::~Cursor() = default;
 
 void mpw::Cursor::move_to(geometry::Point)
 {
+    puts(__PRETTY_FUNCTION__);
 }
 
 void mpw::Cursor::show(graphics::CursorImage const& /*cursor_image*/)

--- a/src/platforms/wayland/cursor.cpp
+++ b/src/platforms/wayland/cursor.cpp
@@ -17,36 +17,133 @@
  */
 
 #include "cursor.h"
+#include "displayclient.h"
+
+#include <mir/fd.h>
 
 #include <wayland-client.h>
 
+#include <boost/throw_exception.hpp>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#include <cstring>
+#include <system_error>
+
 namespace mpw = mir::platform::wayland;
 
-mpw::Cursor::Cursor(wl_display* display, std::shared_ptr<graphics::CursorImage> const& default_image) :
-    display(display),
-    default_image(default_image)
+namespace
 {
-//    puts(__PRETTY_FUNCTION__);
+struct wl_shm_pool* make_shm_pool(struct wl_shm* shm, int size, void **data)
+{
+    static auto (*open_shm_file)() -> mir::Fd = []
+        {
+            open_shm_file = []
+                {
+                    // As we're a Wayland client, create the shm file like Wayland clients.
+                    // While using O_TMPFILE would be more elegant, this works with Snap-confined servers.
+                    static auto const template_filename =
+                        std::string{getenv("XDG_RUNTIME_DIR")} + "/wayland-cursor-shared-XXXXXX";
+
+                    auto const filename = strdup(template_filename.c_str());
+                    mir::Fd fd{mkostemp(filename, O_CLOEXEC)};
+                    if (fd != -1)
+                    {
+                        if (unlink(filename) < 0)
+                        {
+                            free(filename);
+                            return mir::Fd{};
+                        }
+                    }
+                    free(filename);
+                    return fd;
+                };
+
+            return open_shm_file();
+        };
+
+    auto fd = open_shm_file();
+
+    if (fd < 0) {
+        BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to open shm buffer"}));
+    }
+
+    if (auto error = posix_fallocate(fd, 0, size))
+    {
+        BOOST_THROW_EXCEPTION((std::system_error{error, std::system_category(), "Failed to allocate shm buffer"}));
+    }
+
+    if ((*data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0)) == MAP_FAILED)
+    {
+        BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to mmap buffer"}));
+    }
+
+    return wl_shm_create_pool(shm, fd, size);
+}
 }
 
-mpw::Cursor::~Cursor() = default;
+mpw::Cursor::Cursor(wl_display* display, wl_compositor* compositor, wl_shm* shm, std::shared_ptr<graphics::CursorImage> const& default_image) :
+    default_image(default_image),
+    display{display},
+    compositor{compositor},
+    shm{shm},
+    surface{wl_compositor_create_surface(compositor)}
+{
+    if (default_image) show(*default_image);
+}
+
+mpw::Cursor::~Cursor()
+{
+    wl_surface_destroy(surface);
+
+    std::lock_guard<decltype(mutex)> lock{mutex};
+    if (buffer) wl_buffer_destroy(buffer);
+}
 
 void mpw::Cursor::move_to(geometry::Point)
 {
-//    puts(__PRETTY_FUNCTION__);
 }
 
-void mpw::Cursor::show(graphics::CursorImage const& /*cursor_image*/)
+void mpw::Cursor::show(graphics::CursorImage const& cursor_image)
 {
-//    puts(__PRETTY_FUNCTION__);
+    {
+        std::lock_guard<decltype(mutex)> lock{mutex};
+        if (buffer) wl_buffer_destroy(buffer);
+
+        auto const width = cursor_image.size().width.as_uint32_t();
+        auto const height = cursor_image.size().height.as_uint32_t();
+        auto const hotspot_x = cursor_image.hotspot().dx.as_uint32_t();
+        auto const hotspot_y = cursor_image.hotspot().dy.as_uint32_t();
+        void* data_buffer;
+        auto const shm_pool = make_shm_pool(shm, 4 * width * height, &data_buffer);
+        memcpy(data_buffer, cursor_image.as_argb_8888(), 4 * width * height);
+        buffer = wl_shm_pool_create_buffer(shm_pool, 0, width, height, 4 * width, WL_SHM_FORMAT_ARGB8888);
+        wl_surface_attach(surface, buffer, 0, 0);
+        wl_surface_commit(surface);
+        wl_shm_pool_destroy(shm_pool);
+        if (pointer) wl_pointer_set_cursor(pointer, 0, surface, hotspot_x, hotspot_y);
+    }
+    wl_display_roundtrip(display);
 }
 
 void mpw::Cursor::show()
 {
-//    puts(__PRETTY_FUNCTION__);
 }
 
 void mpw::Cursor::hide()
 {
-//    puts(__PRETTY_FUNCTION__);
+}
+
+void mir::platform::wayland::Cursor::enter(wl_pointer* pointer)
+{
+    std::lock_guard<decltype(mutex)> lock{mutex};
+    this->pointer = pointer;
+}
+
+void mir::platform::wayland::Cursor::leave(wl_pointer* /*pointer*/)
+{
+    std::lock_guard<decltype(mutex)> lock{mutex};
+    pointer = nullptr;
 }

--- a/src/platforms/wayland/cursor.cpp
+++ b/src/platforms/wayland/cursor.cpp
@@ -18,33 +18,35 @@
 
 #include "cursor.h"
 
+#include <wayland-client.h>
+
 namespace mpw = mir::platform::wayland;
 
 mpw::Cursor::Cursor(wl_display* display, std::shared_ptr<graphics::CursorImage> const& default_image) :
     display(display),
     default_image(default_image)
 {
-    puts(__PRETTY_FUNCTION__);
+//    puts(__PRETTY_FUNCTION__);
 }
 
 mpw::Cursor::~Cursor() = default;
 
 void mpw::Cursor::move_to(geometry::Point)
 {
-    puts(__PRETTY_FUNCTION__);
+//    puts(__PRETTY_FUNCTION__);
 }
 
 void mpw::Cursor::show(graphics::CursorImage const& /*cursor_image*/)
 {
-    puts(__PRETTY_FUNCTION__);
+//    puts(__PRETTY_FUNCTION__);
 }
 
 void mpw::Cursor::show()
 {
-    puts(__PRETTY_FUNCTION__);
+//    puts(__PRETTY_FUNCTION__);
 }
 
 void mpw::Cursor::hide()
 {
-    puts(__PRETTY_FUNCTION__);
+//    puts(__PRETTY_FUNCTION__);
 }

--- a/src/platforms/wayland/cursor.h
+++ b/src/platforms/wayland/cursor.h
@@ -36,7 +36,7 @@ namespace wayland
 class Cursor : public graphics::Cursor
 {
 public:
-    Cursor(wl_display* display, wl_compositor* compositor, wl_shm* shm, std::shared_ptr<graphics::CursorImage> const& default_image);
+    Cursor(wl_display* display, wl_compositor* compositor, wl_shm* shm);
 
     ~Cursor();
 
@@ -52,8 +52,6 @@ public:
     void leave(wl_pointer* pointer);
 
 private:
-    std::shared_ptr<graphics::CursorImage> const default_image;
-
     wl_display* const display;
     wl_compositor* const compositor;
     wl_shm* const shm;

--- a/src/platforms/wayland/cursor.h
+++ b/src/platforms/wayland/cursor.h
@@ -21,7 +21,10 @@
 
 #include <mir/graphics/cursor.h>
 #include <mir/graphics/cursor_image.h>
+
 #include <wayland-client.h>
+
+#include <mutex>
 
 namespace mir
 {
@@ -33,7 +36,7 @@ namespace wayland
 class Cursor : public graphics::Cursor
 {
 public:
-    Cursor(wl_display* display, std::shared_ptr<graphics::CursorImage> const& default_image);
+    Cursor(wl_display* display, wl_compositor* compositor, wl_shm* shm, std::shared_ptr<graphics::CursorImage> const& default_image);
 
     ~Cursor();
 
@@ -45,9 +48,21 @@ public:
 
     void move_to(geometry::Point position) override;
 
+    void enter(wl_pointer* pointer);
+    void leave(wl_pointer* pointer);
+
 private:
-    wl_display* const display;
     std::shared_ptr<graphics::CursorImage> const default_image;
+
+    wl_display* const display;
+    wl_compositor* const compositor;
+    wl_shm* const shm;
+
+    wl_surface* surface;
+
+    std::mutex mutable mutex;
+    wl_buffer* buffer{nullptr};
+    wl_pointer* pointer{nullptr};
 };
 }
 }

--- a/src/platforms/wayland/cursor.h
+++ b/src/platforms/wayland/cursor.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#ifndef MIR_PLATFORM_WAYLAND_CURSOR_H_
+#define MIR_PLATFORM_WAYLAND_CURSOR_H_
+
+#include <mir/graphics/cursor.h>
+#include <mir/graphics/cursor_image.h>
+#include <wayland-client.h>
+
+namespace mir
+{
+namespace platform
+{
+namespace wayland
+{
+
+class Cursor : public graphics::Cursor
+{
+public:
+    Cursor(wl_display* display, std::shared_ptr<graphics::CursorImage> const& default_image);
+
+    ~Cursor();
+
+    void show(graphics::CursorImage const& image) override;
+
+    void show() override;
+
+    void hide() override;
+
+    void move_to(geometry::Point position) override;
+
+private:
+    wl_display* const display;
+    std::shared_ptr<graphics::CursorImage> const default_image;
+};
+}
+}
+}
+
+#endif //MIR_PLATFORM_WAYLAND_CURSOR_H_

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -28,17 +28,56 @@
 
 #include <boost/throw_exception.hpp>
 
+#include <sys/eventfd.h>
+#include <sys/poll.h>
+
 namespace mgw = mir::graphics::wayland;
 namespace mrg = mir::renderer::gl;
 namespace geom= mir::geometry;
+
+namespace
+{
+class NullInputSink : public mir::input::wayland::InputSinkX
+{
+    void key_press(std::chrono::nanoseconds, xkb_keysym_t, int32_t) override {}
+
+    void key_release(std::chrono::nanoseconds, xkb_keysym_t, int32_t) override {}
+
+    void update_button_state(int) override {}
+
+    void pointer_press(
+        std::chrono::nanoseconds, int, mir::geometry::Point const&,
+        mir::geometry::Displacement) override
+    {
+    }
+
+    void pointer_release(
+        std::chrono::nanoseconds, int, mir::geometry::Point const&,
+        mir::geometry::Displacement) override
+    {
+    }
+
+    void pointer_motion(
+        std::chrono::nanoseconds, mir::geometry::Point const&,
+        mir::geometry::Displacement) override
+    {
+    }
+};
+}
+
+mgw::Display* mgw::the_display = nullptr;
 
 mgw::Display::Display(
     wl_display* const wl_display,
     std::shared_ptr<GLConfig> const& gl_config,
     std::shared_ptr<DisplayReport> const& report) :
     DisplayClient{wl_display, gl_config},
-    report{report}
+    report{report},
+    shutdown_signal{::eventfd(0, EFD_CLOEXEC)},
+    keyboard_sink{std::make_shared<NullInputSink>()}
 {
+    runner = std::thread{[this] { run(); }};
+    the_display = this;
 }
 
 auto mgw::Display::configuration() const -> std::unique_ptr<DisplayConfiguration>
@@ -131,7 +170,124 @@ auto mgw::Display::create_gl_context() const -> std::unique_ptr<mrg::Context>
     return std::make_unique<GlContext>(egldisplay, eglconfig, eglctx);
 }
 
-void  mgw::Display::for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f)
+void mgw::Display::for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f)
 {
     DisplayClient::for_each_display_sync_group(f);
+}
+
+void mgw::Display::set_keyboard_sink(std::shared_ptr<input::wayland::InputSinkX> const& keyboard_sink)
+{
+    std::lock_guard<decltype(sink_mutex)> lock{sink_mutex};
+    if (keyboard_sink)
+    {
+        this->keyboard_sink = keyboard_sink;
+    }
+    else
+    {
+        this->keyboard_sink = std::make_shared<NullInputSink>();
+    }
+}
+
+void mir::graphics::wayland::Display::keyboard_keymap(wl_keyboard* keyboard, uint32_t format, int32_t fd, uint32_t size)
+{
+    DisplayClient::keyboard_keymap(keyboard, format, fd, size);
+}
+
+void mir::graphics::wayland::Display::keyboard_enter(
+    wl_keyboard* keyboard, uint32_t serial, wl_surface* surface, wl_array* keys)
+{
+    DisplayClient::keyboard_enter(keyboard, serial, surface, keys);
+}
+
+void mir::graphics::wayland::Display::keyboard_leave(wl_keyboard* keyboard, uint32_t serial, wl_surface* surface)
+{
+    DisplayClient::keyboard_leave(keyboard, serial, surface);
+}
+
+void mir::graphics::wayland::Display::keyboard_key(wl_keyboard*, uint32_t, uint32_t time, uint32_t key, uint32_t state)
+{
+    auto const keysym = xkb_state_key_get_one_sym(keyboard_state(), key + 8);
+
+    std::lock_guard<decltype(sink_mutex)> lock{sink_mutex};
+    switch (state)
+    {
+    case WL_KEYBOARD_KEY_STATE_PRESSED:
+        keyboard_sink->key_press(std::chrono::milliseconds{time}, keysym, key);
+        break;
+
+    case WL_KEYBOARD_KEY_STATE_RELEASED:
+        keyboard_sink->key_release(std::chrono::milliseconds{time}, keysym, key);
+        break;
+    }
+}
+
+void mir::graphics::wayland::Display::keyboard_modifiers(
+    wl_keyboard* keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked,
+    uint32_t group)
+{
+    DisplayClient::keyboard_modifiers(keyboard, serial, mods_depressed, mods_latched, mods_locked, group);
+}
+
+void mir::graphics::wayland::Display::keyboard_repeat_info(wl_keyboard* wl_keyboard, int32_t rate, int32_t delay)
+{
+    DisplayClient::keyboard_repeat_info(wl_keyboard, rate, delay);
+}
+
+void mir::graphics::wayland::Display::run() const
+{
+    enum FdIndices {
+        display_fd = 0,
+        shutdown,
+        indices
+    };
+
+    pollfd fds[indices] =
+        {
+            fds[display_fd] = {wl_display_get_fd(display), POLLIN, 0},
+            {shutdown_signal, POLLIN, 0},
+        };
+
+    while (!(fds[shutdown].revents & (POLLIN | POLLERR)))
+    {
+        while (wl_display_prepare_read(display) != 0)
+        {
+            if (wl_display_dispatch_pending(display) == -1)
+            {
+                BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to dispatch Wayland events"}));
+            }
+        }
+
+        if (poll(fds, indices, -1) == -1)
+        {
+            wl_display_cancel_read(display);
+            BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to wait for event"}));
+        }
+
+        if (fds[display_fd].revents & (POLLIN | POLLERR))
+        {
+            if (wl_display_read_events(display))
+            {
+                BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to read Wayland events"}));
+            }
+        }
+        else
+        {
+            wl_display_cancel_read(display);
+        }
+    }
+}
+
+void mir::graphics::wayland::Display::stop()
+{
+    if (eventfd_write(shutdown_signal, 1) == -1)
+    {
+        BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to shutdown"}));
+    }
+}
+
+mir::graphics::wayland::Display::~Display()
+{
+    the_display = nullptr;
+    stop();
+    if (runner.joinable()) runner.join();
 }

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -27,6 +27,7 @@
 #include <mir/log.h>
 #include <mir/renderer/gl/context.h>
 
+#include <boost/exception/diagnostic_information.hpp>
 #include <boost/throw_exception.hpp>
 
 #include <sys/eventfd.h>
@@ -231,6 +232,7 @@ void mir::graphics::wayland::Display::keyboard_key(wl_keyboard*, uint32_t, uint3
 }
 
 void mir::graphics::wayland::Display::run() const
+try
 {
     enum FdIndices {
         display_fd = 0,
@@ -272,6 +274,10 @@ void mir::graphics::wayland::Display::run() const
             wl_display_cancel_read(display);
         }
     }
+}
+catch (std::exception const& e)
+{
+    fatal_error("Critical error in Wayland platform: %s\n", boost::diagnostic_information(e).c_str());
 }
 
 void mir::graphics::wayland::Display::stop()

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -313,7 +313,7 @@ void mir::graphics::wayland::Display::pointer_motion(wl_pointer* pointer, uint32
     {
         std::lock_guard<decltype(sink_mutex)> lock{sink_mutex};
         geom::Point const new_pointer{wl_fixed_to_int(x), wl_fixed_to_int(y)};
-        pointer_pos = new_pointer;
+        pointer_pos = new_pointer + pointer_displacement;
         pointer_time = std::chrono::milliseconds{time};
     }
 
@@ -374,6 +374,8 @@ void mir::graphics::wayland::Display::pointer_frame(wl_pointer* pointer)
 void mir::graphics::wayland::Display::touch_down(
     wl_touch* touch, uint32_t serial, uint32_t time, wl_surface* surface, int32_t id, wl_fixed_t x, wl_fixed_t y)
 {
+    DisplayClient::touch_down(touch, serial, time, surface, id, x, y);
+
     {
         std::lock_guard<decltype(sink_mutex)> lock{sink_mutex};
 
@@ -389,11 +391,9 @@ void mir::graphics::wayland::Display::touch_down(
 
         touch_time = std::chrono::milliseconds{time};
         contact->action = mir_touch_action_down;
-        contact->x = wl_fixed_to_double(x);
-        contact->y = wl_fixed_to_double(y);
+        contact->x = wl_fixed_to_double(x) + touch_displacement.dx.as_int();
+        contact->y = wl_fixed_to_double(y) + touch_displacement.dy.as_int();
     }
-
-    DisplayClient::touch_down(touch, serial, time, surface, id, x, y);
 }
 
 void mir::graphics::wayland::Display::touch_up(wl_touch* touch, uint32_t serial, uint32_t time, int32_t id)
@@ -434,8 +434,8 @@ void mir::graphics::wayland::Display::touch_motion(wl_touch* touch, uint32_t tim
             contact->action = mir_touch_action_change;
         }
 
-        contact->x = wl_fixed_to_double(x);
-        contact->y = wl_fixed_to_double(y);
+        contact->x = wl_fixed_to_double(x) + touch_displacement.dx.as_int();
+        contact->y = wl_fixed_to_double(y) + touch_displacement.dy.as_int();
     }
 
     DisplayClient::touch_motion(touch, time, id, x, y);

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <epoxy/egl.h>
+
+#include "display.h"
+#include "cursor.h"
+
+#include <mir/fatal.h>
+#include <mir/graphics/display_configuration.h>
+#include <mir/graphics/virtual_output.h>
+#include <mir/renderer/gl/context.h>
+
+#include <boost/throw_exception.hpp>
+
+namespace mgw = mir::graphics::wayland;
+namespace mrg = mir::renderer::gl;
+namespace geom= mir::geometry;
+
+mgw::Display::Display(wl_display* const wl_display, std::shared_ptr<DisplayReport> const& report) :
+    DisplayClient{wl_display},
+    report{report}
+{
+    puts(__PRETTY_FUNCTION__);
+}
+
+auto mgw::Display::configuration() const -> std::unique_ptr<DisplayConfiguration>
+{
+    puts(__PRETTY_FUNCTION__);
+    return DisplayClient::display_configuration();
+}
+
+void mgw::Display::configure(DisplayConfiguration const& /*conf*/)
+{
+    puts(__PRETTY_FUNCTION__);
+}
+
+void mgw::Display::register_configuration_change_handler(
+    EventHandlerRegister& /*handlers*/,
+    DisplayConfigurationChangeHandler const& /*conf_change_handler*/)
+{
+    puts(__PRETTY_FUNCTION__);
+}
+
+void mgw::Display::register_pause_resume_handlers(
+    EventHandlerRegister& /*handlers*/,
+    DisplayPauseHandler const& /*pause_handler*/,
+    DisplayResumeHandler const& /*resume_handler*/)
+{
+    puts(__PRETTY_FUNCTION__);
+}
+
+void mgw::Display::pause()
+{
+    puts(__PRETTY_FUNCTION__);
+   BOOST_THROW_EXCEPTION(std::runtime_error("'Display::pause()' not yet supported on wayland platform"));
+}
+
+void mgw::Display::resume()
+{
+    puts(__PRETTY_FUNCTION__);
+    BOOST_THROW_EXCEPTION(std::runtime_error("'Display::resume()' not yet supported on wayland platform"));
+}
+
+auto mgw::Display::create_hardware_cursor() -> std::shared_ptr<Cursor>
+{
+    puts(__PRETTY_FUNCTION__);
+    return std::make_shared<platform::wayland::Cursor>(display, std::shared_ptr<CursorImage>{});
+}
+
+auto mgw::Display::create_virtual_output(int /*width*/, int /*height*/) -> std::unique_ptr<VirtualOutput>
+{
+    fatal_error(__PRETTY_FUNCTION__);
+    return {};
+}
+
+auto mgw::Display::native_display() -> NativeDisplay*
+{
+    puts(__PRETTY_FUNCTION__);
+    return this;
+}
+
+bool mgw::Display::apply_if_configuration_preserves_display_buffers(DisplayConfiguration const& /*conf*/)
+{
+    puts(__PRETTY_FUNCTION__);
+    return false;
+}
+
+auto mgw::Display::last_frame_on(unsigned) const -> Frame
+{
+    fatal_error(__PRETTY_FUNCTION__);
+    return {};
+}
+
+auto mgw::Display::create_gl_context() const -> std::unique_ptr<mrg::Context>
+{
+    puts(__PRETTY_FUNCTION__);
+    class WlContext : public mir::renderer::gl::Context
+    {
+    public:
+        WlContext(mgw::Display const* display, EGLSurface surface) : display{display}, surface{surface} { puts(__PRETTY_FUNCTION__); }
+        void make_current()     const override  { puts(__PRETTY_FUNCTION__); display->make_current(surface); }
+        void release_current()  const override  { puts(__PRETTY_FUNCTION__); display->make_current(EGL_NO_SURFACE); }
+
+    private:
+        mgw::Display const* const display;
+        EGLSurface const surface;
+    };
+
+    // TODO: Where do we get a meaningful EGL surface?
+    return std::make_unique<WlContext>(this, EGL_NO_SURFACE);
+}
+
+void  mgw::Display::for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f)
+{
+    DisplayClient::for_each_display_sync_group(f);
+}

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -131,7 +131,7 @@ void mgw::Display::resume()
 
 auto mgw::Display::create_hardware_cursor() -> std::shared_ptr<Cursor>
 {
-    cursor = std::make_shared<platform::wayland::Cursor>(display, compositor, shm, std::shared_ptr<CursorImage>{});
+    cursor = std::make_shared<platform::wayland::Cursor>(display, compositor, shm);
     return cursor;
 }
 

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -30,8 +30,11 @@ namespace mgw = mir::graphics::wayland;
 namespace mrg = mir::renderer::gl;
 namespace geom= mir::geometry;
 
-mgw::Display::Display(wl_display* const wl_display, std::shared_ptr<DisplayReport> const& report) :
-    DisplayClient{wl_display},
+mgw::Display::Display(
+    wl_display* const wl_display,
+    std::shared_ptr<GLConfig> const& gl_config,
+    std::shared_ptr<DisplayReport> const& report) :
+    DisplayClient{wl_display, gl_config},
     report{report}
 {
 }

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -193,22 +193,6 @@ void mgw::Display::set_keyboard_sink(std::shared_ptr<input::wayland::InputSinkX>
     }
 }
 
-void mir::graphics::wayland::Display::keyboard_keymap(wl_keyboard* keyboard, uint32_t format, int32_t fd, uint32_t size)
-{
-    DisplayClient::keyboard_keymap(keyboard, format, fd, size);
-}
-
-void mir::graphics::wayland::Display::keyboard_enter(
-    wl_keyboard* keyboard, uint32_t serial, wl_surface* surface, wl_array* keys)
-{
-    DisplayClient::keyboard_enter(keyboard, serial, surface, keys);
-}
-
-void mir::graphics::wayland::Display::keyboard_leave(wl_keyboard* keyboard, uint32_t serial, wl_surface* surface)
-{
-    DisplayClient::keyboard_leave(keyboard, serial, surface);
-}
-
 void mir::graphics::wayland::Display::keyboard_key(wl_keyboard*, uint32_t, uint32_t time, uint32_t key, uint32_t state)
 {
     auto const keysym = xkb_state_key_get_one_sym(keyboard_state(), key + 8);
@@ -224,18 +208,6 @@ void mir::graphics::wayland::Display::keyboard_key(wl_keyboard*, uint32_t, uint3
         keyboard_sink->key_release(std::chrono::milliseconds{time}, keysym, key);
         break;
     }
-}
-
-void mir::graphics::wayland::Display::keyboard_modifiers(
-    wl_keyboard* keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked,
-    uint32_t group)
-{
-    DisplayClient::keyboard_modifiers(keyboard, serial, mods_depressed, mods_latched, mods_locked, group);
-}
-
-void mir::graphics::wayland::Display::keyboard_repeat_info(wl_keyboard* wl_keyboard, int32_t rate, int32_t delay)
-{
-    DisplayClient::keyboard_repeat_info(wl_keyboard, rate, delay);
 }
 
 void mir::graphics::wayland::Display::run() const

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -43,8 +43,6 @@ class NullInputSink : public mir::input::wayland::InputSinkX
 
     void key_release(std::chrono::nanoseconds, xkb_keysym_t, int32_t) override {}
 
-    void update_button_state(int) override {}
-
     void pointer_press(
         std::chrono::nanoseconds, int, mir::geometry::Point const&,
         mir::geometry::Displacement) override
@@ -320,9 +318,11 @@ void mir::graphics::wayland::Display::pointer_leave(wl_pointer* pointer, uint32_
 void mir::graphics::wayland::Display::pointer_motion(wl_pointer*, uint32_t time, wl_fixed_t x, wl_fixed_t y)
 {
     std::lock_guard<decltype(sink_mutex)> lock{sink_mutex};
-    pointer = {wl_fixed_to_int(x), wl_fixed_to_int(y)};
+    geom::Point const new_pointer{wl_fixed_to_int(x), wl_fixed_to_int(y)};
+    auto const movement = new_pointer - pointer;
+    pointer = new_pointer;
     //            pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll) = 0;
-    pointer_sink->pointer_motion(std::chrono::milliseconds{time}, pointer, {});
+    pointer_sink->pointer_motion(std::chrono::milliseconds{time}, pointer, movement);
 }
 
 void mir::graphics::wayland::Display::pointer_button(wl_pointer*, uint32_t, uint32_t time, uint32_t button, uint32_t state)

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -34,12 +34,10 @@ mgw::Display::Display(wl_display* const wl_display, std::shared_ptr<DisplayRepor
     DisplayClient{wl_display},
     report{report}
 {
-    puts(__PRETTY_FUNCTION__);
 }
 
 auto mgw::Display::configuration() const -> std::unique_ptr<DisplayConfiguration>
 {
-    puts(__PRETTY_FUNCTION__);
     return DisplayClient::display_configuration();
 }
 
@@ -65,31 +63,26 @@ void mgw::Display::register_pause_resume_handlers(
 
 void mgw::Display::pause()
 {
-    puts(__PRETTY_FUNCTION__);
    BOOST_THROW_EXCEPTION(std::runtime_error("'Display::pause()' not yet supported on wayland platform"));
 }
 
 void mgw::Display::resume()
 {
-    puts(__PRETTY_FUNCTION__);
     BOOST_THROW_EXCEPTION(std::runtime_error("'Display::resume()' not yet supported on wayland platform"));
 }
 
 auto mgw::Display::create_hardware_cursor() -> std::shared_ptr<Cursor>
 {
-    puts(__PRETTY_FUNCTION__);
     return std::make_shared<platform::wayland::Cursor>(display, std::shared_ptr<CursorImage>{});
 }
 
 auto mgw::Display::create_virtual_output(int /*width*/, int /*height*/) -> std::unique_ptr<VirtualOutput>
 {
-    fatal_error(__PRETTY_FUNCTION__);
     return {};
 }
 
 auto mgw::Display::native_display() -> NativeDisplay*
 {
-    puts(__PRETTY_FUNCTION__);
     return this;
 }
 
@@ -108,11 +101,10 @@ auto mgw::Display::last_frame_on(unsigned) const -> Frame
 auto mgw::Display::create_gl_context() const -> std::unique_ptr<mrg::Context>
 {
     // AFAICS this is only used for snapshotting the display. Stub it out for now, as that's mirclient only.
-    puts(__PRETTY_FUNCTION__);
     class StubContext : public mir::renderer::gl::Context
     {
     public:
-        StubContext() { puts(__PRETTY_FUNCTION__); }
+        StubContext() { }
         void make_current()     const override  { puts(__PRETTY_FUNCTION__); }
         void release_current()  const override  { puts(__PRETTY_FUNCTION__); }
     };

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -153,6 +153,11 @@ auto mgw::Display::create_gl_context() const -> std::unique_ptr<mrg::Context>
             egldisplay{egldisplay},
             eglctx{eglCreateContext(egldisplay, eglconfig, eglctx, nullptr)} {}
 
+        ~GlContext()
+        {
+            eglDestroyContext(egldisplay, eglctx);
+        }
+
         void make_current()     const override
         {
             if (eglMakeCurrent(egldisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, eglctx) != EGL_TRUE)

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -107,21 +107,17 @@ auto mgw::Display::last_frame_on(unsigned) const -> Frame
 
 auto mgw::Display::create_gl_context() const -> std::unique_ptr<mrg::Context>
 {
+    // AFAICS this is only used for snapshotting the display. Stub it out for now, as that's mirclient only.
     puts(__PRETTY_FUNCTION__);
-    class WlContext : public mir::renderer::gl::Context
+    class StubContext : public mir::renderer::gl::Context
     {
     public:
-        WlContext(mgw::Display const* display, EGLSurface surface) : display{display}, surface{surface} { puts(__PRETTY_FUNCTION__); }
-        void make_current()     const override  { puts(__PRETTY_FUNCTION__); display->make_current(surface); }
-        void release_current()  const override  { puts(__PRETTY_FUNCTION__); display->make_current(EGL_NO_SURFACE); }
-
-    private:
-        mgw::Display const* const display;
-        EGLSurface const surface;
+        StubContext() { puts(__PRETTY_FUNCTION__); }
+        void make_current()     const override  { puts(__PRETTY_FUNCTION__); }
+        void release_current()  const override  { puts(__PRETTY_FUNCTION__); }
     };
 
-    // TODO: Where do we get a meaningful EGL surface?
-    return std::make_unique<WlContext>(this, EGL_NO_SURFACE);
+    return std::make_unique<StubContext>();
 }
 
 void  mgw::Display::for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f)

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -120,7 +120,8 @@ void mgw::Display::resume()
 
 auto mgw::Display::create_hardware_cursor() -> std::shared_ptr<Cursor>
 {
-    return std::make_shared<platform::wayland::Cursor>(display, std::shared_ptr<CursorImage>{});
+    cursor = std::make_shared<platform::wayland::Cursor>(display, compositor, shm, std::shared_ptr<CursorImage>{});
+    return cursor;
 }
 
 auto mgw::Display::create_virtual_output(int /*width*/, int /*height*/) -> std::unique_ptr<VirtualOutput>
@@ -500,4 +501,17 @@ void mir::graphics::wayland::Display::set_touch_sink(std::shared_ptr<input::wayl
     {
         this->touch_sink = std::make_shared<NullInputSink>();
     }
+}
+
+void mir::graphics::wayland::Display::pointer_enter(
+    wl_pointer* pointer, uint32_t serial, wl_surface* surface, wl_fixed_t x, wl_fixed_t y)
+{
+    if (cursor) cursor->enter(pointer);
+    DisplayClient::pointer_enter(pointer, serial, surface, x, y);
+}
+
+void mir::graphics::wayland::Display::pointer_leave(wl_pointer* pointer, uint32_t serial, wl_surface* surface)
+{
+    if (cursor) cursor->leave(pointer);
+    DisplayClient::pointer_leave(pointer, serial, surface);
 }

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -63,9 +63,9 @@ public:
 
     ~Display();
 
-    void set_keyboard_sink(std::shared_ptr<input::wayland::KeyboardInput> const& keyboard_sink);
-    void set_pointer_sink(std::shared_ptr<input::wayland::PointerInput> const& pointer_sink);
-    void set_touch_sink(std::shared_ptr<input::wayland::TouchInput> const& touch_sink);
+    static void set_keyboard_sink(std::shared_ptr<input::wayland::KeyboardInput> const& keyboard_sink);
+    static void set_pointer_sink(std::shared_ptr<input::wayland::PointerInput> const& pointer_sink);
+    static void set_touch_sink(std::shared_ptr<input::wayland::TouchInput> const& touch_sink);
 
     void for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f) override;
 
@@ -147,8 +147,6 @@ private:
     void stop();
 };
 
-// {arg} TODO: this isn't logically, nor thread safe.
-extern Display* the_display;
 }
 }
 

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -32,7 +32,10 @@ class Display : public mir::graphics::Display, public mir::graphics::NativeDispl
                 public mir::renderer::gl::ContextSource, DisplayClient
 {
 public:
-    Display(wl_display* const wl_display, std::shared_ptr<DisplayReport> const& report);
+    Display(
+        wl_display* const wl_display,
+        std::shared_ptr<GLConfig> const& gl_config,
+        std::shared_ptr<DisplayReport> const& report);
 
     void for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f) override;
 

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -40,7 +40,6 @@ class InputSinkX
 public:
     virtual void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) = 0;
     virtual void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) = 0;
-    virtual void update_button_state(int button) = 0;
     virtual void pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) = 0;
     virtual void pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) = 0;
     virtual void pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll) = 0;

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -101,19 +101,8 @@ public:
     auto create_gl_context() const -> std::unique_ptr<mir::renderer::gl::Context> override;
 
 private:
-    void keyboard_keymap(wl_keyboard* keyboard, uint32_t format, int32_t fd, uint32_t size) override;
-
-    void keyboard_enter(wl_keyboard* keyboard, uint32_t serial, wl_surface* surface, wl_array* keys) override;
-
-    void keyboard_leave(wl_keyboard* keyboard, uint32_t serial, wl_surface* surface) override;
 
     void keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state) override;
-
-    void keyboard_modifiers(
-        wl_keyboard* keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked,
-        uint32_t group) override;
-
-    void keyboard_repeat_info(wl_keyboard* wl_keyboard, int32_t rate, int32_t delay) override;
 
     void pointer_motion(wl_pointer* pointer, uint32_t time, wl_fixed_t x, wl_fixed_t y) override;
 

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -112,10 +112,6 @@ private:
 
     void keyboard_repeat_info(wl_keyboard* wl_keyboard, int32_t rate, int32_t delay) override;
 
-    void pointer_enter(wl_pointer* pointer, uint32_t serial, wl_surface* surface, wl_fixed_t x, wl_fixed_t y) override;
-
-    void pointer_leave(wl_pointer* pointer, uint32_t serial, wl_surface* surface) override;
-
     void pointer_motion(wl_pointer* pointer, uint32_t time, wl_fixed_t x, wl_fixed_t y) override;
 
     void pointer_button(wl_pointer* pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) override;
@@ -124,12 +120,6 @@ private:
 
     void pointer_frame(wl_pointer* pointer) override;
 
-    void pointer_axis_source(wl_pointer* pointer, uint32_t axis_source) override;
-
-    void pointer_axis_stop(wl_pointer* pointer, uint32_t time, uint32_t axis) override;
-
-    void pointer_axis_discrete(wl_pointer* pointer, uint32_t axis, int32_t discrete) override;
-
 private:
     std::shared_ptr<DisplayReport> const report;
     mir::Fd const shutdown_signal;
@@ -137,7 +127,9 @@ private:
     std::mutex sink_mutex;
     std::shared_ptr<input::wayland::InputSinkX> keyboard_sink;
     std::shared_ptr<input::wayland::InputSinkX> pointer_sink;
-    geometry::Point pointer;
+    geometry::Point pointer_pos;
+    geometry::Displacement pointer_scroll;
+    std::chrono::nanoseconds pointer_time;
 
     std::thread runner;
     void run() const;

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_PLATFORMS_WAYLAND_DISPLAY_H_
+#define MIR_PLATFORMS_WAYLAND_DISPLAY_H_
+
+#include "displayclient.h"
+#include <mir/graphics/display.h>
+#include <mir/graphics/display_report.h>
+#include <mir/renderer/gl/context_source.h>
+
+namespace mir
+{
+namespace graphics
+{
+namespace wayland
+{
+class Display : public mir::graphics::Display, public mir::graphics::NativeDisplay,
+                public mir::renderer::gl::ContextSource, DisplayClient
+{
+public:
+    Display(wl_display* const wl_display, std::shared_ptr<DisplayReport> const& report);
+
+    void for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f) override;
+
+    auto configuration() const -> std::unique_ptr<DisplayConfiguration> override;
+
+    bool apply_if_configuration_preserves_display_buffers(DisplayConfiguration const& conf) override;
+
+    void configure(DisplayConfiguration const& conf) override;
+
+    void register_configuration_change_handler(EventHandlerRegister& handlers,
+        DisplayConfigurationChangeHandler const& conf_change_handler) override;
+
+    void register_pause_resume_handlers(EventHandlerRegister& handlers,
+        DisplayPauseHandler const& pause_handler, DisplayResumeHandler const& resume_handler) override;
+
+    void pause() override;
+
+    void resume() override;
+
+    auto create_hardware_cursor() -> std::shared_ptr<Cursor>override;
+
+    auto create_virtual_output(int width, int height) -> std::unique_ptr<VirtualOutput> override;
+
+    NativeDisplay* native_display() override;
+
+    auto last_frame_on(unsigned output_id) const -> Frame override;
+
+    auto create_gl_context() const -> std::unique_ptr<mir::renderer::gl::Context> override;
+
+private:
+    std::shared_ptr<DisplayReport> const report;
+};
+
+}
+}
+
+}
+
+#endif  // MIR_PLATFORMS_WAYLAND_DISPLAY_H_

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -68,6 +68,7 @@ public:
     ~Display();
 
     void set_keyboard_sink(std::shared_ptr<input::wayland::InputSinkX> const& keyboard_sink);
+    void set_pointer_sink(std::shared_ptr<input::wayland::InputSinkX> const& pointer_sink);
 
     void for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f) override;
 
@@ -112,12 +113,32 @@ private:
 
     void keyboard_repeat_info(wl_keyboard* wl_keyboard, int32_t rate, int32_t delay) override;
 
+    void pointer_enter(wl_pointer* pointer, uint32_t serial, wl_surface* surface, wl_fixed_t x, wl_fixed_t y) override;
+
+    void pointer_leave(wl_pointer* pointer, uint32_t serial, wl_surface* surface) override;
+
+    void pointer_motion(wl_pointer* pointer, uint32_t time, wl_fixed_t x, wl_fixed_t y) override;
+
+    void pointer_button(wl_pointer* pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) override;
+
+    void pointer_axis(wl_pointer* pointer, uint32_t time, uint32_t axis, wl_fixed_t value) override;
+
+    void pointer_frame(wl_pointer* pointer) override;
+
+    void pointer_axis_source(wl_pointer* pointer, uint32_t axis_source) override;
+
+    void pointer_axis_stop(wl_pointer* pointer, uint32_t time, uint32_t axis) override;
+
+    void pointer_axis_discrete(wl_pointer* pointer, uint32_t axis, int32_t discrete) override;
+
 private:
     std::shared_ptr<DisplayReport> const report;
     mir::Fd const shutdown_signal;
 
     std::mutex sink_mutex;
     std::shared_ptr<input::wayland::InputSinkX> keyboard_sink;
+    std::shared_ptr<input::wayland::InputSinkX> pointer_sink;
+    geometry::Point pointer;
 
     std::thread runner;
     void run() const;

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -63,6 +63,7 @@ public:
 
     ~Display();
 
+    // Set the sinks for input devices. (May be null if there's no corresponding device.)
     static void set_keyboard_sink(std::shared_ptr<input::wayland::KeyboardInput> const& keyboard_sink);
     static void set_pointer_sink(std::shared_ptr<input::wayland::PointerInput> const& pointer_sink);
     static void set_touch_sink(std::shared_ptr<input::wayland::TouchInput> const& touch_sink);

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -32,6 +32,13 @@
 
 namespace mir
 {
+namespace platform
+{
+namespace wayland
+{
+class Cursor;
+}
+}
 namespace input
 {
 namespace wayland
@@ -112,6 +119,10 @@ private:
 
     void pointer_frame(wl_pointer* pointer) override;
 
+    void pointer_enter(wl_pointer* pointer, uint32_t serial, wl_surface* surface, wl_fixed_t x, wl_fixed_t y) override;
+
+    void pointer_leave(wl_pointer* pointer, uint32_t serial, wl_surface* surface) override;
+
     void touch_down(
         wl_touch* touch, uint32_t serial, uint32_t time, wl_surface* surface, int32_t id, wl_fixed_t x,
         wl_fixed_t y) override;
@@ -131,6 +142,7 @@ private:
 private:
     std::shared_ptr<DisplayReport> const report;
     mir::Fd const shutdown_signal;
+    std::shared_ptr<platform::wayland::Cursor> cursor;
 
     std::mutex sink_mutex;
     std::shared_ptr<input::wayland::InputSinkX> keyboard_sink;

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -43,21 +43,9 @@ namespace input
 {
 namespace wayland
 {
-class InputSinkX
-{
-public:
-    virtual void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) = 0;
-    virtual void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) = 0;
-    virtual void pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) = 0;
-    virtual void pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) = 0;
-    virtual void pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll) = 0;
-    virtual void touch_event(std::chrono::nanoseconds event_time, std::vector<events::ContactState> const& contacts) = 0;
-
-    InputSinkX() = default;
-    virtual ~InputSinkX() = default;
-    InputSinkX(InputSinkX const&) = delete;
-    InputSinkX& operator=(InputSinkX const&) = delete;
-};
+class KeyboardInput;
+class PointerInput;
+class TouchInput;
 }
 }
 namespace graphics
@@ -75,9 +63,9 @@ public:
 
     ~Display();
 
-    void set_keyboard_sink(std::shared_ptr<input::wayland::InputSinkX> const& keyboard_sink);
-    void set_pointer_sink(std::shared_ptr<input::wayland::InputSinkX> const& pointer_sink);
-    void set_touch_sink(std::shared_ptr<input::wayland::InputSinkX> const& touch_sink);
+    void set_keyboard_sink(std::shared_ptr<input::wayland::KeyboardInput> const& keyboard_sink);
+    void set_pointer_sink(std::shared_ptr<input::wayland::PointerInput> const& pointer_sink);
+    void set_touch_sink(std::shared_ptr<input::wayland::TouchInput> const& touch_sink);
 
     void for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f) override;
 
@@ -145,9 +133,9 @@ private:
     std::shared_ptr<platform::wayland::Cursor> cursor;
 
     std::mutex sink_mutex;
-    std::shared_ptr<input::wayland::InputSinkX> keyboard_sink;
-    std::shared_ptr<input::wayland::InputSinkX> pointer_sink;
-    std::shared_ptr<input::wayland::InputSinkX> touch_sink;
+    std::shared_ptr<input::wayland::KeyboardInput> keyboard_sink;
+    std::shared_ptr<input::wayland::PointerInput> pointer_sink;
+    std::shared_ptr<input::wayland::TouchInput> touch_sink;
     geometry::Point pointer_pos;
     geometry::Displacement pointer_scroll;
     std::chrono::nanoseconds pointer_time;

--- a/src/platforms/wayland/display_input.h
+++ b/src/platforms/wayland/display_input.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_PLATFORMS_WAYLAND_DISPLAY_INPUT_H_
+#define MIR_PLATFORMS_WAYLAND_DISPLAY_INPUT_H_
+
+#include <mir/fd.h>
+#include <mir/events/contact_state.h>
+#include <mir/geometry/displacement.h>
+
+#include <xkbcommon/xkbcommon.h>
+
+#include <chrono>
+#include <vector>
+
+namespace mir
+{
+namespace input
+{
+namespace wayland
+{
+class KeyboardInput
+{
+public:
+    virtual void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) = 0;
+    virtual void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) = 0;
+
+    KeyboardInput() = default;
+    virtual ~KeyboardInput() = default;
+    KeyboardInput(KeyboardInput const&) = delete;
+    KeyboardInput& operator=(KeyboardInput const&) = delete;
+};
+
+class PointerInput
+{
+public:
+    virtual void pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) = 0;
+    virtual void pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) = 0;
+    virtual void pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll) = 0;
+
+    PointerInput() = default;
+    virtual ~PointerInput() = default;
+    PointerInput(PointerInput const&) = delete;
+    PointerInput& operator=(PointerInput const&) = delete;
+};
+
+class TouchInput
+{
+public:
+    virtual void touch_event(std::chrono::nanoseconds event_time, std::vector<events::ContactState> const& contacts) = 0;
+
+    TouchInput() = default;
+    virtual ~TouchInput() = default;
+    TouchInput(TouchInput const&) = delete;
+    TouchInput& operator=(TouchInput const&) = delete;
+};
+}
+}
+
+}
+
+#endif  // MIR_PLATFORMS_WAYLAND_DISPLAY_INPUT_H_

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -281,12 +281,10 @@ void mgw::DisplayClient::Output::for_each_display_buffer(std::function<void(Disp
 
 void mgw::DisplayClient::Output::post()
 {
-    puts(__PRETTY_FUNCTION__);
 }
 
 auto mgw::DisplayClient::Output::recommended_sleep() const -> std::chrono::milliseconds
 {
-    puts(__PRETTY_FUNCTION__);
     return std::chrono::milliseconds{0};
 }
 
@@ -401,19 +399,16 @@ mgw::DisplayClient::DisplayClient(
 
 void mgw::DisplayClient::on_output_changed(Output const* /*output*/)
 {
-    puts(__PRETTY_FUNCTION__);
     // TODO maybe nothing
 }
 
 void mgw::DisplayClient::on_output_gone(Output const* /*output*/)
 {
-    puts(__PRETTY_FUNCTION__);
     // TODO maybe nothing
 }
 
 void mgw::DisplayClient::on_new_output(Output const* /*output*/)
 {
-    puts(__PRETTY_FUNCTION__);
     // TODO maybe nothing
 }
 

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -22,8 +22,6 @@
 
 #include <fcntl.h>
 #include <sys/mman.h>
-#include <sys/poll.h>
-#include <sys/mman.h>
 #include <xkbcommon/xkbcommon.h>
 
 #include <boost/throw_exception.hpp>

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -451,7 +451,8 @@ void mgw::DisplayClient::new_global(
     }
     else if (strcmp(interface, "wl_seat") == 0)
     {
-        self->seat = static_cast<decltype(self->seat)>(wl_registry_bind(registry, id, &wl_seat_interface, std::min(version, 4u)));
+        if (version < 5) self->fake_pointer_frame = true;
+        self->seat = static_cast<decltype(self->seat)>(wl_registry_bind(registry, id, &wl_seat_interface, std::min(version, 6u)));
         add_seat_listener(self, self->seat);
     }
     else if (strcmp(interface, "wl_output") == 0)
@@ -551,25 +552,31 @@ void mgw::DisplayClient::pointer_leave(wl_pointer* /*pointer*/, uint32_t /*seria
 {
 }
 
-void mgw::DisplayClient::pointer_motion(wl_pointer* /*pointer*/, uint32_t /*time*/, wl_fixed_t /*x*/, wl_fixed_t /*y*/)
+void mgw::DisplayClient::pointer_motion(wl_pointer* pointer, uint32_t /*time*/, wl_fixed_t /*x*/, wl_fixed_t /*y*/)
 {
+    if (fake_pointer_frame)
+        pointer_frame(pointer);
 }
 
 void mgw::DisplayClient::pointer_button(
-    wl_pointer* /*pointer*/,
+    wl_pointer* pointer,
     uint32_t /*serial*/,
     uint32_t /*time*/,
     uint32_t /*button*/,
     uint32_t /*state*/)
 {
+    if (fake_pointer_frame)
+        pointer_frame(pointer);
 }
 
 void mgw::DisplayClient::pointer_axis(
-    wl_pointer* /*pointer*/,
+    wl_pointer* pointer,
     uint32_t /*time*/,
     uint32_t /*axis*/,
     wl_fixed_t /*value*/)
 {
+    if (fake_pointer_frame)
+        pointer_frame(pointer);
 }
 
 void mgw::DisplayClient::pointer_frame(wl_pointer* /*pointer*/)

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -1,0 +1,793 @@
+/*
+ * Copyright © 2018-2019 Octopull Ltd.
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "displayclient.h"
+
+#include <wayland-client.h>
+#include <wayland-egl.h>
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/poll.h>
+#include <sys/mman.h>
+#include <xkbcommon/xkbcommon.h>
+
+#include <boost/throw_exception.hpp>
+
+#include <cstring>
+#include <stdlib.h>
+#include <system_error>
+#include <algorithm>
+
+namespace mgw = mir::graphics::wayland;
+
+class mgw::DisplayClient::Output  :
+    public DisplaySyncGroup,
+    public renderer::gl::RenderTarget,
+    public NativeDisplayBuffer,
+    DisplayBuffer
+{
+public:
+    Output(
+        wl_output* output,
+        DisplayClient* owner,
+        std::function<void(Output const&)> on_constructed,
+        std::function<void(Output const&)> on_change);
+
+    ~Output();
+
+    Output(Output const&) = delete;
+    Output(Output&&) = delete;
+    Output& operator=(Output const&) = delete;
+    Output& operator=(Output&&) = delete;
+
+    DisplayConfigurationOutput dcout;
+
+private:
+    static void done(void* data, wl_output* output);
+
+    static void geometry(
+        void* data,
+        wl_output* wl_output,
+        int32_t x,
+        int32_t y,
+        int32_t physical_width,
+        int32_t physical_height,
+        int32_t subpixel,
+        const char* make,
+        const char* model,
+        int32_t transform);
+
+    static void mode(
+        void* data,
+        wl_output* wl_output,
+        uint32_t flags,
+        int32_t width,
+        int32_t height,
+        int32_t refresh);
+
+    static void scale(void* data, wl_output* wl_output, int32_t factor);
+
+    static wl_output_listener const output_listener;
+
+    wl_output* const output;
+    DisplayClient const* const owner;
+
+    wl_surface* const surface;
+    wl_shell_surface* window{nullptr};
+
+    EGLSurface eglsurface{EGL_NO_SURFACE};
+
+    std::function<void(Output const&)> on_done;
+
+    // DisplaySyncGroup implementation
+    void for_each_display_buffer(std::function<void(DisplayBuffer&)> const& /*f*/) override;
+    void post() override;
+    std::chrono::milliseconds recommended_sleep() const override;
+
+    // DisplayBuffer implementation
+    auto view_area() const -> geometry::Rectangle override;
+    bool overlay(RenderableList const& renderlist) override;
+    auto transformation() const -> glm::mat2 override;
+    auto native_display_buffer() -> NativeDisplayBuffer* override;
+
+    // RenderTarget implementation
+    void make_current() override;
+    void release_current() override;
+    void swap_buffers() override;
+    void bind() override;
+};
+
+
+void mgw::DisplayClient::Output::geometry(
+    void* data,
+    struct wl_output* /*wl_output*/,
+    int32_t x,
+    int32_t y,
+    int32_t physical_width,
+    int32_t physical_height,
+    int32_t subpixel,
+    const char */*make*/,
+    const char */*model*/,
+    int32_t /*transform*/)
+{
+    auto output = static_cast<Output*>(data);
+
+    auto& dcout = output->dcout;
+    dcout.top_left = {x, y};
+    dcout.physical_size_mm = {physical_width, physical_height};
+
+    switch (subpixel)
+    {
+    case WL_OUTPUT_SUBPIXEL_UNKNOWN:
+        dcout.subpixel_arrangement = MirSubpixelArrangement::mir_subpixel_arrangement_unknown;
+        break;
+
+    case WL_OUTPUT_SUBPIXEL_NONE:
+        dcout.subpixel_arrangement = MirSubpixelArrangement::mir_subpixel_arrangement_none;
+        break;
+
+    case WL_OUTPUT_SUBPIXEL_HORIZONTAL_RGB:
+        dcout.subpixel_arrangement = MirSubpixelArrangement::mir_subpixel_arrangement_horizontal_rgb;
+        break;
+
+    case WL_OUTPUT_SUBPIXEL_HORIZONTAL_BGR:
+        dcout.subpixel_arrangement = MirSubpixelArrangement::mir_subpixel_arrangement_horizontal_bgr;
+        break;
+
+    case WL_OUTPUT_SUBPIXEL_VERTICAL_RGB:
+        dcout.subpixel_arrangement = MirSubpixelArrangement::mir_subpixel_arrangement_vertical_rgb;
+        break;
+
+    case WL_OUTPUT_SUBPIXEL_VERTICAL_BGR:
+        dcout.subpixel_arrangement = MirSubpixelArrangement::mir_subpixel_arrangement_vertical_bgr;
+        break;
+
+    default:
+        dcout.subpixel_arrangement = MirSubpixelArrangement::mir_subpixel_arrangement_unknown;
+        break;
+    }
+}
+
+
+void mgw::DisplayClient::Output::mode(
+    void *data,
+    struct wl_output* /*wl_output*/,
+    uint32_t flags,
+    int32_t width,
+    int32_t height,
+    int32_t refresh)
+{
+    auto const output = static_cast<Output*>(data);
+    auto& dcout = output->dcout;
+    auto& modes = dcout.modes;
+
+    auto const mode = DisplayConfigurationMode{{width, height}, refresh/100000.0};
+    bool const is_current   = flags & WL_OUTPUT_MODE_CURRENT;
+    bool const is_preferred = flags & WL_OUTPUT_MODE_PREFERRED;
+
+    auto const found = std::find_if(begin(modes), end(modes), [&](auto const& m)
+        { return mode.size == m.size && mode.vrefresh_hz == m.vrefresh_hz; });
+
+    if (found != end(modes))
+    {
+        if (is_current) dcout.current_mode_index = distance(begin(modes), found);
+        if (is_preferred) dcout.preferred_mode_index = distance(begin(modes), found);
+    }
+    else
+    {
+        modes.push_back(mode);
+        if (is_current) dcout.current_mode_index = modes.size() - 1;
+        if (is_preferred) dcout.preferred_mode_index = modes.size() - 1;
+    }
+}
+
+void mgw::DisplayClient::Output::scale(void* /*data*/, wl_output* /*wl_output*/, int32_t /*factor*/)
+{
+}
+
+mgw::DisplayClient::Output::Output(
+    wl_output* output,
+    DisplayClient* owner,
+    std::function<void(Output const&)> on_constructed,
+    std::function<void(Output const&)> on_change) :
+    output{output},
+    owner{owner},
+    surface{wl_compositor_create_surface(owner->compositor)},
+    on_done{[this, on_constructed = std::move(on_constructed), on_change=std::move(on_change)]
+        (Output const& o) mutable { on_constructed(o), on_done = std::move(on_change); }}
+{
+    wl_output_add_listener(output, &output_listener, this);
+
+    dcout.id = DisplayConfigurationOutputId{0};   // TODO number outputs
+    dcout.card_id = DisplayConfigurationCardId{1};
+    dcout.type = DisplayConfigurationOutputType::unknown;
+    dcout.pixel_formats = {mir_pixel_format_argb_8888};
+    dcout.current_format = mir_pixel_format_argb_8888;
+    dcout.connected = true;
+    dcout.used = true;
+    dcout.power_mode = mir_power_mode_on;
+    dcout.orientation = MirOrientation::mir_orientation_normal;
+    dcout.scale = 1.0;
+    dcout.form_factor = MirFormFactor::mir_form_factor_monitor;
+    dcout.gamma_supported = MirOutputGammaSupported::mir_output_gamma_unsupported;
+}
+
+mgw::DisplayClient::Output::~Output()
+{
+    if (output)
+        wl_output_destroy(output);
+
+    if (eglsurface)
+        eglDestroySurface(owner->egldisplay, eglsurface);
+
+    if (window)
+        wl_shell_surface_destroy(window);
+
+    wl_surface_destroy(surface);
+}
+
+wl_output_listener const mgw::DisplayClient::Output::output_listener = {
+    &geometry,
+    &mode,
+    &done,
+    &scale,
+};
+
+void mgw::DisplayClient::Output::done(void* data, struct wl_output* /*wl_output*/)
+{
+    auto output = static_cast<Output*>(data);
+    output->on_done(*output);
+}
+
+void mgw::DisplayClient::Output::for_each_display_buffer(std::function<void(DisplayBuffer & )> const& f)
+{
+    puts(__PRETTY_FUNCTION__);
+    if (!window)
+    {
+        window = wl_shell_get_shell_surface(owner->shell, surface);
+//    wl_shell_surface_add_listener(window, &shell_surface_listener, this);
+        wl_shell_surface_set_fullscreen(window, WL_SHELL_SURFACE_FULLSCREEN_METHOD_SCALE, 0, output);
+        wl_display_dispatch(owner->display);
+
+        auto const& size = dcout.modes[dcout.current_mode_index].size;
+
+        eglsurface = eglCreateWindowSurface(
+            owner->egldisplay,
+            owner->eglconfig,
+            (EGLNativeWindowType)wl_egl_window_create(surface, size.width.as_int(), size.height.as_int()), NULL);
+    }
+
+    f(*this);
+}
+
+void mgw::DisplayClient::Output::post()
+{
+    puts(__PRETTY_FUNCTION__);
+}
+
+auto mgw::DisplayClient::Output::recommended_sleep() const -> std::chrono::milliseconds
+{
+    puts(__PRETTY_FUNCTION__);
+    return std::chrono::milliseconds{0};
+}
+
+auto mgw::DisplayClient::Output::view_area() const -> geometry::Rectangle
+{
+    return dcout.extents();
+}
+
+bool mgw::DisplayClient::Output::overlay(mir::graphics::RenderableList const&)
+{
+    return false;
+}
+
+auto mgw::DisplayClient::Output::transformation() const -> glm::mat2
+{
+    return glm::mat2{1};
+}
+
+auto mgw::DisplayClient::Output::native_display_buffer() -> NativeDisplayBuffer*
+{
+    return this;
+}
+
+void mgw::DisplayClient::Output::make_current()
+{
+    owner->make_current(eglsurface);
+}
+
+void mgw::DisplayClient::Output::release_current()
+{
+    owner->make_current(EGL_NO_SURFACE);
+}
+
+void mgw::DisplayClient::Output::swap_buffers()
+{
+    if (eglSwapBuffers(owner->egldisplay, eglsurface) != EGL_TRUE)
+        fatal_error("Failed to perform buffer swap");
+}
+
+void mgw::DisplayClient::Output::bind()
+{
+}
+
+mgw::DisplayClient::DisplayClient(wl_display* display) :
+    display{display},
+    keyboard_context_{xkb_context_new(XKB_CONTEXT_NO_FLAGS)},
+    registry{nullptr, [](auto){}}
+{
+    registry = {wl_display_get_registry(display), &wl_registry_destroy};
+
+    static wl_registry_listener const registry_listener = {
+        new_global,
+        remove_global
+    };
+
+    wl_registry_add_listener(registry.get(), &registry_listener, this);
+
+    static unsigned int const bpp = 32; //8*MIR_BYTES_PER_PIXEL(pixel_format);
+
+    static EGLint const attribs[] =
+        {
+            EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+            EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+            EGL_COLOR_BUFFER_TYPE, EGL_RGB_BUFFER,
+            EGL_BUFFER_SIZE, (EGLint) bpp,
+            EGL_NONE
+        };
+
+    egldisplay = eglGetDisplay((EGLNativeDisplayType)(display));
+    if (egldisplay == EGL_NO_DISPLAY)
+        throw std::runtime_error("Can't eglGetDisplay");
+
+    EGLint major;
+    EGLint minor;
+    if (!eglInitialize(egldisplay, &major, &minor))
+        throw std::runtime_error("Can't eglInitialize");
+
+    if (major != 1 || minor < 4)
+        throw std::runtime_error("EGL version is not at least 1.4");
+
+    if (!eglChooseConfig(egldisplay, attribs, &eglconfig, 1, &neglconfigs))
+        throw std::runtime_error("Could not eglChooseConfig");
+
+    if (neglconfigs == 0)
+        throw std::runtime_error("No EGL config available");
+
+    EGLint ctxattribs[] =
+        {
+            EGL_CONTEXT_CLIENT_VERSION, 2,
+            EGL_NONE
+        };
+
+    eglctx = eglCreateContext(egldisplay, eglconfig, EGL_NO_CONTEXT, ctxattribs);
+    if (eglctx == EGL_NO_CONTEXT)
+        throw std::runtime_error("eglCreateContext failed");
+
+    wl_display_roundtrip(display);
+}
+
+void mgw::DisplayClient::on_output_changed(Output const* /*output*/)
+{
+    puts(__PRETTY_FUNCTION__);
+    // TODO maybe nothing
+}
+
+void mgw::DisplayClient::on_output_gone(Output const* /*output*/)
+{
+    puts(__PRETTY_FUNCTION__);
+    // TODO maybe nothing
+}
+
+void mgw::DisplayClient::on_new_output(Output const* /*output*/)
+{
+    puts(__PRETTY_FUNCTION__);
+    // TODO maybe nothing
+}
+
+mgw::DisplayClient::~DisplayClient()
+{
+    eglMakeCurrent(egldisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    eglDestroyContext(egldisplay, eglctx);
+    eglTerminate(egldisplay);
+
+    {
+        std::lock_guard<decltype(outputs_mutex)> lock{outputs_mutex};
+        bound_outputs.clear();
+    }
+    registry.reset();
+    wl_display_roundtrip(display);
+}
+
+void mgw::DisplayClient::new_global(
+    void* data,
+    struct wl_registry* registry,
+    uint32_t id,
+    char const* interface,
+    uint32_t version)
+{
+    (void)version;
+    DisplayClient* self = static_cast<decltype(self)>(data);
+
+    if (strcmp(interface, "wl_compositor") == 0)
+    {
+        self->compositor =
+            static_cast<decltype(self->compositor)>(wl_registry_bind(registry, id, &wl_compositor_interface, std::min(version, 3u)));
+    }
+    else if (strcmp(interface, "wl_shm") == 0)
+    {
+        self->shm = static_cast<decltype(self->shm)>(wl_registry_bind(registry, id, &wl_shm_interface, std::min(version, 1u)));
+        // Normally we'd add a listener to pick up the supported formats here
+        // As luck would have it, I know that argb8888 is the only format we support :)
+    }
+    else if (strcmp(interface, "wl_seat") == 0)
+    {
+        self->seat = static_cast<decltype(self->seat)>(wl_registry_bind(registry, id, &wl_seat_interface, std::min(version, 4u)));
+        add_seat_listener(self, self->seat);
+    }
+    else if (strcmp(interface, "wl_output") == 0)
+    {
+        auto output =
+            static_cast<wl_output*>(wl_registry_bind(registry, id, &wl_output_interface, std::min(version, 2u)));
+        std::lock_guard<decltype(self->outputs_mutex)> lock{self->outputs_mutex};
+        self->bound_outputs.insert(
+            std::make_pair(
+                id,
+                std::make_unique<Output>(
+                    output,
+                    self,
+                    [self](Output const& output) { self->on_new_output(&output); },
+                    [self](Output const& output) { self->on_output_changed(&output); })));
+    }
+    else if (strcmp(interface, "wl_shell") == 0)
+    {
+        self->shell = static_cast<decltype(self->shell)>(wl_registry_bind(registry, id, &wl_shell_interface, std::min(version, 1u)));
+    }
+}
+
+void mgw::DisplayClient::remove_global(
+    void* data,
+    struct wl_registry* /*registry*/,
+    uint32_t id)
+{
+    DisplayClient* self = static_cast<decltype(self)>(data);
+
+    std::lock_guard<decltype(self->outputs_mutex)> lock{self->outputs_mutex};
+    auto const output = self->bound_outputs.find(id);
+    if (output != self->bound_outputs.end())
+    {
+        self->on_output_gone(output->second.get());
+        self->bound_outputs.erase(output);
+    }
+    // TODO: We should probably also delete any other globals we've bound to that disappear.
+}
+
+void mgw::DisplayClient::keyboard_keymap(wl_keyboard* /*keyboard*/, uint32_t /*format*/, int32_t fd, uint32_t size)
+{
+    char* keymap_string = static_cast<decltype(keymap_string)>(mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0));
+    xkb_keymap_unref(keyboard_map_);
+    keyboard_map_ = xkb_keymap_new_from_string(keyboard_context(), keymap_string, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    munmap(keymap_string, size);
+    close (fd);
+    xkb_state_unref(keyboard_state_);
+    keyboard_state_ = xkb_state_new(keyboard_map_);
+}
+
+void mgw::DisplayClient::keyboard_enter(
+    wl_keyboard* /*keyboard*/,
+    uint32_t /*serial*/,
+    wl_surface*/*surface*/,
+    wl_array* /*keys*/)
+{
+}
+
+void mgw::DisplayClient::keyboard_leave(wl_keyboard* /*keyboard*/, uint32_t /*serial*/, wl_surface* /*surface*/)
+{
+}
+
+void mgw::DisplayClient::keyboard_key(
+    wl_keyboard* /*keyboard*/,
+    uint32_t /*serial*/,
+    uint32_t /*time*/,
+    uint32_t /*key*/,
+    uint32_t /*state*/)
+{
+}
+
+void mgw::DisplayClient::keyboard_modifiers(
+    wl_keyboard */*keyboard*/,
+    uint32_t /*serial*/, uint32_t mods_depressed,
+    uint32_t mods_latched,
+    uint32_t mods_locked,
+    uint32_t group)
+{
+    if (keyboard_state_)
+        xkb_state_update_mask(keyboard_state_, mods_depressed, mods_latched, mods_locked, 0, 0, group);
+}
+
+void mgw::DisplayClient::keyboard_repeat_info(wl_keyboard* /*wl_keyboard*/, int32_t /*rate*/, int32_t /*delay*/)
+{
+}
+
+void mgw::DisplayClient::pointer_enter(
+    wl_pointer* /*pointer*/,
+    uint32_t /*serial*/,
+    wl_surface* /*surface*/,
+    wl_fixed_t /*x*/,
+    wl_fixed_t /*y*/)
+{
+}
+
+void mgw::DisplayClient::pointer_leave(wl_pointer* /*pointer*/, uint32_t /*serial*/, wl_surface* /*surface*/)
+{
+}
+
+void mgw::DisplayClient::pointer_motion(wl_pointer* /*pointer*/, uint32_t /*time*/, wl_fixed_t /*x*/, wl_fixed_t /*y*/)
+{
+}
+
+void mgw::DisplayClient::pointer_button(
+    wl_pointer* /*pointer*/,
+    uint32_t /*serial*/,
+    uint32_t /*time*/,
+    uint32_t /*button*/,
+    uint32_t /*state*/)
+{
+}
+
+void mgw::DisplayClient::pointer_axis(
+    wl_pointer* /*pointer*/,
+    uint32_t /*time*/,
+    uint32_t /*axis*/,
+    wl_fixed_t /*value*/)
+{
+}
+
+void mgw::DisplayClient::pointer_frame(wl_pointer* /*pointer*/)
+{
+}
+
+void mgw::DisplayClient::pointer_axis_source(wl_pointer* /*pointer*/, uint32_t /*axis_source*/)
+{
+}
+
+void mgw::DisplayClient::pointer_axis_stop(wl_pointer* /*pointer*/, uint32_t /*time*/, uint32_t /*axis*/)
+{
+}
+
+void mgw::DisplayClient::pointer_axis_discrete(wl_pointer* /*pointer*/, uint32_t /*axis*/, int32_t /*discrete*/)
+{
+}
+
+void mgw::DisplayClient::touch_down(
+    wl_touch* /*touch*/,
+    uint32_t /*serial*/,
+    uint32_t /*time*/,
+    wl_surface* /*surface*/,
+    int32_t /*id*/,
+    wl_fixed_t /*x*/,
+    wl_fixed_t /*y*/)
+{
+}
+
+void mgw::DisplayClient::touch_up(
+    wl_touch* /*touch*/,
+    uint32_t /*serial*/,
+    uint32_t /*time*/,
+    int32_t /*id*/)
+{
+}
+
+void mgw::DisplayClient::touch_motion(
+    wl_touch* /*touch*/,
+    uint32_t /*time*/,
+    int32_t /*id*/,
+    wl_fixed_t /*x*/,
+    wl_fixed_t /*y*/)
+{
+}
+
+void mgw::DisplayClient::touch_frame(wl_touch* /*touch*/)
+{
+}
+    
+void mgw::DisplayClient::touch_cancel(wl_touch* /*touch*/)
+{
+}
+
+void mgw::DisplayClient::touch_shape(
+    wl_touch* /*touch*/,
+    int32_t /*id*/,
+    wl_fixed_t /*major*/,
+    wl_fixed_t /*minor*/)
+{
+}
+
+void mgw::DisplayClient::touch_orientation(
+    wl_touch* /*touch*/,
+    int32_t /*id*/,
+    wl_fixed_t /*orientation*/)
+{
+}
+
+void mgw::DisplayClient::seat_capabilities(wl_seat* seat, uint32_t capabilities)
+{
+    if (capabilities & WL_SEAT_CAPABILITY_POINTER) {
+        static wl_pointer_listener pointer_listener =
+            {
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->pointer_enter(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->pointer_leave(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->pointer_motion(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->pointer_button(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->pointer_axis(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->pointer_frame(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->pointer_axis_source(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->pointer_axis_stop(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->pointer_axis_discrete(args...); },
+            };
+
+        struct wl_pointer *pointer = wl_seat_get_pointer(seat);
+        wl_pointer_add_listener (pointer, &pointer_listener, this);
+    }
+
+    if (capabilities & WL_SEAT_CAPABILITY_KEYBOARD)
+    {
+        static struct wl_keyboard_listener keyboard_listener =
+            {
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->keyboard_keymap(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->keyboard_enter(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->keyboard_leave(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->keyboard_key(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->keyboard_modifiers(args...); },
+                [](void* self, auto... args) { static_cast<DisplayClient*>(self)->keyboard_repeat_info(args...); },
+            };
+
+        wl_keyboard_add_listener(wl_seat_get_keyboard(seat), &keyboard_listener, this);
+    }
+
+    if (capabilities & WL_SEAT_CAPABILITY_TOUCH)
+    {
+        static struct wl_touch_listener touch_listener =
+        {
+            [](void* self, auto... args) { static_cast<DisplayClient*>(self)->touch_down(args...); },
+            [](void* self, auto... args) { static_cast<DisplayClient*>(self)->touch_up(args...); },
+            [](void* self, auto... args) { static_cast<DisplayClient*>(self)->touch_motion(args...); },
+            [](void* self, auto... args) { static_cast<DisplayClient*>(self)->touch_frame(args...); },
+            [](void* self, auto... args) { static_cast<DisplayClient*>(self)->touch_cancel(args...); },
+            [](void* self, auto... args) { static_cast<DisplayClient*>(self)->touch_shape(args...); },
+            [](void* self, auto... args) { static_cast<DisplayClient*>(self)->touch_orientation(args...); },
+        };
+
+        wl_touch_add_listener(wl_seat_get_touch(seat), &touch_listener, this);
+    }
+}
+
+void mgw::DisplayClient::seat_name(wl_seat* /*seat*/, const char */*name*/)
+{
+}
+
+void mgw::DisplayClient::add_seat_listener(DisplayClient* self, wl_seat* seat)
+{
+    static struct wl_seat_listener seat_listener =
+        {
+            [](void* self, auto... args) { static_cast<DisplayClient*>(self)->seat_capabilities(args...); },
+            [](void* self, auto... args) { static_cast<DisplayClient*>(self)->seat_name(args...); },
+        };
+
+    wl_seat_add_listener(seat, &seat_listener, self);
+}
+
+void mgw::DisplayClient::make_current(EGLSurface eglsurface) const
+{
+    if (!eglMakeCurrent(egldisplay, eglsurface, eglsurface, eglctx))
+        throw std::runtime_error("Can't eglMakeCurrent");
+}
+
+namespace mir
+{
+namespace graphics
+{
+namespace wayland
+{
+namespace
+{
+class WaylandDisplayConfiguration : public DisplayConfiguration
+{
+public:
+    explicit WaylandDisplayConfiguration(std::vector<DisplayConfigurationOutput> && outputs);
+    WaylandDisplayConfiguration(WaylandDisplayConfiguration const&);
+
+    void for_each_card(std::function<void(DisplayConfigurationCard const&)> f) const override;
+    void for_each_output(std::function<void(DisplayConfigurationOutput const&)> f) const override;
+    void for_each_output(std::function<void(UserDisplayConfigurationOutput&)> f) override;
+    auto clone() const -> std::unique_ptr<DisplayConfiguration> override;
+
+private:
+    DisplayConfigurationCard card{ DisplayConfigurationCardId{1}, 9 };
+    std::vector<DisplayConfigurationOutput> outputs;
+};
+}
+}
+}
+}
+
+auto mgw::DisplayClient::display_configuration() const -> std::unique_ptr<DisplayConfiguration>
+{
+    std::vector<DisplayConfigurationOutput> outputs;
+
+    {
+        std::lock_guard<decltype(outputs_mutex)> lock{outputs_mutex};
+        for (auto const& output : bound_outputs)
+        {
+            outputs.push_back(output.second->dcout);
+        }
+    }
+
+    return std::make_unique<WaylandDisplayConfiguration>(std::move(outputs));
+}
+
+void mgw::DisplayClient::for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f)
+{
+    puts(__PRETTY_FUNCTION__);
+    std::lock_guard<decltype(outputs_mutex)> lock{outputs_mutex};
+    for (auto& output : bound_outputs)
+    {
+        f(*output.second);
+    }
+}
+
+mgw::WaylandDisplayConfiguration::WaylandDisplayConfiguration(std::vector<DisplayConfigurationOutput> && outputs) :
+    outputs{outputs}
+{
+}
+
+mgw::WaylandDisplayConfiguration::WaylandDisplayConfiguration(WaylandDisplayConfiguration const& rhs) :
+    DisplayConfiguration{},
+    outputs{rhs.outputs}
+{
+}
+
+void mgw::WaylandDisplayConfiguration::for_each_card(
+    std::function<void(DisplayConfigurationCard const&)> f) const
+{
+    f(card);
+}
+
+void mgw::WaylandDisplayConfiguration::for_each_output(
+    std::function<void(DisplayConfigurationOutput const&)> f) const
+{
+    for (auto const& o: outputs)
+    {
+        f(o);
+    }
+}
+
+void mgw::WaylandDisplayConfiguration::for_each_output(
+    std::function<void(UserDisplayConfigurationOutput & )> f)
+{
+    for (auto& o: outputs)
+    {
+        UserDisplayConfigurationOutput udo{o};
+        f(udo);
+    }
+}
+
+auto mgw::WaylandDisplayConfiguration::clone() const -> std::unique_ptr<DisplayConfiguration>
+{
+    return std::make_unique<WaylandDisplayConfiguration>(*this);
+}

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -259,8 +259,14 @@ void mgw::DisplayClient::Output::for_each_display_buffer(std::function<void(Disp
     puts(__PRETTY_FUNCTION__);
     if (!window)
     {
+        static wl_shell_surface_listener const shell_surface_listener{
+            [](void*, wl_shell_surface* shell_surface, uint32_t serial){ wl_shell_surface_pong(shell_surface, serial); },
+            [](void*, wl_shell_surface*, uint32_t, int32_t, int32_t){},
+            [](void*, wl_shell_surface*){}
+        };
+
         window = wl_shell_get_shell_surface(owner->shell, surface);
-//    wl_shell_surface_add_listener(window, &shell_surface_listener, this);
+        wl_shell_surface_add_listener(window, &shell_surface_listener, this);
         wl_shell_surface_set_fullscreen(window, WL_SHELL_SURFACE_FULLSCREEN_METHOD_SCALE, 0, output);
         wl_display_dispatch(owner->display);
 

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -249,6 +249,9 @@ mgw::DisplayClient::Output::~Output()
 
     if (eglsurface != EGL_NO_SURFACE)
         eglDestroySurface(owner->egldisplay, eglsurface);
+
+    if (eglctx != EGL_NO_CONTEXT)
+        eglDestroyContext(owner->egldisplay, eglctx);
 }
 
 wl_output_listener const mgw::DisplayClient::Output::output_listener = {

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -56,7 +56,6 @@ public:
 
     DisplayConfigurationOutput dcout;
 
-private:
     static void done(void* data, wl_output* output);
 
     static void geometry(
@@ -512,7 +511,7 @@ void mgw::DisplayClient::keyboard_keymap(wl_keyboard* /*keyboard*/, uint32_t /*f
 void mgw::DisplayClient::keyboard_enter(
     wl_keyboard* /*keyboard*/,
     uint32_t /*serial*/,
-    wl_surface*/*surface*/,
+    wl_surface* /*surface*/,
     wl_array* /*keys*/)
 {
 }
@@ -548,10 +547,20 @@ void mgw::DisplayClient::keyboard_repeat_info(wl_keyboard* /*wl_keyboard*/, int3
 void mgw::DisplayClient::pointer_enter(
     wl_pointer* /*pointer*/,
     uint32_t /*serial*/,
-    wl_surface* /*surface*/,
+    wl_surface* surface,
     wl_fixed_t /*x*/,
     wl_fixed_t /*y*/)
 {
+    std::lock_guard<decltype(outputs_mutex)> lock{outputs_mutex};
+
+    for (auto const& out : bound_outputs)
+    {
+        if (surface == out.second->surface)
+        {
+            pointer_displacement = out.second->dcout.top_left - geometry::Point{};
+            break;
+        }
+    }
 }
 
 void mgw::DisplayClient::pointer_leave(wl_pointer* /*pointer*/, uint32_t /*serial*/, wl_surface* /*surface*/)
@@ -605,11 +614,21 @@ void mgw::DisplayClient::touch_down(
     wl_touch* /*touch*/,
     uint32_t /*serial*/,
     uint32_t /*time*/,
-    wl_surface* /*surface*/,
+    wl_surface* surface,
     int32_t /*id*/,
     wl_fixed_t /*x*/,
     wl_fixed_t /*y*/)
 {
+    std::lock_guard<decltype(outputs_mutex)> lock{outputs_mutex};
+
+    for (auto const& out : bound_outputs)
+    {
+        if (surface == out.second->surface)
+        {
+            touch_displacement = out.second->dcout.top_left - geometry::Point{};
+            break;
+        }
+    }
 }
 
 void mgw::DisplayClient::touch_up(

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -212,7 +212,7 @@ mgw::DisplayClient::Output::Output(
 {
     wl_output_add_listener(output, &output_listener, this);
 
-    dcout.id = DisplayConfigurationOutputId{0};   // TODO number outputs
+    dcout.id = (DisplayConfigurationOutputId)owner->bound_outputs.size();
     dcout.card_id = DisplayConfigurationCardId{1};
     dcout.type = DisplayConfigurationOutputType::unknown;
     dcout.pixel_formats = {mir_pixel_format_argb_8888,mir_pixel_format_xrgb_8888};
@@ -399,17 +399,14 @@ mgw::DisplayClient::DisplayClient(
 
 void mgw::DisplayClient::on_output_changed(Output const* /*output*/)
 {
-    // TODO maybe nothing
 }
 
 void mgw::DisplayClient::on_output_gone(Output const* /*output*/)
 {
-    // TODO maybe nothing
 }
 
 void mgw::DisplayClient::on_new_output(Output const* /*output*/)
 {
-    // TODO maybe nothing
 }
 
 mgw::DisplayClient::~DisplayClient()

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -38,7 +38,7 @@ class mgw::DisplayClient::Output  :
     public DisplaySyncGroup,
     public renderer::gl::RenderTarget,
     public NativeDisplayBuffer,
-    DisplayBuffer
+    public DisplayBuffer
 {
 public:
     Output(

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -498,8 +498,13 @@ void mgw::DisplayClient::remove_global(
     // TODO: We should probably also delete any other globals we've bound to that disappear.
 }
 
-void mgw::DisplayClient::keyboard_keymap(wl_keyboard* /*keyboard*/, uint32_t /*format*/, int32_t fd, uint32_t size)
+void mgw::DisplayClient::keyboard_keymap(wl_keyboard* /*keyboard*/, uint32_t format, int32_t fd, uint32_t size)
 {
+    if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("platform currently requires a keymap"));
+    }
+
     char* keymap_string = static_cast<decltype(keymap_string)>(mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0));
     xkb_keymap_unref(keyboard_map_);
     keyboard_map_ = xkb_keymap_new_from_string(keyboard_context(), keymap_string, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -254,7 +254,6 @@ void mgw::DisplayClient::Output::done(void* data, struct wl_output* /*wl_output*
 
 void mgw::DisplayClient::Output::for_each_display_buffer(std::function<void(DisplayBuffer & )> const& f)
 {
-    puts(__PRETTY_FUNCTION__);
     if (!window)
     {
         static wl_shell_surface_listener const shell_surface_listener{
@@ -749,7 +748,6 @@ auto mgw::DisplayClient::display_configuration() const -> std::unique_ptr<Displa
 
 void mgw::DisplayClient::for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f)
 {
-    puts(__PRETTY_FUNCTION__);
     std::lock_guard<decltype(outputs_mutex)> lock{outputs_mutex};
     for (auto& output : bound_outputs)
     {

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -160,7 +160,6 @@ private:
 
     EGLDisplay egldisplay;
     EGLConfig eglconfig;
-    EGLint neglconfigs;
     EGLContext eglctx;
 };
 }

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef EGMDE_EGFULLSCREENCLIENT_H
-#define EGMDE_EGFULLSCREENCLIENT_H
+#ifndef MIR_WAYLAND_DISPLAYCLIENT_H_
+#define MIR_WAYLAND_DISPLAYCLIENT_H_
 
 #include <mir/geometry/rectangles.h>
 #include <mir/graphics/display.h>
@@ -173,4 +173,4 @@ protected:
 }
 }
 
-#endif //EGMDE_EGFULLSCREENCLIENT_H
+#endif //MIR_WAYLAND_DISPLAYCLIENT_H_

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -120,8 +120,6 @@ protected:
         int32_t id,
         wl_fixed_t orientation);
 
-    void make_current(EGLSurface eglsurface) const;
-
 private:
     class Output;
     void on_new_output(Output const*);

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -148,6 +148,10 @@ protected:
     void seat_capabilities(wl_seat* seat, uint32_t capabilities);
     void seat_name(wl_seat* seat, const char* name);
 
+    static void add_shm_listener(DisplayClient* self, wl_shm* shm);
+    void shm_format(wl_shm *wl_shm, uint32_t format);
+    MirPixelFormat shm_pixel_format{mir_pixel_format_invalid};
+
     xkb_context* keyboard_context_;
     xkb_keymap* keyboard_map_ = nullptr;
     xkb_state* keyboard_state_ = nullptr;

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -23,6 +23,7 @@
 #include <mir/graphics/display_buffer.h>
 #include <mir/graphics/display_configuration.h>
 #include <mir/renderer/gl/render_target.h>
+#include <mir/graphics/gl_config.h>
 
 #include <wayland-client.h>
 #include <EGL/egl.h>
@@ -46,7 +47,8 @@ namespace wayland
 class DisplayClient
 {
 public:
-    DisplayClient(wl_display* display);
+    DisplayClient(wl_display* display,
+    std::shared_ptr<GLConfig> const& gl_config);
 
     virtual ~DisplayClient();
 

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -122,7 +122,6 @@ protected:
         int32_t id,
         wl_fixed_t orientation);
 
-private:
     class Output;
     void on_new_output(Output const*);
     void on_output_changed(Output const*);

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2018-2019 Octopull Ltd.
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EGMDE_EGFULLSCREENCLIENT_H
+#define EGMDE_EGFULLSCREENCLIENT_H
+
+#include <mir/geometry/rectangles.h>
+#include <mir/graphics/display.h>
+#include <mir/graphics/display_buffer.h>
+#include <mir/graphics/display_configuration.h>
+#include <mir/renderer/gl/render_target.h>
+
+#include <wayland-client.h>
+#include <EGL/egl.h>
+
+#include <functional>
+#include <unordered_map>
+#include <memory>
+#include <mutex>
+
+struct xkb_context;
+struct xkb_keymap;
+struct xkb_state;
+
+namespace mir
+{
+namespace graphics
+{
+namespace wayland
+{
+
+class DisplayClient
+{
+public:
+    DisplayClient(wl_display* display);
+
+    virtual ~DisplayClient();
+
+protected:
+
+    wl_display* const display;
+
+    auto display_configuration() const -> std::unique_ptr<DisplayConfiguration>;
+    void for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f);
+
+    virtual void keyboard_keymap(wl_keyboard* keyboard, uint32_t format, int32_t fd, uint32_t size);
+    virtual void keyboard_enter(wl_keyboard* keyboard, uint32_t serial, wl_surface* surface, wl_array* keys);
+    virtual void keyboard_leave(wl_keyboard* keyboard, uint32_t serial, wl_surface* surface);
+    virtual void keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
+    virtual void keyboard_modifiers(
+        wl_keyboard* keyboard,
+        uint32_t serial,
+        uint32_t mods_depressed,
+        uint32_t mods_latched,
+        uint32_t mods_locked,
+        uint32_t group);
+    virtual void keyboard_repeat_info(wl_keyboard* wl_keyboard, int32_t rate, int32_t delay);
+    xkb_context* keyboard_context() const { return keyboard_context_; }
+    xkb_keymap* keyboard_map() const { return keyboard_map_; }
+    xkb_state* keyboard_state() const { return keyboard_state_; }
+
+    virtual void pointer_enter(wl_pointer* pointer, uint32_t serial, wl_surface* surface, wl_fixed_t x, wl_fixed_t y);
+    virtual void pointer_leave(wl_pointer* pointer, uint32_t serial, wl_surface* surface);
+    virtual void pointer_motion(wl_pointer* pointer, uint32_t time, wl_fixed_t x, wl_fixed_t y);
+    virtual void pointer_button(wl_pointer* pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
+    virtual void pointer_axis(wl_pointer* pointer, uint32_t time, uint32_t axis, wl_fixed_t value);
+    virtual void pointer_frame(wl_pointer* pointer);
+    virtual void pointer_axis_source(wl_pointer* pointer, uint32_t axis_source);
+    virtual void pointer_axis_stop(wl_pointer* pointer, uint32_t time, uint32_t axis);
+    virtual void pointer_axis_discrete(wl_pointer* pointer, uint32_t axis, int32_t discrete);
+
+    virtual void touch_down(
+        wl_touch* touch,
+        uint32_t serial,
+        uint32_t time,
+        wl_surface* surface,
+        int32_t id,
+        wl_fixed_t x,
+        wl_fixed_t y);
+
+    virtual void touch_up(
+        wl_touch* touch,
+        uint32_t serial,
+        uint32_t time,
+        int32_t id);
+
+    virtual void touch_motion(
+        wl_touch* touch,
+        uint32_t time,
+        int32_t id,
+        wl_fixed_t x,
+        wl_fixed_t y);
+
+    virtual void touch_frame(wl_touch* touch);
+
+    virtual void touch_cancel(wl_touch* touch);
+
+    virtual void touch_shape(
+        wl_touch* touch,
+        int32_t id,
+        wl_fixed_t major,
+        wl_fixed_t minor);
+
+    virtual void touch_orientation(
+        wl_touch* touch,
+        int32_t id,
+        wl_fixed_t orientation);
+
+    void make_current(EGLSurface eglsurface) const;
+
+private:
+    class Output;
+    void on_new_output(Output const*);
+    void on_output_changed(Output const*);
+    void on_output_gone(Output const*);
+
+    wl_compositor* compositor = nullptr;
+    wl_shell* shell = nullptr;
+    wl_seat* seat = nullptr;
+    wl_shm* shm = nullptr;
+
+    static void new_global(
+        void* data,
+        struct wl_registry* registry,
+        uint32_t id,
+        char const* interface,
+        uint32_t version);
+
+    static void remove_global(
+        void* data,
+        struct wl_registry* registry,
+        uint32_t name);
+
+    static void add_seat_listener(DisplayClient* self, wl_seat* seat);
+    void seat_capabilities(wl_seat* seat, uint32_t capabilities);
+    void seat_name(wl_seat* seat, const char* name);
+
+    xkb_context* keyboard_context_;
+    xkb_keymap* keyboard_map_ = nullptr;
+    xkb_state* keyboard_state_ = nullptr;
+
+    std::unique_ptr<wl_registry, decltype(&wl_registry_destroy)> registry;
+
+    std::mutex mutable outputs_mutex;
+    std::unordered_map<uint32_t, std::unique_ptr<Output>> bound_outputs;
+
+    EGLDisplay egldisplay;
+    EGLConfig eglconfig;
+    EGLint neglconfigs;
+    EGLContext eglctx;
+};
+}
+}
+}
+
+#endif //EGMDE_EGFULLSCREENCLIENT_H

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -151,6 +151,7 @@ protected:
     xkb_context* keyboard_context_;
     xkb_keymap* keyboard_map_ = nullptr;
     xkb_state* keyboard_state_ = nullptr;
+    bool fake_pointer_frame = false;
 
     std::unique_ptr<wl_registry, decltype(&wl_registry_destroy)> registry;
 

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -32,6 +32,7 @@
 #include <unordered_map>
 #include <memory>
 #include <mutex>
+#include <mir/geometry/displacement.h>
 
 struct xkb_context;
 struct xkb_keymap;
@@ -156,6 +157,8 @@ protected:
     xkb_keymap* keyboard_map_ = nullptr;
     xkb_state* keyboard_state_ = nullptr;
     bool fake_pointer_frame = false;
+    geometry::Displacement pointer_displacement; // Position of current output
+    geometry::Displacement touch_displacement;   // Position of current output
 
     std::unique_ptr<wl_registry, decltype(&wl_registry_destroy)> registry;
 

--- a/src/platforms/wayland/input.cpp
+++ b/src/platforms/wayland/input.cpp
@@ -35,7 +35,7 @@ mir::UniqueModulePtr<mi::Platform> create_input_platform(
     std::shared_ptr<mi::InputReport> const& /*report*/)
 {
     mir::assert_entry_point_signature<mi::CreatePlatform>(&create_input_platform);
-    return mir::make_module_ptr<miw::InputPlatform>(input_device_registry/*, mx::X11Resources::instance.get_conn()*/);
+    return mir::make_module_ptr<miw::InputPlatform>(input_device_registry);
 }
 
 void add_input_platform_options(

--- a/src/platforms/wayland/input.cpp
+++ b/src/platforms/wayland/input.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "wayland_display.h"
+#include "input_platform.h"
+#include "mir/module_properties.h"
+#include "mir/assert_module_entry_point.h"
+#include "mir/libname.h"
+
+namespace mo = mir::options;
+namespace mi = mir::input;
+namespace miw = mir::input::wayland;
+namespace mpw = mir::platform::wayland;
+
+mir::UniqueModulePtr<mi::Platform> create_input_platform(
+    mo::Option const& /*options*/,
+    std::shared_ptr<mir::EmergencyCleanupRegistry> const& /*emergency_cleanup_registry*/,
+    std::shared_ptr<mi::InputDeviceRegistry> const& input_device_registry,
+    std::shared_ptr<mir::ConsoleServices> const& /*console*/,
+    std::shared_ptr<mi::InputReport> const& /*report*/)
+{
+    mir::assert_entry_point_signature<mi::CreatePlatform>(&create_input_platform);
+    return mir::make_module_ptr<miw::InputPlatform>(input_device_registry/*, mx::X11Resources::instance.get_conn()*/);
+}
+
+void add_input_platform_options(
+    boost::program_options::options_description& /*config*/)
+{
+    mir::assert_entry_point_signature<mi::AddPlatformOptions>(&add_input_platform_options);
+}
+
+mi::PlatformPriority probe_input_platform(
+    mo::Option const& /*options*/,
+    mir::ConsoleServices&)
+{
+    if (mpw::connection())
+    {
+        return mi::PlatformPriority::supported;
+    }
+    return mi::PlatformPriority::unsupported;
+}
+
+namespace
+{
+mir::ModuleProperties const description = {
+    "mir:wayland",
+    MIR_VERSION_MAJOR,
+    MIR_VERSION_MINOR,
+    MIR_VERSION_MICRO,
+    mir::libname()
+};
+}
+
+mir::ModuleProperties const* describe_input_module()
+{
+    mir::assert_entry_point_signature<mi::DescribeModule>(&describe_input_module);
+    return &description;
+}

--- a/src/platforms/wayland/input.cpp
+++ b/src/platforms/wayland/input.cpp
@@ -45,10 +45,10 @@ void add_input_platform_options(
 }
 
 mi::PlatformPriority probe_input_platform(
-    mo::Option const& /*options*/,
+    mo::Option const& options,
     mir::ConsoleServices&)
 {
-    if (mpw::connection())
+    if (mpw::connection(options))
     {
         return mi::PlatformPriority::supported;
     }

--- a/src/platforms/wayland/input_device.cpp
+++ b/src/platforms/wayland/input_device.cpp
@@ -213,3 +213,12 @@ void miw::InputDevice::pointer_motion(std::chrono::nanoseconds event_time, geome
         );
     });
 }
+
+void mir::input::wayland::InputDevice::touch_event(
+    std::chrono::nanoseconds event_time, std::vector<events::ContactState> const& contacts)
+{
+    enqueue([=](EventBuilder* b)
+    {
+        return b->touch_event(event_time, contacts);
+    });
+}

--- a/src/platforms/wayland/input_device.cpp
+++ b/src/platforms/wayland/input_device.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "input_device.h"
+
+#include "mir/input/pointer_settings.h"
+#include "mir/input/touchpad_settings.h"
+#include "mir/input/touchscreen_settings.h"
+#include "mir/input/input_device_info.h"
+#include "mir/input/device_capability.h"
+#include "mir/input/event_builder.h"
+#include "mir/input/input_sink.h"
+
+#include <X11/Xlib.h>
+
+namespace mi = mir::input;
+namespace mix = mi::wayland;
+
+namespace
+{
+MirPointerButtons to_mir_button(int button)
+{
+    auto const button_side = 8;
+    auto const button_extra = 9;
+    if (button == Button1)
+        return mir_pointer_button_primary;
+    if (button == Button2)  // tertiary (middle) button is Button2 in X
+        return mir_pointer_button_tertiary;
+    if (button == Button3)
+        return mir_pointer_button_secondary;
+    if (button == button_side)
+        return mir_pointer_button_side;
+    if (button == button_extra)
+        return mir_pointer_button_extra;
+    return 0;
+}
+
+MirPointerButtons to_mir_button_state(int x_button_key_state)
+{
+    MirPointerButtons button_state = 0;
+    if (x_button_key_state & Button1Mask)
+        button_state |= mir_pointer_button_primary;
+    if (x_button_key_state & Button2Mask)
+        button_state |= mir_pointer_button_tertiary;
+    if (x_button_key_state & Button3Mask)
+        button_state |= mir_pointer_button_secondary;
+    if (x_button_key_state & Button4Mask)
+        button_state |= mir_pointer_button_back;
+    if (x_button_key_state & Button5Mask)
+        button_state |= mir_pointer_button_forward;
+    return button_state;
+}
+
+}
+
+mix::InputDevice::InputDevice(InputDeviceInfo const& device_info)
+    : info(device_info)
+{
+}
+
+void mix::InputDevice::start(InputSink* input_sink, EventBuilder* event_builder)
+{
+    sink = input_sink;
+    builder = event_builder;
+}
+
+void mix::InputDevice::stop()
+{
+    sink = nullptr;
+    builder = nullptr;
+}
+
+mi::InputDeviceInfo mix::InputDevice::get_device_info()
+{
+    // TODO
+    return info;
+}
+
+mir::optional_value<mi::PointerSettings> mix::InputDevice::get_pointer_settings() const
+{
+    mir::optional_value<PointerSettings> ret;
+    if (contains(info.capabilities, DeviceCapability::pointer))
+        ret = PointerSettings();
+
+    return ret;
+}
+
+void mix::InputDevice::apply_settings(PointerSettings const&)
+{
+}
+
+mir::optional_value<mi::TouchpadSettings> mix::InputDevice::get_touchpad_settings() const
+{
+    optional_value<TouchpadSettings> ret;
+    if (contains(info.capabilities, DeviceCapability::touchpad))
+        ret = TouchpadSettings();
+
+    return ret;
+}
+
+void mix::InputDevice::apply_settings(TouchpadSettings const&)
+{
+}
+
+mir::optional_value<mi::TouchscreenSettings> mix::InputDevice::get_touchscreen_settings() const
+{
+    optional_value<TouchscreenSettings> ret;
+    if (contains(info.capabilities, DeviceCapability::touchscreen))
+        ret = TouchscreenSettings();
+
+    return ret;
+}
+
+void mix::InputDevice::apply_settings(TouchscreenSettings const&)
+{
+}
+
+bool mix::InputDevice::started() const
+{
+    return sink && builder;
+}
+
+void mix::InputDevice::key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code)
+{
+    sink->handle_input(
+        builder->key_event(
+            event_time,
+            mir_keyboard_action_down,
+            key_sym,
+            key_code
+            )
+        );
+
+}
+
+void mix::InputDevice::key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code)
+{
+    sink->handle_input(
+        builder->key_event(
+            event_time,
+            mir_keyboard_action_up,
+            key_sym,
+            key_code
+            )
+        );
+}
+
+void mix::InputDevice::update_button_state(int button)
+{
+    button_state = to_mir_button_state(button);
+}
+
+void mix::InputDevice::pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll)
+{
+    button_state |= to_mir_button(button);
+
+    auto const movement = pos - pointer_pos;
+    pointer_pos = pos;
+    sink->handle_input(
+        builder->pointer_event(
+            event_time,
+            mir_pointer_action_button_down,
+            button_state,
+            pointer_pos.x.as_int(),
+            pointer_pos.y.as_int(),
+            scroll.dx.as_int(),
+            scroll.dy.as_int(),
+            movement.dx.as_int(),
+            movement.dy.as_int()
+            )
+        );
+}
+
+void mix::InputDevice::pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll)
+{
+    button_state &= ~to_mir_button(button);
+
+    auto const movement = pos - pointer_pos;
+    pointer_pos = pos;
+    sink->handle_input(
+        builder->pointer_event(
+            event_time,
+            mir_pointer_action_button_up,
+            button_state,
+            pointer_pos.x.as_int(),
+            pointer_pos.y.as_int(),
+            scroll.dx.as_int(),
+            scroll.dy.as_int(),
+            movement.dx.as_int(),
+            movement.dy.as_int()
+            )
+        );
+
+}
+
+void mix::InputDevice::pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll)
+{
+    auto const movement = pos - pointer_pos;
+    pointer_pos = pos;
+    sink->handle_input(
+        builder->pointer_event(
+            event_time,
+            mir_pointer_action_motion,
+            button_state,
+            pointer_pos.x.as_int(),
+            pointer_pos.y.as_int(),
+            scroll.dx.as_int(),
+            scroll.dy.as_int(),
+            movement.dx.as_int(),
+            movement.dy.as_int()
+            )
+        );
+}

--- a/src/platforms/wayland/input_device.cpp
+++ b/src/platforms/wayland/input_device.cpp
@@ -33,7 +33,7 @@
 #include <stdexcept>
 
 namespace mi = mir::input;
-namespace mix = mi::wayland;
+namespace miw = mi::wayland;
 
 namespace
 {
@@ -59,7 +59,7 @@ MirPointerButton to_pointer_button(int button, MirPointerHandedness handedness)
 }
 }
 
-mix::InputDevice::InputDevice(
+miw::InputDevice::InputDevice(
     InputDeviceInfo const& device_info,
     std::shared_ptr<dispatch::ActionQueue> const& action_queue) :
     info(device_info),
@@ -67,26 +67,26 @@ mix::InputDevice::InputDevice(
 {
 }
 
-void mix::InputDevice::start(InputSink* input_sink, EventBuilder* event_builder)
+void miw::InputDevice::start(InputSink* input_sink, EventBuilder* event_builder)
 {
     std::lock_guard<decltype(mutex)> lock{mutex};
     sink = input_sink;
     builder = event_builder;
 }
 
-void mix::InputDevice::stop()
+void miw::InputDevice::stop()
 {
     std::lock_guard<decltype(mutex)> lock{mutex};
     sink = nullptr;
     builder = nullptr;
 }
 
-mi::InputDeviceInfo mix::InputDevice::get_device_info()
+mi::InputDeviceInfo miw::InputDevice::get_device_info()
 {
     return info;
 }
 
-mir::optional_value<mi::PointerSettings> mix::InputDevice::get_pointer_settings() const
+mir::optional_value<mi::PointerSettings> miw::InputDevice::get_pointer_settings() const
 {
     mir::optional_value<PointerSettings> ret;
     if (contains(info.capabilities, DeviceCapability::pointer))
@@ -95,11 +95,11 @@ mir::optional_value<mi::PointerSettings> mix::InputDevice::get_pointer_settings(
     return ret;
 }
 
-void mix::InputDevice::apply_settings(PointerSettings const&)
+void miw::InputDevice::apply_settings(PointerSettings const&)
 {
 }
 
-mir::optional_value<mi::TouchpadSettings> mix::InputDevice::get_touchpad_settings() const
+mir::optional_value<mi::TouchpadSettings> miw::InputDevice::get_touchpad_settings() const
 {
     optional_value<TouchpadSettings> ret;
     if (contains(info.capabilities, DeviceCapability::touchpad))
@@ -108,11 +108,11 @@ mir::optional_value<mi::TouchpadSettings> mix::InputDevice::get_touchpad_setting
     return ret;
 }
 
-void mix::InputDevice::apply_settings(TouchpadSettings const&)
+void miw::InputDevice::apply_settings(TouchpadSettings const&)
 {
 }
 
-mir::optional_value<mi::TouchscreenSettings> mix::InputDevice::get_touchscreen_settings() const
+mir::optional_value<mi::TouchscreenSettings> miw::InputDevice::get_touchscreen_settings() const
 {
     optional_value<TouchscreenSettings> ret;
     if (contains(info.capabilities, DeviceCapability::touchscreen))
@@ -121,16 +121,16 @@ mir::optional_value<mi::TouchscreenSettings> mix::InputDevice::get_touchscreen_s
     return ret;
 }
 
-void mix::InputDevice::apply_settings(TouchscreenSettings const&)
+void miw::InputDevice::apply_settings(TouchscreenSettings const&)
 {
 }
 
-bool mix::InputDevice::started() const
+bool miw::InputDevice::started() const
 {
     return sink && builder;
 }
 
-void  mix::InputDevice::enqueue(std::function<EventUPtr(EventBuilder* builder)> const& event)
+void  miw::InputDevice::enqueue(std::function<EventUPtr(EventBuilder* builder)> const& event)
 {
     action_queue->enqueue([=]
           {
@@ -140,17 +140,17 @@ void  mix::InputDevice::enqueue(std::function<EventUPtr(EventBuilder* builder)> 
           });
 }
 
-void mix::InputDevice::key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code)
+void miw::InputDevice::key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code)
 {
     enqueue([=](EventBuilder* b) { return b->key_event(event_time, mir_keyboard_action_down, key_sym, key_code); });
 }
 
-void mix::InputDevice::key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code)
+void miw::InputDevice::key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code)
 {
     enqueue([=](EventBuilder* b) { return b->key_event(event_time, mir_keyboard_action_up, key_sym, key_code); });
 }
 
-void mix::InputDevice::pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll)
+void miw::InputDevice::pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll)
 {
     enqueue([=](EventBuilder* b)
     {
@@ -172,7 +172,7 @@ void mix::InputDevice::pointer_press(std::chrono::nanoseconds event_time, int bu
     });
 }
 
-void mix::InputDevice::pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll)
+void miw::InputDevice::pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll)
 {
     enqueue([=](EventBuilder* b)
     {
@@ -194,7 +194,7 @@ void mix::InputDevice::pointer_release(std::chrono::nanoseconds event_time, int 
     });
 }
 
-void mix::InputDevice::pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll)
+void miw::InputDevice::pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll)
 {
     enqueue([=](EventBuilder* b)
     {

--- a/src/platforms/wayland/input_device.h
+++ b/src/platforms/wayland/input_device.h
@@ -76,7 +76,7 @@ private:
     bool started() const;
     void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) override;
     void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) override;
-    void update_button_state(int button);
+    void update_button_state(int button) override;
     void pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) override;
     void pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) override;
     void pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll) override;

--- a/src/platforms/wayland/input_device.h
+++ b/src/platforms/wayland/input_device.h
@@ -18,18 +18,20 @@
 #ifndef MIR_INPUT_WAYLAND_INPUT_DEVICE_H_
 #define MIR_INPUT_WAYLAND_INPUT_DEVICE_H_
 
-#include "mir/input/input_device.h"
-#include "mir/input/input_device_info.h"
+#include "display.h"
+
+#include <mir/events/event_builders.h>
 #include "mir/geometry/point.h"
 #include "mir/geometry/displacement.h"
+#include "mir/input/input_device.h"
+#include "mir/input/input_device_info.h"
+
 #include "mir/optional_value.h"
 
 #include <xkbcommon/xkbcommon.h>
-
 #include <chrono>
 #include <functional>
 #include <mutex>
-#include <mir/events/event_builders.h>
 
 typedef unsigned int MirPointerButtons;
 
@@ -44,7 +46,7 @@ namespace input
 namespace wayland
 {
 
-class InputDevice : public input::InputDevice
+class InputDevice : public input::InputDevice, public InputSinkX
 {
 public:
     InputDevice(InputDeviceInfo const& info, std::shared_ptr<dispatch::ActionQueue> const& action_queue);
@@ -72,12 +74,12 @@ private:
 
     void enqueue(std::function<EventUPtr(EventBuilder* builder)> const& event);
     bool started() const;
-    void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code);
-    void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code);
+    void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) override;
+    void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) override;
     void update_button_state(int button);
-    void pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll);
-    void pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll);
-    void pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll);
+    void pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) override;
+    void pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) override;
+    void pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll) override;
 };
 }
 }

--- a/src/platforms/wayland/input_device.h
+++ b/src/platforms/wayland/input_device.h
@@ -76,7 +76,6 @@ private:
     bool started() const;
     void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) override;
     void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) override;
-    void update_button_state(int button) override;
     void pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) override;
     void pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) override;
     void pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll) override;

--- a/src/platforms/wayland/input_device.h
+++ b/src/platforms/wayland/input_device.h
@@ -18,17 +18,16 @@
 #ifndef MIR_INPUT_WAYLAND_INPUT_DEVICE_H_
 #define MIR_INPUT_WAYLAND_INPUT_DEVICE_H_
 
-#include "display.h"
+#include "display_input.h"
 
 #include <mir/events/event_builders.h>
-#include "mir/geometry/point.h"
-#include "mir/geometry/displacement.h"
-#include "mir/input/input_device.h"
-#include "mir/input/input_device_info.h"
-
-#include "mir/optional_value.h"
+#include <mir/geometry/point.h>
+#include <mir/geometry/displacement.h>
+#include <mir/input/input_device.h>
+#include <mir/input/input_device_info.h>
 
 #include <xkbcommon/xkbcommon.h>
+
 #include <chrono>
 #include <functional>
 #include <mutex>
@@ -46,39 +45,73 @@ namespace input
 namespace wayland
 {
 
-class InputDevice : public input::InputDevice, public InputSinkX
+class GenericInputDevice : public InputDevice
 {
-public:
-    InputDevice(InputDeviceInfo const& info, std::shared_ptr<dispatch::ActionQueue> const& action_queue);
+protected:
+
+    GenericInputDevice(InputDeviceInfo const& info, std::shared_ptr<dispatch::ActionQueue> const& action_queue);
 
     void start(InputSink* destination, EventBuilder* builder) override;
+
     void stop() override;
+
     InputDeviceInfo get_device_info() override;
 
     optional_value<PointerSettings> get_pointer_settings() const override;
+
     void apply_settings(PointerSettings const& settings) override;
+
     optional_value<TouchpadSettings> get_touchpad_settings() const override;
+
     void apply_settings(TouchpadSettings const& settings) override;
+
     virtual optional_value<TouchscreenSettings> get_touchscreen_settings() const override;
+
     virtual void apply_settings(TouchscreenSettings const&) override;
 
+    void enqueue(std::function<EventUPtr(EventBuilder* builder)> const& event);
+
 private:
+    bool started() const;
+
     InputDeviceInfo const info;
     std::shared_ptr<dispatch::ActionQueue> const action_queue;
 
     std::mutex mutable mutex;
     InputSink* sink{nullptr};
     EventBuilder* builder{nullptr};
+};
+
+class KeyboardInputDevice : public GenericInputDevice, public KeyboardInput
+{
+public:
+    explicit KeyboardInputDevice(std::shared_ptr<dispatch::ActionQueue> const& action_queue);
+
+private:
+    void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) override;
+    void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) override;
+};
+
+class PointerInputDevice : public GenericInputDevice, public PointerInput
+{
+public:
+    PointerInputDevice(std::shared_ptr<dispatch::ActionQueue> const& action_queue);
+
+private:
     MirPointerButtons button_state{0};
     geometry::Point pointer_pos;
 
-    void enqueue(std::function<EventUPtr(EventBuilder* builder)> const& event);
-    bool started() const;
-    void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) override;
-    void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) override;
     void pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) override;
     void pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) override;
     void pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll) override;
+};
+
+class TouchInputDevice : public GenericInputDevice, public TouchInput
+{
+public:
+    TouchInputDevice(std::shared_ptr<dispatch::ActionQueue> const& action_queue);
+
+private:
     void touch_event(std::chrono::nanoseconds event_time, std::vector<events::ContactState> const& contacts) override;
 };
 }

--- a/src/platforms/wayland/input_device.h
+++ b/src/platforms/wayland/input_device.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MIR_INPUT_WAYLAND_INPUT_DEVICE_H_
+#define MIR_INPUT_WAYLAND_INPUT_DEVICE_H_
+
+#include "mir/input/input_device.h"
+#include "mir/input/input_device_info.h"
+#include "mir/geometry/point.h"
+#include "mir/geometry/displacement.h"
+#include "mir/optional_value.h"
+
+#include <xkbcommon/xkbcommon.h>
+
+#include <chrono>
+
+typedef unsigned int MirPointerButtons;
+
+namespace mir
+{
+namespace input
+{
+namespace wayland
+{
+
+class InputDevice : public input::InputDevice
+{
+public:
+    InputDevice(InputDeviceInfo const& info);
+
+    std::shared_ptr<dispatch::Dispatchable> dispatchable();
+    void start(InputSink* destination, EventBuilder* builder) override;
+    void stop() override;
+    InputDeviceInfo get_device_info() override;
+
+    optional_value<PointerSettings> get_pointer_settings() const override;
+    void apply_settings(PointerSettings const& settings) override;
+    optional_value<TouchpadSettings> get_touchpad_settings() const override;
+    void apply_settings(TouchpadSettings const& settings) override;
+    virtual optional_value<TouchscreenSettings> get_touchscreen_settings() const override;
+    virtual void apply_settings(TouchscreenSettings const&) override;
+
+private:
+    MirPointerButtons button_state{0};
+    InputSink* sink{nullptr};
+    EventBuilder* builder{nullptr};
+    geometry::Point pointer_pos;
+    InputDeviceInfo info;
+
+    bool started() const;
+    void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code);
+    void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code);
+    void update_button_state(int button);
+    void pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll);
+    void pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll);
+    void pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll);
+};
+}
+}
+}
+
+#endif // MIR_INPUT_WAYLAND_INPUT_DEVICE_H_

--- a/src/platforms/wayland/input_device.h
+++ b/src/platforms/wayland/input_device.h
@@ -79,6 +79,7 @@ private:
     void pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) override;
     void pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) override;
     void pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll) override;
+    void touch_event(std::chrono::nanoseconds event_time, std::vector<events::ContactState> const& contacts) override;
 };
 }
 }

--- a/src/platforms/wayland/input_platform.cpp
+++ b/src/platforms/wayland/input_platform.cpp
@@ -18,40 +18,38 @@
 #include "input_platform.h"
 #include "input_device.h"
 
-#include "mir/dispatch/multiplexing_dispatchable.h"
-#include "mir/input/input_device_info.h"
-#include "mir/input/input_device_registry.h"
+
+#include <mir/dispatch/action_queue.h>
+#include <mir/input/input_device_info.h>
+#include <mir/input/input_device_registry.h>
 
 namespace md = mir::dispatch;
 namespace miw = mir::input::wayland;
 
 miw::InputPlatform::InputPlatform(std::shared_ptr<InputDeviceRegistry> const& input_device_registry) :
-    dispatchable_(std::make_shared<mir::dispatch::MultiplexingDispatchable>()),
+    action_queue(std::make_shared<md::ActionQueue>()),
     registry(input_device_registry),
-    keyboard(std::make_shared<InputDevice>(InputDeviceInfo{"keyboard-device", "key-dev-1", DeviceCapability::keyboard})),
-    pointer(std::make_shared<InputDevice>(InputDeviceInfo{"mouse-device", "mouse-dev-1", DeviceCapability::pointer})),
-    touch(std::make_shared<InputDevice>(InputDeviceInfo{"touch-device", "touch-dev-1", DeviceCapability::touchscreen}))
+    keyboard(std::make_shared<InputDevice>(InputDeviceInfo{"keyboard-device", "key-dev-1", DeviceCapability::keyboard}, action_queue)),
+    pointer(std::make_shared<InputDevice>(InputDeviceInfo{"mouse-device", "mouse-dev-1", DeviceCapability::pointer}, action_queue)),
+    touch(std::make_shared<InputDevice>(InputDeviceInfo{"touch-device", "touch-dev-1", DeviceCapability::touchscreen}, action_queue))
 {
     puts(__PRETTY_FUNCTION__);
 }
 
 void miw::InputPlatform::start()
 {
-    puts(__PRETTY_FUNCTION__);
     registry->add_device(keyboard);
     registry->add_device(pointer);
     registry->add_device(touch);
 }
 
-std::shared_ptr<md::Dispatchable> miw::InputPlatform::dispatchable()
+auto miw::InputPlatform::dispatchable() -> std::shared_ptr<md::Dispatchable>
 {
-    puts(__PRETTY_FUNCTION__);
-    return dispatchable_;
+    return action_queue;
 }
 
 void miw::InputPlatform::stop()
 {
-    puts(__PRETTY_FUNCTION__);
     registry->remove_device(touch);
     registry->remove_device(pointer);
     registry->remove_device(keyboard);
@@ -59,10 +57,8 @@ void miw::InputPlatform::stop()
 
 void miw::InputPlatform::pause_for_config()
 {
-    puts(__PRETTY_FUNCTION__);
 }
 
 void miw::InputPlatform::continue_after_config()
 {
-    puts(__PRETTY_FUNCTION__);
 }

--- a/src/platforms/wayland/input_platform.cpp
+++ b/src/platforms/wayland/input_platform.cpp
@@ -34,6 +34,7 @@ miw::InputPlatform::InputPlatform(std::shared_ptr<InputDeviceRegistry> const& in
 {
     puts(__PRETTY_FUNCTION__);
     graphics::wayland::the_display->set_keyboard_sink(keyboard);
+    graphics::wayland::the_display->set_pointer_sink(pointer);
 }
 
 void miw::InputPlatform::start()

--- a/src/platforms/wayland/input_platform.cpp
+++ b/src/platforms/wayland/input_platform.cpp
@@ -35,6 +35,7 @@ miw::InputPlatform::InputPlatform(std::shared_ptr<InputDeviceRegistry> const& in
     puts(__PRETTY_FUNCTION__);
     graphics::wayland::the_display->set_keyboard_sink(keyboard);
     graphics::wayland::the_display->set_pointer_sink(pointer);
+    graphics::wayland::the_display->set_touch_sink(touch);
 }
 
 void miw::InputPlatform::start()

--- a/src/platforms/wayland/input_platform.cpp
+++ b/src/platforms/wayland/input_platform.cpp
@@ -18,7 +18,6 @@
 #include "input_platform.h"
 #include "input_device.h"
 
-
 #include <mir/dispatch/action_queue.h>
 #include <mir/input/input_device_info.h>
 #include <mir/input/input_device_registry.h>
@@ -34,6 +33,7 @@ miw::InputPlatform::InputPlatform(std::shared_ptr<InputDeviceRegistry> const& in
     touch(std::make_shared<InputDevice>(InputDeviceInfo{"touch-device", "touch-dev-1", DeviceCapability::touchscreen}, action_queue))
 {
     puts(__PRETTY_FUNCTION__);
+    graphics::wayland::the_display->set_keyboard_sink(keyboard);
 }
 
 void miw::InputPlatform::start()

--- a/src/platforms/wayland/input_platform.cpp
+++ b/src/platforms/wayland/input_platform.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "input_platform.h"
+#include "input_device.h"
+
+#include "mir/dispatch/multiplexing_dispatchable.h"
+#include "mir/input/input_device_info.h"
+#include "mir/input/input_device_registry.h"
+
+namespace md = mir::dispatch;
+namespace miw = mir::input::wayland;
+
+miw::InputPlatform::InputPlatform(std::shared_ptr<InputDeviceRegistry> const& input_device_registry) :
+    dispatchable_(std::make_shared<mir::dispatch::MultiplexingDispatchable>()),
+    registry(input_device_registry),
+    keyboard(std::make_shared<InputDevice>(InputDeviceInfo{"keyboard-device", "key-dev-1", DeviceCapability::keyboard})),
+    pointer(std::make_shared<InputDevice>(InputDeviceInfo{"mouse-device", "mouse-dev-1", DeviceCapability::pointer})),
+    touch(std::make_shared<InputDevice>(InputDeviceInfo{"touch-device", "touch-dev-1", DeviceCapability::touchscreen}))
+{
+    puts(__PRETTY_FUNCTION__);
+}
+
+void miw::InputPlatform::start()
+{
+    puts(__PRETTY_FUNCTION__);
+    registry->add_device(keyboard);
+    registry->add_device(pointer);
+    registry->add_device(touch);
+}
+
+std::shared_ptr<md::Dispatchable> miw::InputPlatform::dispatchable()
+{
+    puts(__PRETTY_FUNCTION__);
+    return dispatchable_;
+}
+
+void miw::InputPlatform::stop()
+{
+    puts(__PRETTY_FUNCTION__);
+    registry->remove_device(touch);
+    registry->remove_device(pointer);
+    registry->remove_device(keyboard);
+}
+
+void miw::InputPlatform::pause_for_config()
+{
+    puts(__PRETTY_FUNCTION__);
+}
+
+void miw::InputPlatform::continue_after_config()
+{
+    puts(__PRETTY_FUNCTION__);
+}

--- a/src/platforms/wayland/input_platform.cpp
+++ b/src/platforms/wayland/input_platform.cpp
@@ -17,9 +17,9 @@
 
 #include "input_platform.h"
 #include "input_device.h"
+#include "display.h"
 
 #include <mir/dispatch/action_queue.h>
-#include <mir/input/input_device_info.h>
 #include <mir/input/input_device_registry.h>
 
 namespace md = mir::dispatch;
@@ -28,11 +28,10 @@ namespace miw = mir::input::wayland;
 miw::InputPlatform::InputPlatform(std::shared_ptr<InputDeviceRegistry> const& input_device_registry) :
     action_queue(std::make_shared<md::ActionQueue>()),
     registry(input_device_registry),
-    keyboard(std::make_shared<InputDevice>(InputDeviceInfo{"keyboard-device", "key-dev-1", DeviceCapability::keyboard}, action_queue)),
-    pointer(std::make_shared<InputDevice>(InputDeviceInfo{"mouse-device", "mouse-dev-1", DeviceCapability::pointer}, action_queue)),
-    touch(std::make_shared<InputDevice>(InputDeviceInfo{"touch-device", "touch-dev-1", DeviceCapability::touchscreen}, action_queue))
+    keyboard(std::make_shared<KeyboardInputDevice>(action_queue)),
+    pointer(std::make_shared<PointerInputDevice>(action_queue)),
+    touch(std::make_shared<TouchInputDevice>(action_queue))
 {
-    puts(__PRETTY_FUNCTION__);
     graphics::wayland::the_display->set_keyboard_sink(keyboard);
     graphics::wayland::the_display->set_pointer_sink(pointer);
     graphics::wayland::the_display->set_touch_sink(touch);

--- a/src/platforms/wayland/input_platform.cpp
+++ b/src/platforms/wayland/input_platform.cpp
@@ -32,9 +32,9 @@ miw::InputPlatform::InputPlatform(std::shared_ptr<InputDeviceRegistry> const& in
     pointer(std::make_shared<PointerInputDevice>(action_queue)),
     touch(std::make_shared<TouchInputDevice>(action_queue))
 {
-    graphics::wayland::the_display->set_keyboard_sink(keyboard);
-    graphics::wayland::the_display->set_pointer_sink(pointer);
-    graphics::wayland::the_display->set_touch_sink(touch);
+    graphics::wayland::Display::set_keyboard_sink(keyboard);
+    graphics::wayland::Display::set_pointer_sink(pointer);
+    graphics::wayland::Display::set_touch_sink(touch);
 }
 
 void miw::InputPlatform::start()

--- a/src/platforms/wayland/input_platform.h
+++ b/src/platforms/wayland/input_platform.h
@@ -21,6 +21,10 @@
 
 namespace mir
 {
+namespace dispatch
+{
+class ActionQueue;
+}
 namespace input
 {
 namespace wayland
@@ -33,14 +37,14 @@ public:
     explicit InputPlatform(std::shared_ptr<InputDeviceRegistry> const& input_device_registry);
     ~InputPlatform() = default;
 
-    std::shared_ptr<dispatch::Dispatchable> dispatchable() override;
+    auto dispatchable() -> std::shared_ptr<dispatch::Dispatchable> override;
     void start() override;
     void stop() override;
     void pause_for_config() override;
     void continue_after_config() override;
 
 private:
-    std::shared_ptr<dispatch::Dispatchable> const dispatchable_;
+    std::shared_ptr<dispatch::ActionQueue> const action_queue;
     std::shared_ptr<InputDeviceRegistry> const registry;
     std::shared_ptr<InputDevice> const keyboard;
     std::shared_ptr<InputDevice> const pointer;

--- a/src/platforms/wayland/input_platform.h
+++ b/src/platforms/wayland/input_platform.h
@@ -29,7 +29,9 @@ namespace input
 {
 namespace wayland
 {
-class InputDevice;
+class TouchInputDevice;
+class KeyboardInputDevice;
+class PointerInputDevice;
 
 class InputPlatform : public input::Platform
 {
@@ -46,9 +48,9 @@ public:
 private:
     std::shared_ptr<dispatch::ActionQueue> const action_queue;
     std::shared_ptr<InputDeviceRegistry> const registry;
-    std::shared_ptr<InputDevice> const keyboard;
-    std::shared_ptr<InputDevice> const pointer;
-    std::shared_ptr<InputDevice> const touch;
+    std::shared_ptr<KeyboardInputDevice> const keyboard;
+    std::shared_ptr<PointerInputDevice> const pointer;
+    std::shared_ptr<TouchInputDevice> const touch;
 };
 }
 }

--- a/src/platforms/wayland/input_platform.h
+++ b/src/platforms/wayland/input_platform.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef MIR_INPUT_WAYLAND_INPUT_PLATFORM_H_
+#define MIR_INPUT_WAYLAND_INPUT_PLATFORM_H_
+
+#include "mir/input/platform.h"
+
+namespace mir
+{
+namespace input
+{
+namespace wayland
+{
+class InputDevice;
+
+class InputPlatform : public input::Platform
+{
+public:
+    explicit InputPlatform(std::shared_ptr<InputDeviceRegistry> const& input_device_registry);
+    ~InputPlatform() = default;
+
+    std::shared_ptr<dispatch::Dispatchable> dispatchable() override;
+    void start() override;
+    void stop() override;
+    void pause_for_config() override;
+    void continue_after_config() override;
+
+private:
+    std::shared_ptr<dispatch::Dispatchable> const dispatchable_;
+    std::shared_ptr<InputDeviceRegistry> const registry;
+    std::shared_ptr<InputDevice> const keyboard;
+    std::shared_ptr<InputDevice> const pointer;
+    std::shared_ptr<InputDevice> const touch;
+};
+}
+}
+}
+
+#endif // MIR_INPUT_WAYLAND_INPUT_PLATFORM_H_

--- a/src/platforms/wayland/platform.cpp
+++ b/src/platforms/wayland/platform.cpp
@@ -71,9 +71,9 @@ std::vector<mir::ExtensionDescription> mgw::Platform::extensions() const
     return {};
 }
 
-mir::UniqueModulePtr<mg::GraphicBufferAllocator> mgw::Platform::create_buffer_allocator(mg::Display const& )
+mir::UniqueModulePtr<mg::GraphicBufferAllocator> mgw::Platform::create_buffer_allocator(mg::Display const& output)
 {
-    return mir::make_module_ptr<mgw::BufferAllocator>();
+    return mir::make_module_ptr<mgw::BufferAllocator>(output);
 }
 
 mg::NativeRenderingPlatform* mgw::Platform::native_rendering_platform()

--- a/src/platforms/wayland/platform.cpp
+++ b/src/platforms/wayland/platform.cpp
@@ -56,38 +56,32 @@ mir::UniqueModulePtr<mg::Display> mgw::Platform::create_display(
 
 mg::NativeDisplayPlatform* mgw::Platform::native_display_platform()
 {
-    puts(__PRETTY_FUNCTION__);
     return nullptr;
 }
 
 EGLNativeDisplayType mgw::Platform::egl_native_display() const
 {
-    puts(__PRETTY_FUNCTION__);
     return eglGetDisplay(wl_display);
 }
 
 
 std::vector<mir::ExtensionDescription> mgw::Platform::extensions() const
 {
-    puts(__PRETTY_FUNCTION__);
     fatal_error("wayland platform does not support mirclient");
     return {};
 }
 
 mir::UniqueModulePtr<mg::GraphicBufferAllocator> mgw::Platform::create_buffer_allocator(mg::Display const& )
 {
-    puts(__PRETTY_FUNCTION__);
     return mir::make_module_ptr<mgw::BufferAllocator>();
 }
 
 mg::NativeRenderingPlatform* mgw::Platform::native_rendering_platform()
 {
-    puts(__PRETTY_FUNCTION__);
     return this;
 }
 mir::UniqueModulePtr<mg::PlatformIpcOperations> mgw::Platform::make_ipc_operations() const
 {
-    puts(__PRETTY_FUNCTION__);
     fatal_error("wayland platform does not support mirclient");
     return {};
 }

--- a/src/platforms/wayland/platform.cpp
+++ b/src/platforms/wayland/platform.cpp
@@ -35,8 +35,6 @@ namespace mg = mir::graphics;
 namespace mgw = mir::graphics::wayland;
 using namespace std::literals;
 
-//TODO replace printf debug messages
-
 mgw::Platform::Platform(struct wl_display* const wl_display, std::shared_ptr<mg::DisplayReport> const& report) :
     wl_display{wl_display},
     report{report}

--- a/src/platforms/wayland/platform.cpp
+++ b/src/platforms/wayland/platform.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+#include "buffer_allocator.h"
+#include "display.h"
+#include "mir/graphics/platform_ipc_operations.h"
+#include "mir/graphics/platform_ipc_package.h"
+#include "mir/graphics/platform_operation_message.h"
+#include "mir/graphics/buffer_ipc_message.h"
+#include "buffer_allocator.h"
+#include "mir/fatal.h"
+
+#include "mir/graphics/egl_error.h"
+
+#include <boost/throw_exception.hpp>
+#include <fcntl.h>
+#include <wayland-client.h>
+#include <wayland-egl.h>
+
+namespace mg = mir::graphics;
+namespace mgw = mir::graphics::wayland;
+using namespace std::literals;
+
+//TODO replace printf debug messages
+
+mgw::Platform::Platform(struct wl_display* const wl_display, std::shared_ptr<mg::DisplayReport> const& report) :
+    wl_display{wl_display},
+    report{report}
+{
+    if (!wl_display)
+    {
+        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to connect to wayland"));
+    }
+}
+
+mir::UniqueModulePtr<mg::Display> mgw::Platform::create_display(
+    std::shared_ptr<DisplayConfigurationPolicy> const&,
+    std::shared_ptr<GLConfig> const& /*gl_config*/)
+{
+  return mir::make_module_ptr<mgw::Display>(wl_display, report);
+}
+
+mg::NativeDisplayPlatform* mgw::Platform::native_display_platform()
+{
+    puts(__PRETTY_FUNCTION__);
+    return nullptr;
+}
+
+EGLNativeDisplayType mgw::Platform::egl_native_display() const
+{
+    puts(__PRETTY_FUNCTION__);
+    return eglGetDisplay(wl_display);
+}
+
+
+std::vector<mir::ExtensionDescription> mgw::Platform::extensions() const
+{
+    puts(__PRETTY_FUNCTION__);
+    fatal_error("wayland platform does not support mirclient");
+    return {};
+}
+
+mir::UniqueModulePtr<mg::GraphicBufferAllocator> mgw::Platform::create_buffer_allocator(mg::Display const& )
+{
+    puts(__PRETTY_FUNCTION__);
+    return mir::make_module_ptr<mgw::BufferAllocator>();
+}
+
+mg::NativeRenderingPlatform* mgw::Platform::native_rendering_platform()
+{
+    puts(__PRETTY_FUNCTION__);
+    return this;
+}
+mir::UniqueModulePtr<mg::PlatformIpcOperations> mgw::Platform::make_ipc_operations() const
+{
+    puts(__PRETTY_FUNCTION__);
+    fatal_error("wayland platform does not support mirclient");
+    return {};
+}

--- a/src/platforms/wayland/platform.cpp
+++ b/src/platforms/wayland/platform.cpp
@@ -49,9 +49,9 @@ mgw::Platform::Platform(struct wl_display* const wl_display, std::shared_ptr<mg:
 
 mir::UniqueModulePtr<mg::Display> mgw::Platform::create_display(
     std::shared_ptr<DisplayConfigurationPolicy> const&,
-    std::shared_ptr<GLConfig> const& /*gl_config*/)
+    std::shared_ptr<GLConfig> const& gl_config)
 {
-  return mir::make_module_ptr<mgw::Display>(wl_display, report);
+  return mir::make_module_ptr<mgw::Display>(wl_display, gl_config, report);
 }
 
 mg::NativeDisplayPlatform* mgw::Platform::native_display_platform()

--- a/src/platforms/wayland/platform.h
+++ b/src/platforms/wayland/platform.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_GRAPHICS_WAYLAND_PLATFORM_H_
+#define MIR_GRAPHICS_WAYLAND_PLATFORM_H_
+
+#include "mir/graphics/platform.h"
+#include "mir/options/option.h"
+#include "mir/graphics/graphic_buffer_allocator.h"
+#include "mir/graphics/display.h"
+#include "mir/graphics/platform_ipc_operations.h"
+#include "mir/fd.h"
+#include "mir/renderer/gl/egl_platform.h"
+
+#include "displayclient.h"
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <wayland-client.h>
+#include <wayland-egl.h>
+
+namespace mir
+{
+namespace graphics
+{
+namespace wayland
+{
+class Platform : public graphics::Platform,
+                 public graphics::NativeRenderingPlatform,
+                 public mir::renderer::gl::EGLPlatform
+{
+public:
+    Platform(struct wl_display* const wl_display, std::shared_ptr<DisplayReport> const& report);
+    ~Platform() = default;
+
+    UniqueModulePtr<GraphicBufferAllocator> create_buffer_allocator(Display const& output) override;
+
+    UniqueModulePtr<Display> create_display(
+        std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
+        std::shared_ptr<GLConfig> const& gl_config) override;
+    NativeDisplayPlatform* native_display_platform() override;
+    std::vector<ExtensionDescription> extensions() const override;
+
+    UniqueModulePtr<PlatformIpcOperations> make_ipc_operations() const override;
+
+    NativeRenderingPlatform* native_rendering_platform() override;
+    EGLNativeDisplayType egl_native_display() const override;
+
+private:
+    struct wl_display* const wl_display;
+    std::shared_ptr<DisplayReport> const report;
+};
+}
+}
+}
+
+#endif // MIR_GRAPHICS_WAYLAND_PLATFORM_H_

--- a/src/platforms/wayland/platform_symbols.cpp
+++ b/src/platforms/wayland/platform_symbols.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include <mir/graphics/platform.h>
+
+#include "wayland_display.h"
+#include "platform.h"
+
+#include <mir/assert_module_entry_point.h>
+#include <mir/libname.h>
+
+namespace mg = mir::graphics;
+namespace mo = mir::options;
+namespace mgw = mir::graphics::wayland;
+namespace mpw = mir::platform::wayland;
+
+namespace
+{
+mir::ModuleProperties const description = {
+    "mir:wayland",
+    MIR_VERSION_MAJOR,
+    MIR_VERSION_MINOR,
+    MIR_VERSION_MICRO,
+    mir::libname()
+};
+}
+
+mir::UniqueModulePtr<mg::Platform> create_host_platform(
+    std::shared_ptr<mo::Option> const&,
+    std::shared_ptr<mir::EmergencyCleanupRegistry> const&,
+    std::shared_ptr<mir::ConsoleServices> const& /*console*/,
+    std::shared_ptr<mg::DisplayReport> const& report,
+    std::shared_ptr<mir::logging::Logger> const&)
+{
+    mir::assert_entry_point_signature<mg::CreateHostPlatform>(&create_host_platform);
+    return mir::make_module_ptr<mgw::Platform>(mpw::connection(), report);
+}
+
+void add_graphics_platform_options(boost::program_options::options_description& /*config*/)
+{
+    mir::assert_entry_point_signature<mg::AddPlatformOptions>(&add_graphics_platform_options);
+}
+
+mg::PlatformPriority probe_graphics_platform(
+    std::shared_ptr<mir::ConsoleServices> const& /*console*/,
+    mo::ProgramOption const& /*options*/)
+{
+    mir::assert_entry_point_signature<mg::PlatformProbe>(&probe_graphics_platform);
+
+    return mpw::connection() ?
+        mg::PlatformPriority::best :
+        mg::PlatformPriority::unsupported;
+}
+
+mir::ModuleProperties const* describe_graphics_module()
+{
+    mir::assert_entry_point_signature<mg::DescribeModule>(&describe_graphics_module);
+    return &description;
+}

--- a/src/platforms/wayland/platform_symbols.cpp
+++ b/src/platforms/wayland/platform_symbols.cpp
@@ -23,6 +23,7 @@
 
 #include <mir/assert_module_entry_point.h>
 #include <mir/libname.h>
+#include <mir/options/program_option.h>
 
 namespace mg = mir::graphics;
 namespace mo = mir::options;
@@ -41,28 +42,29 @@ mir::ModuleProperties const description = {
 }
 
 mir::UniqueModulePtr<mg::Platform> create_host_platform(
-    std::shared_ptr<mo::Option> const&,
+    std::shared_ptr<mo::Option> const& options,
     std::shared_ptr<mir::EmergencyCleanupRegistry> const&,
     std::shared_ptr<mir::ConsoleServices> const& /*console*/,
     std::shared_ptr<mg::DisplayReport> const& report,
     std::shared_ptr<mir::logging::Logger> const&)
 {
     mir::assert_entry_point_signature<mg::CreateHostPlatform>(&create_host_platform);
-    return mir::make_module_ptr<mgw::Platform>(mpw::connection(), report);
+    return mir::make_module_ptr<mgw::Platform>(mpw::connection(*options), report);
 }
 
-void add_graphics_platform_options(boost::program_options::options_description& /*config*/)
+void add_graphics_platform_options(boost::program_options::options_description& config)
 {
     mir::assert_entry_point_signature<mg::AddPlatformOptions>(&add_graphics_platform_options);
+    mpw::add_connection_options(config);
 }
 
 mg::PlatformPriority probe_graphics_platform(
     std::shared_ptr<mir::ConsoleServices> const& /*console*/,
-    mo::ProgramOption const& /*options*/)
+    mo::ProgramOption const& options)
 {
     mir::assert_entry_point_signature<mg::PlatformProbe>(&probe_graphics_platform);
 
-    return mpw::connection() ?
+    return mpw::connection(options) ?
         mg::PlatformPriority::best :
         mg::PlatformPriority::unsupported;
 }

--- a/src/platforms/wayland/symbols.map.in
+++ b/src/platforms/wayland/symbols.map.in
@@ -1,0 +1,18 @@
+@MIR_SERVER_GRAPHICS_PLATFORM_VERSION@ {
+  global:
+    add_graphics_platform_options;
+    create_host_platform;
+    create_guest_platform;
+    probe_graphics_platform;
+    describe_graphics_module;
+  local:
+    *;
+};
+
+@MIR_SERVER_INPUT_PLATFORM_VERSION@ {
+  global:
+   add_input_platform_options;
+   create_input_platform;
+   probe_input_platform;
+   describe_input_module;
+} @MIR_SERVER_GRAPHICS_PLATFORM_VERSION@;

--- a/src/platforms/wayland/wayland_display.cpp
+++ b/src/platforms/wayland/wayland_display.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "wayland_display.h"
+
+namespace mpw = mir::platform::wayland;
+
+namespace
+{
+struct WaylandDisplay
+{
+    struct wl_display* const wl_display = wl_display_connect(getenv("WAYLAND_DISPLAY"));
+
+    ~WaylandDisplay() { if (wl_display) wl_display_disconnect(wl_display); }
+} wayland_display;
+}
+
+auto mpw::connection() -> struct wl_display*
+{
+    return wayland_display.wl_display;
+}

--- a/src/platforms/wayland/wayland_display.h
+++ b/src/platforms/wayland/wayland_display.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#ifndef MIR_PLATFORM_WAYLAND_DISPLAY_H_
+#define MIR_PLATFORM_WAYLAND_DISPLAY_H_
+
+#include <wayland-client.h>
+
+namespace mir
+{
+namespace platform
+{
+namespace wayland
+{
+auto connection() -> wl_display*;
+}
+}
+}
+
+#endif //MIR_PLATFORM_WAYLAND_DISPLAY_H_

--- a/src/platforms/wayland/wayland_display.h
+++ b/src/platforms/wayland/wayland_display.h
@@ -12,8 +12,6 @@
  *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Alan Griffiths <alan@octopull.co.uk>
  */
 
 #ifndef MIR_PLATFORM_WAYLAND_DISPLAY_H_
@@ -21,13 +19,18 @@
 
 #include <wayland-client.h>
 
+#include <boost/program_options/options_description.hpp>
+
 namespace mir
 {
+namespace options { class Option; }
+
 namespace platform
 {
 namespace wayland
 {
-auto connection() -> wl_display*;
+void add_connection_options(boost::program_options::options_description& config);
+auto connection(mir::options::Option const& options) -> wl_display*;
 }
 }
 }

--- a/src/server/input/input_probe.cpp
+++ b/src/server/input/input_probe.cpp
@@ -74,7 +74,9 @@ mir::UniqueModulePtr<mi::Platform> mi::probe_input_platforms(
                 auto const probe = module->load_function<mi::ProbePlatform>(
                     "probe_input_platform", MIR_SERVER_INPUT_PLATFORM_VERSION);
 
-                if (probe(options, *console) > reject_platform_priority)
+                auto const priority = probe(options, *console);
+                printf("************ priority=%d, reject_platform_priority=%d\n", (int)priority, (int)reject_platform_priority);
+                if (priority > reject_platform_priority)
                 {
                     platform_module = module;
 

--- a/src/server/input/input_probe.cpp
+++ b/src/server/input/input_probe.cpp
@@ -75,7 +75,6 @@ mir::UniqueModulePtr<mi::Platform> mi::probe_input_platforms(
                     "probe_input_platform", MIR_SERVER_INPUT_PLATFORM_VERSION);
 
                 auto const priority = probe(options, *console);
-                printf("************ priority=%d, reject_platform_priority=%d\n", (int)priority, (int)reject_platform_priority);
                 if (priority > reject_platform_priority)
                 {
                     platform_module = module;

--- a/tools/update_package_abis.sh
+++ b/tools/update_package_abis.sh
@@ -23,7 +23,8 @@ packages="\
     mir-platform-graphics-mesa-kms:MIR_SERVER_GRAPHICS_PLATFORM_ABI \
     mir-platform-graphics-eglstream-kms:MIR_SERVER_GRAPHICS_PLATFORM_ABI \
     mir-platform-input-evdev:MIR_SERVER_INPUT_PLATFORM_ABI\
-    libmirwayland:MIRWAYLAND_ABI"
+    libmirwayland:MIRWAYLAND_ABI\
+    mir-platform-graphics-wayland:MIR_SERVER_GRAPHICS_PLATFORM_ABI"
 
 package_name()
 {


### PR DESCRIPTION
Assuming there's an existing Wayland server at `wayland-0`, enable connecting to it with:

`--wayland-host wayland-0`

This works well enough as a first cut. The main issue I know of is that the modifier key state gets out of sync when switching between this window and others on a desktop. It's still usable though as toggling the key resynchronises.

Still no tests, but there's not a lot to meaningfully test for platforms beyond "Mir lives". Will look at that after the sprint.