### PR TITLE
Fix `miral-app -demo-server`

### DIFF
--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -101,7 +101,7 @@ else
   # With mir_demo_server ${x11_display_file} contains the X11 display
   if [ -e "${x11_display_file}" ]
   then
-    export DISPLAY=$(cat "${x11_display_file}")
+    export DISPLAY=:$(cat "${x11_display_file}")
     rm "${x11_display_file}"
   else
     unset DISPLAY


### PR DESCRIPTION
Fix `miral-app -demo-server`.

Export DISPLAY correctly when starting mir_demo_server.