### PR TITLE
Create scene surface in attach_wl_surface()

### DIFF
--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -131,12 +131,6 @@ auto property_handler(
 }
 }
 
-struct mf::XWaylandSurface::InitialWlSurfaceData
-{
-    std::vector<shell::StreamSpecification> streams;
-    std::vector<geom::Rectangle> input_shape;
-};
-
 mf::XWaylandSurface::XWaylandSurface(
     XWaylandWM *wm,
     std::shared_ptr<XCBConnection> const& connection,
@@ -271,8 +265,6 @@ void mf::XWaylandSurface::close()
             observer = surface_observer.value();
         }
         surface_observer = std::experimental::nullopt;
-
-        initial_wl_surface_data = std::experimental::nullopt;
     }
 
     connection->delete_property(window, connection->net_wm_desktop);
@@ -525,28 +517,73 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
             connection->window_debug_string(window).c_str());
     }
 
+    WindowState state;
+    std::shared_ptr<scene::Session> session;
+    scene::SurfaceCreationParameters params;
+
     auto const observer = std::make_shared<XWaylandSurfaceObserver>(seat, wl_surface, this);
 
     {
         std::lock_guard<std::mutex> lock{mutex};
 
-        if (surface_observer || weak_session.lock() || initial_wl_surface_data)
+        if (surface_observer || weak_session.lock() || weak_scene_surface.lock())
             BOOST_THROW_EXCEPTION(std::runtime_error("XWaylandSurface::set_wl_surface() called multiple times"));
 
+        session = get_session(wl_surface->resource);
+
         surface_observer = observer;
+        weak_session = session;
 
-        weak_session = get_session(wl_surface->resource);
+        state = cached.state;
+        state.withdrawn = false;
 
-        initial_wl_surface_data = std::make_unique<InitialWlSurfaceData>();
+        params.streams = std::vector<shell::StreamSpecification>{};
+        params.input_shape = std::vector<geom::Rectangle>{};
         wl_surface->populate_surface_data(
-            initial_wl_surface_data.value()->streams,
-            initial_wl_surface_data.value()->input_shape,
+            params.streams.value(),
+            params.input_shape.value(),
             {});
+        params.size = cached.size;
+        params.top_left = cached.top_left;
+        params.type = mir_window_type_freestyle;
+        params.state = state.mir_window_state();
+        params.server_side_decorated = !cached.override_redirect;
     }
 
-    // If a buffer has alread been committed, we need to create the scene::Surface without waiting for next commit
-    if (wl_surface->buffer_size())
-        create_scene_surface_if_needed();
+    std::vector<std::function<void()>> reply_functions;
+
+    // Read all properties
+    for (auto const& handler : property_handlers)
+    {
+        reply_functions.push_back(handler.second());
+    }
+
+    // Wait for and process all the XCB replies
+    for (auto const& reply_function : reply_functions)
+    {
+        reply_function();
+    }
+
+    // property_handlers will have updated the pending spec. Use it.
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        if (auto const spec = consume_pending_spec(lock))
+        {
+            params.update_from(*spec.value());
+        }
+    }
+
+    auto const surface = shell->create_surface(session, params, observer);
+    inform_client_of_window_state(state);
+    connection->configure_window(
+        window,
+        surface->top_left() + surface->content_offset(),
+        surface->content_size());
+
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        weak_scene_surface = surface;
+    }
 }
 
 void mf::XWaylandSurface::move_resize(uint32_t detail)
@@ -721,7 +758,6 @@ void mf::XWaylandSurface::wl_surface_destroyed()
 
 void mf::XWaylandSurface::wl_surface_committed()
 {
-    create_scene_surface_if_needed();
 }
 
 auto mf::XWaylandSurface::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>
