### PR TITLE
XWayland: fix double free of XCB connection

### DIFF
--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -202,11 +202,6 @@ mf::XWaylandWM::~XWaylandWM()
         xcb_free_cursor(*connection, xcb_cursor);
     }
 
-    if (*connection != nullptr)
-    {
-        xcb_disconnect(*connection);
-    }
-
     close(wm_fd);
 }
 


### PR DESCRIPTION
Fixes #1235. Looks like it was just an oversight when moving ownership of the `xcb_connection_t` into `XCBConnection`.