### PR TITLE
Improve XCBConnection atom lookup

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -68,6 +68,9 @@ mf::XCBConnection::Atom::operator xcb_atom_t() const
                 BOOST_THROW_EXCEPTION(std::runtime_error("Failed to look up atom " + name_));
             atom = reply->atom;
             free(reply);
+
+            std::lock_guard<std::mutex> lock{connection->atom_name_cache_mutex};
+            connection->atom_name_cache[atom] = name_;
         }
     }
 
@@ -77,6 +80,8 @@ mf::XCBConnection::Atom::operator xcb_atom_t() const
 mf::XCBConnection::XCBConnection(int fd)
     : xcb_connection{xcb_connect_to_fd(fd, nullptr)},
       xcb_screen{xcb_setup_roots_iterator(xcb_get_setup(xcb_connection)).data},
+      atom_name_cache{
+          {XCB_ATOM_NONE, "None/Any"}},
       wm_protocols{"WM_PROTOCOLS", this},
       wm_take_focus{"WM_TAKE_FOCUS", this},
       wm_delete_window{"WM_DELETE_WINDOW", this},
@@ -143,28 +148,31 @@ auto mf::XCBConnection::root_window() const -> xcb_window_t
 
 auto mf::XCBConnection::query_name(xcb_atom_t atom) const -> std::string
 {
-    // TODO: cache, for cheaper lookup
+    std::lock_guard<std::mutex>{atom_name_cache_mutex};
+    auto const iter = atom_name_cache.find(atom);
 
-    if (atom == XCB_ATOM_NONE)
-        return "None";
-
-    xcb_get_atom_name_cookie_t const cookie = xcb_get_atom_name(xcb_connection, atom);
-    xcb_get_atom_name_reply_t* const reply = xcb_get_atom_name_reply(xcb_connection, cookie, nullptr);
-
-    std::string name;
-
-    if (reply)
+    if (iter == atom_name_cache.end())
     {
-        name = std::string{xcb_get_atom_name_name(reply), static_cast<size_t>(xcb_get_atom_name_name_length(reply))};
+        xcb_get_atom_name_cookie_t const cookie = xcb_get_atom_name(xcb_connection, atom);
+        xcb_get_atom_name_reply_t* const reply = xcb_get_atom_name_reply(xcb_connection, cookie, nullptr);
+
+        std::string name;
+
+        if (reply)
+            name = std::string{xcb_get_atom_name_name(reply), static_cast<size_t>(xcb_get_atom_name_name_length(reply))};
+        else
+            name = "Atom " + std::to_string(atom);
+
+        free(reply);
+
+        atom_name_cache[atom] = name;
+
+        return name;
     }
     else
     {
-        name = "Atom " + std::to_string(atom);
+        return iter->second;
     }
-
-    free(reply);
-
-    return name;
 }
 
 auto mf::XCBConnection::reply_contains_string_data(xcb_get_property_reply_t const* reply) const -> bool

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -80,8 +80,7 @@ mf::XCBConnection::Atom::operator xcb_atom_t() const
 mf::XCBConnection::XCBConnection(int fd)
     : xcb_connection{xcb_connect_to_fd(fd, nullptr)},
       xcb_screen{xcb_setup_roots_iterator(xcb_get_setup(xcb_connection)).data},
-      atom_name_cache{
-          {XCB_ATOM_NONE, "None/Any"}},
+      atom_name_cache{{XCB_ATOM_NONE, "None/Any"}},
       wm_protocols{"WM_PROTOCOLS", this},
       wm_take_focus{"WM_TAKE_FOCUS", this},
       wm_delete_window{"WM_DELETE_WINDOW", this},

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -27,6 +27,8 @@
 #include <string>
 #include <vector>
 #include <functional>
+#include <mutex>
+#include <atomic>
 #include <experimental/optional>
 
 namespace mir
@@ -76,7 +78,12 @@ public:
         XCBConnection* const connection;
         std::string const name_;
         xcb_intern_atom_cookie_t const cookie;
-        std::experimental::optional<xcb_atom_t> mutable atom;
+        std::mutex mutable mutex;
+
+        /// XCB_ATOM_NONE until set
+        /// Accessed locklessly, but only set under lock
+        /// Once set to a value other than XCB_ATOM_NONE, not changed again
+        std::atomic<xcb_atom_t> mutable atom;
     };
 
     explicit XCBConnection(int fd);

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -84,10 +84,9 @@ public:
         xcb_intern_atom_cookie_t const cookie;
         std::mutex mutable mutex;
 
-        /// XCB_ATOM_NONE until set
         /// Accessed locklessly, but only set under lock
         /// Once set to a value other than XCB_ATOM_NONE, not changed again
-        std::atomic<xcb_atom_t> mutable atom;
+        std::atomic<xcb_atom_t> mutable atom{XCB_ATOM_NONE};
     };
 
     explicit XCBConnection(int fd);

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -26,6 +26,7 @@
 #include <xcb/xcb.h>
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include <functional>
 #include <mutex>
 #include <atomic>
@@ -61,6 +62,9 @@ class XCBConnection
 private:
     xcb_connection_t* const xcb_connection;
     xcb_screen_t* const xcb_screen;
+
+    std::mutex mutable atom_name_cache_mutex;
+    std::unordered_map<xcb_atom_t, std::string> mutable atom_name_cache;
 
 public:
     class Atom


### PR DESCRIPTION
Fixes a potential thread safety issue in the resolving of `XCBConnection::Atom` and starts caching atom names for faster lookup.