### PR TITLE
bors: Don't delete merged branches.

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,3 @@
 status = [ "continuous-integration/travis-ci/push" ]
 block-labels = [ "no-merge" ]
 timeout-sec = 12000
-delete-merged-branches = true


### PR DESCRIPTION
Once you delete the base branch of a PR in GitHub it cannot
be retargetted. So, if you have a series of stacked PRs
and bors merges the base branch, deleting that merged branch
means all dependent PRs need to be resubmitted, losing any
commentary.

If bors does *not* delete the merged branch then the PRs can
have their base branch changed to master as the parent gets
merged.