### PR TITLE
Provide a usable default configuration for Xenial era toolkits

### DIFF
--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -77,8 +77,14 @@ unset QT_QPA_PLATFORMTHEME
 
 if [ "${miral_server}" == "miral-shell" ]
 then
+  if [ "$(lsb_release -c -s)" == "xenial" ]
+  then
+    export MIR_SERVER_APP_ENV=GDK_BACKEND=x11:QT_QPA_PLATFORM=ubuntumirclient:SDL_VIDEODRIVER=mir:NO_AT_BRIDGE=1
+    export MIR_SERVER_ENABLE_MIRCLIENT=
+  fi
+
   # miral-shell can launch it's own terminal with Ctrl-Alt-T
-  MIR_SERVER_FILE=${socket} WAYLAND_DISPLAY=${wayland_display} MIR_SERVER_ENABLE_X11=1 MIR_SERVER_SHELL_TERMINAL_EMULATOR=${terminal} ${hostsocket} exec dbus-run-session -- ${bindir}${miral_server} ${enable_mirclient} $*
+  MIR_SERVER_FILE=${socket} WAYLAND_DISPLAY=${wayland_display} MIR_SERVER_ENABLE_X11=1 MIR_SERVER_SHELL_TERMINAL_EMULATOR=${terminal} ${hostsocket} exec dbus-run-session -- ${bindir}${miral_server}$*
 else
   # With mir_demo_server we will get the display saved to this file
   x11_display_file=$(tempfile)

--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -79,7 +79,7 @@ if [ "${miral_server}" == "miral-shell" ]
 then
   if [ "$(lsb_release -c -s)" == "xenial" ]
   then
-    export MIR_SERVER_APP_ENV=GDK_BACKEND=x11:QT_QPA_PLATFORM=ubuntumirclient:SDL_VIDEODRIVER=mir:NO_AT_BRIDGE=1
+    export MIR_SERVER_APP_ENV="GDK_BACKEND=x11:QT_QPA_PLATFORM=ubuntumirclient:SDL_VIDEODRIVER=mir:NO_AT_BRIDGE=1"
     export MIR_SERVER_ENABLE_MIRCLIENT=
   fi
 

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -36,6 +36,7 @@
 
 #include <linux/input.h>
 #include <unistd.h>
+#include <boost/filesystem.hpp>
 
 int main(int argc, char const* argv[])
 {
@@ -83,7 +84,18 @@ int main(int argc, char const* argv[])
                 return true;
 
             case KEY_T:
-                external_client_launcher.launch({terminal_cmd});
+                {
+                    std::vector<std::string> command_line{terminal_cmd};
+                    if (terminal_cmd == "gnome-terminal" && boost::filesystem::exists("/usr/bin/gnome-terminal.real"))
+                    {
+                        // gnome-terminal is a horrid wrapper script on Ubuntu that needs frigging
+                        command_line.emplace_back("--disable-factory");
+                        command_line.emplace_back("--app-id");
+                        command_line.emplace_back("com.canonical.miral.Terminal");
+                    }
+
+                    external_client_launcher.launch(command_line);
+                }
                 return false;
 
             case KEY_X:


### PR DESCRIPTION
Provide a usable default configuration for Xenial era toolkits.

Also fixes up the `gnome-terminal` launch command so that it works on Ubuntu and similar distros, including Xenial.