### PR TITLE
XWayland: more refactoring

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -23,6 +23,7 @@
 #include "boost/throw_exception.hpp"
 
 namespace mf = mir::frontend;
+namespace geom = mir::geometry;
 
 mf::XCBConnection::Atom::Atom(std::string const& name, XCBConnection* connection)
     : connection{connection},
@@ -268,6 +269,34 @@ auto mf::XCBConnection::read_property(
 
             action(values);
         });
+}
+
+void mf::XCBConnection::configure_window(
+    xcb_window_t window,
+    std::experimental::optional<geometry::Point> position,
+    std::experimental::optional<geometry::Size> size)
+{
+    std::vector<uint32_t> values;
+    uint32_t mask = 0;
+
+    if (position)
+    {
+        mask |= XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y;
+        values.push_back(position.value().x.as_int());
+        values.push_back(position.value().y.as_int());
+    }
+
+    if (size)
+    {
+        mask |= XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT;
+        values.push_back(size.value().width.as_int());
+        values.push_back(size.value().height.as_int());
+    }
+
+    if (!values.empty())
+    {
+        xcb_configure_window(xcb_connection, window, mask, values.data());
+    }
 }
 
 auto mf::XCBConnection::xcb_type_atom(XCBType type) const -> xcb_atom_t

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -19,6 +19,9 @@
 #ifndef MIR_FRONTEND_XCB_CONNECTION_H
 #define MIR_FRONTEND_XCB_CONNECTION_H
 
+#include "mir/geometry/point.h"
+#include "mir/geometry/size.h"
+
 #include <xcb/xcb.h>
 #include <string>
 #include <vector>
@@ -143,6 +146,12 @@ public:
     {
         xcb_delete_property(xcb_connection, window, property);
     }
+
+    /// Wrapper around xcb_configure_window
+    void configure_window(
+        xcb_window_t window,
+        std::experimental::optional<geometry::Point> position,
+        std::experimental::optional<geometry::Size> size);
 
     inline void flush()
     {

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -104,7 +104,13 @@ mf::XWaylandSurface::~XWaylandSurface()
 
 void mf::XWaylandSurface::map()
 {
-    scene_surface_state_set(mir_window_state_restored); // TODO: use the real window state
+    WindowState state;
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        state = window_state;
+    }
+    state.withdrawn = false;
+    set_window_state(state);
 }
 
 void mf::XWaylandSurface::close()
@@ -291,13 +297,13 @@ void mf::XWaylandSurface::set_workspace(int workspace)
 
 void mf::XWaylandSurface::unmap()
 {
-    uint32_t const wm_state_properties[]{
-        static_cast<uint32_t>(WmState::WITHDRAWN),
-        XCB_WINDOW_NONE // Icon window
-    };
-    connection->set_property<XCBType::WM_STATE>(window, connection->wm_state, wm_state_properties);
-    connection->delete_property(window, connection->net_wm_state);
-    connection->flush();
+    WindowState state;
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        state = window_state;
+    }
+    state.withdrawn = true;
+    set_window_state(state);
 }
 
 void mf::XWaylandSurface::read_properties()
