### PR TITLE
[mirserver] symbols stanza for mir::Server::x11_display should be 1.7.1

### DIFF
--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -842,7 +842,7 @@ MIR_SERVER_1.7.0 {
   };
 } MIR_SERVER_1.6.0;
 
-MIR_SERVER_1.8.0 {
+MIR_SERVER_1.7.1 {
  global:
   extern "C++" {
     mir::Server::x11_display*;


### PR DESCRIPTION
[mirserver] symbols stanza for mir::Server::x11_display should be 1.7.1