### PR TITLE
ShmBuffer: Ensure GL resources are released

### DIFF
--- a/src/platforms/common/server/CMakeLists.txt
+++ b/src/platforms/common/server/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(server_platform_common STATIC
   shm_buffer.cpp
   one_shot_device_observer.h
   one_shot_device_observer.cpp
-)
+  egl_context_delegate.cpp egl_context_delegate.h)
 
 target_link_libraries(
   server_platform_common

--- a/src/platforms/common/server/egl_context_delegate.cpp
+++ b/src/platforms/common/server/egl_context_delegate.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#include "egl_context_delegate.h"
+#include "mir/renderer/gl/context.h"
+
+namespace mgc = mir::graphics::common;
+
+mgc::EGLContextDelegate::EGLContextDelegate(
+    std::unique_ptr<mir::renderer::gl::Context> context)
+    : ctx{std::move(context)},
+      work{nullptr},
+      egl_thread(std::thread{process_loop, this})
+{
+}
+
+mgc::EGLContextDelegate::~EGLContextDelegate() noexcept
+{
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        shutdown_requested = true;
+    }
+    new_work.notify_all();
+    egl_thread.join();
+}
+
+void mgc::EGLContextDelegate::run_in_egl_context(
+    std::function<void()>&& functor)
+{
+    auto work_notifier = std::make_shared<std::promise<void>>();
+    auto work_done = work_notifier->get_future();
+
+    std::unique_lock<std::mutex> lock{mutex};
+    if (work)
+    {
+        new_work.wait(lock, [this]() { return static_cast<bool>(work); });
+    }
+
+    work =
+        [notifier = std::move(work_notifier), todo = std::move(functor)]() mutable
+        {
+            todo();
+            notifier->set_value();
+        };
+
+    lock.unlock();
+    new_work.notify_all();
+
+    work_done.wait();
+}
+
+void mgc::EGLContextDelegate::process_loop(mgc::EGLContextDelegate* const me)
+{
+    me->ctx->make_current();
+
+    std::unique_lock<std::mutex> lock{me->mutex};
+    while (!me->shutdown_requested)
+    {
+        me->new_work.wait(lock);
+        if (me->work)
+        {
+            me->work();
+            me->work = nullptr;
+        }
+    }
+
+    me->ctx->release_current();
+}

--- a/src/platforms/common/server/egl_context_delegate.h
+++ b/src/platforms/common/server/egl_context_delegate.h
@@ -24,6 +24,7 @@
 #include <thread>
 #include <condition_variable>
 #include <mutex>
+#include <vector>
 
 namespace mir
 {
@@ -45,14 +46,17 @@ public:
     EGLContextDelegate(std::unique_ptr<renderer::gl::Context> context);
     ~EGLContextDelegate() noexcept;
 
-    void run_in_egl_context(std::function<void()>&& functor);
+    /**
+     * Run a run a function on a thread with a current EGL context
+     */
+    void defer_to_egl_context(std::function<void()>&& functor);
 private:
     static void process_loop(EGLContextDelegate* const me);
 
     std::unique_ptr<renderer::gl::Context> const ctx;
     std::mutex mutex;
     std::condition_variable new_work;
-    std::function<void()> work;
+    std::vector<std::function<void()>> work_queue;
     bool shutdown_requested{false};
 
     std::thread egl_thread;

--- a/src/platforms/common/server/egl_context_delegate.h
+++ b/src/platforms/common/server/egl_context_delegate.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef MIR_EGL_CONTEXT_DELEGATE_H
+#define MIR_EGL_CONTEXT_DELEGATE_H
+
+#include <memory>
+#include <future>
+#include <thread>
+#include <condition_variable>
+#include <mutex>
+
+namespace mir
+{
+namespace renderer
+{
+namespace gl
+{
+class Context;
+}
+}
+
+namespace graphics
+{
+namespace common
+{
+class EGLContextDelegate
+{
+public:
+    EGLContextDelegate(std::unique_ptr<renderer::gl::Context> context);
+    ~EGLContextDelegate() noexcept;
+
+    void run_in_egl_context(std::function<void()>&& functor);
+private:
+    static void process_loop(EGLContextDelegate* const me);
+
+    std::unique_ptr<renderer::gl::Context> const ctx;
+    std::mutex mutex;
+    std::condition_variable new_work;
+    std::function<void()> work;
+    bool shutdown_requested{false};
+
+    std::thread egl_thread;
+};
+
+}
+}
+}
+
+#endif //MIR_EGL_CONTEXT_DELEGATE_H

--- a/src/platforms/common/server/shm_buffer.cpp
+++ b/src/platforms/common/server/shm_buffer.cpp
@@ -22,6 +22,7 @@
 #include "shm_buffer.h"
 #include "mir/graphics/program_factory.h"
 #include "mir/graphics/program.h"
+#include "egl_context_delegate.h"
 
 #include MIR_SERVER_GL_H
 #include MIR_SERVER_GLEXT_H
@@ -93,16 +94,19 @@ bool mgc::ShmBuffer::supports(MirPixelFormat mir_format)
 
 mgc::ShmBuffer::ShmBuffer(
     geom::Size const& size,
-    MirPixelFormat const& format)
+    MirPixelFormat const& format,
+    std::shared_ptr<EGLContextDelegate> egl_delegate)
     : size_{size},
