### PR TITLE
Trying to blindly fix 1080

### DIFF
--- a/include/platform/mir/graphics/texture.h
+++ b/include/platform/mir/graphics/texture.h
@@ -35,7 +35,7 @@ class ProgramFactory;
 class Texture
 {
 public:
-    Texture() = default;
+    Texture();
     virtual ~Texture();
 
     Texture(Texture const&) = delete;

--- a/src/platform/graphics/texture.cpp
+++ b/src/platform/graphics/texture.cpp
@@ -18,4 +18,6 @@
 
 #include "mir/graphics/texture.h"
 
+mir::graphics::gl::Texture::Texture() = default;
+
 mir::graphics::gl::Texture::~Texture() = default;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -38,6 +38,7 @@ MIRPLATFORM_1.6 {
     mir::graphics::gl::Program::?Program*;
     mir::graphics::gl::ProgramFactory::?ProgramFactory*;
     mir::graphics::gl::ProgramFactory::compile_fragment_shader*;
+    mir::graphics::gl::Texture::Texture*;
     mir::graphics::gl::Texture::?Texture*;
     mir::graphics::gl_category*;
     mir::graphics::gl_error*;


### PR DESCRIPTION
I *think* egl_wayland_allocator.cpp instantiates Texture::Texture() and toolchain bugs on 16.04/armhf that leads to LTO (incorrectly) complaining about a duplicate vtable.

This ought to stop that, but I don't have armhf kit to test locally.