### PR TITLE
Fix build against GMock/GTest ≥ 1.9

### DIFF
--- a/cmake/FindGtestGmock.cmake
+++ b/cmake/FindGtestGmock.cmake
@@ -62,6 +62,7 @@ if (EXISTS ${GMOCK_SOURCE})
     find_path(GMOCK_INCLUDE_DIR gmock/gmock.h PATHS /usr/src/googletest/googlemock/include)
 
     add_library(GMock STATIC ${GMOCK_SOURCE})
+    target_link_libraries(GMock ${GTEST_LIBRARY})
 
     if (EXISTS /usr/src/googletest/googlemock/src)
         set_source_files_properties(${GMOCK_SOURCE} PROPERTIES COMPILE_FLAGS "-I/usr/src/googletest/googlemock")

--- a/tests/include/gmock_set_arg.h
+++ b/tests/include/gmock_set_arg.h
@@ -34,8 +34,8 @@ class SetArgumentAction {
 
   template <typename Result, typename ArgumentTuple>
   void Perform(const ArgumentTuple& args) const {
-    CompileAssertTypesEqual<void, Result>();
-    ::std::tr1::get<N>(args) = value_;
+    static_assert(std::is_same<void, Result>::value, "Action must have void Result");
+    ::std::get<N>(args) = value_;
   }
 
  private:

--- a/tests/include/mir/test/gmock_fixes.h
+++ b/tests/include/mir/test/gmock_fixes.h
@@ -37,9 +37,11 @@
 
 #include <memory>
 #include <gmock/gmock.h>
+#include "check_gtest_version.h"
 
 namespace testing
 {
+#if !GTEST_AT_LEAST(1, 8, 1) // This is conservative, but that's fine.
 namespace internal
 {
 
@@ -99,6 +101,7 @@ class ActionResultHolder<std::unique_ptr<T, D>>
 };
 
 }
+#endif // GTEST_AT_LEAST(1, 8, 1)
 
 template<typename T>
 class DefaultValue<std::unique_ptr<T, std::default_delete<T>>> {

--- a/tests/include/mir/test/input_config_matchers.h
+++ b/tests/include/mir/test/input_config_matchers.h
@@ -61,7 +61,7 @@ public:
 
     virtual bool MatchAndExplain(MirInputConfig const& container, MatchResultListener* listener) const
     {
-        ::std::vector<string> element_printouts;
+        ::std::vector<std::string> element_printouts;
         MatchMatrix matrix = AnalyzeElements(container, &element_printouts, listener);
 
         const size_t actual_count = matrix.LhsSize();
@@ -91,7 +91,7 @@ private:
     typedef ::std::vector<Matcher<const Element&>> MatcherVec;
 
     MatchMatrix AnalyzeElements(MirInputConfig const& config,
-                                ::std::vector<string>* element_printouts,
+                                ::std::vector<std::string>* element_printouts,
                                 MatchResultListener* listener) const
     {
         element_printouts->clear();

--- a/tests/unit-tests/graphics/offscreen/test_offscreen_display.cpp
+++ b/tests/unit-tests/graphics/offscreen/test_offscreen_display.cpp
@@ -111,12 +111,12 @@ TEST_F(OffscreenDisplayTest, makes_fbo_current_rendering_target)
     std::vector<int> contexts;
     EXPECT_CALL(mock_egl, eglCreateContext(_,_,_,_))
         .Times(AtLeast(1))
-        .WillRepeatedly(WithoutArgs(Invoke(
+        .WillRepeatedly(InvokeWithoutArgs(
             [&] ()
             {
                 contexts.push_back(0);
                 return reinterpret_cast<EGLContext>(&contexts.back());
-            })));
+            }));
 
     mgo::Display display{
         native_display,


### PR DESCRIPTION
There's a 1.9 snapshot in focal-proposed, and Mir fails to build against it.

This fixes the build.