### PR TITLE
Refactor decoration

### DIFF
--- a/src/server/shell/decoration/basic_decoration.cpp
+++ b/src/server/shell/decoration/basic_decoration.cpp
@@ -353,6 +353,19 @@ void msd::BasicDecoration::update()
         shell->modify_surface(session, decoration_surface, spec);
     }
 
+    if (window_updated({
+            &WindowState::focused_state,
+            &WindowState::window_name,
+            &WindowState::titlebar_rect,
+            &WindowState::left_border_rect,
+            &WindowState::right_border_rect,
+            &WindowState::bottom_border_rect}) ||
+        input_updated({
+            &InputState::buttons}))
+    {
+        renderer->update_state(*window_state, *input_state);
+    }
+
     std::vector<std::pair<
         std::shared_ptr<mc::BufferStream>,
         std::experimental::optional<std::shared_ptr<mg::Buffer>>>> new_buffers;
@@ -364,10 +377,10 @@ void msd::BasicDecoration::update()
     {
         new_buffers.emplace_back(
             buffer_streams->left_border,
-            renderer->render_left_border(*window_state));
+            renderer->render_left_border());
         new_buffers.emplace_back(
             buffer_streams->right_border,
-            renderer->render_right_border(*window_state));
+            renderer->render_right_border());
     }
 
     if (window_updated({
@@ -377,7 +390,7 @@ void msd::BasicDecoration::update()
     {
         new_buffers.emplace_back(
             buffer_streams->bottom_border,
-            renderer->render_bottom_border(*window_state));
+            renderer->render_bottom_border());
     }
 
     if (window_updated({
@@ -389,7 +402,7 @@ void msd::BasicDecoration::update()
     {
         new_buffers.emplace_back(
             buffer_streams->titlebar,
-            renderer->render_titlebar(*window_state, *input_state));
+            renderer->render_titlebar());
     }
 
     for (auto const& pair : new_buffers)

--- a/src/server/shell/decoration/basic_decoration.h
+++ b/src/server/shell/decoration/basic_decoration.h
@@ -100,7 +100,7 @@ protected:
     struct DecorationSurfaceObserver;
 
     std::shared_ptr<ThreadsafeAccess<BasicDecoration>> threadsafe_self;
-    std::unique_ptr<StaticGeometry const> const static_geometry;
+    std::shared_ptr<StaticGeometry const> const static_geometry;
     std::unique_ptr<WindowState const> window_state;
     std::unique_ptr<InputState const> input_state;
 

--- a/src/server/shell/decoration/input.h
+++ b/src/server/shell/decoration/input.h
@@ -46,6 +46,7 @@ namespace decoration
 {
 class WindowState;
 class BasicDecoration;
+class StaticGeometry;
 template<typename T> class ThreadsafeAccess;
 
 enum class ButtonState
@@ -104,6 +105,7 @@ class InputManager
 {
 public:
     InputManager(
+        std::shared_ptr<StaticGeometry const> const& static_geometry,
         std::shared_ptr<scene::Surface> const& decoration_surface,
         WindowState const& window_state,
         std::shared_ptr<ThreadsafeAccess<BasicDecoration>> const& decoration);
@@ -116,7 +118,10 @@ private:
     InputManager(InputManager const&) = delete;
     InputManager& operator=(InputManager const&) = delete;
 
-    static auto resize_edge_rect(WindowState const& window_state, MirResizeEdge resize_edge) -> geometry::Rectangle;
+    static auto resize_edge_rect(
+        WindowState const& window_state,
+        StaticGeometry const& static_geometry,
+        MirResizeEdge resize_edge) -> geometry::Rectangle;
     void pointer_event(std::chrono::nanoseconds timestamp, geometry::Point location, bool pressed);
     void pointer_leave(std::chrono::nanoseconds timestamp);
     void touch_event(int32_t id, std::chrono::nanoseconds timestamp, geometry::Point location);
@@ -125,6 +130,7 @@ private:
     class Observer;
 
     std::mutex mutex;
+    std::shared_ptr<StaticGeometry const> const static_geometry;
     std::shared_ptr<scene::Surface> decoration_surface;
     std::shared_ptr<Observer> const observer;
     std::shared_ptr<ThreadsafeAccess<BasicDecoration>> decoration;

--- a/src/server/shell/decoration/renderer.cpp
+++ b/src/server/shell/decoration/renderer.cpp
@@ -36,6 +36,14 @@ namespace msd = mir::shell::decoration;
 
 namespace
 {
+static constexpr auto color(unsigned char r, unsigned char g, unsigned char b, unsigned char a = 0xFF) -> uint32_t
+{
+    return ((uint32_t)b <<  0) |
+           ((uint32_t)g <<  8) |
+           ((uint32_t)r << 16) |
+           ((uint32_t)a << 24);
+}
+
 inline auto area(geom::Size size) -> size_t
 {
     return (size.width > geom::Width{} && size.height > geom::Height{})
@@ -239,12 +247,4 @@ auto msd::Renderer::alloc_pixels(geometry::Size size) -> std::unique_ptr<uint32_
         return std::unique_ptr<uint32_t[]>{new uint32_t[buf_size]};
     else
         return nullptr;
-}
-
-auto msd::Renderer::color(unsigned char r, unsigned char g, unsigned char b, unsigned char a) -> uint32_t
-{
-    return ((uint32_t)b <<  0) |
-           ((uint32_t)g <<  8) |
-           ((uint32_t)r << 16) |
-           ((uint32_t)a << 24);
 }

--- a/src/server/shell/decoration/renderer.cpp
+++ b/src/server/shell/decoration/renderer.cpp
@@ -44,6 +44,11 @@ static constexpr auto color(unsigned char r, unsigned char g, unsigned char b, u
            ((uint32_t)a << 24);
 }
 
+uint32_t const default_focused_background   = color(0x32, 0x32, 0x32);
+uint32_t const default_unfocused_background = color(0x80, 0x80, 0x80);
+uint32_t const default_focused_text         = color(0xFF, 0xFF, 0xFF);
+uint32_t const default_unfocused_text       = color(0xA0, 0xA0, 0xA0);
+
 inline auto area(geom::Size size) -> size_t
 {
     return (size.width > geom::Width{} && size.height > geom::Height{})
@@ -74,11 +79,11 @@ msd::Renderer::Renderer(
     std::shared_ptr<StaticGeometry const> const& static_geometry)
     : buffer_allocator{buffer_allocator},
       focused_theme{
-          /* background */ color(0x32, 0x32, 0x32, 0xFF),
-          /*       text */ color(0xFF, 0xFF, 0xFF, 0xFF)},
+          default_focused_background,
+          default_focused_text},
       unfocused_theme{
-          /* background */ color(0x54, 0x54, 0x54, 0xFF),
-          /*       text */ color(0xA0, 0xA0, 0xA0, 0xFF)},
+          default_unfocused_background,
+          default_unfocused_text},
       current_theme{nullptr},
       static_geometry{static_geometry}
 {

--- a/src/server/shell/decoration/renderer.cpp
+++ b/src/server/shell/decoration/renderer.cpp
@@ -141,7 +141,7 @@ auto msd::Renderer::render_titlebar() -> std::experimental::optional<std::shared
             render_row(
                 titlebar_pixels.get(), titlebar_size,
                 {0, y}, titlebar_size.width,
-                current_theme->background);
+                current_theme->background_color);
         }
     }
 
@@ -205,7 +205,7 @@ void msd::Renderer::update_solid_color_pixels()
         render_row(
             solid_color_pixels.get(), geom::Size{solid_color_pixels_length, 1},
             geom::Point{}, geom::Width{solid_color_pixels_length},
-            current_theme->background);
+            current_theme->background_color);
     }
 
     needs_solid_color_redraw = false;

--- a/src/server/shell/decoration/renderer.cpp
+++ b/src/server/shell/decoration/renderer.cpp
@@ -61,7 +61,9 @@ inline void render_row(
 }
 }
 
-msd::Renderer::Renderer(std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator)
+msd::Renderer::Renderer(
+    std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator,
+    std::shared_ptr<StaticGeometry const> const& static_geometry)
     : buffer_allocator{buffer_allocator},
       focused_theme{
           /* background */ color(0x32, 0x32, 0x32, 0xFF),
@@ -69,7 +71,8 @@ msd::Renderer::Renderer(std::shared_ptr<graphics::GraphicBufferAllocator> const&
       unfocused_theme{
           /* background */ color(0x54, 0x54, 0x54, 0xFF),
           /*       text */ color(0xA0, 0xA0, 0xA0, 0xFF)},
-      current_theme{nullptr}
+      current_theme{nullptr},
+      static_geometry{static_geometry}
 {
 }
 

--- a/src/server/shell/decoration/renderer.h
+++ b/src/server/shell/decoration/renderer.h
@@ -47,41 +47,42 @@ class Renderer
 public:
     Renderer(std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator);
 
-    auto render_titlebar(
-        WindowState const& window_state,
-        InputState const& input_state) -> std::experimental::optional<std::shared_ptr<graphics::Buffer>>;
-    auto render_left_border(
-        WindowState const& window_state) -> std::experimental::optional<std::shared_ptr<graphics::Buffer>>;
-    auto render_right_border(
-        WindowState const& window_state) -> std::experimental::optional<std::shared_ptr<graphics::Buffer>>;
-    auto render_bottom_border(
-        WindowState const& window_state) -> std::experimental::optional<std::shared_ptr<graphics::Buffer>>;
+    void update_state(WindowState const& window_state, InputState const& input_state);
+    auto render_titlebar() -> std::experimental::optional<std::shared_ptr<graphics::Buffer>>;
+    auto render_left_border() -> std::experimental::optional<std::shared_ptr<graphics::Buffer>>;
+    auto render_right_border() -> std::experimental::optional<std::shared_ptr<graphics::Buffer>>;
+    auto render_bottom_border() -> std::experimental::optional<std::shared_ptr<graphics::Buffer>>;
 
 private:
     using Pixel = uint32_t;
 
     struct Theme
     {
-        Pixel focused;
-        Pixel unfocused;
+        Pixel background;
+        Pixel text;
     };
 
     std::shared_ptr<graphics::GraphicBufferAllocator> buffer_allocator;
-    Theme theme;
+    Theme const focused_theme;
+    Theme const unfocused_theme;
+    Theme const* current_theme;
 
+    bool needs_solid_color_redraw{true};
+    geometry::Size left_border_size;
+    geometry::Size right_border_size;
+    geometry::Size bottom_border_size;
     size_t solid_color_pixels_length{0};
-    Pixel solid_color_pixels_color{0};
     std::unique_ptr<Pixel[]> solid_color_pixels; // can be nullptr
 
     geometry::Size titlebar_size{};
     std::unique_ptr<Pixel[]> titlebar_pixels; // can be nullptr
 
-    std::string cached_name;
-    Pixel cached_titlebar_color;
-    std::vector<ButtonInfo> cached_buttons;
+    bool needs_titlebar_redraw{true};
+    bool needs_titlebar_buttons_redraw{true};
+    std::string name;
+    std::vector<ButtonInfo> buttons;
 
-    void update_solid_color_pixels(WindowState const& window_state);
-    auto background_color(WindowState const& window_state) const -> Pixel;
+    void update_solid_color_pixels();
     auto make_buffer(
         Pixel const* pixels,
         geometry::Size size) -> std::experimental::optional<std::shared_ptr<graphics::Buffer>>;

--- a/src/server/shell/decoration/renderer.h
+++ b/src/server/shell/decoration/renderer.h
@@ -59,10 +59,12 @@ public:
 private:
     using Pixel = uint32_t;
 
+    /// A visual theme for a decoration
+    /// Focused and unfocused windows use a different theme
     struct Theme
     {
-        Pixel background;
-        Pixel text;
+        Pixel const background_color;   ///< Color for background of the titlebar and borders
+        Pixel const text_color;         ///< Color the window title is drawn in
     };
 
     std::shared_ptr<graphics::GraphicBufferAllocator> buffer_allocator;

--- a/src/server/shell/decoration/renderer.h
+++ b/src/server/shell/decoration/renderer.h
@@ -38,6 +38,7 @@ namespace decoration
 {
 class WindowState;
 class InputState;
+struct StaticGeometry;
 
 auto const buffer_format = mir_pixel_format_argb_8888;
 auto const bytes_per_pixel = 4;
@@ -45,7 +46,9 @@ auto const bytes_per_pixel = 4;
 class Renderer
 {
 public:
-    Renderer(std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator);
+    Renderer(
+        std::shared_ptr<graphics::GraphicBufferAllocator> const& buffer_allocator,
+        std::shared_ptr<StaticGeometry const> const& static_geometry);
 
     void update_state(WindowState const& window_state, InputState const& input_state);
     auto render_titlebar() -> std::experimental::optional<std::shared_ptr<graphics::Buffer>>;
@@ -66,6 +69,7 @@ private:
     Theme const focused_theme;
     Theme const unfocused_theme;
     Theme const* current_theme;
+    std::shared_ptr<StaticGeometry const> const static_geometry;
 
     bool needs_solid_color_redraw{true};
     geometry::Size left_border_size;

--- a/src/server/shell/decoration/renderer.h
+++ b/src/server/shell/decoration/renderer.h
@@ -93,7 +93,6 @@ private:
         Pixel const* pixels,
         geometry::Size size) -> std::experimental::optional<std::shared_ptr<graphics::Buffer>>;
     static auto alloc_pixels(geometry::Size size) -> std::unique_ptr<Pixel[]>;
-    static auto color(unsigned char r, unsigned char g, unsigned char b, unsigned char a) -> Pixel;
 };
 }
 }

--- a/src/server/shell/decoration/window.cpp
+++ b/src/server/shell/decoration/window.cpp
@@ -77,19 +77,14 @@ auto border_type_for(std::shared_ptr<ms::Surface> const& surface) -> msd::Border
 }
 
 msd::WindowState::WindowState(
-    StaticGeometry const& static_geometry,
+    std::shared_ptr<StaticGeometry const> const& static_geometry,
     std::shared_ptr<scene::Surface> const& surface)
