### PR TITLE
Fix wayland platform touch handling

### DIFF
--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -146,6 +146,7 @@ private:
     std::thread runner;
     void run() const;
     void stop();
+    auto get_touch_contact(int32_t id) -> decltype(touch_contacts)::iterator;
 };
 
 }


### PR DESCRIPTION
Handle touch_up() and touch_cancel() correctly.
De-duplicated almost-correct logic for applying shape and orientation.