### PR TITLE
Ignore devel failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ matrix:
   allow_failures:
     - env: SYSTEM=google:ubuntu-devel-proposed-64 VARIANT=amd64
     - env: SYSTEM=google:fedora-rawhide-64 VARIANT=amd64
+    - env: SYSTEM=google:ubuntu-devel-64 VARIANT=amd64
   fast_finish: true
 
 before_install:


### PR DESCRIPTION
We're seeing intermittent failures to set up ubuntu-devel, ignore them for now.