### PR TITLE
Draw window titles on SSDs

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,4 +1,5 @@
 pkg_check_modules(UUID REQUIRED uuid)
+pkg_check_modules(FREETYPE freetype2 REQUIRED) # For rendering decorated window titles
 
 add_definitions(
   -DMIR_LOG_COMPONENT_FALLBACK="mirserver"
@@ -144,7 +145,13 @@ target_link_libraries(mirserver LINK_PUBLIC
   ${XCB_RENDER_LDFLAGS} ${XCB_RENDER_LIBRARIES}
   ${X11_XCURSOR_LDFLAGS} ${X11_XCURSOR_LIBRARIES}
   ${LTTNG_UST_LDFLAGS} ${LTTNG_UST_LIBRARIES}
+  ${FREETYPE_LDFLAGS} ${FREETYPE_LIBRARIES}
   atomic
+)
+
+target_include_directories(mirshelldecoration
+  PRIVATE
+    ${FREETYPE_INCLUDE_DIRS}
 )
 
 target_include_directories(mirshell

--- a/src/server/shell/decoration/renderer.cpp
+++ b/src/server/shell/decoration/renderer.cpp
@@ -27,6 +27,7 @@
 #include "mir/log.h"
 
 #include <boost/throw_exception.hpp>
+#include <boost/filesystem.hpp>
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
@@ -331,7 +332,7 @@ auto msd::Renderer::Text::Impl::font_path() -> std::string
     std::vector<std::string> usable_search_paths;
     for (auto const& path : font_path_search_paths)
     {
-        if (access(path, R_OK) == 0)
+        if (boost::filesystem::exists(path))
             usable_search_paths.push_back(path);
     }
 
@@ -342,7 +343,7 @@ auto msd::Renderer::Text::Impl::font_path() -> std::string
             for (auto const& path : usable_search_paths)
             {
                 auto const full_font_path = path + '/' + prefix + '/' + font.filename;
-                if (access(full_font_path.c_str(), R_OK) == 0)
+                if (boost::filesystem::exists(full_font_path))
                     return full_font_path;
             }
         }

--- a/src/server/shell/decoration/renderer.cpp
+++ b/src/server/shell/decoration/renderer.cpp
@@ -169,7 +169,11 @@ msd::Renderer::Text::Impl::Impl()
 
 msd::Renderer::Text::Impl::~Impl()
 {
-    // TODO: deinit freetype
+    if (auto const error = FT_Done_Face(face))
+        log_warning("Failed to uninitialize font face with error %d", error);
+
+    if (auto const error = FT_Done_FreeType(library))
+        log_warning("Failed to uninitialize FreeType with error %d", error);
 }
 
 void msd::Renderer::Text::Impl::render(

--- a/src/server/shell/decoration/renderer.h
+++ b/src/server/shell/decoration/renderer.h
@@ -59,7 +59,27 @@ public:
 private:
     using Pixel = uint32_t;
 
-    class Text;
+    class Text
+    {
+    public:
+        static auto instance() -> Text&;
+
+        virtual ~Text() = default;
+
+        virtual void render(
+            Pixel* buf,
+            geometry::Size buf_size,
+            std::string const& text,
+            geometry::Point top_left,
+            geometry::Height height_pixels,
+            Pixel color) = 0;
+
+    private:
+        class Impl;
+        class Null;
+
+        static std::unique_ptr<Text> singleton;
+    };
 
     /// A visual theme for a decoration
     /// Focused and unfocused windows use a different theme

--- a/src/server/shell/decoration/renderer.h
+++ b/src/server/shell/decoration/renderer.h
@@ -62,7 +62,7 @@ private:
     class Text
     {
     public:
-        static auto instance() -> Text&;
+        static auto instance() -> std::shared_ptr<Text>;
 
         virtual ~Text() = default;
 
@@ -78,7 +78,8 @@ private:
         class Impl;
         class Null;
 
-        static std::unique_ptr<Text> singleton;
+        static std::mutex static_mutex;
+        static std::weak_ptr<Text> singleton;
     };
 
     /// A visual theme for a decoration
@@ -109,6 +110,8 @@ private:
     bool needs_titlebar_buttons_redraw{true};
     std::string name;
     std::vector<ButtonInfo> buttons;
+
+    std::shared_ptr<Text> const text;
 
     void update_solid_color_pixels();
     auto make_buffer(

--- a/src/server/shell/decoration/renderer.h
+++ b/src/server/shell/decoration/renderer.h
@@ -59,6 +59,8 @@ public:
 private:
     using Pixel = uint32_t;
 
+    class Text;
+
     /// A visual theme for a decoration
     /// Focused and unfocused windows use a different theme
     struct Theme


### PR DESCRIPTION
Uses FreeType to render window titles on server side decorations. It appears the current XWayland implementation does not update the window title after it is initially set, but this will handle title updates when it happens.