@@ -528,10 +534,14 @@ void mf::XWaylandSurface::create_scene_surface_if_needed()
 
 void mf::XWaylandSurface::set_window_state(WindowState const& new_window_state)
 {
-    WmState const wm_state{
-        new_window_state.minimized ?
-        WmState::ICONIC :
-        WmState::NORMAL};
+    WmState wm_state;
+
+    if (new_window_state.withdrawn)
+        wm_state = WmState::WITHDRAWN;
+    else if (new_window_state.minimized)
+        wm_state = WmState::ICONIC;
+    else
+        wm_state = WmState::NORMAL;
 
     uint32_t const wm_state_properties[]{
         static_cast<uint32_t>(wm_state),
@@ -539,27 +549,39 @@ void mf::XWaylandSurface::set_window_state(WindowState const& new_window_state)
     };
     connection->set_property<XCBType::WM_STATE>(window, connection->wm_state, wm_state_properties);
 
-    std::vector<xcb_atom_t> net_wm_states;
+    if (new_window_state.withdrawn)
+    {
+        xcb_delete_property(
+            *connection,
+            window,
+            connection->net_wm_state);
+    }
+    else
+    {
+        std::vector<xcb_atom_t> net_wm_states;
 
-    if (new_window_state.minimized)
-    {
-        net_wm_states.push_back(connection->net_wm_state_hidden);
-    }
-    if (new_window_state.maximized)
-    {
-        net_wm_states.push_back(connection->net_wm_state_maximized_horz);
-        net_wm_states.push_back(connection->net_wm_state_maximized_vert);
-    }
-    if (new_window_state.fullscreen)
-    {
-        net_wm_states.push_back(connection->net_wm_state_fullscreen);
-    }
-    // TODO: Set _NET_WM_STATE_MODAL if appropriate
+        if (new_window_state.minimized)
+        {
+            net_wm_states.push_back(connection->net_wm_state_hidden);
+        }
+        if (new_window_state.maximized)
+        {
+            net_wm_states.push_back(connection->net_wm_state_maximized_horz);
+            net_wm_states.push_back(connection->net_wm_state_maximized_vert);
+        }
+        if (new_window_state.fullscreen)
+        {
+            net_wm_states.push_back(connection->net_wm_state_fullscreen);
+        }
+        // TODO: Set _NET_WM_STATE_MODAL if appropriate
 
-    connection->set_property<XCBType::ATOM>(window, connection->net_wm_state, net_wm_states);
+        connection->set_property<XCBType::ATOM>(window, connection->net_wm_state, net_wm_states);
+    }
 
     MirWindowState mir_window_state;
 
+    if (new_window_state.withdrawn)
+        mir_window_state = mir_window_state_hidden;
     if (new_window_state.minimized)
         mir_window_state = mir_window_state_minimized;
     else if (new_window_state.fullscreen)

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -224,6 +224,16 @@ void mf::XWaylandSurface::configure_request(xcb_configure_request_event_t* event
             shell->modify_surface(scene_surface->session().lock(), scene_surface, mods);
         }
     }
+    else
+    {
+        connection->configure_window(
+            window,
+            geom::Point{event->x, event->y},
+            geom::Size{event->width, event->height});
+
+        init.position = {event->x, event->y};
+        init.size = {event->width, event->height};
+    }
 }
 
 void mf::XWaylandSurface::net_wm_state_client_message(uint32_t const (&data)[5])

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -119,6 +119,8 @@ void mf::XWaylandSurface::map()
     state.withdrawn = false;
     inform_client_of_window_state(state);
     request_scene_surface_state(state.mir_window_state());
+    xcb_map_window(*connection, window);
+    connection->flush();
 }
 
 void mf::XWaylandSurface::close()
@@ -150,6 +152,9 @@ void mf::XWaylandSurface::close()
 
     state.withdrawn = true;
     inform_client_of_window_state(state);
+
+    xcb_unmap_window(*connection, window);
+    connection->flush();
 
     if (scene_surface && observer)
     {

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -477,15 +477,15 @@ void mf::XWaylandSurface::scene_surface_state_set(MirWindowState new_state)
     inform_client_of_window_state(state);
 }
 
-void mf::XWaylandSurface::scene_surface_resized(const geometry::Size& new_size)
+void mf::XWaylandSurface::scene_surface_resized(geometry::Size const& new_size)
 {
-    uint32_t const mask = XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT;
+    connection->configure_window(window, std::experimental::nullopt, new_size);
+    connection->flush();
+}
 
