### PR TITLE
Report wl_display_add_socket() errors

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -685,10 +685,13 @@ mf::WaylandConnector::WaylandConnector(
 
     if (auto const display_name = getenv("WAYLAND_DISPLAY"))
     {
-        if (!wl_display_add_socket(display.get(), display_name))
+        if (wl_display_add_socket(display.get(), display_name) != 0)
         {
-            wayland_display = display_name;
+            BOOST_THROW_EXCEPTION(
+                std::system_error(errno, std::system_category(), "Failed to add Wayland socket"));
         }
+
+        wayland_display = display_name;
     }
     else
     {

--- a/tests/mir_test_framework/test_wlcs_display_server.cpp
+++ b/tests/mir_test_framework/test_wlcs_display_server.cpp
@@ -819,7 +819,9 @@ miral::TestWlcsDisplayServer::TestWlcsDisplayServer(int argc, char const** argv)
     WlcsDisplayServer::create_touch = &wlcs_server_create_touch;
 
     add_to_environment("MIR_SERVER_ENABLE_KEY_REPEAT", "false");
-    add_to_environment("WAYLAND_DISPLAY", "wlcs-tests");
+    char buffer[32];
+    sprintf(buffer, "wlcs-tests-%d", getpid());
+    add_to_environment("WAYLAND_DISPLAY", buffer);
 
     add_server_init([this](mir::Server& server)
         {

--- a/tests/mir_test_framework/test_wlcs_display_server.cpp
+++ b/tests/mir_test_framework/test_wlcs_display_server.cpp
@@ -823,6 +823,9 @@ miral::TestWlcsDisplayServer::TestWlcsDisplayServer(int argc, char const** argv)
     snprintf(buffer, sizeof buffer, "wlcs-tests-%d", getpid());
     add_to_environment("WAYLAND_DISPLAY", buffer);
 
+    if (getenv("XDG_RUNTIME_DIR") == nullptr)
+        add_to_environment("XDG_RUNTIME_DIR", "/tmp");
+
     add_server_init([this](mir::Server& server)
         {
             server.override_the_session_listener([this]()

--- a/tests/mir_test_framework/test_wlcs_display_server.cpp
+++ b/tests/mir_test_framework/test_wlcs_display_server.cpp
@@ -820,7 +820,7 @@ miral::TestWlcsDisplayServer::TestWlcsDisplayServer(int argc, char const** argv)
 
     add_to_environment("MIR_SERVER_ENABLE_KEY_REPEAT", "false");
     char buffer[32];
-    sprintf(buffer, "wlcs-tests-%d", getpid());
+    snprintf(buffer, sizeof buffer, "wlcs-tests-%d", getpid());
     add_to_environment("WAYLAND_DISPLAY", buffer);
 
     add_server_init([this](mir::Server& server)


### PR DESCRIPTION
If wl_display_add_socket() fails, report an error instead of silently carrying on.

This happens, for example, under GNOME/Wayland as WAYLAND_DISPLAY points to the GNOME socket.

(It also causes wlcs tests to fail if XDB_RUNTIME_DIR is not set, as on LP builders, so work around that too.)