### PR TITLE
[wayland-platform] Apply output scale

### DIFF
--- a/src/platforms/wayland/cursor.cpp
+++ b/src/platforms/wayland/cursor.cpp
@@ -90,16 +90,18 @@ void mpw::Cursor::show(graphics::CursorImage const& cursor_image)
     {
         std::lock_guard<decltype(mutex)> lock{mutex};
         if (buffer) wl_buffer_destroy(buffer);
+        hotspot = cursor_image.hotspot();
 
         auto const width = cursor_image.size().width.as_uint32_t();
         auto const height = cursor_image.size().height.as_uint32_t();
-        auto const hotspot_x = cursor_image.hotspot().dx.as_uint32_t();
-        auto const hotspot_y = cursor_image.hotspot().dy.as_uint32_t();
+        auto const hotspot_x = hotspot.dx.as_uint32_t()/scale_factor;
+        auto const hotspot_y = hotspot.dy.as_uint32_t()/scale_factor;
         void* data_buffer;
         auto const shm_pool = make_shm_pool(shm, 4 * width * height, &data_buffer);
         memcpy(data_buffer, cursor_image.as_argb_8888(), 4 * width * height);
         buffer = wl_shm_pool_create_buffer(shm_pool, 0, width, height, 4 * width, WL_SHM_FORMAT_ARGB8888);
         wl_surface_attach(surface, buffer, 0, 0);
+        wl_surface_set_buffer_scale(surface, scale_factor);
         wl_surface_commit(surface);
         wl_shm_pool_destroy(shm_pool);
         if (pointer) wl_pointer_set_cursor(pointer, 0, surface, hotspot_x, hotspot_y);
@@ -125,4 +127,15 @@ void mir::platform::wayland::Cursor::leave(wl_pointer* /*pointer*/)
 {
     std::lock_guard<decltype(mutex)> lock{mutex};
     pointer = nullptr;
+}
+
+void mir::platform::wayland::Cursor::scale(int factor)
+{
+    std::lock_guard<decltype(mutex)> lock{mutex};
+    scale_factor = factor;
+    auto const hotspot_x = hotspot.dx.as_uint32_t()/scale_factor;
+    auto const hotspot_y = hotspot.dy.as_uint32_t()/scale_factor;
+    wl_surface_set_buffer_scale(surface, factor);
+    wl_surface_commit(surface);
+    if (pointer) wl_pointer_set_cursor(pointer, 0, surface, hotspot_x, hotspot_y);
 }

--- a/src/platforms/wayland/cursor.h
+++ b/src/platforms/wayland/cursor.h
@@ -50,12 +50,15 @@ public:
 
     void enter(wl_pointer* pointer);
     void leave(wl_pointer* pointer);
+    void scale(int factor);
 
 private:
     wl_display* const display;
     wl_shm* const shm;
 
     wl_surface* surface;
+    geometry::Displacement hotspot;
+    int scale_factor = 1;
 
     std::mutex mutable mutex;
     wl_buffer* buffer{nullptr};

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -211,6 +211,7 @@ void mgw::DisplayClient::Output::scale(void* data, wl_output* /*wl_output*/, int
     auto const output = static_cast<Output*>(data);
     auto& dcout = output->dcout;
     dcout.scale = factor;
+    wl_surface_set_buffer_scale(output->surface, factor);
 }
 
 mgw::DisplayClient::Output::Output(
@@ -567,6 +568,7 @@ void mgw::DisplayClient::pointer_enter(
         if (surface == out.second->surface)
         {
             pointer_displacement = out.second->dcout.top_left - geometry::Point{};
+            pointer_scale = out.second->dcout.scale;
             break;
         }
     }
@@ -635,6 +637,7 @@ void mgw::DisplayClient::touch_down(
         if (surface == out.second->surface)
         {
             touch_displacement = out.second->dcout.top_left - geometry::Point{};
+            touch_scale = out.second->dcout.scale;
             break;
         }
     }

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -158,7 +158,9 @@ protected:
     xkb_state* keyboard_state_ = nullptr;
     bool fake_pointer_frame = false;
     geometry::Displacement pointer_displacement; // Position of current output
+    int pointer_scale = 1;
     geometry::Displacement touch_displacement;   // Position of current output
+    int touch_scale = 1;
 
     std::unique_ptr<wl_registry, decltype(&wl_registry_destroy)> registry;
 


### PR DESCRIPTION
Apply output scale. (Fixes: #1133)

Mir uses unscaled coordinates, so we need to mark buffers as pre-scaled and scale some input values.