### PR TITLE
XWayland: manage window state correctly

### DIFF
--- a/src/server/frontend_xwayland/xcb_atoms.cpp
+++ b/src/server/frontend_xwayland/xcb_atoms.cpp
@@ -62,6 +62,7 @@ mf::XCBAtoms::XCBAtoms(xcb_connection_t* xcb_connection)
       net_wm_state{"_NET_WM_STATE", context},
       net_wm_state_maximized_vert{"_NET_WM_STATE_MAXIMIZED_VERT", context},
       net_wm_state_maximized_horz{"_NET_WM_STATE_MAXIMIZED_HORZ", context},
+      net_wm_state_hidden{"_NET_WM_STATE_HIDDEN", context},
       net_wm_state_fullscreen{"_NET_WM_STATE_FULLSCREEN", context},
       net_wm_user_time{"_NET_WM_USER_TIME", context},
       net_wm_icon_name{"_NET_WM_ICON_NAME", context},

--- a/src/server/frontend_xwayland/xcb_atoms.cpp
+++ b/src/server/frontend_xwayland/xcb_atoms.cpp
@@ -53,6 +53,7 @@ mf::XCBAtoms::XCBAtoms(xcb_connection_t* xcb_connection)
       wm_take_focus{"WM_TAKE_FOCUS", context},
       wm_delete_window{"WM_DELETE_WINDOW", context},
       wm_state{"WM_STATE", context},
+      wm_change_state{"WM_CHANGE_STATE", context},
       wm_s0{"WM_S0", context},
       wm_client_machine{"WM_CLIENT_MACHINE", context},
       net_wm_cm_s0{"_NET_WM_CM_S0", context},

--- a/src/server/frontend_xwayland/xcb_atoms.h
+++ b/src/server/frontend_xwayland/xcb_atoms.h
@@ -71,6 +71,7 @@ public:
     Atom const net_wm_state;
     Atom const net_wm_state_maximized_vert;
     Atom const net_wm_state_maximized_horz;
+    Atom const net_wm_state_hidden;
     Atom const net_wm_state_fullscreen;
     Atom const net_wm_user_time;
     Atom const net_wm_icon_name;

--- a/src/server/frontend_xwayland/xcb_atoms.h
+++ b/src/server/frontend_xwayland/xcb_atoms.h
@@ -62,6 +62,7 @@ public:
     Atom const wm_take_focus;
     Atom const wm_delete_window;
     Atom const wm_state;
+    Atom const wm_change_state;
     Atom const wm_s0;
     Atom const wm_client_machine;
     Atom const net_wm_cm_s0;

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -507,9 +507,8 @@ void mf::XWaylandWM::handle_map_request(xcb_map_request_event_t *event)
     if (auto const surface = get_wm_surface(event->window))
     {
         surface.value()->read_properties();
-        surface.value()->set_wm_state(XWaylandWMSurface::NormalState);
-        surface.value()->set_net_wm_state();
         surface.value()->set_workspace(0);
+        surface.value()->apply_mir_state_to_window(mir_window_state_restored); // TODO: get the actual state
         xcb_map_window(xcb_connection, event->window);
         xcb_flush(xcb_connection);
     }
@@ -535,7 +534,7 @@ void mf::XWaylandWM::handle_unmap_notify(xcb_unmap_notify_event_t *event)
 
     if (auto const surface = get_wm_surface(event->window))
     {
-        surface.value()->set_wm_state(XWaylandWMSurface::WithdrawnState);
+        surface.value()->unmap();
         surface.value()->set_workspace(-1);
         xcb_unmap_window(xcb_connection, event->window);
         xcb_flush(xcb_connection);

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -556,7 +556,7 @@ void mf::XWaylandWM::handle_client_message(xcb_client_message_event_t *event)
         if (event->type == xcb_atom.net_wm_moveresize)
             handle_move_resize(surface.value(), event);
         else if (event->type == xcb_atom.net_wm_state)
-            handle_state(surface.value(), event);
+            surface.value()->net_wm_state_client_message(event->data.data32);
         else if (event->type == xcb_atom.wl_surface_id)
             handle_surface_id(surface.value(), event);
     }
