### PR TITLE
Add top_left to shell::SurfaceSpecification

### DIFF
--- a/include/server/mir/shell/surface_specification.h
+++ b/include/server/mir/shell/surface_specification.h
@@ -65,6 +65,7 @@ struct SurfaceSpecification
     bool is_empty() const;
     void update_from(SurfaceSpecification const& that);
 
+    optional_value<geometry::Point> top_left;
     optional_value<geometry::Width> width;
     optional_value<geometry::Height> height;
     optional_value<MirPixelFormat> pixel_format;
@@ -96,7 +97,6 @@ struct SurfaceSpecification
     optional_value<std::vector<geometry::Rectangle>> input_shape;
 
     // TODO scene::SurfaceCreationParameters overlaps this content but has additional fields:
-    //    geometry::Point top_left;
     //    input::InputReceptionMode input_mode;
     //
     //    it also has size instead of width + height

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -67,7 +67,7 @@ struct miral::WindowSpecification::Self
 };
 
 miral::WindowSpecification::Self::Self(mir::shell::SurfaceSpecification const& spec) :
-    top_left(),
+    top_left(spec.top_left),
     size(),
     pixel_format(spec.pixel_format),
     buffer_usage(),

--- a/src/server/scene/surface_creation_parameters.cpp
+++ b/src/server/scene/surface_creation_parameters.cpp
@@ -140,6 +140,8 @@ ms::SurfaceCreationParameters& ms::SurfaceCreationParameters::with_buffer_stream
 
 void ms::SurfaceCreationParameters::update_from(msh::SurfaceSpecification const& that)
 {
+    if (that.top_left.is_set())
+        top_left = that.top_left.value();
     if (that.width.is_set() && that.height.is_set())
         size = geom::Size{that.width.value(), that.height.value()};
     if (that.pixel_format.is_set())

--- a/src/server/shell/surface_specification.cpp
+++ b/src/server/shell/surface_specification.cpp
@@ -39,7 +39,8 @@ bool msh::SurfaceSpecification::is_empty() const
 {
     // You know, compile-time reflection would be pretty
     // useful here :)
-    return !width.is_set() &&
+    return !top_left.is_set() &&
+        !width.is_set() &&
         !height.is_set() &&
         !pixel_format.is_set() &&
         !buffer_usage.is_set() &&
@@ -71,6 +72,8 @@ bool msh::SurfaceSpecification::is_empty() const
 
 void msh::SurfaceSpecification::update_from(SurfaceSpecification const& that)
 {
+    if (that.top_left.is_set())
+        top_left = that.top_left;
     if (that.width.is_set())
         width = that.width;
     if (that.height.is_set())


### PR DESCRIPTION
It appears this was never added because no mirclient or Wayland protocols needed it. XWayland will.