### PR TITLE
[X11] Once we've got the lockfile, check for an existing socket

### DIFF
--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -369,13 +369,13 @@ int create_lockfile(int xdisplay)
     if (fd < 0)
         return EEXIST;
 
-    int const size = dprintf(fd, "%10d\n", getpid());
+    bool const success_writing_to_lock_file = dprintf(fd, "%10d\n", getpid()) == 11;
 
     // Check if anyone else has created the socket (even though we have the lockfile)
     char x11_socket[256];
     snprintf(x11_socket, sizeof x11_socket, x11_socket_fmt, xdisplay);
 
-    if (size != 11 || access(x11_socket, F_OK) == 0)
+    if (!success_writing_to_lock_file || access(x11_socket, F_OK) == 0)
     {
         unlink(lockfile);
         return EEXIST;

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -369,7 +369,12 @@ int create_lockfile(int xdisplay)
     if (fd < 0)
         return EEXIST;
 
-    bool const success_writing_to_lock_file = dprintf(fd, "%10d\n", getpid()) == 11;
+    // We format for consistency with the corresponding code in xorg-server (os/utils.c) which
+    // requires 11 characters. Vis:
+    //
+    //    snprintf(pid_str, sizeof(pid_str), "%10lu\n", (unsigned long) getpid());
+    //    if (write(lfd, pid_str, 11) != 11)
+    bool const success_writing_to_lock_file = dprintf(fd, "%10lu\n", (unsigned long) getpid()) == 11;
 
     // Check if anyone else has created the socket (even though we have the lockfile)
     char x11_socket[256];


### PR DESCRIPTION
[X11] Once we've got the lockfile, check for an existing socket before trying to use it. (Fixes: #1265)