### PR TITLE
Adjust regex to fix build with googletest 1.10.0

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,7 +43,7 @@ else()
 endif()
 
 string(REGEX MATCH
-  "([0-9])\\.([0-9])\\.([0-9])" GTEST_VERSION_PARSED
+  "([0-9])\\.([0-9]+)\\.([0-9])" GTEST_VERSION_PARSED
   ${GTEST_VERSION_STR})
 if (GTEST_VERSION_PARSED)
   set(GTEST_VERSION_MAJOR ${CMAKE_MATCH_1})


### PR DESCRIPTION
The regex in tests/CMakeLists.txt didn't account for two digits and failed for 1.10.0.