### PR TITLE
SSD surface creation param

### DIFF
--- a/include/server/mir/scene/surface_creation_parameters.h
+++ b/include/server/mir/scene/surface_creation_parameters.h
@@ -132,6 +132,9 @@ struct SurfaceCreationParameters
 
     /// See mir::scene::Surface::application_id()
     optional_value<std::string> application_id;
+
+    /// If to enable server-side decorations for this surface
+    optional_value<bool> server_side_decorated;
 };
 
 bool operator==(const SurfaceCreationParameters& lhs, const SurfaceCreationParameters& rhs);

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -30,6 +30,7 @@
 #include "mir/frontend/wayland.h"
 #include "null_event_sink.h"
 
+#include "mir/log.h"
 #include "mir/scene/surface.h"
 #include "mir/scene/surface_creation_parameters.h"
 
@@ -272,6 +273,18 @@ void mf::WindowWlSurfaceRole::set_fullscreen(std::experimental::optional<struct 
         if (output)
             params->output_id = output_manager->output_id_for(client, output.value());
         create_mir_window();
+    }
+}
+
+void mf::WindowWlSurfaceRole::set_server_side_decorated(bool server_side_decorated)
+{
+    if (weak_scene_surface.lock())
+    {
+        log_warning("server_side_decorated decorated property can not be changed after surface created");
+    }
+    else
+    {
+        params->server_side_decorated = server_side_decorated;
     }
 }
 

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -280,7 +280,7 @@ void mf::WindowWlSurfaceRole::set_server_side_decorated(bool server_side_decorat
 {
     if (weak_scene_surface.lock())
     {
-        log_warning("server_side_decorated decorated property can not be changed after surface created");
+        log_warning("Changing server_side_decorated property after surface created not yet possible");
     }
     else
     {

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -85,6 +85,7 @@ public:
     void set_max_size(int32_t width, int32_t height);
     void set_min_size(int32_t width, int32_t height);
     void set_fullscreen(std::experimental::optional<wl_resource*> const& output);
+    void set_server_side_decorated(bool server_side_decorated);
 
     void set_state_now(MirWindowState state);
 

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.cpp
@@ -41,6 +41,7 @@ mf::XWaylandWMShellSurface::XWaylandWMShellSurface(
     : WindowWlSurfaceRole{&seat, client, surface, shell, output_manager}
 {
 //    params->type = mir_window_type_normal;
+    set_server_side_decorated(true);
 }
 
 mf::XWaylandWMShellSurface::~XWaylandWMShellSurface()

--- a/src/server/scene/surface_creation_parameters.cpp
+++ b/src/server/scene/surface_creation_parameters.cpp
@@ -206,6 +206,7 @@ void ms::SurfaceCreationParameters::update_from(msh::SurfaceSpecification const&
         exclusive_rect = that.exclusive_rect.value();
     if (that.application_id.is_set())
         application_id = that.application_id.value();
+    // server_side_decorated not a property of SurfaceSpecification
     // TODO: should SurfaceCreationParameters support cursors?
 //     if (that.cursor_image.is_set())
 //         cursor_image = that.cursor_image;
@@ -253,7 +254,8 @@ bool ms::operator==(
         lhs.depth_layer == rhs.depth_layer &&
         lhs.attached_edges == rhs.attached_edges &&
         lhs.exclusive_rect == rhs.exclusive_rect &&
-        lhs.application_id == rhs.application_id;
+        lhs.application_id == rhs.application_id &&
+        lhs.server_side_decorated == rhs.server_side_decorated;
 }
 
 bool ms::operator!=(

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -28,6 +28,7 @@
 #include "mir/scene/session_coordinator.h"
 #include "mir/scene/session.h"
 #include "mir/scene/surface.h"
+#include "mir/scene/surface_creation_parameters.h"
 #include "mir/input/seat.h"
 #include "decoration/manager.h"
 
@@ -151,6 +152,11 @@ auto msh::AbstractShell::create_surface(
 
     auto const result = window_manager->add_surface(session, params, build);
     report->created_surface(*session, *result);
+
+    if (params.server_side_decorated.is_set() && params.server_side_decorated.value())
+    {
+        decoration_manager->decorate(result);
+    }
     return result;
 }
 


### PR DESCRIPTION
This lets the XWayland frontend mark its windows as server-side-decorated and causes the shell to decorate them.