### PR TITLE
Repurpose XCBAtoms into XCBConnection

### DIFF
--- a/src/server/frontend_xwayland/CMakeLists.txt
+++ b/src/server/frontend_xwayland/CMakeLists.txt
@@ -4,7 +4,7 @@ set(
   xwayland_default_configuration.cpp
   xwayland_connector.cpp  xwayland_connector.h
   xwayland_server.cpp     xwayland_server.h
-  xcb_atoms.cpp           xcb_atoms.h
+  xcb_connection.cpp      xcb_connection.h
   xwayland_wm.cpp         xwayland_wm.h
   xwayland_surface.cpp    xwayland_surface.h
   xwayland_surface_role.cpp xwayland_surface_role.h

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -16,19 +16,19 @@
  *
  */
 
-#include "xcb_atoms.h"
+#include "xcb_connection.h"
 #include "boost/throw_exception.hpp"
 
 namespace mf = mir::frontend;
 
-mf::XCBAtoms::Atom::Atom(std::string const& name, Context const& context)
+mf::XCBConnection::Atom::Atom(std::string const& name, Context const& context)
     : context{context},
       name_{name},
       cookie{xcb_intern_atom(context.xcb_connection, 0, name_.size(), name_.c_str())}
 {
 }
 
-mf::XCBAtoms::Atom::operator xcb_atom_t() const
+mf::XCBConnection::Atom::operator xcb_atom_t() const
 {
     if (!atom)
     {
@@ -41,12 +41,12 @@ mf::XCBAtoms::Atom::operator xcb_atom_t() const
     return atom.value();
 }
 
-auto mf::XCBAtoms::Atom::name() const -> std::string
+auto mf::XCBConnection::Atom::name() const -> std::string
 {
     return name_;
 }
 
-mf::XCBAtoms::XCBAtoms(xcb_connection_t* xcb_connection)
+mf::XCBConnection::XCBConnection(xcb_connection_t* xcb_connection)
     : context{xcb_connection},
       wm_protocols{"WM_PROTOCOLS", context},
       wm_normal_hints{"WM_NORMAL_HINTS", context},

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -21,10 +21,10 @@
 
 namespace mf = mir::frontend;
 
-mf::XCBConnection::Atom::Atom(std::string const& name, Context const& context)
-    : context{context},
+mf::XCBConnection::Atom::Atom(std::string const& name, XCBConnection* connection)
+    : connection{connection},
       name_{name},
-      cookie{xcb_intern_atom(context.xcb_connection, 0, name_.size(), name_.c_str())}
+      cookie{xcb_intern_atom(*connection, 0, name_.size(), name_.c_str())}
 {
 }
 
@@ -32,7 +32,7 @@ mf::XCBConnection::Atom::operator xcb_atom_t() const
 {
     if (!atom)
     {
-        auto const reply = xcb_intern_atom_reply(context.xcb_connection, cookie, nullptr);
+        auto const reply = xcb_intern_atom_reply(*connection, cookie, nullptr);
         if (!reply)
             BOOST_THROW_EXCEPTION(std::runtime_error("Failed to look up atom " + name_));
         atom = reply->atom;
@@ -47,76 +47,81 @@ auto mf::XCBConnection::Atom::name() const -> std::string
 }
 
 mf::XCBConnection::XCBConnection(xcb_connection_t* xcb_connection)
-    : context{xcb_connection},
-      wm_protocols{"WM_PROTOCOLS", context},
-      wm_normal_hints{"WM_NORMAL_HINTS", context},
-      wm_take_focus{"WM_TAKE_FOCUS", context},
-      wm_delete_window{"WM_DELETE_WINDOW", context},
-      wm_state{"WM_STATE", context},
-      wm_change_state{"WM_CHANGE_STATE", context},
-      wm_s0{"WM_S0", context},
-      wm_client_machine{"WM_CLIENT_MACHINE", context},
-      net_wm_cm_s0{"_NET_WM_CM_S0", context},
-      net_wm_name{"_NET_WM_NAME", context},
-      net_wm_pid{"_NET_WM_PID", context},
-      net_wm_icon{"_NET_WM_ICON", context},
-      net_wm_state{"_NET_WM_STATE", context},
-      net_wm_state_maximized_vert{"_NET_WM_STATE_MAXIMIZED_VERT", context},
-      net_wm_state_maximized_horz{"_NET_WM_STATE_MAXIMIZED_HORZ", context},
-      net_wm_state_hidden{"_NET_WM_STATE_HIDDEN", context},
-      net_wm_state_fullscreen{"_NET_WM_STATE_FULLSCREEN", context},
-      net_wm_user_time{"_NET_WM_USER_TIME", context},
-      net_wm_icon_name{"_NET_WM_ICON_NAME", context},
-      net_wm_desktop{"_NET_WM_DESKTOP", context},
-      net_wm_window_type{"_NET_WM_WINDOW_TYPE", context},
-      net_wm_window_type_desktop{"_NET_WM_WINDOW_TYPE_DESKTOP", context},
-      net_wm_window_type_dock{"_NET_WM_WINDOW_TYPE_DOCK", context},
-      net_wm_window_type_toolbar{"_NET_WM_WINDOW_TYPE_TOOLBAR", context},
-      net_wm_window_type_menu{"_NET_WM_WINDOW_TYPE_MENU", context},
-      net_wm_window_type_utility{"_NET_WM_WINDOW_TYPE_UTILITY", context},
-      net_wm_window_type_splash{"_NET_WM_WINDOW_TYPE_SPLASH", context},
-      net_wm_window_type_dialog{"_NET_WM_WINDOW_TYPE_DIALOG", context},
-      net_wm_window_type_dropdown{"_NET_WM_WINDOW_TYPE_DROPDOWN_MENU", context},
-      net_wm_window_type_popup{"_NET_WM_WINDOW_TYPE_POPUP_MENU", context},
-      net_wm_window_type_tooltip{"_NET_WM_WINDOW_TYPE_TOOLTIP", context},
-      net_wm_window_type_notification{"_NET_WM_WINDOW_TYPE_NOTIFICATION", context},
-      net_wm_window_type_combo{"_NET_WM_WINDOW_TYPE_COMBO", context},
-      net_wm_window_type_dnd{"_NET_WM_WINDOW_TYPE_DND", context},
-      net_wm_window_type_normal{"_NET_WM_WINDOW_TYPE_NORMAL", context},
-      net_wm_moveresize{"_NET_WM_MOVERESIZE", context},
-      net_supporting_wm_check{"_NET_SUPPORTING_WM_CHECK", context},
-      net_supported{"_NET_SUPPORTED", context},
-      net_active_window{"_NET_ACTIVE_WINDOW", context},
-      motif_wm_hints{"_MOTIF_WM_HINTS", context},
-      clipboard{"CLIPBOARD", context},
-      clipboard_manager{"CLIPBOARD_MANAGER", context},
-      targets{"TARGETS", context},
-      utf8_string{"UTF8_STRING", context},
-      wl_selection{"_WL_SELECTION", context},
-      incr{"INCR", context},
-      timestamp{"TIMESTAMP", context},
-      multiple{"MULTIPLE", context},
-      compound_text{"COMPOUND_TEXT", context},
-      text{"TEXT", context},
-      string{"STRING", context},
-      window{"WINDOW", context},
-      text_plain_utf8{"text/plain;charset=utf-8", context},
-      text_plain{"text/plain", context},
-      xdnd_selection{"XdndSelection", context},
-      xdnd_aware{"XdndAware", context},
-      xdnd_enter{"XdndEnter", context},
-      xdnd_leave{"XdndLeave", context},
-      xdnd_drop{"XdndDrop", context},
-      xdnd_status{"XdndStatus", context},
-      xdnd_finished{"XdndFinished", context},
-      xdnd_type_list{"XdndTypeList", context},
-      xdnd_action_copy{"XdndActionCopy", context},
-      wl_surface_id{"WL_SURFACE_ID", context},
-      allow_commits{"_XWAYLAND_ALLOW_COMMITS", context}
+    : xcb_connection{xcb_connection},
+      wm_protocols{"WM_PROTOCOLS", this},
+      wm_normal_hints{"WM_NORMAL_HINTS", this},
+      wm_take_focus{"WM_TAKE_FOCUS", this},
+      wm_delete_window{"WM_DELETE_WINDOW", this},
+      wm_state{"WM_STATE", this},
+      wm_change_state{"WM_CHANGE_STATE", this},
+      wm_s0{"WM_S0", this},
+      wm_client_machine{"WM_CLIENT_MACHINE", this},
+      net_wm_cm_s0{"_NET_WM_CM_S0", this},
+      net_wm_name{"_NET_WM_NAME", this},
+      net_wm_pid{"_NET_WM_PID", this},
+      net_wm_icon{"_NET_WM_ICON", this},
+      net_wm_state{"_NET_WM_STATE", this},
+      net_wm_state_maximized_vert{"_NET_WM_STATE_MAXIMIZED_VERT", this},
+      net_wm_state_maximized_horz{"_NET_WM_STATE_MAXIMIZED_HORZ", this},
+      net_wm_state_hidden{"_NET_WM_STATE_HIDDEN", this},
+      net_wm_state_fullscreen{"_NET_WM_STATE_FULLSCREEN", this},
+      net_wm_user_time{"_NET_WM_USER_TIME", this},
+      net_wm_icon_name{"_NET_WM_ICON_NAME", this},
+      net_wm_desktop{"_NET_WM_DESKTOP", this},
+      net_wm_window_type{"_NET_WM_WINDOW_TYPE", this},
+      net_wm_window_type_desktop{"_NET_WM_WINDOW_TYPE_DESKTOP", this},
+      net_wm_window_type_dock{"_NET_WM_WINDOW_TYPE_DOCK", this},
+      net_wm_window_type_toolbar{"_NET_WM_WINDOW_TYPE_TOOLBAR", this},
+      net_wm_window_type_menu{"_NET_WM_WINDOW_TYPE_MENU", this},
+      net_wm_window_type_utility{"_NET_WM_WINDOW_TYPE_UTILITY", this},
+      net_wm_window_type_splash{"_NET_WM_WINDOW_TYPE_SPLASH", this},
+      net_wm_window_type_dialog{"_NET_WM_WINDOW_TYPE_DIALOG", this},
+      net_wm_window_type_dropdown{"_NET_WM_WINDOW_TYPE_DROPDOWN_MENU", this},
+      net_wm_window_type_popup{"_NET_WM_WINDOW_TYPE_POPUP_MENU", this},
+      net_wm_window_type_tooltip{"_NET_WM_WINDOW_TYPE_TOOLTIP", this},
+      net_wm_window_type_notification{"_NET_WM_WINDOW_TYPE_NOTIFICATION", this},
+      net_wm_window_type_combo{"_NET_WM_WINDOW_TYPE_COMBO", this},
+      net_wm_window_type_dnd{"_NET_WM_WINDOW_TYPE_DND", this},
+      net_wm_window_type_normal{"_NET_WM_WINDOW_TYPE_NORMAL", this},
+      net_wm_moveresize{"_NET_WM_MOVERESIZE", this},
+      net_supporting_wm_check{"_NET_SUPPORTING_WM_CHECK", this},
+      net_supported{"_NET_SUPPORTED", this},
+      net_active_window{"_NET_ACTIVE_WINDOW", this},
+      motif_wm_hints{"_MOTIF_WM_HINTS", this},
+      clipboard{"CLIPBOARD", this},
+      clipboard_manager{"CLIPBOARD_MANAGER", this},
+      targets{"TARGETS", this},
+      utf8_string{"UTF8_STRING", this},
+      wl_selection{"_WL_SELECTION", this},
+      incr{"INCR", this},
+      timestamp{"TIMESTAMP", this},
+      multiple{"MULTIPLE", this},
+      compound_text{"COMPOUND_TEXT", this},
+      text{"TEXT", this},
+      string{"STRING", this},
+      window{"WINDOW", this},
+      text_plain_utf8{"text/plain;charset=utf-8", this},
+      text_plain{"text/plain", this},
+      xdnd_selection{"XdndSelection", this},
+      xdnd_aware{"XdndAware", this},
+      xdnd_enter{"XdndEnter", this},
+      xdnd_leave{"XdndLeave", this},
+      xdnd_drop{"XdndDrop", this},
+      xdnd_status{"XdndStatus", this},
+      xdnd_finished{"XdndFinished", this},
+      xdnd_type_list{"XdndTypeList", this},
+      xdnd_action_copy{"XdndActionCopy", this},
+      wl_surface_id{"WL_SURFACE_ID", this},
+      allow_commits{"_XWAYLAND_ALLOW_COMMITS", this}
 {
+}
+
+mf::XCBConnection::~XCBConnection()
+{
+    xcb_disconnect(xcb_connection);
 }
 
 mf::XCBConnection::operator xcb_connection_t*() const
 {
-    return context.xcb_connection;
+    return xcb_connection;
 }

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -46,8 +46,8 @@ auto mf::XCBConnection::Atom::name() const -> std::string
     return name_;
 }
 
-mf::XCBConnection::XCBConnection(xcb_connection_t* xcb_connection)
-    : xcb_connection{xcb_connection},
+mf::XCBConnection::XCBConnection(int fd)
+    : xcb_connection{xcb_connect_to_fd(fd, nullptr)},
       wm_protocols{"WM_PROTOCOLS", this},
       wm_normal_hints{"WM_NORMAL_HINTS", this},
       wm_take_focus{"WM_TAKE_FOCUS", this},

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -115,3 +115,8 @@ mf::XCBConnection::XCBConnection(xcb_connection_t* xcb_connection)
       allow_commits{"_XWAYLAND_ALLOW_COMMITS", context}
 {
 }
+
+mf::XCBConnection::operator xcb_connection_t*() const
+{
+    return context.xcb_connection;
+}

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -30,7 +30,7 @@ namespace frontend
 class XCBConnection
 {
 public:
-    explicit XCBConnection(xcb_connection_t* xcb_connection);
+    explicit XCBConnection(int fd);
     ~XCBConnection();
 
     operator xcb_connection_t*() const;

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -36,7 +36,9 @@ private:
     } const context;
 
 public:
-    XCBConnection(xcb_connection_t* xcb_connection);
+    explicit XCBConnection(xcb_connection_t* xcb_connection);
+
+    operator xcb_connection_t*() const;
 
     class Atom
     {

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -29,22 +29,25 @@ namespace frontend
 {
 class XCBConnection
 {
-private:
-    struct Context
-    {
-        xcb_connection_t* const xcb_connection;
-    } const context;
-
 public:
     explicit XCBConnection(xcb_connection_t* xcb_connection);
+    ~XCBConnection();
 
     operator xcb_connection_t*() const;
 
+private:
+    XCBConnection(XCBConnection&) = delete;
+    XCBConnection(XCBConnection&&) = delete;
+    XCBConnection& operator=(XCBConnection&) = delete;
+
+    xcb_connection_t* const xcb_connection;
+
+public:
     class Atom
     {
     public:
         /// Context should outlive the atom
-        Atom(std::string const& name, Context const& context);
+        Atom(std::string const& name, XCBConnection* connection);
         operator xcb_atom_t() const;
         auto name() const -> std::string;
 
@@ -53,7 +56,7 @@ public:
         Atom(Atom&&) = delete;
         Atom& operator=(Atom&) = delete;
 
-        Context const& context;
+        XCBConnection* const connection;
         std::string const name_;
         xcb_intern_atom_cookie_t const cookie;
         std::experimental::optional<xcb_atom_t> mutable atom;
@@ -124,11 +127,6 @@ public:
     Atom const xdnd_action_copy;
     Atom const wl_surface_id;
     Atom const allow_commits;
-
-private:
-    XCBConnection(XCBConnection&) = delete;
-    XCBConnection(XCBConnection&&) = delete;
-    XCBConnection& operator=(XCBConnection&) = delete;
 };
 }
 }

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef MIR_FRONTEND_XCB_ATOMS_H
-#define MIR_FRONTEND_XCB_ATOMS_H
+#ifndef MIR_FRONTEND_XCB_CONNECTION_H
+#define MIR_FRONTEND_XCB_CONNECTION_H
 
 #include <xcb/xcb.h>
 #include <string>
@@ -27,7 +27,7 @@ namespace mir
 {
 namespace frontend
 {
-class XCBAtoms
+class XCBConnection
 {
 private:
     struct Context
@@ -36,7 +36,7 @@ private:
     } const context;
 
 public:
-    XCBAtoms(xcb_connection_t* xcb_connection);
+    XCBConnection(xcb_connection_t* xcb_connection);
 
     class Atom
     {
@@ -124,11 +124,11 @@ public:
     Atom const allow_commits;
 
 private:
-    XCBAtoms(XCBAtoms&) = delete;
-    XCBAtoms(XCBAtoms&&) = delete;
-    XCBAtoms& operator=(XCBAtoms&) = delete;
+    XCBConnection(XCBConnection&) = delete;
+    XCBConnection(XCBConnection&&) = delete;
+    XCBConnection& operator=(XCBConnection&) = delete;
 };
 }
 }
 
-#endif // MIR_FRONTEND_XCB_ATOMS_H
+#endif // MIR_FRONTEND_XCB_CONNECTION_H

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -85,17 +85,8 @@ mf::XWaylandSurface::XWaylandSurface(
           {event->width, event->height},
           (bool)event->override_redirect}
 {
-    xcb_get_geometry_cookie_t const geometry_cookie = xcb_get_geometry(xwm->get_xcb_connection(), window);
-
-    uint32_t const values[]{
-        XCB_EVENT_MASK_PROPERTY_CHANGE | XCB_EVENT_MASK_FOCUS_CHANGE};
-    xcb_change_window_attributes(xwm->get_xcb_connection(), window, XCB_CW_EVENT_MASK, values);
-
-    xcb_get_geometry_reply_t* const geometry_reply =
-        xcb_get_geometry_reply(xwm->get_xcb_connection(), geometry_cookie, nullptr);
-
-    if (!geometry_reply)
-        mir::log_error("xcb gemom reply faled");
+    uint32_t const value = XCB_EVENT_MASK_PROPERTY_CHANGE | XCB_EVENT_MASK_FOCUS_CHANGE;
+    xcb_change_window_attributes(xwm->get_xcb_connection(), window, XCB_CW_EVENT_MASK, &value);
 }
 
 mf::XWaylandSurface::~XWaylandSurface()

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -135,9 +135,9 @@ class XWaylandSurface
 public:
     XWaylandSurface(
         XWaylandWM *wm,
+        std::shared_ptr<XCBConnection> const& connection,
         WlSeat& seat,
         std::shared_ptr<shell::Shell> const& shell,
-        xcb_connection_t* connection,
         xcb_create_notify_event_t *event);
     ~XWaylandSurface();
 
@@ -196,9 +196,9 @@ private:
     auto latest_input_timestamp(std::lock_guard<std::mutex> const&) -> std::chrono::nanoseconds;
 
     XWaylandWM* const xwm;
+    std::shared_ptr<XCBConnection> const connection;
     WlSeat& seat;
     std::shared_ptr<shell::Shell> const shell;
-    xcb_connection_t* const connection;
     xcb_window_t const window;
 
     std::mutex mutable mutex;

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -137,6 +137,7 @@ public:
         XWaylandWM *wm,
         WlSeat& seat,
         std::shared_ptr<shell::Shell> const& shell,
+        xcb_connection_t* connection,
         xcb_create_notify_event_t *event);
     ~XWaylandSurface();
 
@@ -197,6 +198,7 @@ private:
     XWaylandWM* const xwm;
     WlSeat& seat;
     std::shared_ptr<shell::Shell> const shell;
+    xcb_connection_t* const connection;
     xcb_window_t const window;
 
     std::mutex mutable mutex;

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -479,9 +479,9 @@ void mf::XWaylandWM::handle_create_notify(xcb_create_notify_event_t *event)
     {
         auto const surface = std::make_shared<XWaylandSurface>(
             this,
+            connection,
             wm_shell->seat,
             wm_shell->shell,
-            *connection,
             event);
 
         {

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -478,7 +478,12 @@ void mf::XWaylandWM::handle_create_notify(xcb_create_notify_event_t *event)
 
     if (!is_ours(event->window))
     {
-        auto const surface = std::make_shared<XWaylandSurface>(this, wm_shell->seat, wm_shell->shell, event);
+        auto const surface = std::make_shared<XWaylandSurface>(
+            this,
+            wm_shell->seat,
+            wm_shell->shell,
+            xcb_connection,
+            event);
 
         {
             std::lock_guard<std::mutex> lock{mutex};

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -59,6 +59,7 @@ class XWaylandWM
 {
 private:
     int const wm_fd;
+    std::shared_ptr<XCBConnection> const connection;
 
 public:
     XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, wl_client* wayland_client, int fd);
@@ -66,8 +67,6 @@ public:
 
     auto get_wm_surface(xcb_window_t xcb_window) -> std::experimental::optional<std::shared_ptr<XWaylandSurface>>;
     void run_on_wayland_thread(std::function<void()>&& work);
-
-    std::shared_ptr<XCBConnection> const connection;
 
 private:
 

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -21,7 +21,7 @@
 
 #include "mir/dispatch/threaded_dispatcher.h"
 #include "wayland_connector.h"
-#include "xcb_atoms.h"
+#include "xcb_connection.h"
 
 #include <map>
 #include <thread>
@@ -68,7 +68,7 @@ public:
     auto get_wm_surface(xcb_window_t xcb_window) -> std::experimental::optional<std::shared_ptr<XWaylandSurface>>;
     void run_on_wayland_thread(std::function<void()>&& work);
 
-    XCBAtoms const xcb_atom;
+    XCBConnection const xcb_atom;
 
 private:
 

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -59,7 +59,6 @@ class XWaylandWM
 {
 private:
     int const wm_fd;
-    xcb_connection_t* const xcb_connection;
 
 public:
     XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, wl_client* wayland_client, int fd);
@@ -68,7 +67,7 @@ public:
     auto get_wm_surface(xcb_window_t xcb_window) -> std::experimental::optional<std::shared_ptr<XWaylandSurface>>;
     void run_on_wayland_thread(std::function<void()>&& work);
 
-    XCBConnection const xcb_atom;
+    std::shared_ptr<XCBConnection> const connection;
 
 private:
 

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -65,11 +65,6 @@ public:
     XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, wl_client* wayland_client, int fd);
     ~XWaylandWM();
 
-    auto get_xcb_connection() const -> xcb_connection_t*
-    {
-        return xcb_connection;
-    }
-
     auto get_wm_surface(xcb_window_t xcb_window) -> std::experimental::optional<std::shared_ptr<XWaylandSurface>>;
     void run_on_wayland_thread(std::function<void()>&& work);
 


### PR DESCRIPTION
The new `XCBConnection` class holds atoms as the `XCBAtoms` class used to. It also now manages the lifetime and gives access to the `xcb_connection_t`. It is passed to each surface, which reduces dependence of the surfaces on the window manager. In the future, XCB helper methods such as setting properties on windows could be implemented on the `XCBConnection`.