### PR TITLE
XWaylandWM: make threadsafe

### DIFF
--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -101,33 +101,6 @@ mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, 
       dispatcher{std::make_shared<mir::dispatch::MultiplexingDispatchable>()},
       wayland_client{wayland_client}
 {
-    start();
-}
-
-mf::XWaylandWM::~XWaylandWM()
-{
-    destroy();
-}
-
-void mf::XWaylandWM::destroy() {
-  if (event_thread) {
-    dispatcher->remove_watch(wm_dispatcher);
-    event_thread.reset();
-  }
-
-  // xcb_cursors == 2 when its empty
-  if (xcb_cursors.size() != 2) {
-    mir::log_info("Cleaning cursors");
-    for (auto xcb_cursor : xcb_cursors)
-      xcb_free_cursor(xcb_connection, xcb_cursor);
-  }
-  if (xcb_connection != nullptr)
-    xcb_disconnect(xcb_connection);
-  close(wm_fd);
-}
-
-void mf::XWaylandWM::start()
-{
     if (xcb_connection_has_error(xcb_connection))
     {
         mir::log_error("XWAYLAND: xcb_connect_to_fd failed");
@@ -187,6 +160,30 @@ void mf::XWaylandWM::start()
 
     create_wm_window();
     xcb_flush(xcb_connection);
+}
+
+mf::XWaylandWM::~XWaylandWM()
+{
+    if (event_thread)
+    {
+        dispatcher->remove_watch(wm_dispatcher);
+        event_thread.reset();
+    }
+
+    // xcb_cursors == 2 when its empty
+    if (xcb_cursors.size() != 2)
+    {
+        mir::log_info("Cleaning cursors");
+        for (auto xcb_cursor : xcb_cursors)
+        xcb_free_cursor(xcb_connection, xcb_cursor);
+    }
+
+    if (xcb_connection != nullptr)
+    {
+        xcb_disconnect(xcb_connection);
+    }
+
+    close(wm_fd);
 }
 
 void mf::XWaylandWM::wm_selector()

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -171,7 +171,13 @@ void mf::XWaylandWM::start()
         XCB_ATOM_ATOM, 32, // type and format
         length_of(supported), supported);
 
-    set_net_active_window(XCB_WINDOW_NONE);
+    uint32_t const window_none = XCB_WINDOW_NONE;
+    xcb_change_property(
+        xcb_connection,
+        XCB_PROP_MODE_REPLACE,
+        xcb_screen->root, xcb_atom.net_active_window,
+        xcb_atom.window, 32,
+        1, &window_none);
     wm_selector();
 
     xcb_flush(xcb_connection);
@@ -271,12 +277,6 @@ void mf::XWaylandWM::create_wm_window()
     xcb_set_selection_owner(xcb_connection, xcb_window, xcb_atom.wm_s0, XCB_TIME_CURRENT_TIME);
 
     xcb_set_selection_owner(xcb_connection, xcb_window, xcb_atom.net_wm_cm_s0, XCB_TIME_CURRENT_TIME);
-}
-
-void mf::XWaylandWM::set_net_active_window(xcb_window_t window)
-{
-    xcb_change_property(xcb_connection, XCB_PROP_MODE_REPLACE, xcb_screen->root, xcb_atom.net_active_window,
-                        xcb_atom.window, 32, 1, &window);
 }
 
 auto mf::XWaylandWM::build_shell_surface(

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -69,7 +69,6 @@ public:
         return xcb_connection;
     }
 
-    void set_net_active_window(xcb_window_t window);
     auto build_shell_surface(
         XWaylandWMSurface* wm_surface,
         WlSurface* wayland_surface) -> XWaylandWMShellSurface*;

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -79,9 +79,6 @@ public:
 
 private:
 
-    void start();
-    void destroy();
-
     enum CursorType
     {
         CursorUnset = -1,

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -19,15 +19,16 @@
 #ifndef MIR_FRONTEND_XWAYLAND_WM_H
 #define MIR_FRONTEND_XWAYLAND_WM_H
 
-#include <map>
-#include <thread>
-#include <wayland-server-core.h>
-
 #include "mir/dispatch/threaded_dispatcher.h"
 #include "wayland_connector.h"
 #include "xcb_atoms.h"
 
+#include <map>
+#include <thread>
 #include <experimental/optional>
+#include <mutex>
+
+#include <wayland-server-core.h>
 
 #include <X11/Xcursor/Xcursor.h>
 #include <xcb/composite.h>
@@ -69,9 +70,11 @@ public:
         return xcb_connection;
     }
 
+    /// Should always be called on the Wayland thread
     auto build_shell_surface(
         XWaylandWMSurface* wm_surface,
         WlSurface* wayland_surface) -> XWaylandWMShellSurface*;
+
     auto get_wm_surface(xcb_window_t xcb_window) -> std::experimental::optional<std::shared_ptr<XWaylandWMSurface>>;
     void run_on_wayland_thread(std::function<void()>&& work);
 
@@ -124,6 +127,8 @@ private:
     void handle_configure_notify(xcb_configure_notify_event_t *event);
     void handle_unmap_notify(xcb_unmap_notify_event_t *event);
     void handle_destroy_notify(xcb_destroy_notify_event_t *event);
+
+    std::mutex mutex;
 
     // Cursor
     xcb_cursor_t xcb_cursor_image_load_cursor(const XcursorImage *img);


### PR DESCRIPTION
Introduces and uses a `mutex` and inlines `create()` and `destroy()` into the constructor and destructor (they were only being called from there anyway). 