### PR TITLE
MinimalWindowManager: drag the requested window

### DIFF
--- a/src/miral/minimal_window_manager.cpp
+++ b/src/miral/minimal_window_manager.cpp
@@ -334,12 +334,16 @@ bool miral::MinimalWindowManager::Impl::handle_pointer_event(MirPointerEvent con
             shift_keys == gesture_shift_keys &&
             mir_pointer_event_button_state(event, pointer_gesture_button))
         {
-            if (auto const target = tools.window_at(old_cursor))
+            if (gesture_window &&
+                tools.select_active_window(gesture_window) == gesture_window)
             {
-                if (tools.select_active_window(target) == target)
-                    tools.drag_active_window(new_cursor - old_cursor);
+                tools.drag_active_window(new_cursor - old_cursor);
+                consumes_event = true;
             }
-            consumes_event = true;
+            else
+            {
+                gesture = Gesture::none;
+            }
         }
         else
         {


### PR DESCRIPTION
 ...instead of whatever is under the cursor (fixes #1135)

I believe this is correct implementation because it mirrors what's already in `apply_resize_by()` and `handle_touch_event()`. This should fix a variety of edge cases I've been stumbling on for a while (such as dragging a window under a panel).