### PR TITLE
Give windows human readable names

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -45,6 +45,30 @@ auto data_buffer_to_debug_string(
     ss << "]";
     return ss.str();
 }
+
+template<typename T, size_t length>
+constexpr size_t length_of(T(&)[length])
+{
+    return length;
+}
+
+/// Convert any sort of ID into a human-like readable (and memorable) name for debugging
+/// 0 results in Null, and IDs that are close together often rhyme
+auto number_to_readable_name(uint32_t number) -> std::string
+{
+    static const char* beginnings[]{"N", "Al", "Aver", "B", "Ch", "D", "Ell", "Ev", "F", "G", "Gr", "H", "Iv", "J", "K",
+        "L", "M", "Mr ", "Ms ", "Mx ", "P", "Pr", "Qu", "R", "S", "T", "Tr", "V", "W", "Z"};
+    static const char* middles[]{"u", "a", "ai", "ay", "e", "ee", "el", "en", "i", "ing", "o", "oo", "ou", "or"};
+    static const char* ends[]{"ll", "b", "ck", "cy", "d", "dy", "gh", "gia", "r", "l", "le", "liet", "lie", "mer", "nd",
+        "ny", "rd", "sly", "son", "ss", "thy", "te", "tt", "xon", "y", "yton", "zz", ""};
+    std::stringstream ss;
+    ss << beginnings[number % length_of(beginnings)];
+    number /= length_of(beginnings);
+    ss << middles[number % length_of(middles)];
+    number /= length_of(middles);
+    ss << ends[number % length_of(ends)];
+    return ss.str();
+}
 }
 
 mf::XCBConnection::Atom::Atom(std::string const& name, XCBConnection* connection)
@@ -456,14 +480,14 @@ auto mf::XCBConnection::client_message_debug_string(xcb_client_message_event_t* 
 
 auto mf::XCBConnection::window_debug_string(xcb_window_t window) const -> std::string
 {
-    if (!window)
+    if (window == XCB_WINDOW_NONE)
         return "null window";
     else if (window == xcb_screen->root)
         return "root window";
     else if (is_ours(window))
-        return "our window " + std::to_string(window);
+        return "our window " + number_to_readable_name(window);
     else
-        return "window " + std::to_string(window);
+        return "window " + number_to_readable_name(window);
 }
 
 auto mf::XCBConnection::xcb_type_atom(XCBType type) const -> xcb_atom_t

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -550,7 +550,7 @@ void mf::XWaylandWM::handle_create_notify(xcb_create_notify_event_t *event)
 
             if (surfaces.find(event->window) != surfaces.end())
                 BOOST_THROW_EXCEPTION(
-                    std::runtime_error(connection->window_debug_string(event->window) + " created, but already known"));
+                    std::runtime_error("X11 window " + std::to_string(event->window) + " created, but already known"));
 
             surfaces[event->window] = surface;
         }


### PR DESCRIPTION
Makes remembering window names when debugging much easier. I threw up a generic form of this function here: https://github.com/wmww/name-of/.