### PR TITLE
Don't restart Xwayland if we killed it deliberately

### DIFF
--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -79,7 +79,10 @@ mf::XWaylandServer::~XWaylandServer()
       {
           std::this_thread::sleep_for(100ms);// After 100ms...
           if (kill(pid, 0) == 0)    // ...if Xwayland is still running...
-            kill(pid, SIGKILL);     // ...then kill it!
+          {
+              mir::log_info("Xwayland didn't close, killing it");
+              kill(pid, SIGKILL);     // ...then kill it!
+          }
       }
     }
 
@@ -311,7 +314,12 @@ void mf::XWaylandServer::connect_wm_to_xwayland(int wl_client_server_fd, int wm_
         xserver_status = FAILED;
     }
 
-    if (terminate) return;
+    if (terminate)
+    {
+        xserver_status = STOPPED;   // We don't want to retry Xwayland
+        return;
+    }
+
     wm->destroy();
 }
 

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -134,7 +134,10 @@ void msh::AbstractShell::close_session(
     // this is an ugly kludge to remove the each of the surfaces owned by the session
     // We could likely do this better (and atomically) within the WindowManager
     for (auto const& surface : surfaces)
+    {
+        decoration_manager->undecorate(surface);
         window_manager->remove_surface(session, surface);
+    }
 
     session_coordinator->close_session(session);
     window_manager->remove_session(session);


### PR DESCRIPTION
Don't restart Xwayland if we killed it deliberately. (Fixes: #1169)

This whole area is a mess, as the reason we kill Xwayland is that it is waiting for clients to exit before closing. And if we ensured they were closed, we wouldn't be deleting windows that no longer exist and crashing after this. I'll have a look at that (fixed, second commit).

We still fail to give clients a chance to close nicely, c.f. #1171.