-    uint32_t const values[]{
-        new_size.width.as_uint32_t(),
-        new_size.height.as_uint32_t()};
-
-    xcb_configure_window(*connection, window, mask, values);
+void mf::XWaylandSurface::scene_surface_moved_to(geometry::Point const& new_top_left)
+{
+    connection->configure_window(window, new_top_left, std::experimental::nullopt);
     connection->flush();
 }
 

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -329,7 +329,7 @@ void mf::XWaylandSurface::dirty_properties()
     props_dirty = true;
 }
 
-void mf::XWaylandSurface::set_wl_surface(WlSurface* wl_surface)
+void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
 {
     // We assume we are on the Wayland thread
 

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -239,7 +239,9 @@ void mf::XWaylandSurface::wm_change_state_client_message(uint32_t const (&data)[
             break;
 
         default:
-            break;
+            BOOST_THROW_EXCEPTION(std::runtime_error(
+                "WM_CHANGE_STATE client message sent invalid state " +
+                std::to_string(static_cast<std::underlying_type<WmState>::type>(requested_state))));
         }
     }
 

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -185,19 +185,18 @@ private:
     auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
     /// @}
 
-    /// The last state we have either requested of Mir or been informed of by Mir
-    /// Prevents requesting a window state that we are already in
-    MirWindowState cached_mir_window_state{mir_window_state_unknown};
-
     /// Should NOT be called under lock
     /// Does nothing if we already have a scene::Surface
     void create_scene_surface_if_needed();
 
-    /// Sets the window's _NET_WM_STATE property based on the contents of window_state
-    /// Also sets the state of the scene surface to match window_state
-    /// Should be called after every change to window_state
+    /// Updates the window's WM_STATE and _NET_WM_STATE properties
     /// Should NOT be called under lock
-    void set_window_state(WindowState const& new_window_state);
+    void inform_client_of_window_state(WindowState const& state);
+
+    /// Requests the scene surface be put into the given state
+    /// If the request results in an actual surface state change, the observer will be notified
+    /// Should NOT be called under lock
+    void request_scene_surface_state(MirWindowState new_state);
 
     auto latest_input_timestamp(std::lock_guard<std::mutex> const&) -> std::chrono::nanoseconds;
 

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -149,7 +149,6 @@ public:
     void dirty_properties();
     void read_properties();
     void set_wl_surface(WlSurface* wl_surface); ///< Should only be called on the Wayland thread
-    void set_workspace(int workspace);
     void move_resize(uint32_t detail);
 
 private:

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -150,7 +150,6 @@ public:
     void read_properties();
     void set_wl_surface(WlSurface* wl_surface); ///< Should only be called on the Wayland thread
     void set_workspace(int workspace);
-    void unmap();
     void move_resize(uint32_t detail);
 
 private:

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -157,6 +157,7 @@ private:
     /// (for example if a minimized window would otherwise be maximized)
     struct WindowState
     {
+        bool withdrawn{true};
         bool minimized{false};
         bool maximized{false};
         bool fullscreen{false};

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -161,6 +161,10 @@ private:
         bool minimized{false};
         bool maximized{false};
         bool fullscreen{false};
+
+        auto operator==(WindowState const& that) const -> bool;
+        auto mir_window_state() const -> MirWindowState;
+        auto updated_from(MirWindowState state) const -> WindowState; ///< Does not change original
     };
 
     struct InitialWlSurfaceData;

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -226,7 +226,7 @@ private:
         geometry::Point position;
         geometry::Size size;
         bool override_redirect;
-    } const init;
+    } init;
 
     /// Set in set_wl_surface and cleared when a scene surface is created from it
     std::experimental::optional<std::unique_ptr<InitialWlSurfaceData>> initial_wl_surface_data;

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -143,6 +143,7 @@ public:
 
     void map();
     void close(); ///< Idempotent
