### PR TITLE
BasicSurface: don't allow zero content size

### DIFF
--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -1095,8 +1095,8 @@ void mir::scene::BasicSurface::set_window_margins(
 auto mir::scene::BasicSurface::content_size(ProofOfMutexLock const&) const -> geometry::Size
 {
     return geom::Size{
-        std::max(surface_rect.size.width - margins.left - margins.right, geom::Width{}),
-        std::max(surface_rect.size.height - margins.top - margins.bottom, geom::Height{})};
+        std::max(surface_rect.size.width - margins.left - margins.right, geom::Width{1}),
+        std::max(surface_rect.size.height - margins.top - margins.bottom, geom::Height{1})};
 }
 
 auto mir::scene::BasicSurface::content_top_left(ProofOfMutexLock const&) const -> geometry::Point


### PR DESCRIPTION
Fixes small mistake in implementation of `BasicSurface::content_size()` that may have caused some SSD crashes.

EDIT: doesn't look like the old behavior was causing any problem in practice, but this doesn't hurt.