### PR TITLE
Fix clang found clangers

### DIFF
--- a/src/include/server/mir/frontend/connections.h
+++ b/src/include/server/mir/frontend/connections.h
@@ -48,12 +48,6 @@ public:
         connections.erase(id);
     }
 
-    bool includes(int id) const
-    {
-        std::unique_lock<std::mutex> lock(mutex);
-        return connections.find(id) != connections.end();
-    }
-
     void clear()
     {
         std::unique_lock<std::mutex> lock(mutex);

--- a/tests/miral/resize_window.cpp
+++ b/tests/miral/resize_window.cpp
@@ -103,10 +103,10 @@ struct ResizeWindow : mt::TestWindowManagerTools, WithParamInterface<ResizeParam
         Size old_size = window.size();
         Point result = window.top_left();
 
-        if (edge | mir_resize_edge_west)
+        if (edge & mir_resize_edge_west)
             result.x += old_size.width - new_size.width;
 
-        if (edge | mir_resize_edge_north)
+        if (edge & mir_resize_edge_north)
             result.y += old_size.height - new_size.height;
 
         return result;


### PR DESCRIPTION
Clang 10 picks up a couple of extra warnings, which have picked up some incorrect Mir code.