### PR TITLE
[miral-app] Add `xdg-terminal` to the list of possible terminal commands

### DIFF
--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -4,7 +4,7 @@ miral_server=miral-shell
 hostsocket=
 bindir=$(dirname $0)
 
-for terminal in gnome-terminal weston-terminal qterminal lxterminal x-terminal-emulator
+for terminal in gnome-terminal weston-terminal qterminal lxterminal x-terminal-emulator xdg-terminal
 do
   if which $terminal > /dev/null
   then break;


### PR DESCRIPTION
Add `xdg-terminal` to the list of possible terminal commands.

It isn't earlier in the list as it isn't clear that it "does the right thing" for a specific user any more than `x-terminal-emulator` does. But it does exist on a different range of systems.