### PR TITLE
XCBConnection helpers

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -125,3 +125,20 @@ mf::XCBConnection::operator xcb_connection_t*() const
 {
     return xcb_connection;
 }
+
+auto mf::XCBConnection::xcb_type_atom(XCBType type) const -> xcb_atom_t
+{
+    switch (type)
+    {
+        case XCBType::ATOM:         return XCB_ATOM_ATOM;
+        case XCBType::WINDOW:       return XCB_ATOM_WINDOW;
+        case XCBType::CARDINAL32:   return XCB_ATOM_CARDINAL;
+        case XCBType::STRING:       return XCB_ATOM_STRING;
+        case XCBType::UTF8_STRING:  return utf8_string;
+        case XCBType::WM_STATE:     return wm_state;
+    }
+
+    BOOST_THROW_EXCEPTION(std::runtime_error(
+        "Invalid XCB type " +
+        std::to_string(static_cast<std::underlying_type<XCBType>::type>(type))));
+}

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -114,6 +114,11 @@ public:
         xcb_delete_property(xcb_connection, window, property);
     }
 
+    inline void flush()
+    {
+        xcb_flush(xcb_connection);
+    }
+
     Atom const wm_protocols;
     Atom const wm_normal_hints;
     Atom const wm_take_focus;

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -22,6 +22,7 @@
 #include <xcb/xcb.h>
 #include <string>
 #include <vector>
+#include <functional>
 #include <experimental/optional>
 
 namespace mir
@@ -81,6 +82,30 @@ public:
     auto query_name(xcb_atom_t atom) -> std::string;
     auto reply_contains_string_data(xcb_get_property_reply_t const* reply) -> bool;
     auto string_from(xcb_get_property_reply_t const* reply) -> std::string;
+
+    /// Read a single property of various types from the window
+    /// Returns a function that will wait on the reply before calling action()
+    /// @{
+    auto read_property(
+        xcb_window_t window,
+        xcb_atom_t prop,
+        std::function<void(xcb_get_property_reply_t*)> action) -> std::function<void()>;
+
+    auto read_property(
+        xcb_window_t window,
+        xcb_atom_t prop,
+        std::function<void(std::string const&)> action) -> std::function<void()>;
+
+    auto read_property(
+        xcb_window_t window,
+        xcb_atom_t prop,
+        std::function<void(uint32_t)> action) -> std::function<void()>;
+
+    auto read_property(
+        xcb_window_t window,
+        xcb_atom_t prop,
+        std::function<void(std::vector<uint32_t>)> action) -> std::function<void()>;
+    /// @}
 
     /// Set X11 window properties
     /// Safer and more fun than the C-style function provided by XCB

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -77,6 +77,11 @@ public:
 
     operator xcb_connection_t*() const;
 
+    /// Does a round-trip to the X server and does not cache. Should be improved if needed on normal code paths
+    auto query_name(xcb_atom_t atom) -> std::string;
+    auto reply_contains_string_data(xcb_get_property_reply_t const* reply) -> bool;
+    auto string_from(xcb_get_property_reply_t const* reply) -> std::string;
+
     /// Set X11 window properties
     /// Safer and more fun than the C-style function provided by XCB
     /// @{

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -21,25 +21,35 @@
 
 #include <xcb/xcb.h>
 #include <string>
