### PR TITLE
Simplify miral-app script and make terminal logic more robust

### DIFF
--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -4,7 +4,7 @@ miral_server=miral-shell
 hostsocket=
 bindir=$(dirname $0)
 
-for terminal in weston-terminal gnome-terminal qterminal x-terminal-emulator
+for terminal in x-terminal-emulator weston-terminal gnome-terminal qterminal
 do
   if which $terminal > /dev/null
   then break;

--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 
 miral_server=miral-shell
-launcher=qterminal
 hostsocket=
 bindir=$(dirname $0)
+
+for terminal in weston-terminal gnome-terminal qterminal x-terminal-emulator
+do
+  if which $terminal > /dev/null
+  then break;
+  fi
+done
 
 if [ "$(lsb_release -c -s)" != "xenial" ]
 then
@@ -43,14 +49,14 @@ do
     echo "Usage: $(basename $0) [options] [shell options]"
     echo "Options are:"
     echo "    -kiosk                      use miral-kiosk instead of ${miral_server}"
-    echo "    -launcher <launcher>        use <launcher> instead of '${launcher}'"
+    echo "    -terminal <terminal>        use <terminal> instead of '${terminal}'"
     echo "    -socket <socket>            set the legacy mir socket [${socket}]"
     echo "    -wayland-display <socket>   set the wayland socket [${wayland_display}]"
     echo "    -bindir <bindir>            path to the miral executable [${bindir}]"
     # omit    -demo-server as mir_demo_server is in the mir-test-tools package
     exit 0
   elif [ "$1" == "-kiosk" ];            then miral_server=miral-kiosk
-  elif [ "$1" == "-launcher" ];         then shift; launcher=$1
+  elif [ "$1" == "-terminal" ];         then shift; terminal=$1
   elif [ "$1" == "-socket" ];           then shift; socket=$1
   elif [ "$1" == "-wayland-display" ];  then shift; wayland_display=$1
   elif [ "$1" == "-bindir" ];           then shift; bindir=$1
@@ -65,11 +71,9 @@ if [ "${bindir}" != "" ]; then bindir="${bindir}/"; fi
 if [ -e "${socket}" ]; then echo "Error: session endpoint '${socket}' already exists"; exit 1 ;fi
 if [ -e "${XDG_RUNTIME_DIR}/${wayland_display}" ]; then echo "Error: wayland endpoint '${wayland_display}' already exists"; exit 1 ;fi
 
-
-sh -c "MIR_SERVER_FILE=${socket} WAYLAND_DISPLAY=${wayland_display} ${hostsocket} ${bindir}${miral_server} ${enable_mirclient} $*"&
-
-while [ ! -e "${XDG_RUNTIME_DIR}/${wayland_display}" ]; do echo "waiting for ${wayland_display}"; sleep 1 ;done
-
-unset QT_QPA_PLATFORMTHEME
-MIR_SOCKET=${socket} XDG_SESSION_TYPE=mir GDK_BACKEND=${gdk_backend} QT_QPA_PLATFORM=${qt_qpa} SDL_VIDEODRIVER=${sdl_videodriver} WAYLAND_DISPLAY=${wayland_display} NO_AT_BRIDGE=1 dbus-run-session -- ${launcher}
-killall ${bindir}${miral_server} || killall ${bindir}${miral_server}.bin
+if [ "${miral_server}" == "miral-shell" ]
+then
+  MIR_SERVER_FILE=${socket} WAYLAND_DISPLAY=${wayland_display} MIR_SERVER_SHELL_TERMINAL_EMULATOR=${terminal} NO_AT_BRIDGE=1 ${hostsocket} dbus-run-session -- ${bindir}${miral_server} ${enable_mirclient} $*
+else
+  MIR_SERVER_FILE=${socket} WAYLAND_DISPLAY=${wayland_display}                                                NO_AT_BRIDGE=1 ${hostsocket} dbus-run-session -- ${bindir}${miral_server} ${enable_mirclient} $*
+fi

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -34,6 +34,7 @@
 #include <miral/wayland_extensions.h>
 
 #include <linux/input.h>
+#include <unistd.h>
 
 int main(int argc, char const* argv[])
 {
@@ -54,6 +55,8 @@ int main(int argc, char const* argv[])
     runner.add_stop_callback([&] { shutdown_hook(); });
 
     ExternalClientLauncher external_client_launcher;
+
+    std::string terminal_cmd{"weston-terminal"};
 
     auto const quit_on_ctrl_alt_bksp = [&](MirEvent const* event)
         {
@@ -79,7 +82,7 @@ int main(int argc, char const* argv[])
                 return true;
 
             case KEY_T:
-                external_client_launcher.launch({"weston-terminal"});
+                external_client_launcher.launch({terminal_cmd});
                 return false;
 
             default:
@@ -103,6 +106,8 @@ int main(int argc, char const* argv[])
             AppendEventFilter{quit_on_ctrl_alt_bksp},
             StartupInternalClient{spinner},
             pre_init(CommandLineOption{[&](std::string const& typeface) { ::wallpaper::font_file(typeface); },
-                              "shell-wallpaper-font", "font file to use for wallpaper", ::wallpaper::font_file()})
+                                       "shell-wallpaper-font", "font file to use for wallpaper", ::wallpaper::font_file()}),
+            CommandLineOption{[&](std::string const& cmd) { terminal_cmd = cmd; },
+                              "shell-terminal-emulator", "terminal emulator to use", terminal_cmd}
         });
 }


### PR DESCRIPTION
Simplify miral-app script and make terminal logic more robust.

1. Adds a --shell-terminal-emulator option to miral-shell
2. Uses that (and Ctrl-Alt-T) instead of a separate "launcher" process in miral-app
3. Renames the miral-app "-launcher" option "-terminal"
4. Tries to detect a usable default terminal on the system