### PR TITLE
Drop the --wayland-socket-name configuration option

### DIFF
--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -42,20 +42,20 @@ do
     echo "$(basename $0) - Handy launch script for a hosted miral \"desktop session\""
     echo "Usage: $(basename $0) [options] [shell options]"
     echo "Options are:"
-    echo "    -kiosk                        use miral-kiosk instead of ${miral_server}"
-    echo "    -launcher <launcher>          use <launcher> instead of '${launcher}'"
-    echo "    -socket <socket>              set the legacy mir socket [${socket}]"
-    echo "    -wayland-socket-name <socket> set the wayland socket [${wayland_display}]"
-    echo "    -bindir <bindir>              path to the miral executable [${bindir}]"
+    echo "    -kiosk                      use miral-kiosk instead of ${miral_server}"
+    echo "    -launcher <launcher>        use <launcher> instead of '${launcher}'"
+    echo "    -socket <socket>            set the legacy mir socket [${socket}]"
+    echo "    -wayland-display <socket>   set the wayland socket [${wayland_display}]"
+    echo "    -bindir <bindir>            path to the miral executable [${bindir}]"
     # omit    -demo-server as mir_demo_server is in the mir-test-tools package
     exit 0
-  elif [ "$1" == "-kiosk" ];              then miral_server=miral-kiosk
-  elif [ "$1" == "-launcher" ];           then shift; launcher=$1
-  elif [ "$1" == "-socket" ];             then shift; socket=$1
-  elif [ "$1" == "-wayland-socket-name" ];then shift; wayland_display=$1
-  elif [ "$1" == "-bindir" ];             then shift; bindir=$1
-  elif [ "$1" == "-demo-server" ];        then miral_server=mir_demo_server
-  elif [ "${1:0:2}" == "--" ];            then break
+  elif [ "$1" == "-kiosk" ];            then miral_server=miral-kiosk
+  elif [ "$1" == "-launcher" ];         then shift; launcher=$1
+  elif [ "$1" == "-socket" ];           then shift; socket=$1
+  elif [ "$1" == "-wayland-display" ];  then shift; wayland_display=$1
+  elif [ "$1" == "-bindir" ];           then shift; bindir=$1
+  elif [ "$1" == "-demo-server" ];      then miral_server=mir_demo_server
+  elif [ "${1:0:2}" == "--" ];          then break
   fi
   shift
 done
@@ -66,7 +66,7 @@ if [ -e "${socket}" ]; then echo "Error: session endpoint '${socket}' already ex
 if [ -e "${XDG_RUNTIME_DIR}/${wayland_display}" ]; then echo "Error: wayland endpoint '${wayland_display}' already exists"; exit 1 ;fi
 
 
-sh -c "MIR_SERVER_FILE=${socket} MIR_SERVER_WAYLAND_SOCKET_NAME=${wayland_display} ${hostsocket} ${bindir}${miral_server} ${enable_mirclient} $*"&
+sh -c "MIR_SERVER_FILE=${socket} WAYLAND_DISPLAY=${wayland_display} ${hostsocket} ${bindir}${miral_server} ${enable_mirclient} $*"&
 
 while [ ! -e "${XDG_RUNTIME_DIR}/${wayland_display}" ]; do echo "waiting for ${wayland_display}"; sleep 1 ;done
 

--- a/examples/miral-shell/miral-desktop.sh
+++ b/examples/miral-shell/miral-desktop.sh
@@ -31,20 +31,20 @@ do
     echo "$(basename $0) - Handy launch script for a miral \"desktop session\""
     echo "Usage: $(basename $0) [options] [shell options]"
     echo "Options are:"
-    echo "    -kiosk                        use miral-kiosk instead of ${miral_server}"
-    echo "    -launcher <launcher>          use <launcher> instead of '${launcher}'"
-    echo "    -vt <termid>                  set the virtual terminal [${vt}]"
-    echo "    -socket <socket>              set the legacy mir socket [${socket}]"
-    echo "    -wayland-socket-name <socket> set the wayland socket [${wayland_display}]"
-    echo "    -bindir <bindir>              path to the miral executable [${bindir}]"
+    echo "    -kiosk                    use miral-kiosk instead of ${miral_server}"
+    echo "    -launcher <launcher>      use <launcher> instead of '${launcher}'"
+    echo "    -vt <termid>              set the virtual terminal [${vt}]"
+    echo "    -socket <socket>          set the legacy mir socket [${socket}]"
+    echo "    -wayland-display <socket> set the wayland socket [${wayland_display}]"
+    echo "    -bindir <bindir>          path to the miral executable [${bindir}]"
     exit 0
