### PR TITLE
XWayland: popups!

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -60,6 +60,7 @@ mf::XCBConnection::XCBConnection(int fd)
       wm_change_state{"WM_CHANGE_STATE", this},
       wm_s0{"WM_S0", this},
       wm_client_machine{"WM_CLIENT_MACHINE", this},
+      wm_transient_for{"WM_TRANSIENT_FOR", this},
       net_wm_cm_s0{"_NET_WM_CM_S0", this},
       net_wm_name{"_NET_WM_NAME", this},
       net_wm_pid{"_NET_WM_PID", this},

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -166,6 +166,7 @@ public:
     Atom const wm_change_state;
     Atom const wm_s0;
     Atom const wm_client_machine;
+    Atom const wm_transient_for;
     Atom const net_wm_cm_s0;
     Atom const net_wm_name;
     Atom const net_wm_pid;

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -92,22 +92,26 @@ public:
     auto read_property(
         xcb_window_t window,
         xcb_atom_t prop,
-        std::function<void(xcb_get_property_reply_t*)> action) -> std::function<void()>;
+        std::function<void(xcb_get_property_reply_t*)> action,
+        std::function<void()> on_error) -> std::function<void()>;
 
     auto read_property(
         xcb_window_t window,
         xcb_atom_t prop,
-        std::function<void(std::string const&)> action) -> std::function<void()>;
+        std::function<void(std::string const&)> action,
+        std::function<void()> on_error = [](){}) -> std::function<void()>;
 
     auto read_property(
         xcb_window_t window,
         xcb_atom_t prop,
-        std::function<void(uint32_t)> action) -> std::function<void()>;
+        std::function<void(uint32_t)> action,
+        std::function<void()> on_error = [](){}) -> std::function<void()>;
 
     auto read_property(
         xcb_window_t window,
         xcb_atom_t prop,
-        std::function<void(std::vector<uint32_t>)> action) -> std::function<void()>;
+        std::function<void(std::vector<uint32_t>)> action,
+        std::function<void()> on_error = [](){}) -> std::function<void()>;
     /// @}
 
     /// Set X11 window properties

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -134,7 +134,7 @@ mf::XWaylandSurface::XWaylandSurface(
               [this](auto value)
               {
                   std::lock_guard<std::mutex> lock{mutex};
-                  pending_spec(lock).application_id = value;
+                  this->pending_spec(lock).application_id = value;
               }),
           property_handler<std::string const&>(
               connection,
@@ -143,7 +143,7 @@ mf::XWaylandSurface::XWaylandSurface(
               [this](auto value)
               {
                   std::lock_guard<std::mutex> lock{mutex};
-                  pending_spec(lock).name = value;
+                  this->pending_spec(lock).name = value;
               }),
           property_handler<std::string const&>(
               connection,
@@ -152,7 +152,7 @@ mf::XWaylandSurface::XWaylandSurface(
               [this](auto value)
               {
                   std::lock_guard<std::mutex> lock{mutex};
-                  pending_spec(lock).name = value;
+                  this->pending_spec(lock).name = value;
               }),
           property_handler<xcb_window_t>(
               connection,
@@ -162,7 +162,7 @@ mf::XWaylandSurface::XWaylandSurface(
               {
                   std::shared_ptr<scene::Surface> parent_scene_surface;
 
-                  auto const parent_surface = xwm->get_wm_surface(value);
+                  auto const parent_surface = this->xwm->get_wm_surface(value);
                   if (parent_surface)
                   {
                       std::lock_guard<std::mutex> parent_lock{parent_surface.value()->mutex};
@@ -170,16 +170,16 @@ mf::XWaylandSurface::XWaylandSurface(
                   }
 
                   {
-                      std::lock_guard<std::mutex> lock{mutex};
+                      std::lock_guard<std::mutex> lock{this->mutex};
                       auto const parent = parent_surface.value()->weak_scene_surface.lock(); // Can be nullptr
-                      pending_spec(lock).parent = parent;
-                      set_position(parent, latest_position, pending_spec(lock));
+                      this->pending_spec(lock).parent = parent;
+                      set_position(parent, this->latest_position, this->pending_spec(lock));
                   }
               },
               [this]()
               {
                   std::lock_guard<std::mutex> lock{mutex};
-                  pending_spec(lock).parent = std::weak_ptr<scene::Surface>{};
+                  this->pending_spec(lock).parent = std::weak_ptr<scene::Surface>{};
               }),
           property_handler<std::vector<xcb_atom_t> const&>(
               connection,
@@ -188,12 +188,12 @@ mf::XWaylandSurface::XWaylandSurface(
               [this](std::vector<xcb_atom_t> const& value)
               {
                   std::lock_guard<std::mutex> lock{mutex};
-                  supported_wm_protocols = std::set<xcb_atom_t>{value.begin(), value.end()};
+                  this->supported_wm_protocols = std::set<xcb_atom_t>{value.begin(), value.end()};
               },
               [this]()
               {
                   std::lock_guard<std::mutex> lock{mutex};
-                  supported_wm_protocols.clear();
+                  this->supported_wm_protocols.clear();
               })},
       latest_size{event->width, event->height},
       latest_position{event->x, event->y}

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -160,7 +160,7 @@ mf::XWaylandSurface::XWaylandSurface(
               connection->wm_transient_for,
               [this](xcb_window_t value)
               {
-                  std::shared_ptr<scene::Surface> parent_scene_surface;
+                  std::shared_ptr<scene::Surface> parent_scene_surface; // May remain nullptr
 
                   auto const parent_surface = this->xwm->get_wm_surface(value);
                   if (parent_surface)
@@ -171,9 +171,8 @@ mf::XWaylandSurface::XWaylandSurface(
 
                   {
                       std::lock_guard<std::mutex> lock{this->mutex};
-                      auto const parent = parent_surface.value()->weak_scene_surface.lock(); // Can be nullptr
-                      this->pending_spec(lock).parent = parent;
-                      set_position(parent, this->latest_position, this->pending_spec(lock));
+                      this->pending_spec(lock).parent = parent_scene_surface;
+                      set_position(parent_scene_surface, this->latest_position, this->pending_spec(lock));
                   }
               },
               [this]()

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -162,8 +162,7 @@ mf::XWaylandSurface::XWaylandSurface(
               {
                   std::shared_ptr<scene::Surface> parent_scene_surface; // May remain nullptr
 
-                  auto const parent_surface = this->xwm->get_wm_surface(value);
-                  if (parent_surface)
+                  if (auto const parent_surface = this->xwm->get_wm_surface(value))
                   {
                       std::lock_guard<std::mutex> parent_lock{parent_surface.value()->mutex};
                       parent_scene_surface = parent_surface.value()->weak_scene_surface.lock();

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -146,6 +146,7 @@ public:
     void map();
     void close(); ///< Idempotent
     void configure_request(xcb_configure_request_event_t* event);
+    void configure_notify(xcb_configure_notify_event_t* event);
     void net_wm_state_client_message(uint32_t const (&data)[5]);
     void wm_change_state_client_message(uint32_t const (&data)[5]);
     void property_notify(xcb_atom_t property);
@@ -222,16 +223,11 @@ private:
     /// Should only be modified by set_wm_state()
     WindowState window_state;
 
+    geometry::Size latest_size;
+    geometry::Point latest_position; ///< Always in global coordinates
+
     /// The contents of the _NET_SUPPORTED property set by the client
     std::set<xcb_atom_t> supported_wm_protocols;
-
-    struct
-    {
-        xcb_window_t parent;
-        geometry::Point position;
-        geometry::Size size;
-        bool override_redirect;
-    } init;
 
     /// Set in set_wl_surface and cleared when a scene surface is created from it
     std::experimental::optional<std::unique_ptr<InitialWlSurfaceData>> initial_wl_surface_data;

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -413,15 +413,27 @@ void mf::XWaylandWM::handle_property_notify(xcb_property_notify_event_t *event)
         }
         else
         {
-            auto const reply_function = connection->read_property(event->window, event->atom, [this, event](xcb_get_property_reply_t* reply)
+            auto const log_prop = [this, event](std::string const& value)
                 {
                     auto const prop_name = connection->query_name(event->atom);
-                    auto const reply_str = get_reply_debug_string(reply);
                     log_debug(
                         "XCB_PROPERTY_NOTIFY (%s).%s: %s",
                         get_window_debug_string(event->window).c_str(),
                         prop_name.c_str(),
-                        reply_str.c_str());
+                        value.c_str());
+                };
+
+            auto const reply_function = connection->read_property(
+                event->window,
+                event->atom,
+                [this, log_prop](xcb_get_property_reply_t* reply)
+                {
+                    auto const reply_str = get_reply_debug_string(reply);
+                    log_prop(reply_str);
+                },
+                [log_prop]()
+                {
+                    log_prop("Error getting value");
                 });
 
             reply_function();

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -442,7 +442,7 @@ void mf::XWaylandWM::handle_property_notify(xcb_property_notify_event_t *event)
 
     if (auto const surface = get_wm_surface(event->window))
     {
-        surface.value()->dirty_properties();
+        surface.value()->property_notify(event->atom);
     }
 }
 
@@ -531,7 +531,6 @@ void mf::XWaylandWM::handle_map_request(xcb_map_request_event_t *event)
 
     if (auto const surface = get_wm_surface(event->window))
     {
-        surface.value()->read_properties();
         surface.value()->map();
     }
 }

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -668,6 +668,11 @@ void mf::XWaylandWM::handle_configure_notify(xcb_configure_notify_event_t *event
         if (event->border_width)
             log_warning("border width unsupported (border width %d)", event->border_width);
     }
+
+    if (auto const surface = get_wm_surface(event->window))
+    {
+        surface.value()->configure_notify(event);
+    }
 }
 
 // Cursor


### PR DESCRIPTION
Improve property reading system and place popups correctly. Popups tested with PCManFM (GTK2), gedit (GTK3) and Kate (Qt, see known issues). XTerm and XEyes also tested.

Known issues:
* Tooltips are only sometimes placed correctly on all toolkits
* Specific Kate menus aren't place correctly