-      pixel_format_{format}
+      pixel_format_{format},
+      egl_delegate{std::move(egl_delegate)}
 {
 }
 
 mgc::MemoryBackedShmBuffer::MemoryBackedShmBuffer(
     geom::Size const& size,
-    MirPixelFormat const& pixel_format)
-    : ShmBuffer(size, pixel_format),
+    MirPixelFormat const& pixel_format,
+    std::shared_ptr<EGLContextDelegate> egl_delegate)
+    : ShmBuffer(size, pixel_format, std::move(egl_delegate)),
       stride_{MIR_BYTES_PER_PIXEL(pixel_format) * size.width.as_uint32_t()},
       pixels{new unsigned char[stride_.as_int() * size.height.as_int()]}
 {
@@ -112,7 +116,11 @@ mgc::ShmBuffer::~ShmBuffer() noexcept
 {
     if (tex_id != 0)
     {
-        glDeleteTextures(1, &tex_id);
+        egl_delegate->run_in_egl_context(
+            [id = tex_id]()
+            {
+                glDeleteTextures(1, &id);
+            });
     }
 }
 

--- a/src/platforms/common/server/shm_buffer.cpp
+++ b/src/platforms/common/server/shm_buffer.cpp
@@ -116,7 +116,7 @@ mgc::ShmBuffer::~ShmBuffer() noexcept
 {
     if (tex_id != 0)
     {
-        egl_delegate->run_in_egl_context(
+        egl_delegate->defer_to_egl_context(
             [id = tex_id]()
             {
                 glDeleteTextures(1, &id);

--- a/src/platforms/common/server/shm_buffer.h
+++ b/src/platforms/common/server/shm_buffer.h
@@ -39,6 +39,8 @@ namespace graphics
 {
 namespace common
 {
+class EGLContextDelegate;
+
 class ShmBuffer :
     public BufferBasic,
     public NativeBufferBase,
@@ -58,13 +60,17 @@ public:
     Layout layout() const override;
     void add_syncpoint() override;
 protected:
-    ShmBuffer(geometry::Size const& size, MirPixelFormat const& format);
+    ShmBuffer(
+        geometry::Size const& size,
+        MirPixelFormat const& format,
+        std::shared_ptr<EGLContextDelegate> egl_delegate);
 
     /// \note This must be called with a current GL context
     void upload_to_texture(void const* pixels);
 private:
     geometry::Size const size_;
     MirPixelFormat const pixel_format_;
+    std::shared_ptr<EGLContextDelegate> const egl_delegate;
     GLuint tex_id{0};
 };
 
@@ -75,7 +81,8 @@ class MemoryBackedShmBuffer :
 public:
     MemoryBackedShmBuffer(
         geometry::Size const& size,
-        MirPixelFormat const& pixel_format);
+        MirPixelFormat const& pixel_format,
+        std::shared_ptr<EGLContextDelegate> egl_delegate);
 
     void write(unsigned char const* data, size_t size) override;
     void read(std::function<void(unsigned char const*)> const& do_with_pixels) override;

--- a/src/platforms/eglstream-kms/server/buffer_allocator.h
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.h
@@ -23,6 +23,7 @@
 #include "mir/graphics/wayland_allocator.h"
 #include "mir/graphics/buffer_id.h"
 #include "mir/graphics/egl_extensions.h"
+#include "egl_context_delegate.h"
 
 #include "wayland-eglstream-controller.h"
 
@@ -87,7 +88,8 @@ private:
 
     EGLExtensions::WaylandExtensions const extensions;
     EGLExtensions::NVStreamAttribExtensions const nv_extensions;
-    std::shared_ptr<renderer::gl::Context> const ctx;
+    std::shared_ptr<renderer::gl::Context> const wayland_ctx;
+    std::shared_ptr<common::EGLContextDelegate> const egl_delegate;
     std::unique_ptr<gl::Program> shader;
     static struct wl_eglstream_controller_interface const impl;
 };

--- a/src/platforms/mesa/server/buffer_allocator.cpp
+++ b/src/platforms/mesa/server/buffer_allocator.cpp
@@ -24,6 +24,7 @@
 #include "shm_buffer.h"
 #include "display_helpers.h"
 #include "gbm_format_conversions.h"
+#include "egl_context_delegate.h"
 #include "mir/graphics/egl_extensions.h"
 #include "mir/graphics/egl_error.h"
 #include "mir/graphics/buffer_properties.h"
@@ -247,6 +248,8 @@ mgm::BufferAllocator::BufferAllocator(
     BypassOption bypass_option,
     mgm::BufferImportMethod const buffer_import_method)
     : ctx{context_for_output(output)},
+      egl_delegate{
+          std::make_shared<mgc::EGLContextDelegate>(context_for_output(output))},
       device(device),
       egl_extensions(std::make_shared<mg::EGLExtensions>()),
       bypass_option(buffer_import_method == mgm::BufferImportMethod::dma_buf ?
@@ -328,7 +331,7 @@ std::shared_ptr<mg::Buffer> mgm::BufferAllocator::alloc_software_buffer(
                 "Trying to create SHM buffer with unsupported pixel format"));
     }
 
-    return std::make_shared<mgc::MemoryBackedShmBuffer>(size, format);
+    return std::make_shared<mgc::MemoryBackedShmBuffer>(size, format, egl_delegate);
 }
 
 std::vector<MirPixelFormat> mgm::BufferAllocator::supported_pixel_formats()

--- a/src/platforms/mesa/server/buffer_allocator.h
+++ b/src/platforms/mesa/server/buffer_allocator.h
@@ -49,6 +49,11 @@ namespace graphics
 class Display;
 struct EGLExtensions;
 
+namespace common
+{
+class EGLContextDelegate;
+}
+
 namespace mesa
 {
 
@@ -85,6 +90,7 @@ private:
         graphics::BufferProperties const& buffer_properties);
 
     std::shared_ptr<renderer::gl::Context> const ctx;
+    std::shared_ptr<common::EGLContextDelegate> const egl_delegate;
     std::shared_ptr<Executor> wayland_executor;
     gbm_device* const device;
     std::shared_ptr<EGLExtensions> const egl_extensions;

--- a/src/platforms/wayland/buffer_allocator.cpp
+++ b/src/platforms/wayland/buffer_allocator.cpp
@@ -19,6 +19,7 @@
 #include "buffer_allocator.h"
 #include "shm_buffer.h"
 #include "display.h"
+#include "egl_context_delegate.h"
 
 #include <mir/anonymous_shm_file.h>
 #include <mir/fatal.h>
@@ -69,7 +70,8 @@ std::unique_ptr<mir::renderer::gl::Context> context_for_output(mg::Display const
 
 mgw::BufferAllocator::BufferAllocator(graphics::Display const& output) :
     egl_extensions(std::make_shared<mg::EGLExtensions>()),
-    ctx{context_for_output(output)}
+    ctx{context_for_output(output)},
+    egl_delegate{std::make_shared<mgc::EGLContextDelegate>(context_for_output(output))}
 {
 }
 
@@ -90,7 +92,7 @@ std::shared_ptr<mg::Buffer> mgw::BufferAllocator::alloc_software_buffer(geom::Si
                 "Trying to create SHM buffer with unsupported pixel format"));
     }
 
-    return std::make_shared<mgc::MemoryBackedShmBuffer>(size, format);
+    return std::make_shared<mgc::MemoryBackedShmBuffer>(size, format, egl_delegate);
 }
 
 std::vector<MirPixelFormat> mgw::BufferAllocator::supported_pixel_formats()

--- a/src/platforms/wayland/buffer_allocator.h
+++ b/src/platforms/wayland/buffer_allocator.h
@@ -32,6 +32,11 @@ namespace graphics
 {
 class Display;
 
+namespace common
+{
+class EGLContextDelegate;
+}
+
 namespace wayland
 {
 class BufferAllocator: public GraphicBufferAllocator,
@@ -58,6 +63,7 @@ private:
     std::shared_ptr<Executor> wayland_executor;
     std::shared_ptr<EGLExtensions> const egl_extensions;
     std::shared_ptr<renderer::gl::Context> const ctx;
+    std::shared_ptr<common::EGLContextDelegate> const egl_delegate;
 };
 }
 }

--- a/tests/unit-tests/graphics/test_shm_buffer.cpp
+++ b/tests/unit-tests/graphics/test_shm_buffer.cpp
@@ -261,6 +261,12 @@ TEST_F(ShmBufferTest, texture_is_destroyed_on_thread_with_current_context)
     EGLDisplay const dummy_dpy{reinterpret_cast<EGLDisplay>(0xaabbccdd)};
 
     {
+        /* Use a locally-scoped EGLContextDelegate to make use of
+         * the fact that the destructor ensures the work-queue is drained.
+         */
+        auto egl_delegate = std::make_shared<mgc::EGLContextDelegate>(
+            std::make_unique<DumbGLContext>(reinterpret_cast<EGLContext>(42)));
+
         // Ensure we have a “context” current for creation and bind
         eglMakeCurrent(dummy_dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, dummy_ctx);
 


### PR DESCRIPTION
This sets up a dedicated thread and EGL context for running ShmBuffer code on.

At this point only the GL texture deletion is run there, fixing #1125.