-  elif [ "$1" == "-kiosk" ];              then miral_server=miral-kiosk
-  elif [ "$1" == "-launcher" ];           then shift; launcher=$1
-  elif [ "$1" == "-vt" ];                 then shift; vt=$1
-  elif [ "$1" == "-socket" ];             then shift; socket=$1
-  elif [ "$1" == "-wayland-socket-name" ];then shift; wayland_display=$1
-  elif [ "$1" == "-bindir" ];             then shift; bindir=$1
-  elif [ "${1:0:2}" == "--" ];            then break
+  elif [ "$1" == "-kiosk" ];            then miral_server=miral-kiosk
+  elif [ "$1" == "-launcher" ];         then shift; launcher=$1
+  elif [ "$1" == "-vt" ];               then shift; vt=$1
+  elif [ "$1" == "-socket" ];           then shift; socket=$1
+  elif [ "$1" == "-wayland-display" ];  then shift; wayland_display=$1
+  elif [ "$1" == "-bindir" ];           then shift; bindir=$1
+  elif [ "${1:0:2}" == "--" ];          then break
   fi
   shift
 done
@@ -58,7 +58,7 @@ vt_login_session=$(who -u | grep tty${vt} | grep ${USER} | wc -l)
 if [ "${vt_login_session}" == "0" ]; then echo "Error: please log into tty${vt} first"; exit 1 ;fi
 
 oldvt=$(sudo fgconsole)