+    void configure_request(xcb_configure_request_event_t* event);
     void net_wm_state_client_message(uint32_t const (&data)[5]);
     void wm_change_state_client_message(uint32_t const (&data)[5]);
     void dirty_properties();

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -172,7 +172,8 @@ private:
     /// Overrides from XWaylandSurfaceObserverSurface
     /// @{
     void scene_surface_state_set(MirWindowState new_state) override;
-    void scene_surface_resized(const geometry::Size& new_size) override;
+    void scene_surface_resized(geometry::Size const& new_size) override;
+    void scene_surface_moved_to(geometry::Point const& new_top_left) override;
     void scene_surface_close_requested() override;
     void run_on_wayland_thread(std::function<void()>&& work) override;
     /// @}

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -148,7 +148,7 @@ public:
     void wm_change_state_client_message(uint32_t const (&data)[5]);
     void dirty_properties();
     void read_properties();
-    void set_wl_surface(WlSurface* wl_surface); ///< Should only be called on the Wayland thread
+    void attach_wl_surface(WlSurface* wl_surface); ///< Should only be called on the Wayland thread
     void move_resize(uint32_t detail);
 
 private:

--- a/src/server/frontend_xwayland/xwayland_surface_observer.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.cpp
@@ -81,6 +81,11 @@ void mf::XWaylandSurfaceObserver::content_resized_to(ms::Surface const*, geom::S
     wm_surface->scene_surface_resized(content_size);
 }
 
