### PR TITLE
Use EGL_NO_X11 as well as MESA_EGL_NO_X11_HEADERS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,7 @@ add_definitions(
 endif(MIR_DISABLE_EPOLL_REACTOR)
 
 add_definitions(-DEGL_NO_X11)
+add_definitions(-DMESA_EGL_NO_X11_HEADERS) # Can be removed when all platforms support EGL_NO_X11
 
 pkg_check_modules(WAYLAND_EGLSTREAM wayland-eglstream)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ add_definitions(
 )
 endif(MIR_DISABLE_EPOLL_REACTOR)
 
-add_definitions(-DMESA_EGL_NO_X11_HEADERS)
+add_definitions(-DEGL_NO_X11)
 
 pkg_check_modules(WAYLAND_EGLSTREAM wayland-eglstream)
 


### PR DESCRIPTION
Only tested on Arch so far. I don't know how long `EGL_NO_X11` has been around. If this fails on older distros, I'll just use both defines.

Fixes #1086