@@ -569,12 +569,6 @@ void mf::XWaylandWM::handle_move_resize(std::shared_ptr<XWaylandWMSurface> surfa
 
     int detail = event->data.data32[2];
     surface->move_resize(detail);
-}
-
-void mf::XWaylandWM::handle_state(std::shared_ptr<XWaylandWMSurface> surface, xcb_client_message_event_t *event)
-{
-    if (!surface || !event)
-        return;
 }
 
 void mf::XWaylandWM::handle_surface_id(std::shared_ptr<XWaylandWMSurface> surface, xcb_client_message_event_t *event)

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -557,6 +557,8 @@ void mf::XWaylandWM::handle_client_message(xcb_client_message_event_t *event)
             handle_move_resize(surface.value(), event);
         else if (event->type == xcb_atom.net_wm_state)
             surface.value()->net_wm_state_client_message(event->data.data32);
+        else if (event->type == xcb_atom.wm_change_state)
+            surface.value()->wm_change_state_client_message(event->data.data32);
         else if (event->type == xcb_atom.wl_surface_id)
             handle_surface_id(surface.value(), event);
     }

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -120,7 +120,6 @@ private:
     void handle_motion_notify(xcb_motion_notify_event_t *event);
     void handle_property_notify(xcb_property_notify_event_t *event);
     void handle_map_request(xcb_map_request_event_t *event);
-    void handle_state(std::shared_ptr<XWaylandWMSurface> surface, xcb_client_message_event_t *event);
     void handle_surface_id(std::shared_ptr<XWaylandWMSurface> surface, xcb_client_message_event_t *event);
     void handle_move_resize(std::shared_ptr<XWaylandWMSurface> surface, xcb_client_message_event_t *event);
     void handle_client_message(xcb_client_message_event_t *event);

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.cpp
@@ -56,6 +56,11 @@ void mf::XWaylandWMShellSurface::destroy()
     delete this;
 }
 
+void mf::XWaylandWMShellSurface::handle_state_change(MirWindowState new_state)
+{
+    surface->apply_mir_state_to_window(new_state);
+}
+
 void mf::XWaylandWMShellSurface::handle_resize(std::experimental::optional<geometry::Point> const& /*new_top_left*/,
                                                geometry::Size const& new_size)
 {

--- a/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shellsurface.h
@@ -44,7 +44,7 @@ public:
 protected:
     void destroy() override;
     void handle_commit() override {};
-    void handle_state_change(MirWindowState /*new_state*/) override {};
+    void handle_state_change(MirWindowState new_state) override;
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left, geometry::Size const& new_size) override;
     void handle_close_request() override;

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -176,7 +176,6 @@ void mf::XWaylandWMSurface::read_properties()
     props[XCB_ATOM_WM_TRANSIENT_FOR] = XCB_ATOM_WINDOW;
     props[xwm->xcb_atom.wm_protocols] = TYPE_WM_PROTOCOLS;
     props[xwm->xcb_atom.wm_normal_hints] = TYPE_WM_NORMAL_HINTS;
-    props[xwm->xcb_atom.net_wm_state] = TYPE_NET_WM_STATE;
     props[xwm->xcb_atom.net_wm_window_type] = XCB_ATOM_ATOM;
     props[xwm->xcb_atom.net_wm_name] = XCB_ATOM_STRING;
     props[xwm->xcb_atom.motif_wm_hints] = TYPE_MOTIF_WM_HINTS;
