### PR TITLE
BasicWindowManager requests on unknown windows should noop

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -100,7 +100,10 @@ void miral::BasicWindowManager::remove_session(std::shared_ptr<scene::Session> c
     auto info = app_info.find(session);
     if (info == app_info.end())
     {
-        log_warning("Removed unknwon session");
+        log_debug(
+            "BasicWindowManager::remove_session() called with unknown or already removed session %s (PID: %d)",
+            session->name().c_str(),
+            session->process_id());
         return;
     }
     policy->advise_delete_app(info->second);

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -180,9 +180,8 @@ void miral::BasicWindowManager::modify_surface(
     shell::SurfaceSpecification const& modifications)
 {
     Locker lock{this};
-    if (!surface_known(surface))
+    if (!surface_known(surface, "modify"))
     {
-        log_warning("Unknown surface modified");
         return;
     }
     auto& info = info_for(surface);
@@ -199,7 +198,10 @@ void miral::BasicWindowManager::remove_surface(
     Locker lock{this};
     if (app_info.find(session) == app_info.end())
     {
-        log_warning("Removed surface with unknwon session");
+        log_debug(
+            "BasicWindowManager::remove_surface() called with unknown or already removed session %s (PID: %d)",
+            session->name().c_str(),
+            session->process_id());
         return;
     }
 

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -264,6 +264,8 @@ private:
     void update_event_timestamp(MirTouchEvent const* tev);
     void update_event_timestamp(MirInputEvent const* iev);
 
+    auto surface_known(std::weak_ptr<mir::scene::Surface> const& surface) -> bool;
+
     auto can_activate_window_for_session(miral::Application const& session) -> bool;
     auto can_activate_window_for_session_in_workspace(
         miral::Application const& session,

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -264,7 +264,7 @@ private:
     void update_event_timestamp(MirTouchEvent const* tev);
     void update_event_timestamp(MirInputEvent const* iev);
 
-    auto surface_known(std::weak_ptr<mir::scene::Surface> const& surface) -> bool;
+    auto surface_known(std::weak_ptr<mir::scene::Surface> const& surface, std::string const& action) -> bool;
 
     auto can_activate_window_for_session(miral::Application const& session) -> bool;
     auto can_activate_window_for_session_in_workspace(

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -44,6 +44,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     initial_window_placement.cpp
     window_placement_attached.cpp
     window_placement_fullscreen.cpp
+    invalid_requests.cpp
     ${MIRAL_TEST_SOURCES}
 )
 

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -44,7 +44,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     initial_window_placement.cpp
     window_placement_attached.cpp
     window_placement_fullscreen.cpp
-    invalid_requests.cpp
+    ignored_requests.cpp
     ${MIRAL_TEST_SOURCES}
 )
 

--- a/tests/miral/ignored_requests.cpp
+++ b/tests/miral/ignored_requests.cpp
@@ -33,20 +33,20 @@ Height const display_height{480};
 Rectangle const display_area{{display_left,  display_top},
                              {display_width, display_height}};
 
-struct InvalidRequests;
+struct IgnoredRequests;
 
-struct InvalidParam
+struct IgnoredRequestParam
 {
     std::string name;
-    std::function<Window(InvalidRequests&)> window;
+    std::function<Window(IgnoredRequests&)> window;
 };
 
-std::ostream& operator<<(std::ostream& ostream, InvalidParam const& param)
+std::ostream& operator<<(std::ostream& ostream, IgnoredRequestParam const& param)
 {
     return ostream << param.name;
 }
 
-struct InvalidRequests : mt::TestWindowManagerTools, WithParamInterface<InvalidParam>
+struct IgnoredRequests : mt::TestWindowManagerTools, WithParamInterface<IgnoredRequestParam>
 {
     Size const window_size{200, 200};
     mir::shell::SurfaceSpecification simple_modification;
@@ -104,70 +104,70 @@ struct InvalidRequests : mt::TestWindowManagerTools, WithParamInterface<InvalidP
 };
 }
 
-TEST_P(InvalidRequests, modify_invalid_surface_noops)
+TEST_P(IgnoredRequests, modify_unknown_surface_noops)
 {
     auto const window = GetParam().window(*this);
     basic_window_manager.modify_surface(session, window, simple_modification);
 }
 
-TEST_P(InvalidRequests, remove_invalid_surface_noops)
+TEST_P(IgnoredRequests, remove_unknown_surface_noops)
 {
     auto const window = GetParam().window(*this);
     basic_window_manager.remove_surface(session, window);
 }
 
-TEST_P(InvalidRequests, set_attribute_on_invalid_surface_noops)
+TEST_P(IgnoredRequests, set_attribute_on_unknown_surface_noops)
 {
     auto const window = GetParam().window(*this);
     basic_window_manager.set_surface_attribute(session, window, mir_window_attrib_state, mir_window_state_maximized);
 }
 
-TEST_P(InvalidRequests, raise_invalid_surface_noops)
+TEST_P(IgnoredRequests, raise_unknown_surface_noops)
 {
     auto const window = GetParam().window(*this);
     basic_window_manager.handle_raise_surface(session, window, 100);
 }
 
-TEST_P(InvalidRequests, drag_and_drop_invalid_surface_noops)
+TEST_P(IgnoredRequests, drag_and_drop_unknown_surface_noops)
 {
     auto const window = GetParam().window(*this);
     basic_window_manager.handle_request_drag_and_drop(session, window, 100);
 }
 
-TEST_P(InvalidRequests, move_invalid_surface_noops)
+TEST_P(IgnoredRequests, move_unknown_surface_noops)
 {
     auto const window = GetParam().window(*this);
     basic_window_manager.handle_request_move(session, window, 100);
 }
 
-TEST_P(InvalidRequests, resize_invalid_surface_noops)
+TEST_P(IgnoredRequests, resize_unknown_surface_noops)
 {
     auto const window = GetParam().window(*this);
 
     basic_window_manager.handle_request_resize(session, window, 100, mir_resize_edge_southeast);
 }
 
-TEST_F(InvalidRequests, remove_session_twice_noops)
+TEST_F(IgnoredRequests, remove_session_twice_noops)
 {
     basic_window_manager.remove_session(session);
     basic_window_manager.remove_session(session);
 }
 
-INSTANTIATE_TEST_CASE_P(InvalidWindow, InvalidRequests, ::testing::Values(
-    InvalidParam{
+INSTANTIATE_TEST_CASE_P(UnknownWindow, IgnoredRequests, ::testing::Values(
+    IgnoredRequestParam{
         "null window",
-        [](InvalidRequests& test){ return test.create_null_window(); }},
-    InvalidParam{
+        [](IgnoredRequests& test){ return test.create_null_window(); }},
+    IgnoredRequestParam{
         "destroyed window",
-        [](InvalidRequests& test){ return test.create_destroyed_window(); }},
-    InvalidParam{
+        [](IgnoredRequests& test){ return test.create_destroyed_window(); }},
+    IgnoredRequestParam{
         "never before seen window",
-        [](InvalidRequests& test){ return test.create_never_before_seen_window(); }}));
+        [](IgnoredRequests& test){ return test.create_never_before_seen_window(); }}));
 
-INSTANTIATE_TEST_CASE_P(InvalidSession, InvalidRequests, ::testing::Values(
-    InvalidParam{
+INSTANTIATE_TEST_CASE_P(UnknownSession, IgnoredRequests, ::testing::Values(
+    IgnoredRequestParam{
         "destroyed session",
-        [](InvalidRequests& test)
+        [](IgnoredRequests& test)
         {
             Window const window = test.create_window();
             test.basic_window_manager.remove_session(test.session);

--- a/tests/miral/invalid_requests.cpp
+++ b/tests/miral/invalid_requests.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "test_window_manager_tools.h"
+
+using namespace miral;
+using namespace testing;
+namespace mt = mir::test;
+using mir::operator<<;
+
+namespace
+{
+X const display_left{0};
+Y const display_top{0};
+Width const display_width{640};
+Height const display_height{480};
+
+Rectangle const display_area{{display_left,  display_top},
+                             {display_width, display_height}};
+
+struct InvalidRequests;
+
+struct InvalidParam
+{
+    std::string name;
+    std::function<Window(InvalidRequests&)> window;
+};
+
+std::ostream& operator<<(std::ostream& ostream, InvalidParam const& param)
+{
+    return ostream << param.name;
+}
+
+struct InvalidRequests : mt::TestWindowManagerTools, WithParamInterface<InvalidParam>
+{
+    Size const window_size{200, 200};
+    mir::shell::SurfaceSpecification simple_modification;
+
+    void SetUp() override
+    {
+        simple_modification.state = mir_window_state_maximized;
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
+        basic_window_manager.add_session(session);
+    }
+
+    auto create_window() -> Window
+    {
+        Window window;
+
+        mir::scene::SurfaceCreationParameters creation_parameters;
+        creation_parameters.type = mir_window_type_normal;
+        creation_parameters.size = window_size;
+
+        EXPECT_CALL(*window_manager_policy, advise_new_window(_))
+            .WillOnce(
+                Invoke(
+                    [&window](WindowInfo const& window_info)
+                        { window = window_info.window(); }));
+
+        basic_window_manager.add_surface(session, creation_parameters, &create_surface);
+        basic_window_manager.select_active_window(window);
+
+        // Clear the expectations used to capture parent & child
+        Mock::VerifyAndClearExpectations(window_manager_policy);
+
+        return window;
+    }
+
+    auto create_destroyed_window() -> Window
+    {
+        auto const window = create_window();
+        basic_window_manager.remove_surface(session, window);
+        return window;
+    }
+
+    auto create_never_before_seen_window() -> Window
+    {
+        mir::scene::SurfaceCreationParameters creation_parameters;
+        creation_parameters.type = mir_window_type_normal;
+        creation_parameters.size = window_size;
+
+        return Window{session, create_surface(session, creation_parameters)};
+    }
+
+    auto create_null_window() const -> Window
+    {
+        return Window{session, nullptr};
+    }
+};
+}
+
+TEST_P(InvalidRequests, modify_invalid_surface_noops)
+{
+    auto const window = GetParam().window(*this);
+    basic_window_manager.modify_surface(session, window, simple_modification);
+}
+
+TEST_P(InvalidRequests, remove_invalid_surface_noops)
+{
+    auto const window = GetParam().window(*this);
+    basic_window_manager.remove_surface(session, window);
+}
+
+TEST_P(InvalidRequests, set_attribute_on_invalid_surface_noops)
+{
+    auto const window = GetParam().window(*this);
+    basic_window_manager.set_surface_attribute(session, window, mir_window_attrib_state, mir_window_state_maximized);
+}
+
+TEST_P(InvalidRequests, raise_invalid_surface_noops)
+{
+    auto const window = GetParam().window(*this);
+    basic_window_manager.handle_raise_surface(session, window, 100);
+}
+
+TEST_P(InvalidRequests, drag_and_drop_invalid_surface_noops)
+{
+    auto const window = GetParam().window(*this);
+    basic_window_manager.handle_request_drag_and_drop(session, window, 100);
+}
+
+TEST_P(InvalidRequests, move_invalid_surface_noops)
+{
+    auto const window = GetParam().window(*this);
+    basic_window_manager.handle_request_move(session, window, 100);
+}
+
+TEST_P(InvalidRequests, resize_invalid_surface_noops)
+{
+    auto const window = GetParam().window(*this);
+
+    basic_window_manager.handle_request_resize(session, window, 100, mir_resize_edge_southeast);
+}
+
+TEST_F(InvalidRequests, remove_session_twice_noops)
+{
+    basic_window_manager.remove_session(session);
+    basic_window_manager.remove_session(session);
+}
+
+INSTANTIATE_TEST_CASE_P(InvalidWindow, InvalidRequests, ::testing::Values(
+    InvalidParam{
+        "null window",
+        [](InvalidRequests& test){ return test.create_null_window(); }},
+    InvalidParam{
+        "destroyed window",
+        [](InvalidRequests& test){ return test.create_destroyed_window(); }},
+    InvalidParam{
+        "never before seen window",
+        [](InvalidRequests& test){ return test.create_never_before_seen_window(); }}));
+
+INSTANTIATE_TEST_CASE_P(InvalidSession, InvalidRequests, ::testing::Values(
+    InvalidParam{
+        "destroyed session",
+        [](InvalidRequests& test)
+        {
+            Window const window = test.create_window();
+            test.basic_window_manager.remove_session(test.session);
+            return window;
+        }}));


### PR DESCRIPTION
It is impossible for one subsystem in Mir to know if another subsystem on another thread is in the process of destroying a surface. It is also impossible to externally lock the window manager. Therefore, a surface may be destroyed twice in quick succession, or the window manager may get a `modify_surface` after the surface has been destroyed.

The current behavior is to `fatal_error()` if a surface is destroyed twice, and throw `std::out_of_range` or do nothing in other cases.

This PR implements, documents and tests: Requests on unknown windows warn and noop.