### PR TITLE
Fix GTest deprecation

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,7 +88,7 @@ if (HAS_W_INCONSISTENT_MISSING_OVERRIDE)
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override")
 endif()
 if (HAS_W_GNU_ZERO_VARIADIC_MACRO_ARGUMENTS)
-  # INSTANTIATE_TEST_CASE_P hits this like a slice of lemon wrapped around a large gold brick.
+  # INSTANTIATE_TEST_SUITE_P hits this like a slice of lemon wrapped around a large gold brick.
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-gnu-zero-variadic-macro-arguments")
 else()
   # GCC is a bit less flexible than clang and needs a bigger hammer...
@@ -111,6 +111,13 @@ list(APPEND CMAKE_REQUIRED_LIBRARIES "-lpthread")
 string(REPLACE " -Werror " " " CMAKE_C_FLAGS ${CMAKE_C_FLAGS})    # This flag breaks check_symbol_exists()
 check_symbol_exists(pthread_getname_np pthread.h HAVE_PTHREAD_GETNAME_NP)
 list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "-lpthread")
+
+list(APPEND CMAKE_REQUIRED_HEADERS ${GTEST_INCLUDE_DIRECTORIES})
+check_cxx_symbol_exists(INSTANTIATE_TEST_SUITE_P "gtest/gtest.h" HAVE_INSTANTIATE_TEST_SUITE_P)
+if (NOT HAVE_INSTANTIATE_TEST_SUITE_P)
+  #GTest conveniently renamed INSTANTIATE_TEST_CASE_P and then deprecated it.
+  add_definitions(-DINSTANTIATE_TEST_SUITE_P=INSTANTIATE_TEST_CASE_P)
+endif()
 
 if (MIR_BUILD_PLATFORM_MESA_KMS)
   add_definitions(-DMIR_BUILD_PLATFORM_MESA_KMS)

--- a/tests/acceptance-tests/server_signal_handling.cpp
+++ b/tests/acceptance-tests/server_signal_handling.cpp
@@ -90,7 +90,7 @@ TEST_P(AbortDeathTest, cleanup_handler_is_called_for)
     cleanup_done.wait_for_signal_ready_for(timeout);
 }
 
-INSTANTIATE_TEST_CASE_P(ServerSignal, AbortDeathTest,
+INSTANTIATE_TEST_SUITE_P(ServerSignal, AbortDeathTest,
     ::testing::Values(SIGQUIT, SIGABRT, SIGFPE, SIGSEGV, SIGBUS));
 
 using ServerSignalDeathTest = ServerSignal;

--- a/tests/acceptance-tests/test_client_scaling.cpp
+++ b/tests/acceptance-tests/test_client_scaling.cpp
@@ -191,4 +191,4 @@ TEST_P(SurfaceScaling, compositor_sees_size_different_when_scaled)
     EXPECT_TRUE(an_entry_with_differing_size);
 }
 
-INSTANTIATE_TEST_CASE_P(PerSwapInterval, SurfaceScaling, ::testing::Values(0,1));
+INSTANTIATE_TEST_SUITE_P(PerSwapInterval, SurfaceScaling, ::testing::Values(0,1));

--- a/tests/acceptance-tests/test_client_surface_events.cpp
+++ b/tests/acceptance-tests/test_client_surface_events.cpp
@@ -267,7 +267,7 @@ TEST_P(OrientationEvents, surface_receives_orientation_events)
     EXPECT_THAT(last_event, mt::OrientationEvent(direction));
 }
 
-INSTANTIATE_TEST_CASE_P(ClientSurfaceEvents,
+INSTANTIATE_TEST_SUITE_P(ClientSurfaceEvents,
     OrientationEvents,
     Values(mir_orientation_normal, mir_orientation_left, mir_orientation_inverted, mir_orientation_right));
 

--- a/tests/acceptance-tests/test_client_surfaces.cpp
+++ b/tests/acceptance-tests/test_client_surfaces.cpp
@@ -140,7 +140,7 @@ TEST_P(WithOrientation, have_requested_preferred_orientation)
     mir_window_release_sync(window);
 }
 
