### PR TITLE
Don't set input regions when they are not set

### DIFF
--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -418,8 +418,10 @@ void mf::WindowWlSurfaceRole::create_mir_window()
 {
     params->size = pending_size();
     params->streams = std::vector<shell::StreamSpecification>{};
-    params->input_shape = std::vector<geom::Rectangle>{};
-    surface->populate_surface_data(params->streams.value(), params->input_shape.value(), {});
+
+    std::vector<geom::Rectangle> input_shape;
+    surface->populate_surface_data(params->streams.value(), input_shape, {});
+    if (input_shape.size()) params->input_shape = input_shape;
 
     auto const scene_surface = shell->create_surface(session, *params, observer);
     weak_scene_surface = scene_surface;

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -197,10 +197,6 @@ void mf::WlSurface::populate_surface_data(std::vector<shell::StreamSpecification
             input_shape_accumulator.push_back(rect);
         }
     }
-    else
-    {
-        input_shape_accumulator.push_back(surface_rect);
-    }
 
     for (WlSubsurface* subsurface : children)
     {


### PR DESCRIPTION
Don't set input regions when they are not set. (Fixes: #1091)