### PR TITLE
Forward declare wl types to fix build on Arch

### DIFF
--- a/include/test/mir/test/doubles/mock_egl.h
+++ b/include/test/mir/test/doubles/mock_egl.h
@@ -35,6 +35,9 @@
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 
+struct wl_display;
+struct wl_resource;
+
 namespace mir
 {
 namespace test


### PR DESCRIPTION
Not sure what broke here, but the fix is harmless enough I'm not motivated to dig into it