### PR TITLE
XWayland: make names more verbose

### DIFF
--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -27,10 +27,10 @@ namespace mf = mir::frontend;
 
 mf::XWaylandConnector::XWaylandConnector(
     const int xdisplay,
-    std::shared_ptr<WaylandConnector> const& wc,
+    std::shared_ptr<WaylandConnector> const& wayland_connector,
     std::string const& xwayland_path) :
-    start_xwayland{wc->get_extension("x11-support") ?
-        [=]{ return std::make_unique<XWaylandServer>(xdisplay, wc, xwayland_path); } :
+    start_xwayland{wayland_connector->get_extension("x11-support") ?
+        [=]{ return std::make_unique<XWaylandServer>(xdisplay, wayland_connector, xwayland_path); } :
         decltype(start_xwayland){[]{ return std::unique_ptr<XWaylandServer>{}; }}}
 {
 }

--- a/src/server/frontend_xwayland/xwayland_connector.h
+++ b/src/server/frontend_xwayland/xwayland_connector.h
@@ -30,7 +30,10 @@ class XWaylandServer;
 class XWaylandConnector : public Connector
 {
 public:
-    XWaylandConnector(const int xdisplay, std::shared_ptr<WaylandConnector> const& wc, std::string const& xwayland_path);
+    XWaylandConnector(
+        const int xdisplay,
+        std::shared_ptr<WaylandConnector> const& wayland_connector,
+        std::string const& xwayland_path);
     ~XWaylandConnector() override;
 
     void start() override;

--- a/src/server/frontend_xwayland/xwayland_default_configuration.cpp
+++ b/src/server/frontend_xwayland/xwayland_default_configuration.cpp
@@ -66,10 +66,10 @@ std::shared_ptr<mf::Connector> mir::DefaultServerConfiguration::the_xwayland_con
         {
             try
             {
-                auto wc = std::static_pointer_cast<mf::WaylandConnector>(the_wayland_connector());
+                auto wayland_connector = std::static_pointer_cast<mf::WaylandConnector>(the_wayland_connector());
                 return std::make_shared<mf::XWaylandConnector>(
                     options->get<int>(mo::x11_display_opt),
-                    wc,
+                    wayland_connector,
                     options->get<std::string>("xwayland-path"));
             }
             catch (...)

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -46,9 +46,9 @@ using namespace std::chrono_literals;
 
 mf::XWaylandServer::XWaylandServer(
     const int xdisplay,
-    std::shared_ptr<mf::WaylandConnector> wc,
+    std::shared_ptr<mf::WaylandConnector> wayland_connector,
     std::string const& xwayland_path) :
-    wlc(wc),
+    wayland_connector{wayland_connector},
     dispatcher{std::make_shared<md::MultiplexingDispatchable>()},
     xserver_thread{std::make_unique<dispatch::ThreadedDispatcher>(
         "Mir/X11 Reader", dispatcher, []() { terminate_with_current_exception(); })},
@@ -264,7 +264,7 @@ void mf::XWaylandServer::connect_wm_to_xwayland(
         std::mutex client_mutex;
         std::condition_variable client_ready;
 
-        wlc->run_on_wayland_display(
+        wayland_connector->run_on_wayland_display(
             [wl_client_server_fd, &client, &client_mutex, &client_ready](wl_display* display)
             {
                 std::lock_guard<std::mutex> lock{client_mutex};
@@ -291,7 +291,7 @@ void mf::XWaylandServer::connect_wm_to_xwayland(
         return;
     }
 
-    XWaylandWM wm{wlc, client, wm_server_fd};
+    XWaylandWM wm{wayland_connector, client, wm_server_fd};
     mir::log_info("XServer is running");
     spawn_thread_xserver_status = RUNNING;
     auto const pid = spawn_thread_pid; // For clarity only as this is only written on this thread

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -39,7 +39,7 @@ class WaylandConnector;
 class XWaylandServer
 {
 public:
-    XWaylandServer(const int xdisp, std::shared_ptr<WaylandConnector> wc, std::string const& xwayland_path);
+    XWaylandServer(const int xdisp, std::shared_ptr<WaylandConnector> wayland_connector, std::string const& xwayland_path);
     ~XWaylandServer();
 
 private:
@@ -69,7 +69,7 @@ private:
         FAILED = -2
     };
 
-    std::shared_ptr<WaylandConnector> const wlc;
+    std::shared_ptr<WaylandConnector> const wayland_connector;
     std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
     std::unique_ptr<dispatch::ThreadedDispatcher> const xserver_thread;
     SocketFd const sockets;

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -25,6 +25,7 @@
 #include "wl_surface.h"
 #include "xwayland_wm_shellsurface.h"
 #include "xwayland_wm_surface.h"
+#include "xwayland_wm_shell.h"
 
 #include "mir/dispatch/multiplexing_dispatchable.h"
 #include "mir/dispatch/readable_fd.h"
@@ -245,6 +246,14 @@ void mf::XWaylandWM::set_net_active_window(xcb_window_t window)
 {
     xcb_change_property(xcb_connection, XCB_PROP_MODE_REPLACE, xcb_screen->root, xcb_atom.net_active_window,
                         xcb_atom.window, 32, 1, &window);
+}
+
+auto mf::XWaylandWM::build_shell_surface(
+    XWaylandWMSurface* wm_surface,
+    WlSurface* wayland_surface) -> std::shared_ptr<XWaylandWMShellSurface>
+{
+    auto const shell = std::static_pointer_cast<XWaylandWMShell>(wayland_connector->get_extension("x11-support"));
+    return shell->build_shell_surface(wm_surface, wayland_client, wayland_surface);
 }
 
 /* Events */

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -78,10 +78,10 @@ static const struct cursor_alternatives cursors[] = {
 
 namespace mf = mir::frontend;
 
-mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wc, wl_client* wlc, int fd)
-    : wlc(wc),
+mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, wl_client* wayland_client, int fd)
+    : wayland_connector(wayland_connector),
       dispatcher{std::make_shared<mir::dispatch::MultiplexingDispatchable>()},
-      wlclient{wlc},
+      wayland_client{wayland_client},
       wm_fd{fd},
       xcb_connection(nullptr)
 {
@@ -485,9 +485,9 @@ void mf::XWaylandWM::handle_surface_id(std::shared_ptr<XWaylandWMSurface> surfac
     uint32_t id = event->data.data32[0];
     surface->set_surface_id(id);
 
-    wlc->run_on_wayland_display([wlclient=wlclient, id, surface](auto)
+    wayland_connector->run_on_wayland_display([client=wayland_client, id, surface](auto)
         {
-            wl_resource* resource = wl_client_get_object(wlclient, id);
+            wl_resource* resource = wl_client_get_object(client, id);
             auto* wlsurface = resource ? WlSurface::from(resource) : nullptr;
             if (wlsurface)
                 surface->set_surface(wlsurface);

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -420,7 +420,6 @@ void mf::XWaylandWM::handle_unmap_notify(xcb_unmap_notify_event_t *event)
 
     auto surface = surfaces[event->window];
 
-    surface->set_surface_id(0);
     surface->set_wm_state(XWaylandWMSurface::WithdrawnState);
     surface->set_workspace(-1);
     xcb_unmap_window(xcb_connection, event->window);
@@ -492,7 +491,6 @@ void mf::XWaylandWM::handle_surface_id(std::shared_ptr<XWaylandWMSurface> surfac
     }
 
     uint32_t id = event->data.data32[0];
-    surface->set_surface_id(id);
 
     wayland_connector->run_on_wayland_display([client=wayland_client, id, surface](auto)
         {

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -109,6 +109,9 @@ class MultiplexingDispatchable;
 namespace frontend
 {
 class XWaylandWMSurface;
+class XWaylandWMShellSurface;
+class WlSurface;
+
 class XWaylandWM
 {
 public:
@@ -119,14 +122,9 @@ public:
 
     void dump_property(xcb_atom_t property, xcb_get_property_reply_t *reply);
     void set_net_active_window(xcb_window_t window);
-    std::shared_ptr<WaylandConnector> get_wl_connector()
-    {
-        return wayland_connector;
-    }
-    wl_client *get_wl_client()
-    {
-        return wayland_client;
-    }
+    auto build_shell_surface(
+        XWaylandWMSurface* wm_surface,
+        WlSurface* wayland_surface) -> std::shared_ptr<XWaylandWMShellSurface>;
 
     atom_t xcb_atom;
 

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -112,7 +112,7 @@ class XWaylandWMSurface;
 class XWaylandWM
 {
 public:
-    XWaylandWM(std::shared_ptr<WaylandConnector> wc, wl_client* wlc, int fd);
+    XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, wl_client* wayland_client, int fd);
     ~XWaylandWM();
 
     xcb_connection_t *get_xcb_connection();
@@ -121,11 +121,11 @@ public:
     void set_net_active_window(xcb_window_t window);
     std::shared_ptr<WaylandConnector> get_wl_connector()
     {
-        return wlc;
+        return wayland_connector;
     }
     wl_client *get_wl_client()
     {
-        return wlclient;
+        return wayland_client;
     }
 
     atom_t xcb_atom;
@@ -182,9 +182,9 @@ private:
     xcb_cursor_t xcb_cursor_images_load_cursor(const XcursorImages *images);
     xcb_cursor_t xcb_cursor_library_load_cursor(const char *file);
 
-    std::shared_ptr<WaylandConnector> const wlc;
+    std::shared_ptr<WaylandConnector> const wayland_connector;
     std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
-    wl_client* const wlclient;
+    wl_client* const wayland_client;
     int const wm_fd;
 
     xcb_connection_t *xcb_connection;

--- a/src/server/frontend_xwayland/xwayland_wm_shell.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shell.h
@@ -34,6 +34,7 @@ class WlSeat;
 class WlSurface;
 class XWaylandWMSurface;
 class XWaylandWMShellSurface;
+
 class XWaylandWMShell
 {
 public:

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -19,8 +19,6 @@
 #include "xwayland_log.h"
 
 #include "xwayland_wm_surface.h"
-
-#include "xwayland_wm_shell.h"
 #include "xwayland_wm_shellsurface.h"
 
 #include <wayland-client-core.h>
@@ -93,8 +91,7 @@ void mf::XWaylandWMSurface::set_surface(WlSurface *wls)
 {
     wlsurface = wls;
 
-    auto shell = std::static_pointer_cast<XWaylandWMShell>(xwm->get_wl_connector()->get_extension("x11-support"));
-    shell_surface = shell->build_shell_surface(this, xwm->get_wl_client(), wlsurface);
+    shell_surface = xwm->build_shell_surface(this, wlsurface);
 
     if (!properties.title.empty())
       shell_surface->set_title(properties.title);

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -87,17 +87,15 @@ void mf::XWaylandWMSurface::set_surface_id(uint32_t id)
     surface_id = id;
 }
 
-void mf::XWaylandWMSurface::set_surface(WlSurface *wls)
+void mf::XWaylandWMSurface::set_surface(WlSurface* wayland_surface)
 {
-    wlsurface = wls;
-
-    shell_surface = xwm->build_shell_surface(this, wlsurface);
+    shell_surface = xwm->build_shell_surface(this, wayland_surface);
 
     if (!properties.title.empty())
       shell_surface->set_title(properties.title);
 
     // If a buffer has alread been committed, we need to create the scene::Surface without waiting for next commit
-    if (wls->buffer_size())
+    if (wayland_surface->buffer_size())
         shell_surface->create_scene_surface();
 
     xcb_flush(xwm->get_xcb_connection());

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -82,11 +82,6 @@ void mf::XWaylandWMSurface::dirty_properties()
     props_dirty = true;
 }
 
-void mf::XWaylandWMSurface::set_surface_id(uint32_t id)
-{
-    surface_id = id;
-}
-
 void mf::XWaylandWMSurface::set_surface(WlSurface* wayland_surface)
 {
     shell_surface = xwm->build_shell_surface(this, wayland_surface);

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -146,8 +146,9 @@ public:
 
 private:
     XWaylandWM* const xwm;
-    xcb_window_t window;
+    xcb_window_t const window;
     std::shared_ptr<XWaylandWMShellSurface> shell_surface;
+
     bool props_dirty;
     bool maximized;
     bool fullscreen;

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -132,7 +132,7 @@ public:
     void dirty_properties();
     void read_properties();
     void set_surface_id(uint32_t surface_id);
-    void set_surface(WlSurface *wls);
+    void set_surface(WlSurface* wayland_surface);
     void set_workspace(int workspace);
     void set_wm_state(WmState state);
     void set_net_wm_state();
@@ -148,7 +148,6 @@ public:
 private:
     XWaylandWM *xwm;
     xcb_window_t window;
-    WlSurface *wlsurface;
     std::shared_ptr<XWaylandWMShellSurface> shell_surface;
     bool props_dirty;
     uint32_t surface_id;

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -145,7 +145,7 @@ public:
     }
 
 private:
-    XWaylandWM *xwm;
+    XWaylandWM* const xwm;
     xcb_window_t window;
     std::shared_ptr<XWaylandWMShellSurface> shell_surface;
     bool props_dirty;

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -131,7 +131,6 @@ public:
     ~XWaylandWMSurface();
     void dirty_properties();
     void read_properties();
-    void set_surface_id(uint32_t surface_id);
     void set_surface(WlSurface* wayland_surface);
     void set_workspace(int workspace);
     void set_wm_state(WmState state);
@@ -150,7 +149,6 @@ private:
     xcb_window_t window;
     std::shared_ptr<XWaylandWMShellSurface> shell_surface;
     bool props_dirty;
-    uint32_t surface_id;
     bool maximized;
     bool fullscreen;
 


### PR DESCRIPTION
Also moves some logic from `XWaylandWMSurface` into `XWaylandWM` that removes the need for a few getters.