### PR TITLE
Add mir-spinner to mir-test-tools

### DIFF
--- a/debian/mir-test-tools.install
+++ b/debian/mir-test-tools.install
@@ -2,6 +2,7 @@ usr/bin/mir_stress
 usr/bin/mir_performance_tests
 usr/bin/mir-smoke-test-runner
 usr/bin/mir_platform_graphics_test_harness
+usr/bin/mir-spinner
 usr/lib/*/mir/tools/libmirclientlttng.so
 usr/lib/*/mir/tools/libmirserverlttng.so
 usr/bin/mir_demo_client_*

--- a/examples/miral-shell/CMakeLists.txt
+++ b/examples/miral-shell/CMakeLists.txt
@@ -50,10 +50,10 @@ target_link_libraries(miral-shell
     miral-spinner
 )
 
-mir_add_wrapped_executable(spinner
+mir_add_wrapped_executable(mir-spinner
     spinner.cpp
 )
 
-target_link_libraries(spinner
+target_link_libraries(mir-spinner
     miral-spinner
 )


### PR DESCRIPTION
This is the last bit of uninstalled stuff; packages now build locally, so *should* also build in the PPA! 