### PR TITLE
Fix process snap version check

### DIFF
--- a/tools/process_snaps.py
+++ b/tools/process_snaps.py
@@ -60,7 +60,12 @@ PENDING_BUILD = (
     "Uploading build",
 )
 
-MIR_VERSION_RE = re.compile(r"^(.*)-[^-]+$")
+# See https://regex101.com/r/b8otIx/2
+MIR_VERSION_RE = re.compile(r"^(?P<version>[0-9\.]+)"              # major.minor.patch
+                            r"(?:(?P<build>[+~](?:rc|dev)[0-9]+)"  # optional [~+]{rc,dev}* build tag
+                            r"-g(?P<commit>[0-9a-f]+))?"           # ... with git suffix
+                            r"-(?P<distro>[^-]+)$")                # distro
+
 SNAP_VERSION_RE = re.compile(r"^(?:(?P<server>.+)-mir)?"
                              r"(?P<mir>.+?)"
                              r"(?:-snap(?P<snap>.+))?$")
@@ -181,7 +186,7 @@ if __name__ == '__main__':
                 logger.debug("Latest source: %s", latest_source.display_name)
 
                 mir_version = (
-                    MIR_VERSION_RE.match(latest_source.source_package_version)[1]
+                    "".join(v or "" for v in MIR_VERSION_RE.fullmatch(latest_source.source_package_version).groups()[0:2])
                 )
                 logger.debug("Parsed upstream version: %s", mir_version)
 

--- a/tools/process_snaps.py
+++ b/tools/process_snaps.py
@@ -220,7 +220,7 @@ if __name__ == '__main__':
 
             if all(store_snap is None
                    or mir_version is None
-                   or mir_version.startswith(SNAP_VERSION_RE.match(store_snap["version"]).group("mir"))
+                   or mir_version == SNAP_VERSION_RE.match(store_snap["version"]).group("mir")
                    for store_snap in store_snaps):
 
                 if check_notices:


### PR DESCRIPTION
We want to update "edge" channels when master has a different version. E.g.

     >>> "1.6.0+dev73".startswith("1.6.0")
     True
     >>> "1.6.0+dev73" =="1.6.0"
     False