### PR TITLE
decoration type doesn't need a titlebar

### DIFF
--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -402,6 +402,7 @@ bool miral::WindowInfo::needs_titlebar(MirWindowType type)
     case mir_window_type_inputmethod:
     case mir_window_type_gloss:
     case mir_window_type_tip:
+    case mir_window_type_decoration:
         // No decorations for these surface types
         return false;
     default:


### PR DESCRIPTION
Any code surrounding MirAL title bars probably needs to be removed, but this function is part of the ABI so for now just fix it. This PR fixes positioning of my new SSD titlebars.