### PR TITLE
Make `mir-spinner` a `mir_demo_client`

### DIFF
--- a/debian/mir-test-tools.install
+++ b/debian/mir-test-tools.install
@@ -2,7 +2,6 @@ usr/bin/mir_stress
 usr/bin/mir_performance_tests
 usr/bin/mir-smoke-test-runner
 usr/bin/mir_platform_graphics_test_harness
-usr/bin/mir-spinner
 usr/lib/*/mir/tools/libmirclientlttng.so
 usr/lib/*/mir/tools/libmirserverlttng.so
 usr/bin/mir_demo_client_*

--- a/examples/miral-shell/CMakeLists.txt
+++ b/examples/miral-shell/CMakeLists.txt
@@ -50,10 +50,10 @@ target_link_libraries(miral-shell
     miral-spinner
 )
 
-mir_add_wrapped_executable(mir-spinner
+mir_add_wrapped_executable(mir_demo_client_wayland_egl_spinner
     spinner.cpp
 )
 
-target_link_libraries(mir-spinner
+target_link_libraries(mir_demo_client_wayland_egl_spinner
     miral-spinner
 )


### PR DESCRIPTION
Make `mir-spinner` a `mir_demo_client` that will be picked up by `mir-smoke-test-runner`.