@@ -747,84 +783,6 @@ auto mf::XWaylandSurface::consume_pending_spec(
         return move(nullable_pending_spec);
     else
         return std::experimental::nullopt;
-}
-
-void mf::XWaylandSurface::create_scene_surface_if_needed()
-{
-    WindowState state;
-    scene::SurfaceCreationParameters params;
-    std::shared_ptr<scene::SurfaceObserver> observer;
-    std::shared_ptr<scene::Session> session;
-
-    {
-        std::lock_guard<std::mutex> lock{mutex};
-
-        session = weak_session.lock();
-
-        if (weak_scene_surface.lock() ||
-            !initial_wl_surface_data ||
-            !surface_observer ||
-            !session)
-        {
-            // surface is already created, being created or not ready to be created
-            return;
-        }
-
-        if (verbose_xwayland_logging_enabled())
-        {
-            log_debug("creating scene surface for %s", connection->window_debug_string(window).c_str());
-        }
-
-        state = cached.state;
-        state.withdrawn = false;
-
-        observer = surface_observer.value();
-
-        params.streams = std::move(initial_wl_surface_data.value()->streams);
-        params.input_shape = std::move(initial_wl_surface_data.value()->input_shape);
-        initial_wl_surface_data = std::experimental::nullopt;
-
-        params.size = cached.size;
-        params.top_left = cached.top_left;
-        params.type = mir_window_type_freestyle;
-        params.state = state.mir_window_state();
-        params.server_side_decorated = !cached.override_redirect;
-    }
-
-    std::vector<std::function<void()>> reply_functions;
-
-    // Read all properties
-    for (auto const& handler : property_handlers)
-    {
-        reply_functions.push_back(handler.second());
-    }
-
-    // Wait for and process all the XCB replies
-    for (auto const& reply_function : reply_functions)
-    {
-        reply_function();
-    }
-
-    // property_handlers will have updated the pending spec. Use it.
-    {
-        std::lock_guard<std::mutex> lock{mutex};
-        if (auto const spec = consume_pending_spec(lock))
-        {
-            params.update_from(*spec.value());
-        }
-    }
-
-    auto const surface = shell->create_surface(session, params, observer);
-    inform_client_of_window_state(state);
-    connection->configure_window(
-        window,
-        surface->top_left() + surface->content_offset(),
-        surface->content_size());
-
-    {
-        std::lock_guard<std::mutex> lock{mutex};
-        weak_scene_surface = surface;
-    }
 }
 
 void mf::XWaylandSurface::inform_client_of_window_state(WindowState const& new_window_state)

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -756,10 +756,6 @@ void mf::XWaylandSurface::wl_surface_destroyed()
     close();
 }
 
-void mf::XWaylandSurface::wl_surface_committed()
-{
-}
-
 auto mf::XWaylandSurface::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>
 {
     std::lock_guard<std::mutex> lock{mutex};

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -98,7 +98,6 @@ private:
     /// Should only be called on the Wayland thread
     /// @{
     void wl_surface_destroyed() override;
-    void wl_surface_committed() override;
     auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
     /// @}
 

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -110,10 +110,6 @@ private:
     auto consume_pending_spec(
         std::lock_guard<std::mutex> const&) -> std::experimental::optional<std::unique_ptr<shell::SurfaceSpecification>>;
 
-    /// Should NOT be called under lock
-    /// Does nothing if we already have a scene::Surface
-    void create_scene_surface_if_needed();
-
     /// Updates the window's WM_STATE and _NET_WM_STATE properties
     /// Should NOT be called under lock
     void inform_client_of_window_state(WindowState const& state);
@@ -151,7 +147,6 @@ private:
     } cached;
 
     /// Set in set_wl_surface and cleared when a scene surface is created from it
-    std::experimental::optional<std::unique_ptr<InitialWlSurfaceData>> initial_wl_surface_data;
     std::experimental::optional<std::shared_ptr<XWaylandSurfaceObserver>> surface_observer;
     std::weak_ptr<scene::Session> weak_session;
     std::unique_ptr<shell::SurfaceSpecification> nullable_pending_spec;

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -95,11 +95,6 @@ void mf::XWaylandSurfaceRole::commit(WlSurfaceState const& state)
     {
         refresh_surface_data_now();
     }
-
-    if (auto const wm_surface = weak_wm_surface.lock())
-    {
-        wm_surface->wl_surface_committed();
-    }
 }
 
 void mf::XWaylandSurfaceRole::visiblity(bool /*visible*/)

--- a/src/server/frontend_xwayland/xwayland_surface_role_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface_role_surface.h
@@ -37,7 +37,6 @@ class XWaylandSurfaceRoleSurface
 {
 public:
     virtual void wl_surface_destroyed() = 0;
-    virtual void wl_surface_committed() = 0;
     virtual auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> = 0;
 
     virtual ~XWaylandSurfaceRoleSurface() = default;


### PR DESCRIPTION
Fixes #1249 and simplifies `XWaylandSurface` logic. `attach_wl_surface()` can now create a `scene::Surface`, even if the `wl_surface` hasn't committed yet. Presumably there used to be a problem with this course of action, but it doesn't seem to be an issue any more (I've tested with gedit, pcmanfm, xxeyes, xterm, kate, blender and steam).

Edit: #1249 was caused by `attach_wl_surface()` caching a pre-commit input area, and the commit not updating the area correctly because there wasn't yet a surface to update. This fixes it because there is no gap between reading the initial input area and creating a scene surface (which allows updates to the input area)