+#include <vector>
 #include <experimental/optional>
 
 namespace mir
 {
 namespace frontend
 {
+/// Types for window properties
+enum class XCBType
+{
+    ATOM,
+    WINDOW,
+    CARDINAL32, ///< also known as an unsigned int
+    STRING,
+    UTF8_STRING,
+    WM_STATE,
+};
+
+template<XCBType T> struct NativeXCBType                { typedef void type;};
+template<> struct NativeXCBType<XCBType::ATOM>          { typedef xcb_atom_t type; };
+template<> struct NativeXCBType<XCBType::WINDOW>        { typedef xcb_window_t type; };
+template<> struct NativeXCBType<XCBType::CARDINAL32>    { typedef uint32_t type; };
+template<> struct NativeXCBType<XCBType::STRING>        { typedef char type; };
+template<> struct NativeXCBType<XCBType::UTF8_STRING>   { typedef char type; };
+template<> struct NativeXCBType<XCBType::WM_STATE>      { typedef uint32_t type; };
+
 class XCBConnection
 {
-public:
-    explicit XCBConnection(int fd);
-    ~XCBConnection();
-
-    operator xcb_connection_t*() const;
-
 private:
-    XCBConnection(XCBConnection&) = delete;
-    XCBConnection(XCBConnection&&) = delete;
-    XCBConnection& operator=(XCBConnection&) = delete;
-
     xcb_connection_t* const xcb_connection;
 
 public:
@@ -61,6 +71,48 @@ public:
         xcb_intern_atom_cookie_t const cookie;
         std::experimental::optional<xcb_atom_t> mutable atom;
     };
+
+    explicit XCBConnection(int fd);
+    ~XCBConnection();
+
+    operator xcb_connection_t*() const;
+
+    /// Set X11 window properties
+    /// Safer and more fun than the C-style function provided by XCB
+    /// @{
+    template<XCBType type, typename T>
+    inline void set_property(xcb_window_t window, xcb_atom_t property, T data)
+    {
+        set_property<type>(window, property, 1, &data);
+    }
+
+    template<XCBType type, typename T, size_t length>
+    inline void set_property(xcb_window_t window, xcb_atom_t property, T(&data)[length])
+    {
+        set_property<type>(window, property, length, data);
+    }
+
+    template<XCBType type, typename T>
+    inline void set_property(xcb_window_t window, xcb_atom_t property, std::vector<T> const& data)
+    {
+        set_property<type>(window, property, data.size(), data.data());
+    }
+
+    template<XCBType type>
+    inline void set_property(xcb_window_t window, xcb_atom_t property, std::string const& data)
+    {
+        static_assert(
+            type == XCBType::STRING || type == XCBType::UTF8_STRING,
+            "String data should only be used with a string type");
+        set_property<type>(window, property, data.size(), data.c_str());
+    }
+    /// @}
+
+    /// Delete an X11 window property
+    inline void delete_property(xcb_window_t window, xcb_atom_t property)
+    {
+        xcb_delete_property(xcb_connection, window, property);
+    }
 
     Atom const wm_protocols;
     Atom const wm_normal_hints;
@@ -127,6 +179,37 @@ public:
     Atom const xdnd_action_copy;
     Atom const wl_surface_id;
     Atom const allow_commits;
+
+private:
+    XCBConnection(XCBConnection&) = delete;
+    XCBConnection(XCBConnection&&) = delete;
+    XCBConnection& operator=(XCBConnection&) = delete;
+
+    auto xcb_type_atom(XCBType type) const -> xcb_atom_t;
+
+    template<XCBType type, typename T>
+    inline void set_property(
+        xcb_window_t window,
+        xcb_atom_t property,
+        size_t length,
+        T const* data)
+    {
+        // Accidentally sending a pointer instead of the actual data is an easy error to make
+        static_assert(!std::is_pointer<T>::value, "Data type should not be a pointer");
+        static_assert(!std::is_same<typename NativeXCBType<type>::type, void>::value, "Missing Native specialization");
+        static_assert(std::is_same<typename NativeXCBType<type>::type, T>::value, "Specified type does not match data type");
+        auto const format = sizeof(typename NativeXCBType<type>::type) * 8;
+        static_assert(format == 8 || format == 16 || format == 32, "Invalid format");
+        xcb_change_property(
+            xcb_connection,
+            XCB_PROP_MODE_REPLACE,
+            window,
+            property,
+            xcb_type_atom(type),
+            format,
+            length,
+            data);
+    }
 };
 }
 }

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -91,10 +91,8 @@ private:
     void set_cursor(xcb_window_t id, const CursorType &cursor);
     void create_wm_cursor();
     void wm_get_resources();
-    auto get_reply_string(xcb_get_property_reply_t* reply) -> std::experimental::optional<std::string>;
     auto get_reply_debug_string(xcb_get_property_reply_t* reply) -> std::string;
     auto get_window_debug_string(xcb_window_t window) -> std::string;
-    auto get_atom_name(xcb_atom_t atom) -> std::string;
     bool is_ours(uint32_t id);
     void setup_visual_and_colormap();
 


### PR DESCRIPTION
Adds helper methods to `XCBConnection` for getting and setting window properties.

The new property setters are wrappers around the XCB calls that also catch various type and format issues at compile time.

The getters request a property and return a function. When called, the function waits for the property and processes it. This way a number of properties can be queued up, then all read at once (which is more efficient than requiring a round-trip for each one). The old code *was* doing this, but the way it worked was error-prone and required the property request and property processing logic to be split up.