-INSTANTIATE_TEST_CASE_P(ClientSurfaces,
+INSTANTIATE_TEST_SUITE_P(ClientSurfaces,
     WithOrientation, ::testing::Values(
         mir_orientation_mode_portrait, mir_orientation_mode_landscape,
         mir_orientation_mode_portrait_inverted, mir_orientation_mode_landscape_inverted,

--- a/tests/acceptance-tests/test_new_display_configuration.cpp
+++ b/tests/acceptance-tests/test_new_display_configuration.cpp
@@ -540,13 +540,13 @@ TEST_P(DisplaySubpixelSetting, can_get_all_subpixel_arrangements)
 }
 
 
-INSTANTIATE_TEST_CASE_P(DisplayConfiguration, DisplayPowerSetting,
+INSTANTIATE_TEST_SUITE_P(DisplayConfiguration, DisplayPowerSetting,
     Values(mir_power_mode_on, mir_power_mode_standby, mir_power_mode_suspend, mir_power_mode_off));
 
-INSTANTIATE_TEST_CASE_P(DisplayConfiguration, DisplayFormatSetting,
+INSTANTIATE_TEST_SUITE_P(DisplayConfiguration, DisplayFormatSetting,
     ValuesIn(formats));
 
-INSTANTIATE_TEST_CASE_P(DisplayConfiguration, DisplaySubpixelSetting,
+INSTANTIATE_TEST_SUITE_P(DisplayConfiguration, DisplaySubpixelSetting,
     Values(
         mir_subpixel_arrangement_unknown,
         mir_subpixel_arrangement_horizontal_rgb,

--- a/tests/acceptance-tests/test_server_shutdown.cpp
+++ b/tests/acceptance-tests/test_server_shutdown.cpp
@@ -73,7 +73,7 @@ TEST_P(ServerShutdownWithGraphicsPlatformException, clean_shutdown_on_exception)
     server.run();
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     PlatformExceptions,
     ServerShutdownWithGraphicsPlatformException,
     ::testing::Values(
@@ -243,7 +243,7 @@ TEST_P(OnSignalDeathTest, removes_endpoint)
     }
 }
 
-INSTANTIATE_TEST_CASE_P(ServerShutdown,
+INSTANTIATE_TEST_SUITE_P(ServerShutdown,
     OnSignalDeathTest,
     ::testing::Values(SIGQUIT, SIGABRT, SIGFPE, SIGSEGV, SIGBUS));
 

--- a/tests/acceptance-tests/test_surface_modifications.cpp
+++ b/tests/acceptance-tests/test_surface_modifications.cpp
@@ -555,7 +555,7 @@ TEST_P(SurfaceSpecStateCase, set_state_affects_surface_visibility)
        });
 }
 
-INSTANTIATE_TEST_CASE_P(SurfaceModifications, SurfaceSpecStateCase,
+INSTANTIATE_TEST_SUITE_P(SurfaceModifications, SurfaceSpecStateCase,
     Values(
         StatePair{mir_window_state_hidden, mir_window_state_restored},
         StatePair{mir_window_state_hidden, mir_window_state_maximized},
@@ -589,7 +589,7 @@ TEST_P(SurfaceStateCase, set_state_affects_surface_visibility)
     received_new_state.wait_for(400ms);
 }
 
-INSTANTIATE_TEST_CASE_P(SurfaceModifications, SurfaceStateCase,
+INSTANTIATE_TEST_SUITE_P(SurfaceModifications, SurfaceStateCase,
     Values(
         StatePair{mir_window_state_hidden, mir_window_state_restored},
         StatePair{mir_window_state_hidden, mir_window_state_maximized},

--- a/tests/acceptance-tests/test_surface_morphing.cpp
+++ b/tests/acceptance-tests/test_surface_morphing.cpp
@@ -403,7 +403,7 @@ TEST_P(TargetMayHaveParent, not_setting_parent_succeeds)
         });
 }
 
-INSTANTIATE_TEST_CASE_P(SurfaceMorphing, TargetWithoutParent,
+INSTANTIATE_TEST_SUITE_P(SurfaceMorphing, TargetWithoutParent,
     Values(
         TypePair{mir_window_type_normal, mir_window_type_utility},
         TypePair{mir_window_type_utility, mir_window_type_normal},
@@ -411,14 +411,14 @@ INSTANTIATE_TEST_CASE_P(SurfaceMorphing, TargetWithoutParent,
         TypePair{mir_window_type_dialog, mir_window_type_normal}
     ));
 
-INSTANTIATE_TEST_CASE_P(SurfaceMorphing, TargetNeedingParent,
+INSTANTIATE_TEST_SUITE_P(SurfaceMorphing, TargetNeedingParent,
     Values(
         TypePair{mir_window_type_normal, mir_window_type_satellite},
         TypePair{mir_window_type_utility, mir_window_type_satellite},
         TypePair{mir_window_type_dialog, mir_window_type_satellite}
     ));
 
-INSTANTIATE_TEST_CASE_P(SurfaceMorphing, TargetMayHaveParent,
+INSTANTIATE_TEST_SUITE_P(SurfaceMorphing, TargetMayHaveParent,
     Values(
         TypePair{mir_window_type_normal, mir_window_type_dialog},
         TypePair{mir_window_type_utility, mir_window_type_dialog}

--- a/tests/acceptance-tests/test_surface_placement.cpp
+++ b/tests/acceptance-tests/test_surface_placement.cpp
@@ -498,7 +498,7 @@ TEST_P(UnparentedSurface, small_window_is_optically_centered_on_first_display)
     mir_window_release_sync(window);
 }
 
-INSTANTIATE_TEST_CASE_P(SurfacePlacement, UnparentedSurface,
+INSTANTIATE_TEST_SUITE_P(SurfacePlacement, UnparentedSurface,
     ::testing::Values(
         mir_window_type_normal,
         mir_window_type_utility,
@@ -564,7 +564,7 @@ TEST_P(ParentedSurface, small_window_is_optically_centered_on_parent)
     mir_window_release_sync(parent);
 }
 
-INSTANTIATE_TEST_CASE_P(SurfacePlacement, ParentedSurface,
+INSTANTIATE_TEST_SUITE_P(SurfacePlacement, ParentedSurface,
     ::testing::Values(
         mir_window_type_dialog,
         mir_window_type_satellite,

--- a/tests/acceptance-tests/test_surface_specification.cpp
+++ b/tests/acceptance-tests/test_surface_specification.cpp
@@ -729,11 +729,11 @@ TEST_P(SurfaceMayHaveParent, not_setting_parent_succeeds)
     EXPECT_THAT(surface, IsValidSurface());
 }
 
-INSTANTIATE_TEST_CASE_P(SurfaceSpecification, SurfaceWithoutParent,
+INSTANTIATE_TEST_SUITE_P(SurfaceSpecification, SurfaceWithoutParent,
                         Values(mir_window_type_utility, mir_window_type_normal));
 
-INSTANTIATE_TEST_CASE_P(SurfaceSpecification, SurfaceNeedingParent,
+INSTANTIATE_TEST_SUITE_P(SurfaceSpecification, SurfaceNeedingParent,
                         Values(mir_window_type_satellite, mir_window_type_gloss, mir_window_type_tip));
 
-INSTANTIATE_TEST_CASE_P(SurfaceSpecification, SurfaceMayHaveParent,
+INSTANTIATE_TEST_SUITE_P(SurfaceSpecification, SurfaceMayHaveParent,
                         Values(mir_window_type_dialog, mir_window_type_freestyle));

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -1,4 +1,4 @@
-# We can't tell which version of gtest we're building against and INSTANTIATE_TEST_CASE_P changed in
+# We can't tell which version of gtest we're building against and INSTANTIATE_TEST_SUITE_P changed in
 # a way that relies on a gcc extension to support backward-compatible code, So...
 check_cxx_compiler_flag(-Wno-gnu-zero-variadic-macro-arguments MIRAL_COMPILE_WITH_W_NO_GNU_ZERO_VARIADIC_MACRO_ARGUMENTS)
 check_cxx_compiler_flag(-Wno-pedantic MIRAL_COMPILE_WITH_W_NO_PEDANTIC)

--- a/tests/miral/depth_layer.cpp
+++ b/tests/miral/depth_layer.cpp
@@ -276,7 +276,7 @@ TEST_P(DepthLayer, grand_child_moved_with_grand_parent)
     EXPECT_THAT(grand_child_surface->depth_layer(), Eq(layer));
 }
 
-INSTANTIATE_TEST_CASE_P(DepthLayer, DepthLayer, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(DepthLayer, DepthLayer, ::testing::Values(
     mir_depth_layer_background,
     mir_depth_layer_below,
     mir_depth_layer_application,

--- a/tests/miral/drag_active_window.cpp
+++ b/tests/miral/drag_active_window.cpp
@@ -107,7 +107,7 @@ TEST_P(ForUnmoveableTypes, doesnt_move)
 // Popups, glosses, and tips should not be.
 // Freestyle surfaces may or may not be, as specified by the app.
 //                              Mir and Unity: Surfaces, input, and displays (v0.3)
-INSTANTIATE_TEST_CASE_P(DragActiveWindow, ForMoveableTypes, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(DragActiveWindow, ForMoveableTypes, ::testing::Values(
     mir_window_type_normal,
     mir_window_type_utility,
     mir_window_type_dialog,
@@ -121,7 +121,7 @@ INSTANTIATE_TEST_CASE_P(DragActiveWindow, ForMoveableTypes, ::testing::Values(
 ));
 
 
-INSTANTIATE_TEST_CASE_P(DragActiveWindow, ForUnmoveableTypes, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(DragActiveWindow, ForUnmoveableTypes, ::testing::Values(
 //    mir_window_type_normal,
 //    mir_window_type_utility,
 //    mir_window_type_dialog,

--- a/tests/miral/ignored_requests.cpp
+++ b/tests/miral/ignored_requests.cpp
@@ -153,7 +153,7 @@ TEST_F(IgnoredRequests, remove_session_twice_noops)
     basic_window_manager.remove_session(session);
 }
 
-INSTANTIATE_TEST_CASE_P(UnknownWindow, IgnoredRequests, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(UnknownWindow, IgnoredRequests, ::testing::Values(
     IgnoredRequestParam{
         "null window",
         [](IgnoredRequests& test){ return test.create_null_window(); }},
@@ -164,7 +164,7 @@ INSTANTIATE_TEST_CASE_P(UnknownWindow, IgnoredRequests, ::testing::Values(
         "never before seen window",
         [](IgnoredRequests& test){ return test.create_never_before_seen_window(); }}));
 
-INSTANTIATE_TEST_CASE_P(UnknownSession, IgnoredRequests, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(UnknownSession, IgnoredRequests, ::testing::Values(
     IgnoredRequestParam{
         "destroyed session",
         [](IgnoredRequests& test)

--- a/tests/miral/modify_window_state.cpp
+++ b/tests/miral/modify_window_state.cpp
@@ -92,7 +92,7 @@ TEST_P(ForNormalSurface, state)
 }
 }
 
-INSTANTIATE_TEST_CASE_P(ModifyWindowState, ForNormalSurface, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(ModifyWindowState, ForNormalSurface, ::testing::Values(
 //    mir_window_state_unknown,
     mir_window_state_restored,
     mir_window_state_minimized,

--- a/tests/miral/window_placement_attached.cpp
+++ b/tests/miral/window_placement_attached.cpp
@@ -682,7 +682,7 @@ TEST_P(WindowPlacementAttached, window_placed_correctly_when_output_id_changes)
     EXPECT_THAT(window.size(), Eq(placement.size));
 }
 
-INSTANTIATE_TEST_CASE_P(WindowPlacementAttached, WindowPlacementAttached, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(WindowPlacementAttached, WindowPlacementAttached, ::testing::Values(
     mir_placement_gravity_center,
     mir_placement_gravity_west,
     mir_placement_gravity_east,

--- a/tests/unit-tests/graphics/test_shm_buffer.cpp
+++ b/tests/unit-tests/graphics/test_shm_buffer.cpp
@@ -289,7 +289,7 @@ std::string to_string(MirPixelFormat format)
 }
 
 #if GTEST_AT_LEAST(1, 8, 0)
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ShmBuffer,
     UploadTest,
     ValuesIn(test_cases),
@@ -299,7 +299,7 @@ INSTANTIATE_TEST_CASE_P(
     });
 #else
 // TODO: The version of gtest in 16.04 doesn't have the “print the test nicely” option.
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ShmBuffer,
     UploadTest,
     ValuesIn(test_cases));

--- a/tests/unit-tests/input/evdev/test_evdev_device_detection.cpp
+++ b/tests/unit-tests/input/evdev/test_evdev_device_detection.cpp
@@ -48,7 +48,7 @@ TEST_P(EvdevDeviceDetection, evaluates_expected_input_class)
     EXPECT_THAT(info.capabilities, Eq(std::get<1>(param)));
 }
 
-INSTANTIATE_TEST_CASE_P(InputDeviceCapabilityDetection,
+INSTANTIATE_TEST_SUITE_P(InputDeviceCapabilityDetection,
                         EvdevDeviceDetection,
                         ::testing::Values(
                             std::make_tuple(

--- a/tests/unit-tests/input/evdev/test_evdev_input_platform.cpp
+++ b/tests/unit-tests/input/evdev/test_evdev_input_platform.cpp
@@ -230,7 +230,7 @@ TEST_P(EvdevInputPlatform, removes_devices_on_stop)
     platform->stop();
 }
 
-INSTANTIATE_TEST_CASE_P(DeviceHandling,
+INSTANTIATE_TEST_SUITE_P(DeviceHandling,
                         EvdevInputPlatform,
                         ::testing::Values(
                             "synaptics-touchpad",

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -899,22 +899,22 @@ TEST_P(BasicSurfaceAttributeTest, throws_on_invalid_value)
         }, std::logic_error);
 }
 
-INSTANTIATE_TEST_CASE_P(SurfaceTypeAttributeTest, BasicSurfaceAttributeTest,
+INSTANTIATE_TEST_SUITE_P(SurfaceTypeAttributeTest, BasicSurfaceAttributeTest,
    ::testing::Values(surface_type_test_parameters));
 
-INSTANTIATE_TEST_CASE_P(SurfaceVisibilityAttributeTest, BasicSurfaceAttributeTest,
+INSTANTIATE_TEST_SUITE_P(SurfaceVisibilityAttributeTest, BasicSurfaceAttributeTest,
    ::testing::Values(surface_visibility_test_parameters));
 
-INSTANTIATE_TEST_CASE_P(SurfaceStateAttributeTest, BasicSurfaceAttributeTest,
+INSTANTIATE_TEST_SUITE_P(SurfaceStateAttributeTest, BasicSurfaceAttributeTest,
    ::testing::Values(surface_state_test_parameters));
 
-INSTANTIATE_TEST_CASE_P(SurfaceSwapintervalAttributeTest, BasicSurfaceAttributeTest,
+INSTANTIATE_TEST_SUITE_P(SurfaceSwapintervalAttributeTest, BasicSurfaceAttributeTest,
    ::testing::Values(surface_swapinterval_test_parameters));
 
-INSTANTIATE_TEST_CASE_P(SurfaceDPIAttributeTest, BasicSurfaceAttributeTest,
+INSTANTIATE_TEST_SUITE_P(SurfaceDPIAttributeTest, BasicSurfaceAttributeTest,
    ::testing::Values(surface_dpi_test_parameters));
 
-INSTANTIATE_TEST_CASE_P(SurfaceFocusAttributeTest, BasicSurfaceAttributeTest,
+INSTANTIATE_TEST_SUITE_P(SurfaceFocusAttributeTest, BasicSurfaceAttributeTest,
    ::testing::Values(surface_focus_test_parameters));
 
 TEST_F(BasicSurfaceTest, default_focus_state)

--- a/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
+++ b/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
@@ -711,7 +711,7 @@ TEST_P(ResizeBasicDecoration, sets_cursor)
     EXPECT_TRUE(spec.cursor_image.is_set());
 }
 
-INSTANTIATE_TEST_CASE_P(ResizeBasicDecorationInsideCorners, ResizeBasicDecoration, Values(
+INSTANTIATE_TEST_SUITE_P(ResizeBasicDecorationInsideCorners, ResizeBasicDecoration, Values(
     ResizeParam{nine_points(default_window_size)[0][0], mir_resize_edge_northwest},
     ResizeParam{nine_points(default_window_size)[0][1], mir_resize_edge_north},
     ResizeParam{nine_points(default_window_size)[0][2], mir_resize_edge_northeast},


### PR DESCRIPTION
GTest conveniently renamed `INSTANTIATE_TEST_CASE_P` to `INSTANTATE_TEST_SUITE_P` and deprecated the old name. This breaks the build on Focal.

Switch to the new name, providing the old name on older GTests via a compatibility `#define`.