### PR TITLE
Allow adding a scene observer to the surface stack

### DIFF
--- a/include/server/mir/shell/surface_stack.h
+++ b/include/server/mir/shell/surface_stack.h
@@ -33,6 +33,7 @@ class Surface;
 struct SurfaceCreationParameters;
 class SurfaceObserver;
 class Session;
+class Observer;
 }
 
 namespace shell
@@ -53,6 +54,9 @@ public:
     virtual void remove_surface(std::weak_ptr<scene::Surface> const& surface) = 0;
 
     virtual auto surface_at(geometry::Point) const -> std::shared_ptr<scene::Surface> = 0;
+
+    virtual void add_observer(std::shared_ptr<scene::Observer> const& observer) = 0;
+    virtual void remove_observer(std::weak_ptr<scene::Observer> const& observer) = 0;
 
 protected:
     SurfaceStack() = default;

--- a/include/server/mir/shell/surface_stack_wrapper.h
+++ b/include/server/mir/shell/surface_stack_wrapper.h
@@ -42,6 +42,9 @@ public:
 
     auto surface_at(geometry::Point) const -> std::shared_ptr<scene::Surface> override;
 
+    void add_observer(std::shared_ptr<scene::Observer> const& observer) override;
+    void remove_observer(std::weak_ptr<scene::Observer> const& observer) override;
+
 protected:
     std::shared_ptr<SurfaceStack> const wrapped;
 };

--- a/src/server/shell/surface_stack_wrapper.cpp
+++ b/src/server/shell/surface_stack_wrapper.cpp
@@ -55,3 +55,13 @@ auto msh::SurfaceStackWrapper::surface_at(geometry::Point point) const -> std::s
 {
     return wrapped->surface_at(point);
 }
+
+void msh::SurfaceStackWrapper::add_observer(std::shared_ptr<scene::Observer> const& observer)
+{
+    wrapped->add_observer(observer);
+}
+
+void msh::SurfaceStackWrapper::remove_observer(std::weak_ptr<scene::Observer> const& observer)
+{
+    wrapped->remove_observer(observer);
+}

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -835,6 +835,14 @@ MIR_SERVER_1.6.0 {
  local: *;
 };
 
+MIR_SERVER_1.7.0 {
+ global:
+  extern "C++" {
+    mir::shell::SurfaceStackWrapper::add_observer*;
+    mir::shell::SurfaceStackWrapper::remove_observer*;
+  };
+} MIR_SERVER_1.6.0;
+
 # these symbols are needed by the "throwback" tests but are not intended to be public
 MIR_SERVER_DETAIL_FOR_TESTING_1.4 {
  global:
@@ -937,4 +945,4 @@ MIR_SERVER_DETAIL_FOR_TESTING_1.4 {
 
     mir::DefaultServerConfiguration::the_decoration_manager*;
   };
-} MIR_SERVER_1.6.0;
+} MIR_SERVER_1.7.0;

--- a/tests/include/mir/test/doubles/mock_surface_stack.h
+++ b/tests/include/mir/test/doubles/mock_surface_stack.h
@@ -41,6 +41,9 @@ struct MockSurfaceStack : public shell::SurfaceStack
 
     MOCK_METHOD1(remove_surface, void(std::weak_ptr<scene::Surface> const& surface));
     MOCK_CONST_METHOD1(surface_at, std::shared_ptr<scene::Surface>(geometry::Point));
+
+    MOCK_METHOD1(add_observer, void(std::shared_ptr<scene::Observer> const&));
+    MOCK_METHOD1(remove_observer, void(std::weak_ptr<scene::Observer> const&));
 };
 
 }

--- a/tests/integration-tests/session_management.cpp
+++ b/tests/integration-tests/session_management.cpp
@@ -86,6 +86,8 @@ struct TestSurfaceStack : public msh::SurfaceStack
         wrapped->raise(surface);
     }
 
+    void add_observer(std::shared_ptr<ms::Observer> const&) override {}
+    void remove_observer(std::weak_ptr<ms::Observer> const&) override {}
 };
 
 struct TestConfiguration : public mir_test_framework::StubbedServerConfiguration

--- a/tests/unit-tests/scene/test_application_session.cpp
+++ b/tests/unit-tests/scene/test_application_session.cpp
@@ -127,6 +127,12 @@ struct StubSurfaceStack : public msh::SurfaceStack
     {
         return std::shared_ptr<ms::Surface>{};
     }
+    void add_observer(std::shared_ptr<mir::scene::Observer> const&) override
+    {
+    }
+    void remove_observer(std::weak_ptr<mir::scene::Observer> const&) override
+    {
+    }
 };
 
 struct ApplicationSession : public testing::Test


### PR DESCRIPTION
The primary implementation of `shell::SurfaceStack` (`scene::SurfaceStack`) already implements add/remove observer for `compositor::Scene` and `input::Scene`. This just exposes that through the `SurfaceStack` interface.