### PR TITLE
Add Surface::set_window_margins() for SSD

### DIFF
--- a/include/core/mir/geometry/displacement.h
+++ b/include/core/mir/geometry/displacement.h
@@ -91,6 +91,16 @@ inline constexpr Displacement operator-(Point const& lhs, Point const& rhs)
     return Displacement{lhs.x - rhs.x, lhs.y - rhs.y};
 }
 
+inline constexpr Point& operator+=(Point& lhs, Displacement const& rhs)
+{
+    return lhs = lhs + rhs;
+}
+
+inline constexpr Point& operator-=(Point& lhs, Displacement const& rhs)
+{
+    return lhs = lhs - rhs;
+}
+
 inline bool operator<(Displacement const& lhs, Displacement const& rhs)
 {
     return lhs.length_squared() < rhs.length_squared();

--- a/include/server/mir/frontend/surface.h
+++ b/include/server/mir/frontend/surface.h
@@ -46,6 +46,9 @@ class Surface
 public:
     virtual ~Surface() = default;
 
+    /// The offset of the content rect relative to the window's position
+    virtual auto content_offset() const -> geometry::Displacement = 0;
+
     /// Size of the client area of the surface (excluding any decorations)
     virtual auto content_size() const -> geometry::Size = 0;
 

--- a/include/server/mir/scene/surface.h
+++ b/include/server/mir/scene/surface.h
@@ -142,6 +142,15 @@ public:
 
     /// The session this surface was created by
     virtual auto session() const -> std::weak_ptr<Session> = 0;
+
+    /// Sets the geometry of the margins around a surface
+    /// Margins make room for server-side-decorations, which are attached as a child surface
+    /// This call will trigger the content_size to be adjusted and the window_size will remain unchanged
+    virtual void set_window_margins(
+        geometry::DeltaY top,
+        geometry::DeltaX left,
+        geometry::DeltaY bottom,
+        geometry::DeltaX right) = 0;
 };
 }
 }

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -33,6 +33,7 @@ struct StubSurface : scene::Surface
     std::string name() const override;
     void move_to(geometry::Point const& top_left) override;
     geometry::Size window_size() const override;
+    geometry::Displacement content_offset() const override;
     geometry::Size content_size() const override;
     std::shared_ptr<frontend::BufferStream> primary_buffer_stream() const override;
     void set_streams(std::list<scene::StreamInfo> const& streams) override;

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -78,7 +78,12 @@ struct StubSurface : scene::Surface
     void set_focus_state(MirWindowFocusState new_state) override;
     std::string application_id() const override;
     void set_application_id(std::string const& application_id) override;
-    std::weak_ptr<scene::Session> session() const  override;
+    std::weak_ptr<scene::Session> session() const override;
+    void set_window_margins(
+        geometry::DeltaY top,
+        geometry::DeltaX left,
+        geometry::DeltaY bottom,
+        geometry::DeltaX right) override;
 };
 }
 }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -1052,3 +1052,16 @@ auto mir::scene::BasicSurface::session() const -> std::weak_ptr<Session>
     std::lock_guard<std::mutex> lock(guard);
     return session_;
 }
+
+void mir::scene::BasicSurface::set_window_margins(
+    geom::DeltaY top,
+    geom::DeltaX left,
+    geom::DeltaY bottom,
+    geom::DeltaX right)
+{
+    (void)top;
+    (void)left;
+    (void)bottom;
+    (void)right;
+    // TODO
+}

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -346,6 +346,12 @@ mir::geometry::Size ms::BasicSurface::window_size() const
     return surface_rect.size;
 }
 
