### PR TITLE
Revert "Merge #1089"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ matrix:
   allow_failures:
     - env: SYSTEM=google:ubuntu-devel-proposed-64 VARIANT=amd64
     - env: SYSTEM=google:fedora-rawhide-64 VARIANT=amd64
-    - env: SYSTEM=google:ubuntu-devel-64 VARIANT=amd64
   fast_finish: true
 
 before_install:


### PR DESCRIPTION
We're no longer seeing intermittent failures to set up ubuntu-devel. Reinstate in CI.

This reverts commit a9a7bd592c7996d98ffd7d54d63f06deb6cd7fcd, reversing
changes made to 5fdc44755a982374b1723ee0308eb4e76920b9e0.