### PR TITLE
Make XWaylandWMSurface thread safe

### DIFF
--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -256,6 +256,11 @@ auto mf::XWaylandWM::build_shell_surface(
     return shell->build_shell_surface(wm_surface, wayland_client, wayland_surface);
 }
 
+void mf::XWaylandWM::run_on_wayland_thread(std::function<void()>&& work)
+{
+    wayland_connector->run_on_wayland_display([work = move(work)](auto){ work(); });
+}
+
 /* Events */
 void mf::XWaylandWM::handle_events()
 {

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -484,12 +484,6 @@ void mf::XWaylandWM::handle_surface_id(std::shared_ptr<XWaylandWMSurface> surfac
         return;
     mir::log_verbose("handle surface_id");
 
-    if (surface->has_surface())
-    {
-        mir::log_verbose("Window already has a surface id");
-        return;
-    }
-
     uint32_t id = event->data.data32[0];
 
     wayland_connector->run_on_wayland_display([client=wayland_client, id, surface](auto)
@@ -516,31 +510,19 @@ void mf::XWaylandWM::handle_configure_request(xcb_configure_request_event_t *eve
     if (event->value_mask & XCB_CONFIG_WINDOW_X)
     {
         values[++i] = event->x;
-        if (shellSurface && shellSurface->has_surface())
-        {
-        }
     }
     if (event->value_mask & XCB_CONFIG_WINDOW_Y)
     {
         values[++i] = event->y;
-        if (shellSurface && shellSurface->has_surface())
-        {
-        }
     }
 
     if (event->value_mask & XCB_CONFIG_WINDOW_WIDTH)
     {
         values[++i] = event->width;
-        if (shellSurface && shellSurface->has_surface())
-        {
-        }
     }
     if (event->value_mask & XCB_CONFIG_WINDOW_HEIGHT)
     {
         values[++i] = event->height;
-        if (shellSurface && shellSurface->has_surface())
-        {
-        }
     }
 
     if (event->value_mask & XCB_CONFIG_WINDOW_SIBLING)

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -250,7 +250,7 @@ void mf::XWaylandWM::set_net_active_window(xcb_window_t window)
 
 auto mf::XWaylandWM::build_shell_surface(
     XWaylandWMSurface* wm_surface,
-    WlSurface* wayland_surface) -> std::shared_ptr<XWaylandWMShellSurface>
+    WlSurface* wayland_surface) -> XWaylandWMShellSurface*
 {
     auto const shell = std::static_pointer_cast<XWaylandWMShell>(wayland_connector->get_extension("x11-support"));
     return shell->build_shell_surface(wm_surface, wayland_client, wayland_surface);

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -125,6 +125,7 @@ public:
     auto build_shell_surface(
         XWaylandWMSurface* wm_surface,
         WlSurface* wayland_surface) -> XWaylandWMShellSurface*;
+    void run_on_wayland_thread(std::function<void()>&& work);
 
     atom_t xcb_atom;
 

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -124,7 +124,7 @@ public:
     void set_net_active_window(xcb_window_t window);
     auto build_shell_surface(
         XWaylandWMSurface* wm_surface,
-        WlSurface* wayland_surface) -> std::shared_ptr<XWaylandWMShellSurface>;
+        WlSurface* wayland_surface) -> XWaylandWMShellSurface*;
 
     atom_t xcb_atom;
 

--- a/src/server/frontend_xwayland/xwayland_wm_shell.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_shell.cpp
@@ -38,16 +38,16 @@ mf::XWaylandWMShell::XWaylandWMShell(
 {
 }
 
-std::shared_ptr<mf::XWaylandWMShellSurface> mf::XWaylandWMShell::build_shell_surface(
+auto mf::XWaylandWMShell::build_shell_surface(
     XWaylandWMSurface* xwayland_surface,
     wl_client* client,
-    WlSurface* surface)
+    WlSurface* surface) -> XWaylandWMShellSurface*
 {
-    return std::make_shared<mf::XWaylandWMShellSurface>(
+    return new XWaylandWMShellSurface{
         xwayland_surface,
         client,
         surface,
         shell,
         seat,
-        output_manager);
+        output_manager};
 }

--- a/src/server/frontend_xwayland/xwayland_wm_shell.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shell.h
@@ -43,10 +43,10 @@ public:
         WlSeat& seat,
         OutputManager* const output_manager);
 
-    std::shared_ptr<XWaylandWMShellSurface> build_shell_surface(
+    auto build_shell_surface(
         XWaylandWMSurface* xwayland_surface,
         wl_client* client,
-        WlSurface* surface);
+        WlSurface* surface) -> XWaylandWMShellSurface*;
 
 private:
     std::shared_ptr<shell::Shell> const shell;

--- a/src/server/frontend_xwayland/xwayland_wm_shell.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shell.h
@@ -43,6 +43,7 @@ public:
         WlSeat& seat,
         OutputManager* const output_manager);
 
+    /// Should only be called on the Wayland thread
     auto build_shell_surface(
         XWaylandWMSurface* xwayland_surface,
         wl_client* client,

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.cpp
@@ -52,7 +52,8 @@ mf::XWaylandWMShellSurface::~XWaylandWMShellSurface()
 
 void mf::XWaylandWMShellSurface::destroy()
 {
-
+    *destroyed = true;
+    delete this;
 }
 
 void mf::XWaylandWMShellSurface::handle_resize(std::experimental::optional<geometry::Point> const& /*new_top_left*/,

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
@@ -29,6 +29,8 @@ namespace frontend
 {
 class OutputManager;
 class XWaylandWMSurface;
+
+/// Should only be accessed on the Wayland thread
 class XWaylandWMShellSurface : public WindowWlSurfaceRole
 {
 public:

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -57,7 +57,8 @@ mf::XWaylandWMSurface::XWaylandWMSurface(XWaylandWM *wm, xcb_create_notify_event
           event->parent,
           {event->x, event->y},
           {event->width, event->height},
-          (bool)event->override_redirect}
+          (bool)event->override_redirect},
+      shell_surface_destroyed{std::make_shared<bool>(true)}
 {
     uint32_t values[1];
     xcb_get_geometry_cookie_t geometry_cookie;
@@ -75,6 +76,10 @@ mf::XWaylandWMSurface::XWaylandWMSurface(XWaylandWM *wm, xcb_create_notify_event
 
 mf::XWaylandWMSurface::~XWaylandWMSurface()
 {
+    if (!*shell_surface_destroyed)
+    {
+        delete shell_surface;
+    }
 }
 
 void mf::XWaylandWMSurface::dirty_properties()
@@ -85,6 +90,7 @@ void mf::XWaylandWMSurface::dirty_properties()
 void mf::XWaylandWMSurface::set_surface(WlSurface* wayland_surface)
 {
     shell_surface = xwm->build_shell_surface(this, wayland_surface);
+    shell_surface_destroyed = shell_surface->destroyed_flag();
 
     if (!properties.title.empty())
       shell_surface->set_title(properties.title);

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -282,15 +282,25 @@ void mf::XWaylandWMSurface::read_properties()
 
 void mf::XWaylandWMSurface::move_resize(uint32_t detail)
 {
-    aquire_shell_surface([detail](auto shell_surface)
+
+    if (detail == _NET_WM_MOVERESIZE_MOVE)
+    {
+        aquire_shell_surface([](auto shell_surface)
         {
-            if (detail == _NET_WM_MOVERESIZE_MOVE)
-                shell_surface->initiate_interactive_move();
-            else if (auto const edge = wm_resize_edge_to_mir_resize_edge(detail))
-                shell_surface->initiate_interactive_resize(edge.value());
-            else
-                mir::log_warning("XWaylandWMSurface::move_resize() called with unknown detail %d", detail);
+            shell_surface->initiate_interactive_move();
         });
+    }
+    else if (auto const edge = wm_resize_edge_to_mir_resize_edge(detail))
+    {
+        aquire_shell_surface([edge](auto shell_surface)
+        {
+            shell_surface->initiate_interactive_resize(edge.value());
+        });
+    }
+    else
+    {
+        mir::log_warning("XWaylandWMSurface::move_resize() called with unknown detail %d", detail);
+    }
 }
 
 void mf::XWaylandWMSurface::set_state(MirWindowState state)

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -21,6 +21,8 @@
 #include "wl_surface.h"
 #include "xwayland_wm.h"
 
+#include <mutex>
+
 extern "C" {
 #include <xcb/xcb.h>
 }
@@ -144,11 +146,17 @@ private:
     XWaylandWM* const xwm;
     xcb_window_t const window;
 
+    std::mutex mutex;
+
     bool props_dirty;
     bool maximized;
     bool fullscreen;
-
-    //XWaylandWMSurface *transientFor;
+    struct
+    {
+        std::string title;
+        std::string appId;
+        int deleteWindow;
+    } properties;
 
     struct
     {
@@ -157,13 +165,6 @@ private:
         geometry::Size size;
         bool override_redirect;
     } const init;
-
-    struct
-    {
-        std::string title;
-        std::string appId;
-        int deleteWindow;
-    } properties;
 
     /// shell_surface should not be accessed unless this is false
     /// Should only be accessed on the Wayland thread

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -133,7 +133,7 @@ public:
     ~XWaylandWMSurface();
     void dirty_properties();
     void read_properties();
-    void set_surface(WlSurface* wayland_surface);
+    void set_surface(WlSurface* wayland_surface); ///< Should only be called on the Wayland thread
     void set_workspace(int workspace);
     void set_wm_state(WmState state);
     void set_net_wm_state();

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -143,6 +143,9 @@ public:
     void send_close_request();
 
 private:
+    /// Runs work on the Wayland thread if the shell surface hasn't been destroyed
+    void aquire_shell_surface(std::function<void(XWaylandWMShellSurface* shell_surface)>&& work);
+
     XWaylandWM* const xwm;
     xcb_window_t const window;
 
@@ -170,13 +173,13 @@ private:
     /// Should only be accessed on the Wayland thread
     std::shared_ptr<bool> shell_surface_destroyed;
 
-    /// Should only be accessed on the Wayland thread
+    /// Only safe to access when shell_surface_destroyed is false and on the Wayland thread (use aquire_shell_surface())
     /// When the associated wl_surface is destroyed:
     /// - The WlSurface will call destory() on its role (this shell surface)
     /// - shell_surface_destroyed will be set to true
     /// - The shell surface will delete itself
-    /// This class may also safely delete the shell surface at any time (as long as it's on the Wayland thread)
-    XWaylandWMShellSurface* shell_surface;
+    /// Can be deleted on the Wayland thread at any time (which will result in shell_surface_destroyed being set to true)
+    XWaylandWMShellSurface* shell_surface_unsafe;
 };
 } /* frontend */
 } /* mir */

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -139,10 +139,6 @@ public:
     void set_state(MirWindowState state);
     void send_resize(const geometry::Size& new_size);
     void send_close_request();
-    bool has_surface()
-    {
-        return !*shell_surface_destroyed;
-    }
 
 private:
     XWaylandWM* const xwm;

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -141,13 +141,12 @@ public:
     void send_close_request();
     bool has_surface()
     {
-        return !!shell_surface;
+        return !*shell_surface_destroyed;
     }
 
 private:
     XWaylandWM* const xwm;
     xcb_window_t const window;
-    std::shared_ptr<XWaylandWMShellSurface> shell_surface;
 
     bool props_dirty;
     bool maximized;
@@ -169,6 +168,18 @@ private:
         std::string appId;
         int deleteWindow;
     } properties;
+
+    /// shell_surface should not be accessed unless this is false
+    /// Should only be accessed on the Wayland thread
+    std::shared_ptr<bool> shell_surface_destroyed;
+
+    /// Should only be accessed on the Wayland thread
+    /// When the associated wl_surface is destroyed:
+    /// - The WlSurface will call destory() on its role (this shell surface)
+    /// - shell_surface_destroyed will be set to true
+    /// - The shell surface will delete itself
+    /// This class may also safely delete the shell surface at any time (as long as it's on the Wayland thread)
+    XWaylandWMShellSurface* shell_surface;
 };
 } /* frontend */
 } /* mir */


### PR DESCRIPTION
Make Wayland calls on the Wayland thread and lock everything else behind a mutext