### PR TITLE
Use focused window as default popup parent

### DIFF
--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -279,6 +279,12 @@ auto mf::XWaylandWM::get_wm_surface(
         return surface->second;
 }
 
+auto mf::XWaylandWM::get_focused_window() -> std::experimental::optional<xcb_window_t>
+{
+    std::lock_guard<std::mutex> lock{mutex};
+    return focused_window;
+}
+
 void mf::XWaylandWM::set_focus(xcb_window_t xcb_window, bool should_be_focused)
 {
     bool was_focused;

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -65,6 +65,7 @@ public:
     ~XWaylandWM();
 
     auto get_wm_surface(xcb_window_t xcb_window) -> std::experimental::optional<std::shared_ptr<XWaylandSurface>>;
+    auto get_focused_window() -> std::experimental::optional<xcb_window_t>;
     void set_focus(xcb_window_t xcb_window, bool should_be_focused);
     void run_on_wayland_thread(std::function<void()>&& work);
 


### PR DESCRIPTION
When `TRANSIENT_FOR` is set to a window without a scene surface, use the currently focused window as the fallback popup parent. This happens, for example, when opening Kate's `Bookmarks` menu. This PR works somewhat on its own, and better in conjunction with #1296 