-sudo --preserve-env sh -c "MIR_SERVER_FILE=${socket} MIR_SERVER_WAYLAND_SOCKET_NAME=${wayland_display} MIR_SERVER_CONSOLE_PROVIDER=vt MIR_SERVER_VT=${vt} MIR_SERVER_ARW_FILE=on ${bindir}${miral_server} ${enable_mirclient} $*&\
+sudo --preserve-env sh -c "MIR_SERVER_FILE=${socket} WAYLAND_DISPLAY=${wayland_display} MIR_SERVER_CONSOLE_PROVIDER=vt MIR_SERVER_VT=${vt} MIR_SERVER_ARW_FILE=on ${bindir}${miral_server} ${enable_mirclient} $*&\
     while [ ! -e \"${XDG_RUNTIME_DIR}/${wayland_display}\" ]; do echo \"waiting for ${wayland_display}\"; sleep 1 ;done;\
     su -c \"MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=${gdk_backend} QT_QPA_PLATFORM=${qt_qpa} SDL_VIDEODRIVER=${sdl_videodriver} WAYLAND_DISPLAY=${wayland_display} NO_AT_BRIDGE=1 dbus-run-session -- ${launcher}\" $USER;\
     (sudo killall -w ${bindir}${miral_server} || sudo killall -w ${bindir}${miral_server}.bin); chvt ${oldvt}"

--- a/src/include/platform/mir/options/configuration.h
+++ b/src/include/platform/mir/options/configuration.h
@@ -27,7 +27,6 @@ namespace mir
 {
 namespace options
 {
-extern char const* const wayland_socket_name_opt;
 extern char const* const server_socket_opt;
 extern char const* const prompt_socket_opt;
 extern char const* const no_server_socket_opt;
@@ -46,7 +45,6 @@ extern char const* const input_report_opt;
 extern char const* const seat_report_opt;
 extern char const* const host_socket_opt;
 extern char const* const nested_passthrough_opt;
-extern char const* const frontend_threads_opt;
 extern char const* const touchspots_opt;
 extern char const* const cursor_opt;
 extern char const* const fatal_except_opt;

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -26,7 +26,6 @@
 
 namespace mo = mir::options;
 
-char const* const mo::wayland_socket_name_opt     = "wayland-socket-name";
 char const* const mo::server_socket_opt           = "file,f";
 char const* const mo::prompt_socket_opt           = "prompt-file,p";
 char const* const mo::no_server_socket_opt        = "no-file";
@@ -45,7 +44,6 @@ char const* const mo::shared_library_prober_report_opt = "shared-library-prober-
 char const* const mo::shell_report_opt            = "shell-report";
 char const* const mo::host_socket_opt             = "host-socket";
 char const* const mo::nested_passthrough_opt      = "nested-passthrough";
-char const* const mo::frontend_threads_opt        = "ipc-thread-pool";
 char const* const mo::name_opt                    = "name";
 char const* const mo::offscreen_opt               = "offscreen";
 char const* const mo::touchspots_opt              = "enable-touchspots";
@@ -151,8 +149,6 @@ mo::DefaultConfiguration::DefaultConfiguration(
     namespace po = boost::program_options;
 
     add_options()
-        (wayland_socket_name_opt, po::value<std::string>(),
-         "Overrides the default socket name used for communicating with clients")
         (host_socket_opt, po::value<std::string>(),
             "Host socket filename")
         (server_socket_opt, po::value<std::string>()->default_value(::mir::default_server_socket),

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -106,7 +106,6 @@ MIRPLATFORM_1.6 {
     mir::options::enable_key_repeat_opt*;
     mir::options::enable_mirclient_opt;
     mir::options::fatal_except_opt*;
-    mir::options::frontend_threads_opt*;
     mir::options::glog*;
     mir::options::glog_log_dir*;
     mir::options::glog_minloglevel*;
@@ -139,7 +138,6 @@ MIRPLATFORM_1.6 {
     mir::options::vt_option_name*;
     mir::options::wayland_extensions_opt;
     mir::options::wayland_extensions_value;
-    mir::options::wayland_socket_name_opt*;
     mir::options::x11_display_opt;
     
     # These are "private" (declared in src/include) but are used by libmirserver.

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -145,9 +145,6 @@ std::shared_ptr<mf::Connector>
 
             optional_value<std::string> display_name;
 
-            if (options->is_set(options::wayland_socket_name_opt))
-                display_name = options->get<std::string>(options::wayland_socket_name_opt);
-
             auto wayland_extensions = std::set<std::string>{
                 enabled_wayland_extensions.begin(),
                 enabled_wayland_extensions.end()};

--- a/tests/mir_test_framework/test_wlcs_display_server.cpp
+++ b/tests/mir_test_framework/test_wlcs_display_server.cpp
@@ -819,7 +819,6 @@ miral::TestWlcsDisplayServer::TestWlcsDisplayServer(int argc, char const** argv)
     WlcsDisplayServer::create_touch = &wlcs_server_create_touch;
 
     add_to_environment("MIR_SERVER_ENABLE_KEY_REPEAT", "false");
-    add_to_environment("MIR_SERVER_WAYLAND_SOCKET_NAME", "wlcs-tests");
     add_to_environment("WAYLAND_DISPLAY", "wlcs-tests");
 
     add_server_init([this](mir::Server& server)

--- a/tests/performance-tests/test_glmark2-es2-mir.cpp
+++ b/tests/performance-tests/test_glmark2-es2-mir.cpp
@@ -127,7 +127,6 @@ struct GLMark2Wayland : AbstractGLMark2Test
 {
     GLMark2Wayland()
     {
-        add_to_environment("MIR_SERVER_WAYLAND_SOCKET_NAME", "GLMark2Wayland");
         add_to_environment("WAYLAND_DISPLAY",                "GLMark2Wayland");
     }
 

--- a/tools/mir-smoke-test-runner.sh
+++ b/tools/mir-smoke-test-runner.sh
@@ -6,7 +6,7 @@ date --utc --iso-8601=seconds | xargs echo "[timestamp] Start time :"
 mir_rc=0
 timeout=3
 wayland_display="mir-smoke-test"
-options="--wayland-socket-name=${wayland_display} --test-timeout=${timeout}"
+options="--wayland-display=${wayland_display} --test-timeout=${timeout}"
 
 if [ -v MIR_SOCKET ]
 then


### PR DESCRIPTION
Drop the --wayland-socket-name configuration option: It duplicates what WAYLAND_DISPLAY means to a server, so use that instead.