### PR TITLE
mg::common::ShmBuffer: Drop legacy interfaces.

### DIFF
--- a/src/platforms/common/server/shm_buffer.h
+++ b/src/platforms/common/server/shm_buffer.h
@@ -24,7 +24,6 @@
 #include "mir/geometry/dimensions.h"
 #include "mir/geometry/size.h"
 #include "mir_toolkit/common.h"
-#include "mir/renderer/gl/texture_source.h"
 #include "mir/renderer/gl/texture_target.h"
 #include "mir_toolkit/mir_native_buffer.h"
 #include "mir/renderer/sw/pixel_source.h"
@@ -40,48 +39,11 @@ namespace graphics
 {
 namespace common
 {
-/*
- * renderer::gl::TextureSource and graphics::gl::Texture both have
- * a bind() method. They need to do different things.
- *
- * Because we can't just override them based on their signature,
- * do the intermediate-base-class trick of having two proxy bases
- * which do nothing but rename bind() to something unique.
- */
-
-class BindResolverTex : public gl::Texture
-{
-public:
-    BindResolverTex() = default;
-
-    void bind() override final
-    {
-        tex_bind();
-    }
-
-protected:
-    virtual void tex_bind() = 0;
-};
-
-class BindResolverTexTarget : public renderer::gl::TextureSource
-{
-public:
-    BindResolverTexTarget() = default;
-
-    void bind() override final
-    {
-        upload_to_texture();
-    }
-
-protected:
-    virtual void upload_to_texture() = 0;
-};
-
-class ShmBuffer : public BufferBasic, public NativeBufferBase,
-                  public BindResolverTexTarget,
-                  public renderer::gl::TextureTarget,
-                  public renderer::software::PixelSource,
-                  public BindResolverTex
+class ShmBuffer :
+    public BufferBasic,
+    public NativeBufferBase,
+    public graphics::gl::Texture,
+    public renderer::software::PixelSource
 {
 public:
     static bool supports(MirPixelFormat);
@@ -91,24 +53,17 @@ public:
     geometry::Size size() const override;
     geometry::Stride stride() const override;
     MirPixelFormat pixel_format() const override;
-    void gl_bind_to_texture() override;
-    void upload_to_texture() override;
-    void secure_for_render() override;
     void write(unsigned char const* data, size_t size) override;
     void read(std::function<void(unsigned char const*)> const& do_with_pixels) override;
     NativeBufferBase* native_buffer_base() override;
 
-    void tex_bind() override;
+    void bind() override;
     gl::Program const& shader(gl::ProgramFactory& cache) const override;
     Layout layout() const override;
     void add_syncpoint() override;
 
     //each platform will have to return the NativeBuffer type that the platform has defined.
     virtual std::shared_ptr<graphics::NativeBuffer> native_buffer_handle() const override = 0;
-
-    void bind_for_write() override;
-    void commit() override;
-
 protected:
     ShmBuffer(std::unique_ptr<ShmFile> shm_file,
               geometry::Size const& size,

--- a/tests/unit-tests/graphics/test_shm_buffer.cpp
+++ b/tests/unit-tests/graphics/test_shm_buffer.cpp
@@ -98,7 +98,7 @@ TEST_F(ShmBufferTest, cant_upload_bgr_888)
                 .Times(0);
 
     PlatformlessShmBuffer buf(std::make_unique<StubShmFile>(), size, mir_pixel_format_bgr_888);
-    buf.gl_bind_to_texture();
+    buf.bind();
 }
 
 TEST_F(ShmBufferTest, uploads_rgb_888_correctly)
@@ -110,7 +110,7 @@ TEST_F(ShmBufferTest, uploads_rgb_888_correctly)
                                       stub_shm_file->fake_mapping));
 
     PlatformlessShmBuffer buf(std::make_unique<StubShmFile>(), size, mir_pixel_format_rgb_888);
-    buf.gl_bind_to_texture();
+    buf.bind();
 }
 
 TEST_F(ShmBufferTest, uploads_rgb_565_correctly)
@@ -123,7 +123,7 @@ TEST_F(ShmBufferTest, uploads_rgb_565_correctly)
                                       stub_shm_file->fake_mapping));
 
     PlatformlessShmBuffer buf(std::make_unique<StubShmFile>(), size, mir_pixel_format_rgb_565);
-    buf.gl_bind_to_texture();
+    buf.bind();
 }
 
 TEST_F(ShmBufferTest, uploads_rgba_5551_correctly)
@@ -136,7 +136,7 @@ TEST_F(ShmBufferTest, uploads_rgba_5551_correctly)
                                       stub_shm_file->fake_mapping));
 
     PlatformlessShmBuffer buf(std::make_unique<StubShmFile>(), size, mir_pixel_format_rgba_5551);
-    buf.gl_bind_to_texture();
+    buf.bind();
 }
 
 TEST_F(ShmBufferTest, uploads_rgba_4444_correctly)
@@ -149,7 +149,7 @@ TEST_F(ShmBufferTest, uploads_rgba_4444_correctly)
                                       stub_shm_file->fake_mapping));
 
     PlatformlessShmBuffer buf(std::make_unique<StubShmFile>(), size, mir_pixel_format_rgba_4444);
-    buf.gl_bind_to_texture();
+    buf.bind();
 }
 
 TEST_F(ShmBufferTest, uploads_xrgb_8888_correctly)
@@ -161,7 +161,7 @@ TEST_F(ShmBufferTest, uploads_xrgb_8888_correctly)
                                       stub_shm_file->fake_mapping));
 #endif
     PlatformlessShmBuffer buf(std::make_unique<StubShmFile>(), size, mir_pixel_format_xrgb_8888);
-    buf.gl_bind_to_texture();
+    buf.bind();
 }
 
 TEST_F(ShmBufferTest, uploads_argb_8888_correctly)
@@ -173,7 +173,7 @@ TEST_F(ShmBufferTest, uploads_argb_8888_correctly)
                                       stub_shm_file->fake_mapping));
 #endif
     PlatformlessShmBuffer buf(std::make_unique<StubShmFile>(), size, mir_pixel_format_argb_8888);
-    buf.gl_bind_to_texture();
+    buf.bind();
 }
 
 TEST_F(ShmBufferTest, uploads_xbgr_8888_correctly)
@@ -185,7 +185,7 @@ TEST_F(ShmBufferTest, uploads_xbgr_8888_correctly)
                                       stub_shm_file->fake_mapping));
 #endif
     PlatformlessShmBuffer buf(std::make_unique<StubShmFile>(), size, mir_pixel_format_xbgr_8888);
-    buf.gl_bind_to_texture();
+    buf.bind();
 }
 
 TEST_F(ShmBufferTest, uploads_abgr_8888_correctly)
@@ -197,5 +197,5 @@ TEST_F(ShmBufferTest, uploads_abgr_8888_correctly)
                                       stub_shm_file->fake_mapping));
 #endif
     PlatformlessShmBuffer buf(std::make_unique<StubShmFile>(), size, mir_pixel_format_abgr_8888);
-    buf.gl_bind_to_texture();
+    buf.bind();
 }


### PR DESCRIPTION
We no longer need to support `renderer::gl::TextureSource`, as our renderer can use the `mg::gl::Texture` interface (as can QtMir, our only other known renderer implementation).

`renderer::gl::TextureSource` is only used by the Screencast interface, which is mirclient only.

This lets us drop the funky disambiguating classes required to let ShmBuffer implement both `mg::gl::Texture` and `renderer::gl::TextureSource`.