### PR TITLE
Make fatal_error() doc comment match the code

### DIFF
--- a/include/core/mir/fatal.h
+++ b/include/core/mir/fatal.h
@@ -30,9 +30,11 @@ namespace mir
 {
 /**
  * fatal_error() is strictly for "this should never happen" situations that
- * you cannot recover from. By default it points at fatal_error_except().
+ * you cannot recover from. By default it points at fatal_error_abort().
  * Note the reason parameter is a simple char* so its value is clearly visible
  * in stack trace output.
+ * \remark There is no attempt to make this thread-safe, if it needs to be changed
+ * that should be done before spinning up the Mir server.
  *   \param [in] reason  A printf-style format string.
  */
 extern void (*fatal_error)(char const* reason, ...);


### PR DESCRIPTION
Make fatal_error() doc comment match the code.