@@ -244,27 +243,6 @@ void mf::XWaylandWMSurface::read_properties()
         }
         case TYPE_WM_NORMAL_HINTS:
         {
-            break;
-        }
-        case TYPE_NET_WM_STATE:
-        {
-            xcb_atom_t *value = reinterpret_cast<xcb_atom_t *>(xcb_get_property_value(reply));
-            uint32_t i;
-            for (i = 0; i < reply->value_len; i++)
-            {
-                if (value[i] == xwm->xcb_atom.net_wm_state_fullscreen && !fullscreen)
-                {
-                    fullscreen = true;
-                }
-            }
-            if (value[i] == xwm->xcb_atom.net_wm_state_maximized_horz && !maximized)
-            {
-                maximized = true;
-            }
-            if (value[i] == xwm->xcb_atom.net_wm_state_maximized_vert && !maximized)
-            {
-                maximized = true;
-            }
             break;
         }
         case TYPE_MOTIF_WM_HINTS:

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -106,14 +106,10 @@ void mf::XWaylandWMSurface::net_wm_state_client_message(uint32_t const (&data)[5
         TOGGLE = 2,
     };
 
-    int i = 0;
-    auto const action = static_cast<Action>(data[i]);
-    i++;
-    auto const prop_a = static_cast<xcb_atom_t>(data[i]);
-    i++;
-    auto const prop_b = static_cast<xcb_atom_t>(data[i]);
-    i++;
-    auto const source_indication = static_cast<SourceIndication>(data[i]);
+    auto const* pdata = data;
+    auto const action = static_cast<Action>(*pdata++);
+    xcb_atom_t const properties[2] = { static_cast<xcb_atom_t>(*pdata++),  static_cast<xcb_atom_t>(*pdata++) };
+    auto const source_indication = static_cast<SourceIndication>(*pdata++);
 
     (void)source_indication;
 
@@ -124,7 +120,7 @@ void mf::XWaylandWMSurface::net_wm_state_client_message(uint32_t const (&data)[5
 
         new_window_state = window_state;
 
-        for (xcb_atom_t const property : {prop_a, prop_b})
+        for (xcb_atom_t const property : properties)
         {
             if (property) // if there is only one property, the 2nd is 0
             {

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -221,12 +221,13 @@ void mf::XWaylandWMSurface::set_workspace(int workspace)
 
 void mf::XWaylandWMSurface::apply_mir_state_to_window(MirWindowState new_state)
 {
-    std::vector<xcb_atom_t> net_wm_states;
-
     WindowState new_window_state;
 
     {
         std::lock_guard<std::mutex> lock{mutex};
+
+        if (new_state == cached_mir_window_state)
+            return;
 
         cached_mir_window_state = new_state;
         new_window_state = window_state;

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -458,7 +458,7 @@ void mf::XWaylandWMSurface::set_window_state(WindowState const& new_window_state
 
     std::vector<xcb_atom_t> net_wm_states;
 
-    if (new_window_state.maximized)
+    if (new_window_state.minimized)
     {
         net_wm_states.push_back(xwm->xcb_atom.net_wm_state_hidden);
     }

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -94,7 +94,7 @@ mf::XWaylandWMSurface::~XWaylandWMSurface()
         });
 }
 
-void mf::XWaylandWMSurface::net_wm_state_client_message(uint32_t (&data)[5])
+void mf::XWaylandWMSurface::net_wm_state_client_message(uint32_t const (&data)[5])
 {
     // The client is requesting a change in state
     // see https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html#idm45390969565536
@@ -148,11 +148,11 @@ void mf::XWaylandWMSurface::net_wm_state_client_message(uint32_t (&data)[5])
     set_window_state(new_window_state);
 }
 
-void mf::XWaylandWMSurface::wm_change_state_client_message(uint32_t (&data)[5])
+void mf::XWaylandWMSurface::wm_change_state_client_message(uint32_t const (&data)[5])
 {
     // See ICCCM 4.1.4 (https://tronche.com/gui/x/icccm/sec-4.html)
 
-    WmState requested_state = (WmState)data[0];
+    WmState const requested_state = (WmState)data[0];
 
     WindowState new_window_state;
 

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -29,27 +29,6 @@ namespace mf = mir::frontend;
 
 namespace
 {
-struct ClientMessageData
-{
-    ClientMessageData(uint32_t const(&data)[5])
-        : data{data}
-    {
-    }
-
-    template<typename T>
-    T unpack()
-    {
-        if (i >= 5)
-            mir::fatal_error("ClientMessageData::unpack() called too many times");
-        auto prev = i;
-        i++;
-        return static_cast<T>(data[prev]);
-    }
-
-    uint32_t const* const data;
-    size_t i{0};
-};
-
 /// See ICCCM 4.1.3.1 (https://tronche.com/gui/x/icccm/sec-4.html)
 enum class WmState: uint32_t
 {
@@ -127,11 +106,14 @@ void mf::XWaylandWMSurface::net_wm_state_client_message(uint32_t const (&data)[5
         TOGGLE = 2,
     };
 
-    ClientMessageData values{data};
-    auto const action = values.unpack<Action>();
-    auto const prop_a = values.unpack<xcb_atom_t>();
-    auto const prop_b = values.unpack<xcb_atom_t>();
-    auto const source_indication = values.unpack<SourceIndication>();
+    int i = 0;
+    auto const action = static_cast<Action>(data[i]);
+    i++;
+    auto const prop_a = static_cast<xcb_atom_t>(data[i]);
+    i++;
+    auto const prop_b = static_cast<xcb_atom_t>(data[i]);
+    i++;
+    auto const source_indication = static_cast<SourceIndication>(data[i]);
 
     (void)source_indication;
 

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -300,14 +300,6 @@ void mf::XWaylandWMSurface::move_resize(uint32_t detail)
     }
 }
 
-void mf::XWaylandWMSurface::set_state(MirWindowState state)
-{
-    aquire_shell_surface([state](auto shell_surface)
-        {
-            shell_surface->set_state_now(state);
-        });
-}
-
 void mf::XWaylandWMSurface::send_resize(const geometry::Size& new_size)
 {
     uint32_t const mask = XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT;

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -111,9 +111,12 @@ void mf::XWaylandWMSurface::net_wm_state_client_message(uint32_t const (&data)[5
         NetWmStateClientMessageAction const action;
         xcb_atom_t const properties[2];
         SourceIndication const source_indication;
+        uint32_t const pad;
     };
 
-    auto const message = (NetWmStateClientMessage*)data;
+    static_assert(sizeof(NetWmStateClientMessage) == sizeof(data), "Structure size incorrect");
+
+    auto const message = reinterpret_cast<NetWmStateClientMessage const*>(data);
 
     WindowState new_window_state;
 
@@ -152,7 +155,7 @@ void mf::XWaylandWMSurface::wm_change_state_client_message(uint32_t const (&data
 {
     // See ICCCM 4.1.4 (https://tronche.com/gui/x/icccm/sec-4.html)
 
-    WmState const requested_state = (WmState)data[0];
+    WmState const requested_state = static_cast<WmState>(data[0]);
 
     WindowState new_window_state;
 

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -252,7 +252,6 @@ void mf::XWaylandWMSurface::apply_mir_state_to_window(MirWindowState new_state)
         case mir_window_state_maximized:
         case mir_window_state_vertmaximized:
         case mir_window_state_horizmaximized:
-        case mir_window_state_attached:
             new_window_state.minimized = false;
             new_window_state.maximized = true;
             new_window_state.fullscreen = false;
@@ -260,6 +259,7 @@ void mf::XWaylandWMSurface::apply_mir_state_to_window(MirWindowState new_state)
 
         case mir_window_state_restored:
         case mir_window_state_unknown:
+        case mir_window_state_attached:
             new_window_state.minimized = false;
             new_window_state.maximized = false;
             new_window_state.fullscreen = false;

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -148,6 +148,37 @@ void mf::XWaylandWMSurface::net_wm_state_client_message(uint32_t (&data)[5])
     set_window_state(new_window_state);
 }
 
+void mf::XWaylandWMSurface::wm_change_state_client_message(uint32_t (&data)[5])
+{
+    // See ICCCM 4.1.4 (https://tronche.com/gui/x/icccm/sec-4.html)
+
+    WmState requested_state = (WmState)data[0];
+
+    WindowState new_window_state;
+
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+
+        new_window_state = window_state;
+
+        switch (requested_state)
+        {
+        case WmState::NORMAL:
+            new_window_state.minimized = false;
+            break;
+
+        case WmState::ICONIC:
+            new_window_state.minimized = true;
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    set_window_state(new_window_state);
+}
+
 void mf::XWaylandWMSurface::dirty_properties()
 {
     std::lock_guard<std::mutex> lock{mutex};

--- a/src/server/frontend_xwayland/xwayland_wm_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.cpp
@@ -491,6 +491,7 @@ void mf::XWaylandWMSurface::set_window_state(WindowState const& new_window_state
     {
         net_wm_states.push_back(xwm->xcb_atom.net_wm_state_fullscreen);
     }
+    // TODO: Set _NET_WM_STATE_MODAL if appropriate
 
     xcb_change_property(
         xwm->get_xcb_connection(),

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -145,10 +145,33 @@ private:
     /// Runs work on the Wayland thread if the shell surface hasn't been destroyed
     void aquire_shell_surface(std::function<void(XWaylandWMShellSurface* shell_surface)>&& work);
 
+    /// contains more information than just a MirWindowState
+    /// (for example if a minimized window would otherwise be maximized)
+    struct WindowState
+    {
+        bool minimized{false};
+        bool maximized{false};
+        bool fullscreen{false};
+    };
+
+    /// The last state we have either requested of Mir or been informed of by Mir
+    /// Prevents requesting a window state that we are already in
+    MirWindowState cached_mir_window_state{mir_window_state_unknown};
+
+    /// Sets the window's _NET_WM_STATE property based on the contents of window_state
+    /// Also sets the state of the scene surface to match window_state
+    /// Should be called after every change to window_state
+    /// Should NOT be called under lock
+    void set_window_state(WindowState const& new_window_state);
+
     XWaylandWM* const xwm;
     xcb_window_t const window;
 
     std::mutex mutex;
+
+    /// Reflects the _NET_WM_STATE and WM_STATE we have currently set on the window
+    /// Should only be modified by set_wm_state()
+    WindowState window_state;
 
     bool props_dirty;
     bool maximized;

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -22,7 +22,6 @@
 #include "xwayland_wm.h"
 
 #include <mutex>
-#include <set>
 
 extern "C" {
 #include <xcb/xcb.h>

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -138,7 +138,6 @@ public:
     void set_wm_state(WmState state);
     void set_net_wm_state();
     void move_resize(uint32_t detail);
-    void set_state(MirWindowState state);
     void send_resize(const geometry::Size& new_size);
     void send_close_request();
 

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -126,6 +126,7 @@ public:
     XWaylandWMSurface(XWaylandWM *wm, xcb_create_notify_event_t *event);
     ~XWaylandWMSurface();
     void net_wm_state_client_message(uint32_t (&data)[5]);
+    void wm_change_state_client_message(uint32_t (&data)[5]);
     void dirty_properties();
     void read_properties();
     void set_surface(WlSurface* wayland_surface); ///< Should only be called on the Wayland thread

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -22,6 +22,7 @@
 #include "xwayland_wm.h"
 
 #include <mutex>
+#include <set>
 
 extern "C" {
 #include <xcb/xcb.h>
@@ -122,21 +123,14 @@ class XWaylandWMShellSurface;
 class XWaylandWMSurface
 {
 public:
-    enum WmState
-    {
-        WithdrawnState = 0,
-        NormalState = 1,
-        IconicState = 3
-    };
-
     XWaylandWMSurface(XWaylandWM *wm, xcb_create_notify_event_t *event);
     ~XWaylandWMSurface();
     void dirty_properties();
     void read_properties();
     void set_surface(WlSurface* wayland_surface); ///< Should only be called on the Wayland thread
     void set_workspace(int workspace);
-    void set_wm_state(WmState state);
-    void set_net_wm_state();
+    void apply_mir_state_to_window(MirWindowState new_state);
+    void unmap();
     void move_resize(uint32_t detail);
     void send_resize(const geometry::Size& new_size);
     void send_close_request();
@@ -174,8 +168,6 @@ private:
     WindowState window_state;
 
     bool props_dirty;
-    bool maximized;
-    bool fullscreen;
     struct
     {
         std::string title;

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -125,8 +125,8 @@ class XWaylandWMSurface
 public:
     XWaylandWMSurface(XWaylandWM *wm, xcb_create_notify_event_t *event);
     ~XWaylandWMSurface();
-    void net_wm_state_client_message(uint32_t (&data)[5]);
-    void wm_change_state_client_message(uint32_t (&data)[5]);
+    void net_wm_state_client_message(uint32_t const (&data)[5]);
+    void wm_change_state_client_message(uint32_t const (&data)[5]);
     void dirty_properties();
     void read_properties();
     void set_surface(WlSurface* wayland_surface); ///< Should only be called on the Wayland thread

--- a/src/server/frontend_xwayland/xwayland_wm_surface.h
+++ b/src/server/frontend_xwayland/xwayland_wm_surface.h
@@ -125,6 +125,7 @@ class XWaylandWMSurface
 public:
     XWaylandWMSurface(XWaylandWM *wm, xcb_create_notify_event_t *event);
     ~XWaylandWMSurface();
+    void net_wm_state_client_message(uint32_t (&data)[5]);
     void dirty_properties();
     void read_properties();
     void set_surface(WlSurface* wayland_surface); ///< Should only be called on the Wayland thread


### PR DESCRIPTION
Fixes #1210. Also alerts windows to their current state (for example, Gedit draws slightly differently when it knows it's maximized).