-    : static_geometry_{static_geometry},
+    : static_geometry{static_geometry},
       window_size_{surface->window_size()},
       border_type_{border_type_for(surface)},
       focus_state_{surface->focus_state()},
       window_name_{surface->name()}
 {
-}
-
-auto msd::WindowState::static_geometry() const -> StaticGeometry const&
-{
-    return static_geometry_;
 }
 
 auto msd::WindowState::window_size() const -> geom::Size
@@ -133,7 +128,7 @@ auto msd::WindowState::titlebar_height() const -> geom::Height
     {
     case BorderType::Full:
     case BorderType::Titlebar:
-        return static_geometry_.titlebar_height;
+        return static_geometry->titlebar_height;
     case BorderType::None:
         return {};
     }
@@ -147,7 +142,7 @@ auto msd::WindowState::side_border_width() const -> geom::Width
     switch (border_type_)
     {
     case BorderType::Full:
-        return static_geometry_.border_width;
+        return static_geometry->side_border_width;
     case BorderType::Titlebar:
     case BorderType::None:
         return {};
@@ -182,7 +177,7 @@ auto msd::WindowState::bottom_border_height() const -> geom::Height
     switch (border_type_)
     {
     case BorderType::Full:
-        return static_geometry_.border_height;
+        return static_geometry->bottom_border_height;
     case BorderType::Titlebar:
     case BorderType::None:
         return {};
@@ -223,10 +218,14 @@ auto msd::WindowState::bottom_border_rect() const -> geom::Rectangle
 auto msd::WindowState::button_rect(unsigned n) const -> geom::Rectangle
 {
     geom::Rectangle titlebar = titlebar_rect();
-    geom::X x = titlebar.right() - geom::DeltaX{4} - (n + 1) * as_delta(static_geometry_.button_width + geom::DeltaX{4});
+    geom::X x =
+        titlebar.right() -
+        as_delta(side_border_width()) -
+        n * as_delta(static_geometry->button_width + static_geometry->padding_between_buttons) -
+        as_delta(static_geometry->button_width);
     return geom::Rectangle{
         {x, titlebar.top()},
-        {static_geometry_.button_width, titlebar.size.height}};
+        {static_geometry->button_width, titlebar.size.height}};
 }
 
 class msd::WindowSurfaceObserverManager::Observer

--- a/src/server/shell/decoration/window.h
+++ b/src/server/shell/decoration/window.h
@@ -49,11 +49,16 @@ enum class BorderType
 /// Decoration geometry properties that don't change
 struct StaticGeometry
 {
-    geometry::Height titlebar_height;   ///< Visible height of the top titlebar with the window's name and buttons
-    geometry::Width border_width;       ///< Visible width of the side borders
-    geometry::Height border_height;     ///< Visible height of the bottom border
-    geometry::Width button_width;       ///< The width of window control buttons
-    geometry::Size resize_corner_size;  ///< The size of a resizable corner (does not effect surface input area)
+    geometry::Height titlebar_height;           ///< Visible height of the top titlebar with the window's name and buttons
+    geometry::Width side_border_width;          ///< Visible width of the side borders
+    geometry::Height bottom_border_height;      ///< Visible height of the bottom border
+    geometry::Size resize_corner_input_size;    ///< The size of the input area of a resizable corner
+                                                ///< (does not effect surface input area, only where in the surface is
+                                                ///< considered a resize corner)
+    geometry::Width button_width;               ///< The width of window control buttons
+    geometry::Width padding_between_buttons;    ///< The gep between titlebar buttons
+    geometry::Height title_font_height;         ///< Height of the text used to render the window title
+    geometry::Point title_font_top_left;        ///< Where to render the window title
 };
 
 /// Information about the geometry and type of decorations for a given window
@@ -62,10 +67,8 @@ class WindowState
 {
 public:
     WindowState(
-        StaticGeometry const& static_geometry,
+        std::shared_ptr<StaticGeometry const> const& static_geometry,
         std::shared_ptr<scene::Surface> const& window_surface);
-
-    auto static_geometry() const -> StaticGeometry const&;
 
     auto window_size() const -> geometry::Size;
     auto border_type() const -> BorderType;
@@ -93,7 +96,7 @@ private:
     WindowState(WindowState const&) = delete;
     WindowState& operator=(WindowState const&) = delete;
 
-    StaticGeometry const static_geometry_;
+    std::shared_ptr<StaticGeometry const> const static_geometry;
     geometry::Size const window_size_;
     BorderType const border_type_;
     MirWindowFocusState const focus_state_;

--- a/src/server/shell/decoration/window.h
+++ b/src/server/shell/decoration/window.h
@@ -49,16 +49,16 @@ enum class BorderType
 /// Decoration geometry properties that don't change
 struct StaticGeometry
 {
-    geometry::Height titlebar_height;           ///< Visible height of the top titlebar with the window's name and buttons
-    geometry::Width side_border_width;          ///< Visible width of the side borders
-    geometry::Height bottom_border_height;      ///< Visible height of the bottom border
-    geometry::Size resize_corner_input_size;    ///< The size of the input area of a resizable corner
-                                                ///< (does not effect surface input area, only where in the surface is
-                                                ///< considered a resize corner)
-    geometry::Width button_width;               ///< The width of window control buttons
-    geometry::Width padding_between_buttons;    ///< The gep between titlebar buttons
-    geometry::Height title_font_height;         ///< Height of the text used to render the window title
-    geometry::Point title_font_top_left;        ///< Where to render the window title
+    geometry::Height const titlebar_height;           ///< Visible height of the top titlebar with the window's name and buttons
+    geometry::Width const side_border_width;          ///< Visible width of the side borders
+    geometry::Height const bottom_border_height;      ///< Visible height of the bottom border
+    geometry::Size const resize_corner_input_size;    ///< The size of the input area of a resizable corner
+                                                      ///< (does not effect surface input area, only where in the surface is
+                                                      ///< considered a resize corner)
+    geometry::Width const button_width;               ///< The width of window control buttons
+    geometry::Width const padding_between_buttons;    ///< The gep between titlebar buttons
+    geometry::Height const title_font_height;         ///< Height of the text used to render the window title
+    geometry::Point const title_font_top_left;        ///< Where to render the window title
 };
 
 /// Information about the geometry and type of decorations for a given window

--- a/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
+++ b/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
@@ -50,7 +50,7 @@ using namespace testing;
 namespace
 {
 geom::DeltaX const button_width{28};
-geom::Size const default_window_size{180, 120};
+geom::Size const default_window_size{240, 120};
 geom::Point const local_point_on_titlebar{20, 7};
 geom::Point const local_close_button_location{
     as_x(default_window_size.width) - button_width * 0.5,


### PR DESCRIPTION
* Add a few properties to the `StaticGeometry` struct that were previously magic numbers strewn about the code
* Make `static_geometry` a shared pointer and give all decoration components that need it a copy (instead of having to request it from a `WindowState`
* Give `Renderer` a new `Theme` struct that can be changed when switching between the focused and unfocused look

A PR adding title text rendering is to come after this is merged.