### PR TITLE
Debian packaging: Include platform test harness in mir-test-tools

### DIFF
--- a/debian/mir-test-tools.install
+++ b/debian/mir-test-tools.install
@@ -1,6 +1,7 @@
 usr/bin/mir_stress
 usr/bin/mir_performance_tests
 usr/bin/mir-smoke-test-runner
+usr/bin/mir_platform_graphics_test_harness
 usr/lib/*/mir/tools/libmirclientlttng.so
 usr/lib/*/mir/tools/libmirserverlttng.so
 usr/bin/mir_demo_client_*


### PR DESCRIPTION
This should fix the package builds.