### PR TITLE
Add wayland platform to debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -44,9 +44,9 @@ endif
 $(info COMMON_CONFIGURE_OPTIONS: ${COMMON_CONFIGURE_OPTIONS})
 
 ifneq ($(filter amd64 i386,$(DEB_HOST_ARCH)),)
-  AVAILABLE_PLATFORMS=mesa-kms\;mesa-x11\;eglstream-kms
+  AVAILABLE_PLATFORMS=mesa-kms\;mesa-x11\;wayland\;eglstream-kms
 else
-	AVAILABLE_PLATFORMS=mesa-kms\;mesa-x11
+	AVAILABLE_PLATFORMS=mesa-kms\;mesa-x11\;wayland
 endif
 
 override_dh_auto_configure:


### PR DESCRIPTION
Add wayland platform to debian/rules. (Fixes: #1073)