### PR TITLE
miral-system-compositor

### DIFF
--- a/debian/mir-demos.install
+++ b/debian/mir-demos.install
@@ -4,5 +4,6 @@ usr/bin/miral-kiosk
 usr/bin/miral-xrun
 usr/bin/miral-desktop
 usr/bin/miral-app
+usr/bin/miral-system-compositor
 usr/share/applications/miral-shell.desktop
 usr/share/icons/hicolor/scalable/apps/ubuntu-logo.svg

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(example-server-lib)
 
 add_subdirectory(miral-shell)
 add_subdirectory(miral-kiosk)
+add_subdirectory(miral-system-compositor)
 add_subdirectory(mir_demo_server)
 
 add_subdirectory(mirclient)

--- a/examples/miral-system-compositor/CMakeLists.txt
+++ b/examples/miral-system-compositor/CMakeLists.txt
@@ -1,0 +1,10 @@
+mir_add_wrapped_executable(miral-system-compositor
+        system_compositor_main.cpp
+)
+
+target_include_directories(miral-system-compositor
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/include/client
+)
+
+target_link_libraries(miral-system-compositor miral)

--- a/examples/miral-system-compositor/system_compositor_main.cpp
+++ b/examples/miral-system-compositor/system_compositor_main.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include <miral/append_event_filter.h>
+#include <miral/command_line_option.h>
+#include <miral/runner.h>
+
+#include <linux/input.h>
+
+#include <atomic>
+
+int main(int argc, char const* argv[])
+{
+    using namespace miral;
+
+    MirRunner runner{argc, argv};
+
+    std::atomic<bool> allow_quit{true};
+
+    CommandLineOption disable_quit{
+        [&](bool disable_quit) { allow_quit = !disable_quit; },
+        "disable-quit",
+        "Disable Ctrl-Alt-Shift-BkSp to quit"};
+
+    AppendEventFilter quit_on_ctrl_alt_bksp{[&](MirEvent const* event)
+        {
+            if (!allow_quit)
+                return false;
+
+            if (mir_event_get_type(event) != mir_event_type_input)
+                return false;
+
+            MirInputEvent const* input_event = mir_event_get_input_event(event);
+            if (mir_input_event_get_type(input_event) != mir_input_event_type_key)
+                return false;
+
+            MirKeyboardEvent const* kev = mir_input_event_get_keyboard_event(input_event);
+            if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
+                return false;
+
+            MirInputEventModifiers mods = mir_keyboard_event_modifiers(kev);
+            if (!(mods & mir_input_event_modifier_alt) ||
+                !(mods & mir_input_event_modifier_ctrl)||
+                !(mods & mir_input_event_modifier_shift))
+                return false;
+
+            switch (mir_keyboard_event_scan_code(kev))
+            {
+            case KEY_BACKSPACE:
+                runner.stop();
+                return true;
+
+            default:
+                return false;
+            };
+        }};
+
+    return runner.run_with({quit_on_ctrl_alt_bksp, disable_quit});
+}

--- a/include/server/mir/shell/system_compositor_window_manager.h
+++ b/include/server/mir/shell/system_compositor_window_manager.h
@@ -124,6 +124,16 @@ private:
     std::mutex mutable mutex;
     OutputMap output_map;
 };
+
+/**
+ * Mir's default window manager adds Ctrl-Alt-PgUp/Ctrl-Alt-PgDn for session switching
+ */
+class DefaultWindowManager : public SystemCompositorWindowManager
+{
+public:
+    using SystemCompositorWindowManager::SystemCompositorWindowManager;
+    bool handle_keyboard_event(MirKeyboardEvent const* event) override;
+};
 }
 }
 

--- a/src/miral/window_management_options.cpp
+++ b/src/miral/window_management_options.cpp
@@ -32,7 +32,6 @@ namespace msh = mir::shell;
 namespace
 {
 char const* const wm_option = "window-manager";
-char const* const wm_system_compositor = "system-compositor";
 char const* const trace_option = "window-management-trace";
 }
 
@@ -40,10 +39,16 @@ void miral::WindowManagerOptions::operator()(mir::Server& server) const
 {
     std::string description = "window management strategy [{";
 
+    auto first = true;
     for (auto const& option : policies)
-        description += option.name + "|";
+    {
+        if (!first) description += "|";
+        first = false;
 
-    description += "system-compositor}]";
+        description += option.name;
+    }
+
+    description += "}]";
 
     server.add_configuration_option(wm_option, description, policies.begin()->name);
     server.add_configuration_option(trace_option, "log trace message", mir::OptionType::null);
@@ -83,14 +88,6 @@ void miral::WindowManagerOptions::operator()(mir::Server& server) const
                          *server.the_display_configuration_observer_registrar(),
                          option.build);
                 }
-            }
-
-            if (selection == wm_system_compositor)
-            {
-                return std::make_shared<msh::SystemCompositorWindowManager>(
-                    focus_controller,
-                    display_layout,
-                    server.the_session_coordinator());
             }
 
             throw mir::AbnormalExit("Unknown window manager: " + selection);

--- a/src/server/shell/default_configuration.cpp
+++ b/src/server/shell/default_configuration.cpp
@@ -53,7 +53,7 @@ auto mir::DefaultServerConfiguration::the_shell() -> std::shared_ptr<msh::Shell>
 auto mir::DefaultServerConfiguration::the_window_manager_builder() -> shell::WindowManagerBuilder
 {
     return [this](msh::FocusController* focus_controller)
-        { return std::make_shared<msh::SystemCompositorWindowManager>(
+        { return std::make_shared<msh::DefaultWindowManager>(
             focus_controller,
             the_shell_display_layout(),
             the_session_coordinator()); };


### PR DESCRIPTION
Because miral-shell incorporates too much keyboard handling it is a poor host to other compositors.

Extract the example system-compositor code from miral-shell and create a new miral-system-compositor example.

Usage:
```
miral-system-compositor
miral-shell --wayland-host wayland-0
egmde-confined-desktop --wayland-host wayland-0
```

Switch between hosted sessions using Ctrl-Alt-PgUp/Ctrl-Alt-PgDn

(The session switching behavior is in a new class to avoid changes that might break unity-system-compositor as used by UBPorts.)