### PR TITLE
Wait for wl_surface to appear before attaching it to XWayland surface

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -246,9 +246,12 @@ public:
     {
     }
 
+    void on_surface_created(wl_client* client, uint32_t id, std::function<void(WlSurface*)> const& callback);
+
 private:
     std::shared_ptr<mg::WaylandAllocator> const allocator;
     std::shared_ptr<mir::Executor> const executor;
+    std::map<std::pair<wl_client*, uint32_t>, std::vector<std::function<void(WlSurface*)>>> surface_callbacks;
 
     class Instance : wayland::Compositor
     {
@@ -271,9 +274,34 @@ private:
     }
 };
 
+void WlCompositor::on_surface_created(wl_client* client, uint32_t id, std::function<void(WlSurface*)> const& callback)
+{
+    wl_resource* resource = wl_client_get_object(client, id);
+    auto const wl_surface = resource ? WlSurface::from(resource) : nullptr;
+    if (wl_surface)
+    {
+        callback(wl_surface);
+    }
+    else
+    {
+        surface_callbacks[std::make_pair(client, id)].push_back(callback);
+    }
+}
+
 void WlCompositor::Instance::create_surface(wl_resource* new_surface)
 {
-    new WlSurface{new_surface, compositor->executor, compositor->allocator};
+    auto const surface = new WlSurface{new_surface, compositor->executor, compositor->allocator};
+    auto const key = std::make_pair(wl_resource_get_client(new_surface), wl_resource_get_id(new_surface));
+    auto const callbacks = compositor->surface_callbacks.find(key);
+    if (callbacks != compositor->surface_callbacks.end())
+    {
+        for (auto const& callback : callbacks->second)
+        {
+            callback(surface);
+        }
+        compositor->surface_callbacks.erase(callbacks);
+    }
+    // Wayland ojects delete themselves
 }
 
 void WlCompositor::Instance::create_region(wl_resource* new_region)
@@ -842,6 +870,14 @@ int mf::WaylandConnector::client_socket_fd(
 void mf::WaylandConnector::run_on_wayland_display(std::function<void(wl_display*)> const& functor)
 {
     executor->spawn([display_ref = display.get(), functor]() { functor(display_ref); });
+}
+
+void mf::WaylandConnector::on_surface_created(
+    wl_client* client,
+    uint32_t id,
+    std::function<void(WlSurface*)> const& callback)
+{
+    compositor_global->on_surface_created(client, id, callback);
 }
 
 auto mf::WaylandConnector::socket_name() const -> optional_value<std::string>

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -65,6 +65,7 @@ class OutputManager;
 class MirDisplay;
 class SessionAuthorizer;
 class DataDeviceManager;
+class WlSurface;
 
 class WaylandExtensions
 {
@@ -116,6 +117,10 @@ public:
         std::function<void(std::shared_ptr<scene::Session> const& session)> const& connect_handler) const override;
 
     void run_on_wayland_display(std::function<void(wl_display*)> const& functor);
+
+    /// Runs callback the first time a wl_surface with the given id is created, or immediately if one currently exists
+    /// Callback is never called if a wl_surface with the id is never created
+    void on_surface_created(wl_client* client, uint32_t id, std::function<void(WlSurface*)> const& callback);
 
     auto socket_name() const -> optional_value<std::string> override;
 

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -517,6 +517,14 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
 {
     // We assume we are on the Wayland thread
 
+    if (verbose_xwayland_logging_enabled())
+    {
+        log_debug(
+            "Attaching wl_surface@%d to %s...",
+            wl_resource_get_id(wl_surface->resource),
+            connection->window_debug_string(window).c_str());
+    }
+
     auto const observer = std::make_shared<XWaylandSurfaceObserver>(seat, wl_surface, this);
 
     {
@@ -821,15 +829,6 @@ void mf::XWaylandSurface::create_scene_surface_if_needed()
 
 void mf::XWaylandSurface::inform_client_of_window_state(WindowState const& new_window_state)
 {
-    if (verbose_xwayland_logging_enabled())
-    {
-        log_debug("inform_client_of_window_state(window:     %s", connection->window_debug_string(window).c_str());
-        log_debug("                              withdrawn:  %s", new_window_state.withdrawn ? "yes" : "no");
-        log_debug("                              minimized:  %s", new_window_state.minimized ? "yes" : "no");
-        log_debug("                              maximized:  %s", new_window_state.maximized ? "yes" : "no");
-        log_debug("                              fullscreen: %s)", new_window_state.fullscreen ? "yes" : "no");
-    }
-
     {
         std::lock_guard<std::mutex> lock{mutex};
 
@@ -837,6 +836,17 @@ void mf::XWaylandSurface::inform_client_of_window_state(WindowState const& new_w
             return;
 
         cached.state = new_window_state;
+    }
+
+    if (verbose_xwayland_logging_enabled())
+    {
+        log_debug(
+            "%s state set to %s%s%s%s",
+            connection->window_debug_string(window).c_str(),
+            new_window_state.withdrawn ? "withdrawn, " : "",
+            new_window_state.minimized ? "minimized, " : "",
+            new_window_state.fullscreen ? "fullscreen, " : "",
+            new_window_state.maximized ? "maximized" : "unmaximized");
     }
 
     WmState wm_state;

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -18,6 +18,7 @@
 
 #include "xwayland_surface_role.h"
 #include "xwayland_surface_role_surface.h"
+#include "xwayland_log.h"
 
 #include "wl_surface.h"
 #include "mir/shell/surface_specification.h"
@@ -38,11 +39,19 @@ mf::XWaylandSurfaceRole::XWaylandSurfaceRole(
       wl_surface{wl_surface}
 {
     wl_surface->set_role(this);
+    if (verbose_xwayland_logging_enabled())
+    {
+        log_debug("Created XWaylandSurfaceRole for wl_surface@%d", wl_resource_get_id(wl_surface->resource));
+    }
 }
 
 mf::XWaylandSurfaceRole::~XWaylandSurfaceRole()
 {
     wl_surface->clear_role();
+    if (verbose_xwayland_logging_enabled())
+    {
+        log_debug("Destroyed XWaylandSurfaceRole for wl_surface@%d", wl_resource_get_id(wl_surface->resource));
+    }
 }
 
 auto mf::XWaylandSurfaceRole::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -101,7 +101,7 @@ private:
     void handle_motion_notify(xcb_motion_notify_event_t *event);
     void handle_property_notify(xcb_property_notify_event_t *event);
     void handle_map_request(xcb_map_request_event_t *event);
-    void handle_surface_id(std::shared_ptr<XWaylandSurface> surface, xcb_client_message_event_t *event);
+    void handle_surface_id(std::weak_ptr<XWaylandSurface> const& weak_surface, xcb_client_message_event_t *event);
     void handle_move_resize(std::shared_ptr<XWaylandSurface> surface, xcb_client_message_event_t *event);
     void handle_client_message(xcb_client_message_event_t *event);
     void handle_configure_request(xcb_configure_request_event_t *event);


### PR DESCRIPTION
Fixes #1269. See that issue for more info on the problem. This allows XWayland to register a callback when a surface with a particular ID is created. It is admittedly a lot of new code, and may not be worth it. It's probably not worth the complexity just to fix Mir under wayland-debug, but hypothetically we could hit the same race condition on a very slow machine, or in some other situation where the Wayland thread was bogged down. I'm open to alternative ideas on how to solve this.