+void mf::XWaylandSurfaceObserver::moved_to(ms::Surface const*, geom::Point const& top_left)
+{
+    wm_surface->scene_surface_moved_to(top_left);
+}
+
 void mf::XWaylandSurfaceObserver::client_surface_close_requested(ms::Surface const*)
 {
     wm_surface->scene_surface_close_requested();

--- a/src/server/frontend_xwayland/xwayland_surface_observer.h
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.h
@@ -54,6 +54,7 @@ public:
     ///@{
     void attrib_changed(scene::Surface const*, MirWindowAttrib attrib, int value) override;
     void content_resized_to(scene::Surface const*, geometry::Size const& content_size) override;
+    void moved_to(scene::Surface const*, geometry::Point const& top_left) override;
     void client_surface_close_requested(scene::Surface const*) override;
     void keymap_changed(
         scene::Surface const*,

--- a/src/server/frontend_xwayland/xwayland_surface_observer_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface_observer_surface.h
@@ -33,7 +33,8 @@ class XWaylandSurfaceObserverSurface
 {
 public:
     virtual void scene_surface_state_set(MirWindowState new_state) = 0;
-    virtual void scene_surface_resized(const geometry::Size& new_size) = 0;
+    virtual void scene_surface_resized(geometry::Size const& new_size) = 0;
+    virtual void scene_surface_moved_to(geometry::Point const& new_top_left) = 0;
     virtual void scene_surface_close_requested() = 0;
     virtual void run_on_wayland_thread(std::function<void()>&& work) = 0;
 

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -89,7 +89,7 @@ void mf::XWaylandSurfaceRole::commit(WlSurfaceState const& state)
 
     if (auto const wm_surface = weak_wm_surface.lock())
     {
-        wm_surface->wl_surface_committed(wl_surface);
+        wm_surface->wl_surface_committed();
     }
 }
 

--- a/src/server/frontend_xwayland/xwayland_surface_role_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface_role_surface.h
@@ -37,7 +37,7 @@ class XWaylandSurfaceRoleSurface
 {
 public:
     virtual void wl_surface_destroyed() = 0;
-    virtual void wl_surface_committed(WlSurface* wl_surface) = 0;
+    virtual void wl_surface_committed() = 0;
     virtual auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> = 0;
 
     virtual ~XWaylandSurfaceRoleSurface() = default;

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -553,7 +553,7 @@ void mf::XWaylandWM::handle_unmap_notify(xcb_unmap_notify_event_t *event)
 
     if (auto const surface = get_wm_surface(event->window))
     {
-        surface.value()->unmap();
+        surface.value()->close();
         surface.value()->set_workspace(-1);
         xcb_unmap_window(*connection, event->window);
         connection->flush();

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -619,7 +619,7 @@ void mf::XWaylandWM::handle_surface_id(std::shared_ptr<XWaylandSurface> surface,
             auto* wl_surface = resource ? WlSurface::from(resource) : nullptr;
             if (wl_surface)
             {
-                surface->set_wl_surface(wl_surface);
+                surface->attach_wl_surface(wl_surface);
 
                 // will destroy itself
                 new XWaylandSurfaceRole{shell, surface, wl_surface};

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -625,7 +625,7 @@ void mf::XWaylandWM::handle_surface_id(std::shared_ptr<XWaylandSurface> surface,
             auto* wl_surface = resource ? WlSurface::from(resource) : nullptr;
             if (wl_surface)
             {
-                surface->set_surface(wl_surface);
+                surface->set_wl_surface(wl_surface);
 
                 // will destroy itself
                 new XWaylandSurfaceRole{shell, surface, wl_surface};

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -526,7 +526,6 @@ void mf::XWaylandWM::handle_map_request(xcb_map_request_event_t *event)
     if (auto const surface = get_wm_surface(event->window))
     {
         surface.value()->read_properties();
-        surface.value()->set_workspace(0);
         surface.value()->map();
         xcb_map_window(*connection, event->window);
         connection->flush();
@@ -554,7 +553,6 @@ void mf::XWaylandWM::handle_unmap_notify(xcb_unmap_notify_event_t *event)
     if (auto const surface = get_wm_surface(event->window))
     {
         surface.value()->close();
-        surface.value()->set_workspace(-1);
         xcb_unmap_window(*connection, event->window);
         connection->flush();
     }

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -649,42 +649,9 @@ void mf::XWaylandWM::handle_configure_request(xcb_configure_request_event_t *eve
             log_warning("border width unsupported (border width %d)", event->border_width);
     }
 
-    std::vector<uint32_t> values;
-
-    if (event->value_mask & XCB_CONFIG_WINDOW_X)
+    if (auto const surface = get_wm_surface(event->window))
     {
-        values.push_back(event->x);
-    }
-
-    if (event->value_mask & XCB_CONFIG_WINDOW_Y)
-    {
-        values.push_back(event->y);
-    }
-
-    if (event->value_mask & XCB_CONFIG_WINDOW_WIDTH)
-    {
-        values.push_back(event->width);
-    }
-
-    if (event->value_mask & XCB_CONFIG_WINDOW_HEIGHT)
-    {
-        values.push_back(event->height);
-    }
-
-    if (event->value_mask & XCB_CONFIG_WINDOW_SIBLING)
-    {
-        values.push_back(event->sibling);
-    }
-
-    if (event->value_mask & XCB_CONFIG_WINDOW_STACK_MODE)
-    {
-        values.push_back(event->stack_mode);
-    }
-
-    if (!values.empty())
-    {
-        xcb_configure_window(*connection, event->window, event->value_mask, values.data());
-        connection->flush();
+        surface.value()->configure_request(event);
     }
 }
 

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -527,8 +527,6 @@ void mf::XWaylandWM::handle_map_request(xcb_map_request_event_t *event)
     {
         surface.value()->read_properties();
         surface.value()->map();
-        xcb_map_window(*connection, event->window);
-        connection->flush();
     }
 }
 
@@ -553,8 +551,6 @@ void mf::XWaylandWM::handle_unmap_notify(xcb_unmap_notify_event_t *event)
     if (auto const surface = get_wm_surface(event->window))
     {
         surface.value()->close();
-        xcb_unmap_window(*connection, event->window);
-        connection->flush();
     }
 }
 


### PR DESCRIPTION
In addition to general cleanup, this changes the flow of configure requests to go though the Mir window manager, so they should no longer be ignored.