### PR TITLE
XWayland refactor and fix

### DIFF
--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -132,6 +132,8 @@ void mf::XWaylandServer::spawn()
         break;
 
     case 0:
+        close(wl_client_fd[server]);
+        close(wm_fd[server]);
         execl_xwayland(wl_client_fd[client], wm_fd[client]);
         break;
 

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -59,7 +59,12 @@ public:
     static bool xserver_ready;
 
 private:
+    /// Forks off the XWayland process
     void spawn();
+    /// Called after fork() if we should turn into XWayland
+    void execl_xwayland(int wl_client_client_fd, int wm_client_fd);
+    /// Called after fork() if we should continue on as Mir
+    void connect_to_xwayland(int wl_client_server_fd, int wm_server_fd);
     void new_spawn_thread();
     int create_lockfile();
     int create_socket(struct sockaddr_un *addr, size_t path_size);


### PR DESCRIPTION
Previously, `XWaylandServer::spawn()` forked, and handled both forks in a large switch statement. This splits the two branches into `XWaylandServer::execl_xwayland()` and `XWaylandServer::connect_to_xwayland()`. Also runs `wl_client_create()` on the Wayland thread to fix #1147. It may be helpful to look over the commits individually.