### PR TITLE
BasicSurface: allow frame to be posted after surface destroyed

### DIFF
--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -287,8 +287,6 @@ ms::BasicSurface::BasicSurface(
         {
             if (auto const o = observers.lock())
                 o->frame_posted(this, 1, size);
-            else
-                BOOST_THROW_EXCEPTION(std::runtime_error("Frame posted to dead surface"));
         };
 
     for (auto& layer : layers)
@@ -925,8 +923,6 @@ void ms::BasicSurface::set_streams(std::list<scene::StreamInfo> const& s)
                 {
                     if (auto const o = observers.lock())
                         o->frame_posted(this, 1, size);
-                    else
-                        BOOST_THROW_EXCEPTION(std::runtime_error("Frame posted to dead surface"));
                 });
         surface_top_left = surface_rect.top_left;
     }

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -1319,10 +1319,8 @@ TEST_F(BasicSurfaceTest, registers_frame_callbacks_on_construction)
         { buffer_stream1, {0,0}, {} }
     };
 
-    EXPECT_CALL(*buffer_stream0, set_frame_posted_callback(_))
-        .Times(2); // Once on construction, once on destruction
-    EXPECT_CALL(*buffer_stream1, set_frame_posted_callback(_))
-        .Times(2); // Once on construction, once on destruction
+    EXPECT_CALL(*buffer_stream0, set_frame_posted_callback(_));
+    EXPECT_CALL(*buffer_stream1, set_frame_posted_callback(_));
 
     ms::BasicSurface child{
         nullptr /* session */,
@@ -1346,10 +1344,8 @@ TEST_F(BasicSurfaceTest, registers_frame_callbacks_on_set_streams)
         { buffer_stream1, {0,0}, {} }
     };
 
-    EXPECT_CALL(*buffer_stream0, set_frame_posted_callback(_))
-        .Times(2); // Once on construction, once on destruction
-    EXPECT_CALL(*buffer_stream1, set_frame_posted_callback(_))
-        .Times(2); // Once on construction, once on destruction
+    EXPECT_CALL(*buffer_stream0, set_frame_posted_callback(_));
+    EXPECT_CALL(*buffer_stream1, set_frame_posted_callback(_));
 
     surface.set_streams(streams);
 }
@@ -1596,7 +1592,7 @@ TEST_F(BasicSurfaceTest, buffer_can_be_submitted_to_original_stream_after_surfac
     std::function<void(geom::Size const&)> callback = [](auto){};
 
     EXPECT_CALL(*local_stream, set_frame_posted_callback(_))
-        .Times(2)
+        .Times(AtLeast(1))
         .WillRepeatedly(SaveArg<0>(&callback));
 
     auto surface = std::make_unique<ms::BasicSurface>(
@@ -1621,7 +1617,7 @@ TEST_F(BasicSurfaceTest, buffer_can_be_submitted_to_set_stream_after_surface_des
     std::function<void(geom::Size const&)> callback = [](auto){};
 
     EXPECT_CALL(*local_stream, set_frame_posted_callback(_))
-        .Times(2)
+        .Times(AtLeast(1))
         .WillRepeatedly(SaveArg<0>(&callback));
 
     auto surface = std::make_unique<ms::BasicSurface>(


### PR DESCRIPTION
Reading through the code, it looks like setting all buffer stream callbacks to `[](){}` is allowed (that's what we already do in `BasicSurface::set_streams()`, and why shouldn't it be?). If an noop callback is allowed, a conditionally noop callback should also be allowed. I see no reason to throw this error, as it is perfectly reasonable for a surface to be destroyed before its buffer streams.

Fixes #1272