### PR TITLE
XWayland: create scene surface only when needed

### DIFF
--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -429,6 +429,9 @@ mir::shell::SurfaceSpecification& mf::WindowWlSurfaceRole::spec()
 
 void mf::WindowWlSurfaceRole::create_scene_surface()
 {
+    if (weak_scene_surface.lock())
+        return;
+
     params->size = pending_size();
     params->streams = std::vector<shell::StreamSpecification>{};
     params->input_shape = std::vector<geom::Rectangle>{};

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -272,7 +272,7 @@ void mf::WindowWlSurfaceRole::set_fullscreen(std::experimental::optional<struct 
         params->state = mir_window_state_fullscreen;
         if (output)
             params->output_id = output_manager->output_id_for(client, output.value());
-        create_mir_window();
+        create_scene_surface();
     }
 }
 
@@ -299,7 +299,7 @@ void mf::WindowWlSurfaceRole::set_state_now(MirWindowState state)
     else
     {
         params->state = state;
-        create_mir_window();
+        create_scene_surface();
     }
 }
 
@@ -386,7 +386,7 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
     }
     else
     {
-        create_mir_window();
+        create_scene_surface();
     }
 
     committed_size = size;
@@ -427,7 +427,7 @@ mir::shell::SurfaceSpecification& mf::WindowWlSurfaceRole::spec()
     return *pending_changes;
 }
 
-void mf::WindowWlSurfaceRole::create_mir_window()
+void mf::WindowWlSurfaceRole::create_scene_surface()
 {
     params->size = pending_size();
     params->streams = std::vector<shell::StreamSpecification>{};

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -88,6 +88,7 @@ public:
     void set_server_side_decorated(bool server_side_decorated);
 
     void set_state_now(MirWindowState state);
+    void create_mir_window();
 
     /// Gets called after the surface has committed (so current_size() may return the committed buffer size) but before
     /// the Mir window is modified (so if a pending size is set or a spec is applied those changes will take effect)
@@ -153,7 +154,6 @@ private:
     void visiblity(bool visible) override;
 
     shell::SurfaceSpecification& spec();
-    void create_mir_window();
 };
 
 }

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -88,7 +88,7 @@ public:
     void set_server_side_decorated(bool server_side_decorated);
 
     void set_state_now(MirWindowState state);
-    void create_mir_window();
+    void create_scene_surface();
 
     /// Gets called after the surface has committed (so current_size() may return the committed buffer size) but before
     /// the Mir window is modified (so if a pending size is set or a spec is applied those changes will take effect)

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -99,7 +99,10 @@ void mf::XWaylandWMSurface::set_surface(WlSurface *wls)
     if (!properties.title.empty())
       shell_surface->set_title(properties.title);
 
-    shell_surface->set_state_now(mir_window_state_restored);
+    // If a buffer has alread been committed, we need to create the scene::Surface without waiting for next commit
+    if (wls->buffer_size())
+        shell_surface->create_scene_surface();
+
     xcb_flush(xwm->get_xcb_connection());
 }
 


### PR DESCRIPTION
XWayland: create scene surface only when needed. (Fixes: #1172)