+mir::geometry::Displacement ms::BasicSurface::content_offset() const
+{
+    std::lock_guard<std::mutex> lock(guard);
+    return geom::Displacement{margins.left, margins.top};
+}
+
 mir::geometry::Size ms::BasicSurface::content_size() const
 {
     std::lock_guard<std::mutex> lock(guard);

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -85,6 +85,8 @@ public:
     void set_hidden(bool is_hidden);
 
     geometry::Size window_size() const override;
+
+    geometry::Displacement content_offset() const override;
     geometry::Size content_size() const override;
 
     std::shared_ptr<frontend::BufferStream> primary_buffer_stream() const override;

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -159,6 +159,12 @@ public:
 
     auto session() const -> std::weak_ptr<Session> override;
 
+    void set_window_margins(
+        geometry::DeltaY top,
+        geometry::DeltaX left,
+        geometry::DeltaY bottom,
+        geometry::DeltaX right) override;
+
 private:
     struct ProofOfMutexLock
     {

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -181,6 +181,8 @@ private:
     MirWindowVisibility set_visibility(MirWindowVisibility v);
     int set_swap_interval(int);
     MirOrientationMode set_preferred_orientation(MirOrientationMode mode);
+    auto content_size(ProofOfMutexLock const&) const -> geometry::Size;
+    auto content_top_left(ProofOfMutexLock const&) const -> geometry::Point;
 
     std::shared_ptr<SurfaceObservers> observers = std::make_shared<SurfaceObservers>();
     std::mutex mutable guard;
@@ -215,6 +217,13 @@ private:
     std::string application_id_;
 
     std::weak_ptr<Session> session_;
+
+    struct {
+        geometry::DeltaY top;
+        geometry::DeltaX left;
+        geometry::DeltaY bottom;
+        geometry::DeltaX right;
+    } margins;
 };
 
 }

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -171,6 +171,9 @@ void msh::AbstractShell::modify_surface(std::shared_ptr<scene::Session> const& s
     if (wm_relevant_mods.min_height.is_set())
         wm_relevant_mods.min_height.value() += vert_frame_padding;
 
+    if (wm_relevant_mods.aux_rect.is_set())
+        wm_relevant_mods.aux_rect.value().top_left += surface->content_offset();
+
     report->update_surface(*session, *surface, wm_relevant_mods);
 
     if (wm_relevant_mods.streams.is_set())

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -152,9 +152,27 @@ auto msh::AbstractShell::create_surface(
 
 void msh::AbstractShell::modify_surface(std::shared_ptr<scene::Session> const& session, std::shared_ptr<scene::Surface> const& surface, SurfaceSpecification const& modifications)
 {
-    report->update_surface(*session, *surface, modifications);
-
     auto wm_relevant_mods = modifications;
+
+    auto const window_size{surface->window_size()};
+    auto const content_size{surface->content_size()};
+    auto const horiz_frame_padding = window_size.width - content_size.width;
+    auto const vert_frame_padding = window_size.height - content_size.height;
+    if (wm_relevant_mods.width.is_set())
+        wm_relevant_mods.width.value() += horiz_frame_padding;
+    if (wm_relevant_mods.height.is_set())
+        wm_relevant_mods.height.value() += vert_frame_padding;
+    if (wm_relevant_mods.max_width.is_set())
+        wm_relevant_mods.max_width.value() += horiz_frame_padding;
+    if (wm_relevant_mods.max_height.is_set())
+        wm_relevant_mods.max_height.value() += vert_frame_padding;
+    if (wm_relevant_mods.min_width.is_set())
+        wm_relevant_mods.min_width.value() += horiz_frame_padding;
+    if (wm_relevant_mods.min_height.is_set())
+        wm_relevant_mods.min_height.value() += vert_frame_padding;
+
+    report->update_surface(*session, *surface, wm_relevant_mods);
+
     if (wm_relevant_mods.streams.is_set())
     {
         session->configure_streams(*surface, wm_relevant_mods.streams.consume());

--- a/tests/include/mir/test/doubles/stub_scene_surface.h
+++ b/tests/include/mir/test/doubles/stub_scene_surface.h
@@ -105,6 +105,12 @@ public:
     void set_application_id(std::string const& /*application_id*/) override {}
 
     auto session() const -> std::weak_ptr<scene::Session> override { return {}; }
+
+    void set_window_margins(
+        geometry::DeltaY /*top*/,
+        geometry::DeltaX /*left*/,
+        geometry::DeltaY /*bottom*/,
+        geometry::DeltaX /*right*/) override {}
 };
 
 }

--- a/tests/include/mir/test/doubles/stub_scene_surface.h
+++ b/tests/include/mir/test/doubles/stub_scene_surface.h
@@ -44,6 +44,7 @@ public:
 
     std::string name() const override { return {}; }
     geometry::Point top_left() const override { return {}; }
+    geometry::Displacement content_offset() const override { return {};}
     geometry::Size content_size() const override { return {};}
     geometry::Size window_size() const override { return {}; }
     geometry::Rectangle input_bounds() const override { return {{},{}}; }

--- a/tests/mir_test_framework/stub_surface.cpp
+++ b/tests/mir_test_framework/stub_surface.cpp
@@ -237,6 +237,10 @@ std::weak_ptr<mir::scene::Session> mtd::StubSurface::session() const
     return {};
 }
 
+void mtd::StubSurface::set_window_margins(geometry::DeltaY, geometry::DeltaX, geometry::DeltaY, geometry::DeltaX)
+{
+}
+
 namespace
 {
 // Ensure we don't accidentally have an abstract class

--- a/tests/mir_test_framework/stub_surface.cpp
+++ b/tests/mir_test_framework/stub_surface.cpp
@@ -34,6 +34,11 @@ mir::geometry::Size mtd::StubSurface::window_size() const
     return {};
 }
 
+mir::geometry::Displacement mtd::StubSurface::content_offset() const
+{
+    return {};
+}
+
 mir::geometry::Size mtd::StubSurface::content_size() const
 {
     return {};

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -599,6 +599,102 @@ TEST_F(AbstractShell, modify_surface_does_not_call_wm_for_empty_changes)
     shell.modify_surface(session, surface, stream_modification);
 }
 
+TEST_F(AbstractShell, size_gets_adjusted_for_windows_with_margins)
+{
+    geom::DeltaY const top{3};
+    geom::DeltaX const left{4};
+    geom::DeltaY const bottom{2};
+    geom::DeltaX const right{6};
+    geom::Size const content_size{102, 87};
+    geom::Size const window_size{
+        content_size.width + left + right,
+        content_size.height + top + bottom};
+    std::shared_ptr<ms::Session> session =
+        shell.open_session(__LINE__, "XPlane", std::shared_ptr<mf::EventSink>());
+
+    auto creation_params = ms::a_surface()
+        .with_buffer_stream(session->create_buffer_stream(properties));
+    auto surface = shell.create_surface(session, creation_params, nullptr);
+    surface->resize({50, 50});
+    surface->set_window_margins(top, left, bottom, right);
+
+    msh::SurfaceSpecification modifications;
+    modifications.width = content_size.width;
+    modifications.height = content_size.height;
+
+    msh::SurfaceSpecification wm_modifications;
+    EXPECT_CALL(*wm, modify_surface(_,_,_)).WillOnce(SaveArg<2>(&wm_modifications));
+
+    shell.modify_surface(session, surface, modifications);
+
+    ASSERT_THAT(wm_modifications.width, Eq(mir::optional_value<geom::Width>(window_size.width)));
+    ASSERT_THAT(wm_modifications.height, Eq(mir::optional_value<geom::Height>(window_size.height)));
+}
+
+TEST_F(AbstractShell, max_size_gets_adjusted_for_windows_with_margins)
+{
+    geom::DeltaY const top{3};
+    geom::DeltaX const left{4};
+    geom::DeltaY const bottom{2};
+    geom::DeltaX const right{6};
+    geom::Size const content_size{102, 87};
+    geom::Size const window_size{
+        content_size.width + left + right,
+        content_size.height + top + bottom};
+    std::shared_ptr<ms::Session> session =
+        shell.open_session(__LINE__, "XPlane", std::shared_ptr<mf::EventSink>());
+
+    auto creation_params = ms::a_surface()
+        .with_buffer_stream(session->create_buffer_stream(properties));
+    auto surface = shell.create_surface(session, creation_params, nullptr);
+    surface->resize({50, 50});
+    surface->set_window_margins(top, left, bottom, right);
+
+    msh::SurfaceSpecification modifications;
+    modifications.max_width = content_size.width;
+    modifications.max_height = content_size.height;
+
+    msh::SurfaceSpecification wm_modifications;
+    EXPECT_CALL(*wm, modify_surface(_,_,_)).WillOnce(SaveArg<2>(&wm_modifications));
+
+    shell.modify_surface(session, surface, modifications);
+
+    ASSERT_THAT(wm_modifications.max_width, Eq(mir::optional_value<geom::Width>(window_size.width)));
+    ASSERT_THAT(wm_modifications.max_height, Eq(mir::optional_value<geom::Height>(window_size.height)));
+}
+
+TEST_F(AbstractShell, min_size_gets_adjusted_for_windows_with_margins)
+{
+    geom::DeltaY const top{3};
+    geom::DeltaX const left{4};
+    geom::DeltaY const bottom{2};
+    geom::DeltaX const right{6};
+    geom::Size const content_size{102, 87};
+    geom::Size const window_size{
+        content_size.width + left + right,
+        content_size.height + top + bottom};
+    std::shared_ptr<ms::Session> session =
+        shell.open_session(__LINE__, "XPlane", std::shared_ptr<mf::EventSink>());
+
+    auto creation_params = ms::a_surface()
+        .with_buffer_stream(session->create_buffer_stream(properties));
+    auto surface = shell.create_surface(session, creation_params, nullptr);
+    surface->resize({50, 50});
+    surface->set_window_margins(top, left, bottom, right);
+
+    msh::SurfaceSpecification modifications;
+    modifications.min_width = content_size.width;
+    modifications.min_height = content_size.height;
+
+    msh::SurfaceSpecification wm_modifications;
+    EXPECT_CALL(*wm, modify_surface(_,_,_)).WillOnce(SaveArg<2>(&wm_modifications));
+
+    shell.modify_surface(session, surface, modifications);
+
+    ASSERT_THAT(wm_modifications.min_width, Eq(mir::optional_value<geom::Width>(window_size.width)));
+    ASSERT_THAT(wm_modifications.min_height, Eq(mir::optional_value<geom::Height>(window_size.height)));
+}
+
 // lp:1625401
 TEST_F(AbstractShell, when_remaining_session_has_no_surface_focus_next_session_doesnt_loop_endlessly)
 {


### PR DESCRIPTION
This allows setting a surface's "window margins" (the padding around a surface that makes room for decorations). There are alternative ways we could have done this, each with its advantages and disadvantages. We settled on this approach several weeks ago because it's easy to implement with minimum code churn, and appears to be similar to what whoever was here last intended to do. In the future (especially if we split up the `scene::Surface` interface) we may want to refactor this, but it has proven to be sufficient for usable SSDs.