### PR TITLE
Use ByteSizeLong instead of deprecated ByteSize

### DIFF
--- a/src/client/display_configuration.h
+++ b/src/client/display_configuration.h
@@ -43,10 +43,17 @@ struct MirDisplayConfig
         return wrapped;
     }
 
+#if GOOGLE_PROTOBUF_VERSION >= 3010000
+    size_t ByteSize() const
+    {
+        return wrapped.ByteSizeLong();
+    }
+#else
     int ByteSize() const
     {
         return wrapped.ByteSize();
     }
+#endif
 
     uint8_t* SerializeWithCachedSizesToArray(uint8_t* target) const
     {

--- a/src/client/mir_blob.cpp
+++ b/src/client/mir_blob.cpp
@@ -109,7 +109,11 @@ try
         protobuf_output->set_orientation(output->orientation);
     }
 
+#if GOOGLE_PROTOBUF_VERSION >= 3010000
+    auto blob = std::make_unique<MirManagedBlob>(static_cast<size_t>(protobuf_config.ByteSizeLong()));
+#else
     auto blob = std::make_unique<MirManagedBlob>(static_cast<size_t>(protobuf_config.ByteSize()));
+#endif
 
     protobuf_config.SerializeWithCachedSizesToArray(blob->data());
 

--- a/src/client/rpc/mir_basic_rpc_channel.cpp
+++ b/src/client/rpc/mir_basic_rpc_channel.cpp
@@ -154,7 +154,11 @@ mir::protobuf::wire::Invocation mclr::MirBasicRpcChannel::invocation_for(
     size_t num_side_channel_fds)
 {
     mir::VariableLengthArray<mir::frontend::serialization_buffer_size>
+#if GOOGLE_PROTOBUF_VERSION >= 3010000
+        buffer{static_cast<size_t>(request->ByteSizeLong())};
+#else
         buffer{static_cast<size_t>(request->ByteSize())};
+#endif
 
     request->SerializeWithCachedSizesToArray(buffer.data());
 

--- a/src/client/rpc/mir_protobuf_rpc_channel.cpp
+++ b/src/client/rpc/mir_protobuf_rpc_channel.cpp
@@ -265,7 +265,11 @@ void mclr::MirProtobufRpcChannel::send_message(
     mir::protobuf::wire::Invocation const& invocation,
     std::vector<mir::Fd>& fds)
 {
+#if GOOGLE_PROTOBUF_VERSION >= 3010000
+    const size_t size = body.ByteSizeLong();
+#else
     const size_t size = body.ByteSize();
+#endif
     const unsigned char header_bytes[2] =
     {
         static_cast<unsigned char>((size >> 8) & 0xff),

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -31,7 +31,7 @@
 #include <boost/throw_exception.hpp>
 
 #include <sys/eventfd.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <algorithm>
 #include <vector>
 

--- a/src/server/frontend/event_sender.cpp
+++ b/src/server/frontend/event_sender.cpp
@@ -104,13 +104,21 @@ void mfd::EventSender::handle_input_config_change(MirInputConfig const& config)
 void mfd::EventSender::send_event_sequence(mp::EventSequence& seq, FdSets const& fds)
 {
     mir::VariableLengthArray<frontend::serialization_buffer_size>
+#if GOOGLE_PROTOBUF_VERSION >= 3010000
+        send_buffer{static_cast<size_t>(seq.ByteSizeLong())};
+#else
         send_buffer{static_cast<size_t>(seq.ByteSize())};
+#endif
 
     seq.SerializeWithCachedSizesToArray(send_buffer.data());
 
     mir::protobuf::wire::Result result;
     result.add_events(send_buffer.data(), send_buffer.size());
+#if GOOGLE_PROTOBUF_VERSION >= 3010000
+    send_buffer.resize(result.ByteSizeLong());
+#else
     send_buffer.resize(result.ByteSize());
+#endif
     result.SerializeWithCachedSizesToArray(send_buffer.data());
 
     try

--- a/src/server/frontend/protobuf_responder.cpp
+++ b/src/server/frontend/protobuf_responder.cpp
@@ -39,7 +39,11 @@ void mfd::ProtobufResponder::send_response(
     FdSets const& fd_sets)
 {
     mir::VariableLengthArray<serialization_buffer_size>
+#if GOOGLE_PROTOBUF_VERSION >= 3010000
+        send_response_buffer{static_cast<size_t>(response->ByteSizeLong())};
+#else
         send_response_buffer{static_cast<size_t>(response->ByteSize())};
+#endif
 
     response->SerializeWithCachedSizesToArray(send_response_buffer.data());
 
@@ -49,7 +53,11 @@ void mfd::ProtobufResponder::send_response(
         send_response_result.set_id(id);
         send_response_result.set_response(send_response_buffer.data(), send_response_buffer.size());
 
+#if GOOGLE_PROTOBUF_VERSION >= 3010000
+        send_response_buffer.resize(send_response_result.ByteSizeLong());
+#else
         send_response_buffer.resize(send_response_result.ByteSize());
+#endif
         send_response_result.SerializeWithCachedSizesToArray(send_response_buffer.data());
     }
 


### PR DESCRIPTION
Fixes #1127 

I've also included a patch which fixes another warning with the musl libc (sys/poll.h -> poll.h).

The build seems to be warning-free now except for
```
/home/pmos/build/src/mir-1.6.0/tests/mir_test_framework/test_wlcs_display_server.cpp: In function 'void {anonymous}::wlcs_pointer_move_relative(WlcsPointer*, wl_fixed_t, wl_fixed_t)':
/home/pmos/build/src/mir-1.6.0/tests/mir_test_framework/test_wlcs_display_server.cpp:659:10: warning: '*((void*)& event +16)' may be used uninitialized in this function [-Wmaybe-uninitialized]
  659 |     auto event = mir::input::synthesis::a_pointer_event()
      |          ^~~~~

```