### PR TITLE
Split WaylandInputDispatcher out from WaylandSurfaceObserver

### DIFF
--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -14,6 +14,7 @@ set(
   wayland_executor.cpp          wayland_executor.h
   null_event_sink.cpp           null_event_sink.h
   wayland_surface_observer.cpp  wayland_surface_observer.h
+  wayland_input_dispatcher.cpp  wayland_input_dispatcher.h
   data_device.cpp               data_device.h
   output_manager.cpp            output_manager.h
   wl_subcompositor.cpp          wl_subcompositor.h

--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -37,10 +37,9 @@ namespace mi = mir::input;
 
 mf::WaylandInputDispatcher::WaylandInputDispatcher(
     WlSeat* seat,
-    wl_client* client,
     WlSurface* wl_surface)
     : seat{seat},
-      client{client},
+      client{wl_surface->client},
       wl_surface{wl_surface},
       wl_surface_destroyed{wl_surface->destroyed_flag()}
 {

--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -1,0 +1,279 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "wayland_input_dispatcher.h"
+#include "wl_surface.h"
+#include "wl_seat.h"
+#include "wl_pointer.h"
+#include "wl_keyboard.h"
+#include "wl_touch.h"
+
+#include <mir/input/xkb_mapper.h>
+#include <mir/input/keymap.h>
+#include <mir/log.h>
+
+#include <linux/input-event-codes.h>
+#include <boost/throw_exception.hpp>
+
+namespace mf = mir::frontend;
+namespace ms = mir::scene;
+namespace geom = mir::geometry;
+namespace mi = mir::input;
+
+mf::WaylandInputDispatcher::WaylandInputDispatcher(
+    WlSeat* seat,
+    wl_client* client,
+    WlSurface* wl_surface)
+    : seat{seat},
+      client{client},
+      wl_surface{wl_surface},
+      wl_surface_destroyed{wl_surface->destroyed_flag()}
+{
+}
+
+void mf::WaylandInputDispatcher::set_keymap(mi::Keymap const& keymap)
+{
+    if (*wl_surface_destroyed)
+        return;
+
+    seat->for_each_listener(client, [keymap](WlKeyboard* keyboard)
+        {
+            keyboard->set_keymap(keymap);
+        });
+}
+
+void mf::WaylandInputDispatcher::set_focus(bool has_focus)
+{
+    if (*wl_surface_destroyed)
+        return;
+
+    if (has_focus)
+        seat->notify_focus(client);
+
+    seat->for_each_listener(client, [wl_surface = wl_surface, has_focus = has_focus](WlKeyboard* keyboard)
+        {
+            keyboard->focussed(wl_surface, has_focus);
+        });
+}
+
+void mf::WaylandInputDispatcher::handle_event(MirEvent const* event)
+{
+    if (*wl_surface_destroyed)
+        return;
+
+    if (mir_event_get_type(event) != mir_event_type_input)
+    {
+        log_warning(
+            "WaylandInputDispatcher::input_consumed() got non-input event type %d",
+            mir_event_get_type(event));
+        return;
+    }
+
+    auto const input_ev = mir_event_get_input_event(event);
+    handle_input_event(input_ev);
+}
+
+void mf::WaylandInputDispatcher::handle_input_event(MirInputEvent const* event)
+{
+    auto const ns = std::chrono::nanoseconds{mir_input_event_get_event_time(event)};
+    auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(ns);
+
+    // Remember the timestamp of any events "signed" with a cookie
+    if (mir_input_event_has_cookie(event))
+        timestamp = ns;
+
+    switch (mir_input_event_get_type(event))
+    {
+    case mir_input_event_type_key:
+        handle_keyboard_event(ms, mir_input_event_get_keyboard_event(event));
+        break;
+    case mir_input_event_type_pointer:
+        handle_pointer_event(ms, mir_input_event_get_pointer_event(event));
+        break;
+    case mir_input_event_type_touch:
+        handle_touch_event(ms, mir_input_event_get_touch_event(event));
+        break;
+    default:
+        break;
+    }
+}
+
+void mf::WaylandInputDispatcher::handle_keyboard_event(std::chrono::milliseconds const& ms, MirKeyboardEvent const* event)
+{
+    MirKeyboardAction const action = mir_keyboard_event_action(event);
+    if (action == mir_keyboard_action_down || action == mir_keyboard_action_up)
+    {
+        int const scancode = mir_keyboard_event_scan_code(event);
+        bool const down = action == mir_keyboard_action_down;
+        seat->for_each_listener(client, [&ms, scancode, down](WlKeyboard* keyboard)
+            {
+                keyboard->key(ms, scancode, down);
+            });
+    }
+}
+
+void mf::WaylandInputDispatcher::handle_pointer_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event)
+{
+    switch(mir_pointer_event_action(event))
+    {
+        case mir_pointer_action_button_down:
+        case mir_pointer_action_button_up:
+            handle_pointer_button_event(ms, event);
+            break;
+        case mir_pointer_action_enter:
+        {
+            geom::Point const position{
+                mir_pointer_event_axis_value(event, mir_pointer_axis_x),
+                mir_pointer_event_axis_value(event, mir_pointer_axis_y)};
+            seat->for_each_listener(client, [wl_surface = wl_surface, &position](WlPointer* pointer)
+                {
+                    pointer->enter(wl_surface, position);
+                    pointer->frame();
+                });
+            break;
+        }
+        case mir_pointer_action_leave:
+            seat->for_each_listener(client, [](WlPointer* pointer)
+                {
+                    pointer->leave();
+                    pointer->frame();
+                });
+            break;
+        case mir_pointer_action_motion:
+            handle_pointer_motion_event(ms, event);
+            break;
+        case mir_pointer_actions:
+            break;
+    }
+}
+
+void mf::WaylandInputDispatcher::handle_pointer_button_event(
+    std::chrono::milliseconds const& ms,
+    MirPointerEvent const* event)
+{
+    MirPointerButtons const event_buttons = mir_pointer_event_buttons(event);
+    std::vector<std::pair<uint32_t, bool>> buttons;
+
+    for (auto const& mapping :
+        {
+            std::make_pair(mir_pointer_button_primary, BTN_LEFT),
+            std::make_pair(mir_pointer_button_secondary, BTN_RIGHT),
+            std::make_pair(mir_pointer_button_tertiary, BTN_MIDDLE),
+            std::make_pair(mir_pointer_button_back, BTN_BACK),
+            std::make_pair(mir_pointer_button_forward, BTN_FORWARD),
+            std::make_pair(mir_pointer_button_side, BTN_SIDE),
+            std::make_pair(mir_pointer_button_task, BTN_TASK),
+            std::make_pair(mir_pointer_button_extra, BTN_EXTRA)
+        })
+    {
+        if (mapping.first & (event_buttons ^ last_pointer_buttons))
+        {
+            bool const pressed = (mapping.first & event_buttons);
+            buttons.push_back(std::make_pair(mapping.second, pressed));
+        }
+    }
+
+    if (!buttons.empty())
+    {
+        seat->for_each_listener(client, [&ms, &buttons](WlPointer* pointer)
+            {
+                for (auto& button : buttons)
+                {
+                    pointer->button(ms, button.first, button.second);
+                }
+                pointer->frame();
+            });
+    }
+
+    last_pointer_buttons = event_buttons;
+}
+
+void mf::WaylandInputDispatcher::handle_pointer_motion_event(
+    std::chrono::milliseconds const& ms,
+    MirPointerEvent const* event)
+{
+    // TODO: send axis_source, axis_stop and axis_discrete events where appropriate
+    // (may require significant eworking of the input system)
+
+    geom::Point const position{
+        mir_pointer_event_axis_value(event, mir_pointer_axis_x),
+        mir_pointer_event_axis_value(event, mir_pointer_axis_y)};
+    geom::Displacement const axis_motion{
+        mir_pointer_event_axis_value(event, mir_pointer_axis_hscroll) * 10,
+        mir_pointer_event_axis_value(event, mir_pointer_axis_vscroll) * 10};
+    bool const send_motion = (!last_pointer_position || position != last_pointer_position.value());
+    bool const send_axis = (axis_motion != geom::Displacement{});
+
+    last_pointer_position = position;
+
+    if (send_motion || send_axis)
+    {
+        seat->for_each_listener(
+            client,
+            [&ms, wl_surface = wl_surface, &send_motion, &position, &send_axis, &axis_motion](WlPointer* pointer)
+            {
+                if (send_motion)
+                    pointer->motion(ms, wl_surface, position);
+                if (send_axis)
+                    pointer->axis(ms, axis_motion);
+                pointer->frame();
+            });
+    }
+}
+
+void mf::WaylandInputDispatcher::handle_touch_event(
+    std::chrono::milliseconds const& ms,
+    MirTouchEvent const* event)
+{
+    for (auto i = 0u; i < mir_touch_event_point_count(event); ++i)
+    {
+        geometry::Point const position{
+            mir_touch_event_axis_value(event, i, mir_touch_axis_x),
+            mir_touch_event_axis_value(event, i, mir_touch_axis_y)};
+        int const touch_id = mir_touch_event_id(event, i);
+        MirTouchAction const action = mir_touch_event_action(event, i);
+
+        switch (action)
+        {
+        case mir_touch_action_down:
+            seat->for_each_listener(client, [&ms, touch_id, wl_surface = wl_surface, &position](WlTouch* touch)
+                {
+                    touch->down(ms, touch_id, wl_surface, position);
+                });
+            break;
+        case mir_touch_action_up:
+            seat->for_each_listener(client, [&ms, touch_id](WlTouch* touch)
+                {
+                    touch->up(ms, touch_id);
+                });
+            break;
+        case mir_touch_action_change:
+            seat->for_each_listener(client, [&ms, touch_id, wl_surface = wl_surface, &position](WlTouch* touch)
+                {
+                    touch->motion(ms, touch_id, wl_surface, position);
+                });
+            break;
+        case mir_touch_actions:;
+        }
+    }
+
+    seat->for_each_listener(client, [](WlTouch* touch)
+        {
+            touch->frame();
+        });
+}

--- a/src/server/frontend_wayland/wayland_input_dispatcher.h
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.h
@@ -47,7 +47,6 @@ class WaylandInputDispatcher
 public:
     WaylandInputDispatcher(
         WlSeat* seat,
-        wl_client* client,
         WlSurface* wl_surface);
     ~WaylandInputDispatcher() = default;
 

--- a/src/server/frontend_wayland/wayland_input_dispatcher.h
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_FRONTEND_WAYLAND_INPUT_DISPATCHER_H
+#define MIR_FRONTEND_WAYLAND_INPUT_DISPATCHER_H
+
+#include "mir_toolkit/common.h"
+#include "mir_toolkit/events/event.h"
+#include "mir/geometry/point.h"
+
+#include <memory>
+#include <chrono>
+#include <experimental/optional>
+
+struct wl_client;
+
+namespace mir
+{
+namespace input
+{
+class Keymap;
+}
+namespace frontend
+{
+class WlSeat;
+class WlSurface;
+
+/// Dispatches input events to Wayland clients
+/// Should only be used from the Wayland thread
+class WaylandInputDispatcher
+{
+public:
+    WaylandInputDispatcher(
+        WlSeat* seat,
+        wl_client* client,
+        WlSurface* wl_surface);
+    ~WaylandInputDispatcher() = default;
+
+    void set_keymap(input::Keymap const& keymap);
+    void set_focus(bool has_focus);
+    void handle_event(MirEvent const* event);
+
+    auto latest_timestamp() const -> std::chrono::nanoseconds { return timestamp; }
+
+private:
+    WaylandInputDispatcher(WaylandInputDispatcher const&) = delete;
+    WaylandInputDispatcher& operator=(WaylandInputDispatcher const&) = delete;
+
+    WlSeat* const seat;
+    wl_client* const client;
+    WlSurface* const wl_surface;
+    std::shared_ptr<bool> const wl_surface_destroyed;
+
+    std::chrono::nanoseconds timestamp{0};
+    MirPointerButtons last_pointer_buttons{0};
+    std::experimental::optional<geometry::Point> last_pointer_position;
+
+    /// Handle user input events
+    ///@{
+    void handle_input_event(MirInputEvent const* event);
+    void handle_keyboard_event(std::chrono::milliseconds const& ms, MirKeyboardEvent const* event);
+    void handle_pointer_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
+    void handle_pointer_button_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
+    void handle_pointer_motion_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
+    void handle_touch_event(std::chrono::milliseconds const& ms, MirTouchEvent const* event);
+    ///@}
+};
+}
+}
+
+#endif // MIR_FRONTEND_WAYLAND_INPUT_DISPATCHER_H

--- a/src/server/frontend_wayland/wayland_surface_observer.cpp
+++ b/src/server/frontend_wayland/wayland_surface_observer.cpp
@@ -36,12 +36,11 @@ namespace mi = mir::input;
 
 mf::WaylandSurfaceObserver::WaylandSurfaceObserver(
     WlSeat* seat,
-    wl_client* client,
     WlSurface* surface,
     WindowWlSurfaceRole* window)
     : seat{seat},
       window{window},
-      input_dispatcher{std::make_unique<WaylandInputDispatcher>(seat, client, surface)},
+      input_dispatcher{std::make_unique<WaylandInputDispatcher>(seat, surface)},
       window_size{geometry::Size{0,0}},
       destroyed{std::make_shared<bool>(false)}
 {

--- a/src/server/frontend_wayland/wayland_surface_observer.cpp
+++ b/src/server/frontend_wayland/wayland_surface_observer.cpp
@@ -19,22 +19,14 @@
 
 #include "wayland_surface_observer.h"
 #include "wl_seat.h"
-#include "wl_pointer.h"
-#include "wl_keyboard.h"
-#include "wl_touch.h"
-#include "wl_surface.h"
 #include "wayland_utils.h"
 #include "window_wl_surface_role.h"
+#include "wayland_input_dispatcher.h"
 
-#include <mir_toolkit/events/window_placement.h>
-#include <mir_toolkit/events/event.h>
 #include <mir/events/event_builders.h>
-#include <mir/input/xkb_mapper.h>
+
 #include <mir/input/keymap.h>
 #include <mir/log.h>
-
-#include <linux/input-event-codes.h>
-#include <boost/throw_exception.hpp>
 
 namespace mf = mir::frontend;
 namespace ms = mir::scene;
@@ -48,9 +40,8 @@ mf::WaylandSurfaceObserver::WaylandSurfaceObserver(
     WlSurface* surface,
     WindowWlSurfaceRole* window)
     : seat{seat},
-      client{client},
-      surface{surface},
       window{window},
+      input_dispatcher{std::make_unique<WaylandInputDispatcher>(seat, client, surface)},
       window_size{geometry::Size{0,0}},
       destroyed{std::make_shared<bool>(false)}
 {
@@ -69,13 +60,8 @@ void mf::WaylandSurfaceObserver::attrib_changed(ms::Surface const*, MirWindowAtt
         run_on_wayland_thread_unless_destroyed([this, value]()
             {
                 auto has_focus = static_cast<bool>(value);
-                if (has_focus)
-                    seat->notify_focus(client);
+                input_dispatcher->set_focus(has_focus);
                 window->handle_active_change(has_focus);
-                seat->for_each_listener(client, [surface = surface, has_focus = has_focus](WlKeyboard* keyboard)
-                    {
-                        keyboard->focussed(surface, has_focus);
-                    });
             });
         break;
 
@@ -127,10 +113,7 @@ void mf::WaylandSurfaceObserver::keymap_changed(
     run_on_wayland_thread_unless_destroyed(
         [this, keymap]()
         {
-            seat->for_each_listener(client, [&keymap](WlKeyboard* keyboard)
-                {
-                    keyboard->set_keymap(*keymap);
-                });
+            input_dispatcher->set_keymap(*keymap);
         });
 }
 
@@ -151,209 +134,16 @@ void mf::WaylandSurfaceObserver::input_consumed(ms::Surface const*, MirEvent con
     run_on_wayland_thread_unless_destroyed(
         [this, owned_event]()
         {
-            if (mir_event_get_type(owned_event.get()) != mir_event_type_input)
-            {
-                log_warning(
-                    "WaylandSurfaceObserver::input_consumed() got non-input event type %d",
-                    mir_event_get_type(owned_event.get()));
-                return;
-            }
-            auto const input_ev = mir_event_get_input_event(owned_event.get());
-            handle_input_event(input_ev);
+            input_dispatcher->handle_event(owned_event.get());
         });
+}
+
+auto mf::WaylandSurfaceObserver::latest_timestamp() const -> std::chrono::nanoseconds
+{
+    return input_dispatcher->latest_timestamp();
 }
 
 void mf::WaylandSurfaceObserver::run_on_wayland_thread_unless_destroyed(std::function<void()>&& work)
 {
     seat->spawn(run_unless(destroyed, work));
-}
-
-void mf::WaylandSurfaceObserver::handle_input_event(MirInputEvent const* event)
-{
-    auto const ns = std::chrono::nanoseconds{mir_input_event_get_event_time(event)};
-    auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(ns);
-
-    // Remember the timestamp of any events "signed" with a cookie
-    if (mir_input_event_has_cookie(event))
-        timestamp = ns;
-
-    switch (mir_input_event_get_type(event))
-    {
-    case mir_input_event_type_key:
-        handle_keyboard_event(ms, mir_input_event_get_keyboard_event(event));
-        break;
-    case mir_input_event_type_pointer:
-        handle_pointer_event(ms, mir_input_event_get_pointer_event(event));
-        break;
-    case mir_input_event_type_touch:
-        handle_touch_event(ms, mir_input_event_get_touch_event(event));
-        break;
-    default:
-        break;
-    }
-}
-
-void mf::WaylandSurfaceObserver::handle_keyboard_event(std::chrono::milliseconds const& ms, MirKeyboardEvent const* event)
-{
-    MirKeyboardAction const action = mir_keyboard_event_action(event);
-    if (action == mir_keyboard_action_down || action == mir_keyboard_action_up)
-    {
-        int const scancode = mir_keyboard_event_scan_code(event);
-        bool const down = action == mir_keyboard_action_down;
-        seat->for_each_listener(client, [&ms, scancode, down](WlKeyboard* keyboard)
-            {
-                keyboard->key(ms, scancode, down);
-            });
-    }
-}
-
-void mf::WaylandSurfaceObserver::handle_pointer_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event)
-{
-    switch(mir_pointer_event_action(event))
-    {
-        case mir_pointer_action_button_down:
-        case mir_pointer_action_button_up:
-            handle_pointer_button_event(ms, event);
-            break;
-        case mir_pointer_action_enter:
-        {
-            geom::Point const position{
-                mir_pointer_event_axis_value(event, mir_pointer_axis_x),
-                mir_pointer_event_axis_value(event, mir_pointer_axis_y)};
-            seat->for_each_listener(client, [surface = surface, &position](WlPointer* pointer)
-                {
-                    pointer->enter(surface, position);
-                    pointer->frame();
-                });
-            break;
-        }
-        case mir_pointer_action_leave:
-            seat->for_each_listener(client, [](WlPointer* pointer)
-                {
-                    pointer->leave();
-                    pointer->frame();
-                });
-            break;
-        case mir_pointer_action_motion:
-            handle_pointer_motion_event(ms, event);
-            break;
-        case mir_pointer_actions:
-            break;
-    }
-}
-
-void mf::WaylandSurfaceObserver::handle_pointer_button_event(
-    std::chrono::milliseconds const& ms,
-    MirPointerEvent const* event)
-{
-    MirPointerButtons const event_buttons = mir_pointer_event_buttons(event);
-    std::vector<std::pair<uint32_t, bool>> buttons;
-
-    for (auto const& mapping :
-        {
-            std::make_pair(mir_pointer_button_primary, BTN_LEFT),
-            std::make_pair(mir_pointer_button_secondary, BTN_RIGHT),
-            std::make_pair(mir_pointer_button_tertiary, BTN_MIDDLE),
-            std::make_pair(mir_pointer_button_back, BTN_BACK),
-            std::make_pair(mir_pointer_button_forward, BTN_FORWARD),
-            std::make_pair(mir_pointer_button_side, BTN_SIDE),
-            std::make_pair(mir_pointer_button_task, BTN_TASK),
-            std::make_pair(mir_pointer_button_extra, BTN_EXTRA)
-        })
-    {
-        if (mapping.first & (event_buttons ^ last_pointer_buttons))
-        {
-            bool const pressed = (mapping.first & event_buttons);
-            buttons.push_back(std::make_pair(mapping.second, pressed));
-        }
-    }
-
-    if (!buttons.empty())
-    {
-        seat->for_each_listener(client, [&ms, &buttons](WlPointer* pointer)
-            {
-                for (auto& button : buttons)
-                {
-                    pointer->button(ms, button.first, button.second);
-                }
-                pointer->frame();
-            });
-    }
-
-    last_pointer_buttons = event_buttons;
-}
-
-void mf::WaylandSurfaceObserver::handle_pointer_motion_event(
-    std::chrono::milliseconds const& ms,
-    MirPointerEvent const* event)
-{
-    // TODO: send axis_source, axis_stop and axis_discrete events where appropriate
-    // (may require significant eworking of the input system)
-
-    geom::Point const position{
-        mir_pointer_event_axis_value(event, mir_pointer_axis_x),
-        mir_pointer_event_axis_value(event, mir_pointer_axis_y)};
-    geom::Displacement const axis_motion{
-        mir_pointer_event_axis_value(event, mir_pointer_axis_hscroll) * 10,
-        mir_pointer_event_axis_value(event, mir_pointer_axis_vscroll) * 10};
-    bool const send_motion = (!last_pointer_position || position != last_pointer_position.value());
-    bool const send_axis = (axis_motion != geom::Displacement{});
-
-    last_pointer_position = position;
-
-    if (send_motion || send_axis)
-    {
-        seat->for_each_listener(
-            client,
-            [&ms, surface = surface, &send_motion, &position, &send_axis, &axis_motion](WlPointer* pointer)
-            {
-                if (send_motion)
-                    pointer->motion(ms, surface, position);
-                if (send_axis)
-                    pointer->axis(ms, axis_motion);
-                pointer->frame();
-            });
-    }
-}
-
-void mf::WaylandSurfaceObserver::handle_touch_event(
-    std::chrono::milliseconds const& ms,
-    MirTouchEvent const* event)
-{
-    for (auto i = 0u; i < mir_touch_event_point_count(event); ++i)
-    {
-        geometry::Point const position{
-            mir_touch_event_axis_value(event, i, mir_touch_axis_x),
-            mir_touch_event_axis_value(event, i, mir_touch_axis_y)};
-        int const touch_id = mir_touch_event_id(event, i);
-        MirTouchAction const action = mir_touch_event_action(event, i);
-
-        switch (action)
-        {
-        case mir_touch_action_down:
-            seat->for_each_listener(client, [&ms, touch_id, surface = surface, &position](WlTouch* touch)
-                {
-                    touch->down(ms, touch_id, surface, position);
-                });
-            break;
-        case mir_touch_action_up:
-            seat->for_each_listener(client, [&ms, touch_id](WlTouch* touch)
-                {
-                    touch->up(ms, touch_id);
-                });
-            break;
-        case mir_touch_action_change:
-            seat->for_each_listener(client, [&ms, touch_id, surface = surface, &position](WlTouch* touch)
-                {
-                    touch->motion(ms, touch_id, surface, position);
-                });
-            break;
-        case mir_touch_actions:;
-        }
-    }
-
-    seat->for_each_listener(client, [](WlTouch* touch)
-        {
-            touch->frame();
-        });
 }

--- a/src/server/frontend_wayland/wayland_surface_observer.h
+++ b/src/server/frontend_wayland/wayland_surface_observer.h
@@ -42,7 +42,7 @@ class WaylandSurfaceObserver
     : public scene::NullSurfaceObserver
 {
 public:
-    WaylandSurfaceObserver(WlSeat* seat, wl_client* client, WlSurface* surface, WindowWlSurfaceRole* window);
+    WaylandSurfaceObserver(WlSeat* seat, WlSurface* surface, WindowWlSurfaceRole* window);
     ~WaylandSurfaceObserver();
 
     /// Overrides from scene::SurfaceObserver

--- a/src/server/frontend_wayland/wayland_surface_observer.h
+++ b/src/server/frontend_wayland/wayland_surface_observer.h
@@ -36,6 +36,7 @@ namespace frontend
 class WlSurface;
 class WlSeat;
 class WindowWlSurfaceRole;
+class WaylandInputDispatcher;
 
 class WaylandSurfaceObserver
     : public scene::NullSurfaceObserver
@@ -70,10 +71,7 @@ public:
         return requested_size;
     }
 
-    auto latest_timestamp() const -> std::chrono::nanoseconds
-    {
-        return timestamp;
-    }
+    auto latest_timestamp() const -> std::chrono::nanoseconds;
 
     auto state() const -> MirWindowState
     {
@@ -83,29 +81,16 @@ public:
     void disconnect() { *destroyed = true; }
 
 private:
-    WlSeat* const seat;
-    wl_client* const client;
-    WlSurface* const surface;
-    WindowWlSurfaceRole* window;
+    WlSeat* const seat; // only used by run_on_wayland_thread_unless_destroyed()
+    WindowWlSurfaceRole* const window;
+    std::unique_ptr<WaylandInputDispatcher> const input_dispatcher;
+
     geometry::Size window_size;
-    std::chrono::nanoseconds timestamp{0};
     std::experimental::optional<geometry::Size> requested_size;
     MirWindowState current_state{mir_window_state_unknown};
-    MirPointerButtons last_pointer_buttons{0};
-    std::experimental::optional<mir::geometry::Point> last_pointer_position;
     std::shared_ptr<bool> const destroyed;
 
     void run_on_wayland_thread_unless_destroyed(std::function<void()>&& work);
-
-    /// Handle user input events
-    ///@{
-    void handle_input_event(MirInputEvent const* event);
-    void handle_keyboard_event(std::chrono::milliseconds const& ms, MirKeyboardEvent const* event);
-    void handle_pointer_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
-    void handle_pointer_button_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
-    void handle_pointer_motion_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
-    void handle_touch_event(std::chrono::milliseconds const& ms, MirTouchEvent const* event);
-    ///@}
 };
 }
 }

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -74,7 +74,7 @@ mf::WindowWlSurfaceRole::WindowWlSurfaceRole(
       shell{shell},
       session{get_session(client)},
       output_manager{output_manager},
-      observer{std::make_shared<WaylandSurfaceObserver>(seat, client, surface, this)},
+      observer{std::make_shared<WaylandSurfaceObserver>(seat, surface, this)},
       params{std::make_unique<scene::SurfaceCreationParameters>(
           scene::SurfaceCreationParameters().of_type(mir_window_type_freestyle))},
       committed_min_size{0, 0},


### PR DESCRIPTION
Splits input event dispatching out from the rest of the Wayland surface observer. This will allow more easily writing an `XWaylandSurfaceObserver`.