### PR TITLE
X11 platform: scale option for "fake" output

### DIFF
--- a/src/platforms/mesa/server/x11/graphics/display.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display.cpp
@@ -27,6 +27,7 @@
 #include "mir/graphics/transformation.h"
 #include "display_configuration.h"
 #include "display.h"
+#include "platform.h"
 #include "display_buffer.h"
 #include "../X11_resources.h"
 
@@ -234,7 +235,7 @@ unsigned long mgx::X11Window::red_mask() const
 }
 
 mgx::Display::Display(::Display* x_dpy,
-                      std::vector<geom::Size> const& requested_sizes,
+                      std::vector<X11OutputConfig> const& requested_sizes,
                       std::shared_ptr<GLConfig> const& gl_config,
                       std::shared_ptr<DisplayReport> const& report)
     : shared_egl{*gl_config},
@@ -251,7 +252,7 @@ mgx::Display::Display(::Display* x_dpy,
 
     for (auto const& requested_size : requested_sizes)
     {
-        auto actual_size = clip_to_display(x_dpy, requested_size);
+        auto actual_size = clip_to_display(x_dpy, requested_size.size);
         auto window = std::make_unique<X11Window>(x_dpy, shared_egl.display(), actual_size, shared_egl.config());
         auto red_mask = window->red_mask();
         auto pf = (red_mask == 0xFF0000 ?

--- a/src/platforms/mesa/server/x11/graphics/display.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display.cpp
@@ -263,7 +263,7 @@ mgx::Display::Display(::Display* x_dpy,
             actual_size,
             top_left,
             geom::Size{actual_size.width * pixel_width, actual_size.height * pixel_height},
-            1.0f,
+            requested_size.scale,
             mir_orientation_normal);
         auto display_buffer = std::make_unique<mgx::DisplayBuffer>(
             x_dpy,

--- a/src/platforms/mesa/server/x11/graphics/display.h
+++ b/src/platforms/mesa/server/x11/graphics/display.h
@@ -45,6 +45,7 @@ namespace X
 {
 
 class DisplayBuffer;
+class X11OutputConfig;
 
 class X11Window
 {
@@ -70,7 +71,7 @@ class Display : public graphics::Display,
 {
 public:
     explicit Display(::Display* x_dpy,
-                     std::vector<geometry::Size> const& requested_size,
+                     std::vector<X11OutputConfig> const& requested_size,
                      std::shared_ptr<GLConfig> const& gl_config,
                      std::shared_ptr<DisplayReport> const& report);
     ~Display() noexcept;

--- a/src/platforms/mesa/server/x11/graphics/graphics.cpp
+++ b/src/platforms/mesa/server/x11/graphics/graphics.cpp
@@ -66,7 +66,8 @@ void add_graphics_platform_options(boost::program_options::options_description& 
     config.add_options()
         (x11_displays_option_name,
          boost::program_options::value<std::string>()->default_value("1280x1024"),
-         "[mir-on-X specific] Colon separated list of WIDTHxHEIGHT sizes for \"output\" windows.");
+         "[mir-on-X specific] Colon separated list of WIDTHxHEIGHT sizes for \"output\" windows."
+         " ^SCALE may also be appended to any output");
 }
 
 mg::PlatformPriority probe_graphics_platform(

--- a/src/platforms/mesa/server/x11/graphics/graphics.cpp
+++ b/src/platforms/mesa/server/x11/graphics/graphics.cpp
@@ -55,7 +55,7 @@ mir::UniqueModulePtr<mg::Platform> create_host_platform(
 
     return mir::make_module_ptr<mgx::Platform>(
         mx::X11Resources::instance.get_conn(),
-        output_sizes,
+        move(output_sizes),
         report
     );
 }
@@ -125,7 +125,7 @@ mir::UniqueModulePtr<mir::graphics::DisplayPlatform> create_display_platform(
 
     return mir::make_module_ptr<mgx::Platform>(
         mx::X11Resources::instance.get_conn(),
-        output_sizes,
+        move(output_sizes),
         report);
 }
 

--- a/src/platforms/mesa/server/x11/graphics/platform.cpp
+++ b/src/platforms/mesa/server/x11/graphics/platform.cpp
@@ -88,21 +88,21 @@ auto parse_size(std::string const& str) -> mgx::X11OutputConfig
 }
 }
 
-auto mgx::Platform::parse_output_sizes(std::string output_sizes) -> std::unique_ptr<std::vector<mgx::X11OutputConfig>>
+auto mgx::Platform::parse_output_sizes(std::string output_sizes) -> std::vector<mgx::X11OutputConfig>
 {
-    auto sizes = std::make_unique<std::vector<mgx::X11OutputConfig>>();
+    std::vector<mgx::X11OutputConfig> sizes;
     for (int start = 0, end; start - 1 < (int)output_sizes.size(); start = end + 1)
     {
         end = output_sizes.find(':', start);
         if (end == (int)std::string::npos)
             end = output_sizes.size();
-        sizes->push_back(parse_size(output_sizes.substr(start, end - start)));
+        sizes.push_back(parse_size(output_sizes.substr(start, end - start)));
     }
     return sizes;
 }
 
 mgx::Platform::Platform(std::shared_ptr<::Display> const& conn,
-                        std::unique_ptr<std::vector<X11OutputConfig>> output_sizes,
+                        std::vector<X11OutputConfig> output_sizes,
                         std::shared_ptr<mg::DisplayReport> const& report)
     : x11_connection{conn},
       udev{std::make_shared<mir::udev::Context>()},
@@ -127,7 +127,7 @@ mir::UniqueModulePtr<mg::Display> mgx::Platform::create_display(
     std::shared_ptr<DisplayConfigurationPolicy> const& /*initial_conf_policy*/,
     std::shared_ptr<GLConfig> const& gl_config)
 {
-    return make_module_ptr<mgx::Display>(x11_connection.get(), *output_sizes, gl_config, report);
+    return make_module_ptr<mgx::Display>(x11_connection.get(), output_sizes, gl_config, report);
 }
 
 mg::NativeDisplayPlatform* mgx::Platform::native_display_platform()

--- a/src/platforms/mesa/server/x11/graphics/platform.h
+++ b/src/platforms/mesa/server/x11/graphics/platform.h
@@ -38,13 +38,21 @@ namespace X
 struct X11OutputConfig
 {
     inline X11OutputConfig(geometry::Size const& size)
-        : size{size}
+        : size{size},
+          scale{1.0f}
+    {
+    }
+
+    inline X11OutputConfig(geometry::Size const& size, float scale)
+        : size{size},
+          scale{scale}
     {
     }
 
     ~X11OutputConfig() = default;
 
     geometry::Size size;
+    float scale;
 };
 
 class Platform : public graphics::Platform,

--- a/src/platforms/mesa/server/x11/graphics/platform.h
+++ b/src/platforms/mesa/server/x11/graphics/platform.h
@@ -61,10 +61,10 @@ class Platform : public graphics::Platform,
 {
 public:
     // Parses colon separated list of sizes in the form WIDTHxHEIGHT^SCALE (^SCALE is optional)
-    static auto parse_output_sizes(std::string output_sizes) -> std::unique_ptr<std::vector<X11OutputConfig>>;
+    static auto parse_output_sizes(std::string output_sizes) -> std::vector<X11OutputConfig>;
 
     explicit Platform(std::shared_ptr<::Display> const& conn,
-                      std::unique_ptr<std::vector<X11OutputConfig>> output_sizes,
+                      std::vector<X11OutputConfig> output_sizes,
                       std::shared_ptr<DisplayReport> const& report);
     ~Platform() = default;
 
@@ -88,7 +88,7 @@ private:
     std::shared_ptr<mesa::helpers::DRMHelper> const drm;
     std::shared_ptr<DisplayReport> const report;
     mesa::helpers::GBMHelper gbm;
-    std::unique_ptr<std::vector<X11OutputConfig>> const output_sizes;
+    std::vector<X11OutputConfig> const output_sizes;
     std::unique_ptr<mesa::DRMNativePlatformAuthFactory> auth_factory;
 };
 

--- a/src/platforms/mesa/server/x11/graphics/platform.h
+++ b/src/platforms/mesa/server/x11/graphics/platform.h
@@ -60,7 +60,7 @@ class Platform : public graphics::Platform,
                  public mir::renderer::gl::EGLPlatform
 {
 public:
-    // Parses colon separated list of sizes in the form WIDTHxHEIGHT
+    // Parses colon separated list of sizes in the form WIDTHxHEIGHT^SCALE (^SCALE is optional)
     static auto parse_output_sizes(std::string output_sizes) -> std::unique_ptr<std::vector<X11OutputConfig>>;
 
     explicit Platform(std::shared_ptr<::Display> const& conn,

--- a/src/platforms/mesa/server/x11/graphics/platform.h
+++ b/src/platforms/mesa/server/x11/graphics/platform.h
@@ -35,6 +35,17 @@ namespace graphics
 {
 namespace X
 {
+struct X11OutputConfig
+{
+    inline X11OutputConfig(geometry::Size const& size)
+        : size{size}
+    {
+    }
+
+    ~X11OutputConfig() = default;
+
+    geometry::Size size;
+};
 
 class Platform : public graphics::Platform,
                  public graphics::NativeRenderingPlatform,
@@ -42,10 +53,10 @@ class Platform : public graphics::Platform,
 {
 public:
     // Parses colon separated list of sizes in the form WIDTHxHEIGHT
-    static std::vector<geometry::Size> parse_output_sizes(std::string output_sizes);
+    static auto parse_output_sizes(std::string output_sizes) -> std::unique_ptr<std::vector<X11OutputConfig>>;
 
     explicit Platform(std::shared_ptr<::Display> const& conn,
-                      std::vector<mir::geometry::Size> const output_sizes,
+                      std::unique_ptr<std::vector<X11OutputConfig>> output_sizes,
                       std::shared_ptr<DisplayReport> const& report);
     ~Platform() = default;
 
@@ -69,7 +80,7 @@ private:
     std::shared_ptr<mesa::helpers::DRMHelper> const drm;
     std::shared_ptr<DisplayReport> const report;
     mesa::helpers::GBMHelper gbm;
-    std::vector<mir::geometry::Size> const output_sizes;
+    std::unique_ptr<std::vector<X11OutputConfig>> const output_sizes;
     std::unique_ptr<mesa::DRMNativePlatformAuthFactory> auth_factory;
 };
 

--- a/tests/unit-tests/platforms/mesa/x11/test_display.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_display.cpp
@@ -192,6 +192,28 @@ TEST_F(X11DisplayTest, calculates_physical_size_of_display_based_on_default_scre
     EXPECT_THAT(reported_size, Eq(expected_size));
 }
 
+TEST_F(X11DisplayTest, sets_output_scale)
+{
+    auto const scale = 2.5f;
+    auto const pixel = geom::Size{2880, 1800};
+    auto const mm = geom::Size{677, 290};
+    auto const window = geom::Size{1280, 1024};
+
+    setup_x11_screen(pixel, mm, {{window, scale}});
+
+    auto display = create_display();
+    auto config = display->configuration();
+    float reported_scale = -10.0f;
+    config->for_each_output(
+        [&reported_scale](mg::DisplayConfigurationOutput const& output)
+        {
+            reported_scale = output.scale;
+        }
+        );
+
+    EXPECT_THAT(reported_scale, FloatEq(scale));
+}
+
 TEST_F(X11DisplayTest, reports_a_resolution_that_matches_the_window_size)
 {
     auto const pixel = geom::Size{2880, 1800};

--- a/tests/unit-tests/platforms/mesa/x11/test_display.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_display.cpp
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 
 #include "src/platforms/mesa/server/x11/graphics/display.h"
+#include "src/platforms/mesa/server/x11/graphics/platform.h"
 #include "src/server/report/null/display_report.h"
 
 #include "mir/graphics/display_configuration.h"
@@ -45,7 +46,7 @@ namespace
 class X11DisplayTest : public ::testing::Test
 {
 public:
-    std::vector<geom::Size> sizes{{1280, 1024}};
+    std::vector<mgx::X11OutputConfig> sizes{{geom::Size{1280, 1024}}};
 
     X11DisplayTest()
     {
@@ -66,14 +67,14 @@ public:
                                           mock_egl.fake_egl_surface,
                                           EGL_WIDTH,
                                           _))
-            .WillByDefault(DoAll(SetArgPointee<3>(sizes[0].width.as_int()),
+            .WillByDefault(DoAll(SetArgPointee<3>(sizes[0].size.width.as_int()),
                             Return(EGL_TRUE)));
 
         ON_CALL(mock_egl, eglQuerySurface(mock_egl.fake_egl_display,
                                           mock_egl.fake_egl_surface,
                                           EGL_HEIGHT,
                                           _))
-            .WillByDefault(DoAll(SetArgPointee<3>(sizes[0].height.as_int()),
+            .WillByDefault(DoAll(SetArgPointee<3>(sizes[0].size.height.as_int()),
                             Return(EGL_TRUE)));
 
         ON_CALL(mock_egl, eglGetConfigAttrib(mock_egl.fake_egl_display,
@@ -89,7 +90,10 @@ public:
                        Return(1)));
     }
 
-    void setup_x11_screen(geom::Size const& pixel, geom::Size const& mm, std::vector<geom::Size> const& window_sizes)
+    void setup_x11_screen(
+        geom::Size const& pixel,
+        geom::Size const& mm,
+        std::vector<mgx::X11OutputConfig> const& window_sizes)
     {
         mock_x11.fake_x11.screen.width = pixel.width.as_int();
         mock_x11.fake_x11.screen.height = pixel.height.as_int();
@@ -122,7 +126,14 @@ TEST_F(X11DisplayTest, creates_display_successfully)
 {
     using namespace testing;
 
-    EXPECT_CALL(mock_x11, XCreateWindow_wrapper(mock_x11.fake_x11.display,_, sizes[0].width.as_int(), sizes[0].height.as_int(),_,_,_,_,_,_))
+    EXPECT_CALL(
+        mock_x11,
+        XCreateWindow_wrapper(
+            mock_x11.fake_x11.display,
+            _,
+            sizes[0].size.width.as_int(),
+            sizes[0].size.height.as_int()
+            ,_ ,_ ,_ ,_ ,_ ,_))
         .Times(Exactly(1));
 
     EXPECT_CALL(mock_x11, XNextEvent(mock_x11.fake_x11.display,_))
@@ -206,7 +217,7 @@ TEST_F(X11DisplayTest, reports_resolutions_that_match_multiple_window_sizes)
 {
     auto const pixel = geom::Size{2880, 1800};
     auto const mm = geom::Size{677, 290};
-    auto const window_sizes = std::vector<geom::Size>{{1280, 1024}, {600, 500}, {20, 50}, {600, 500}};
+    auto const window_sizes = std::vector<mgx::X11OutputConfig>{{{1280, 1024}}, {{600, 500}}, {{20, 50}}, {{600, 500}}};
 
     setup_x11_screen(pixel, mm, window_sizes);
 
@@ -219,7 +230,7 @@ TEST_F(X11DisplayTest, reports_resolutions_that_match_multiple_window_sizes)
             bool output_found = false;
             for (auto i = 0u; i < remaining_sizes.size(); i++)
             {
-                if (remaining_sizes[i] == output.modes[0].size)
+                if (remaining_sizes[i].size == output.modes[0].size)
                 {
                     output_found = true;
                     remaining_sizes.erase(remaining_sizes.begin() + i);
@@ -237,7 +248,7 @@ TEST_F(X11DisplayTest, multiple_outputs_are_organized_horizontally)
 {
     auto const pixel = geom::Size{2880, 1800};
     auto const mm = geom::Size{677, 290};
-    auto const window_sizes = std::vector<geom::Size>{{1280, 1024}, {600, 500}, {20, 50}, {600, 500}};
+    auto const window_sizes = std::vector<mgx::X11OutputConfig>{{{1280, 1024}}, {{600, 500}}, {{20, 50}}, {{600, 500}}};
     auto const top_lefts = std::vector<geom::Point>{{0, 0}, {1280, 0}, {1880, 0}, {1900, 0}};
 
     setup_x11_screen(pixel, mm, window_sizes);
@@ -250,7 +261,7 @@ TEST_F(X11DisplayTest, multiple_outputs_are_organized_horizontally)
             bool output_found = false;
             for (auto i = 0u; i < window_sizes.size(); i++)
             {
-                if (window_sizes[i] == output.modes[0].size && top_lefts[i] == output.top_left)
+                if (window_sizes[i].size == output.modes[0].size && top_lefts[i] == output.top_left)
                 {
                     output_found = true;
                     break;
@@ -287,7 +298,7 @@ TEST_F(X11DisplayTest, multiple_outputs_are_organized_horizontally_after_adjusti
     auto const pixel = geom::Size{1000, 1000};
     auto const mm = geom::Size{677, 290};
     auto const border = 150; //must match the border value in clip_to_display()
-    auto const window_sizes = std::vector<geom::Size>{{1280, 1024}, {100, 100}};
+    auto const window_sizes = std::vector<mgx::X11OutputConfig>{{{1280, 1024}}, {{100, 100}}};
 
     setup_x11_screen(pixel, mm, window_sizes);
 

--- a/tests/unit-tests/platforms/mesa/x11/test_display_generic.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_display_generic.cpp
@@ -97,6 +97,7 @@ public:
 
     std::shared_ptr<mg::Display> create_display()
     {
+        std::vector<mg::X::X11OutputConfig> const output_config{{{1280, 1024}}};
         auto const platform = std::make_shared<mg::X::Platform>(
             std::shared_ptr<::Display>(
                 XOpenDisplay(nullptr),
@@ -104,7 +105,7 @@ public:
                 {
                     XCloseDisplay(display);
                 }),
-            std::vector<mir::geometry::Size>{{1280, 1024}},
+            std::make_unique<std::vector<mg::X::X11OutputConfig>>(output_config),
             std::make_shared<mir::report::null::DisplayReport>());
         return platform->create_display(
             std::make_shared<mg::CloneDisplayConfigurationPolicy>(),

--- a/tests/unit-tests/platforms/mesa/x11/test_display_generic.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_display_generic.cpp
@@ -97,7 +97,6 @@ public:
 
     std::shared_ptr<mg::Display> create_display()
     {
-        std::vector<mg::X::X11OutputConfig> const output_config{{{1280, 1024}}};
         auto const platform = std::make_shared<mg::X::Platform>(
             std::shared_ptr<::Display>(
                 XOpenDisplay(nullptr),
@@ -105,7 +104,7 @@ public:
                 {
                     XCloseDisplay(display);
                 }),
-            std::make_unique<std::vector<mg::X::X11OutputConfig>>(output_config),
+            std::vector<mg::X::X11OutputConfig>{{{1280, 1024}}},
             std::make_shared<mir::report::null::DisplayReport>());
         return platform->create_display(
             std::make_shared<mg::CloneDisplayConfigurationPolicy>(),

--- a/tests/unit-tests/platforms/mesa/x11/test_graphics_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_graphics_platform.cpp
@@ -80,6 +80,7 @@ public:
 
     std::shared_ptr<mg::Platform> create_platform()
     {
+        std::vector<mg::X::X11OutputConfig> const output_config{{{1280, 1024}}};
         return std::make_shared<mg::X::Platform>(
             std::shared_ptr<::Display>(
                 XOpenDisplay(nullptr),
@@ -87,7 +88,7 @@ public:
                 {
                     XCloseDisplay(display);
                 }),
-            std::vector<mir::geometry::Size>{{1280, 1024}},
+            std::make_unique<std::vector<mg::X::X11OutputConfig>>(output_config),
             std::make_shared<mir::report::null::DisplayReport>());
     }
 

--- a/tests/unit-tests/platforms/mesa/x11/test_graphics_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_graphics_platform.cpp
@@ -80,7 +80,6 @@ public:
 
     std::shared_ptr<mg::Platform> create_platform()
     {
-        std::vector<mg::X::X11OutputConfig> const output_config{{{1280, 1024}}};
         return std::make_shared<mg::X::Platform>(
             std::shared_ptr<::Display>(
                 XOpenDisplay(nullptr),
@@ -88,7 +87,7 @@ public:
                 {
                     XCloseDisplay(display);
                 }),
-            std::make_unique<std::vector<mg::X::X11OutputConfig>>(output_config),
+            std::vector<mg::X::X11OutputConfig>{{{1280, 1024}}},
             std::make_shared<mir::report::null::DisplayReport>());
     }
 

--- a/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
@@ -38,7 +38,8 @@ namespace X
 {
 auto operator==(X11OutputConfig const& a, X11OutputConfig const& b) -> bool
 {
-    return a.size == b.size;
+    return a.size == b.size &&
+           testing::Value(a.scale, testing::FloatEq(b.scale));
 }
 }
 }

--- a/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
@@ -70,7 +70,6 @@ public:
 
     std::shared_ptr<mg::Platform> create_platform()
     {
-        std::vector<mg::X::X11OutputConfig> const output_config{{{1280, 1024}}};
         return std::make_shared<mg::X::Platform>(
             std::shared_ptr<::Display>(
                 XOpenDisplay(nullptr),
@@ -78,7 +77,7 @@ public:
                 {
                     XCloseDisplay(display);
                 }),
-            std::make_unique<std::vector<mg::X::X11OutputConfig>>(output_config),
+            std::vector<mg::X::X11OutputConfig>{{{1280, 1024}}},
             std::make_shared<mir::report::null::DisplayReport>());
     }
 
@@ -161,7 +160,7 @@ TEST_F(X11GraphicsPlatformTest, parses_simple_output_size)
     auto str = "1280x720";
     auto parsed = mg::X::Platform::parse_output_sizes(str);
 
-    EXPECT_THAT(*parsed, ElementsAre(mgx::X11OutputConfig{{1280, 720}}));
+    EXPECT_THAT(parsed, ElementsAre(mgx::X11OutputConfig{{1280, 720}}));
 }
 
 TEST_F(X11GraphicsPlatformTest, parses_output_size_with_whole_number_scale)
@@ -171,7 +170,7 @@ TEST_F(X11GraphicsPlatformTest, parses_output_size_with_whole_number_scale)
     auto str = "1280x720^2";
     auto parsed = mg::X::Platform::parse_output_sizes(str);
 
-    EXPECT_THAT(*parsed, ElementsAre(mgx::X11OutputConfig{{1280, 720}, 2}));
+    EXPECT_THAT(parsed, ElementsAre(mgx::X11OutputConfig{{1280, 720}, 2}));
 }
 
 TEST_F(X11GraphicsPlatformTest, parses_output_size_with_fractional_scale)
@@ -182,7 +181,7 @@ TEST_F(X11GraphicsPlatformTest, parses_output_size_with_fractional_scale)
     auto parsed = mg::X::Platform::parse_output_sizes(str);
 
     // X11OutputConfig equality operator does not do exact float comparison
-    EXPECT_THAT(*parsed, ElementsAre(mgx::X11OutputConfig{{1280, 720}, 0.8}));
+    EXPECT_THAT(parsed, ElementsAre(mgx::X11OutputConfig{{1280, 720}, 0.8}));
 }
 
 TEST_F(X11GraphicsPlatformTest, parses_multiple_output_sizes)
@@ -192,7 +191,7 @@ TEST_F(X11GraphicsPlatformTest, parses_multiple_output_sizes)
     auto str = "1280x1024:600x600:30x750";
     auto parsed = mg::X::Platform::parse_output_sizes(str);
 
-    EXPECT_THAT(*parsed, ElementsAre(
+    EXPECT_THAT(parsed, ElementsAre(
         mgx::X11OutputConfig{{1280, 1024}},
         mgx::X11OutputConfig{{600, 600}},
         mgx::X11OutputConfig{{30, 750}}));
@@ -205,7 +204,7 @@ TEST_F(X11GraphicsPlatformTest, parses_multiple_output_sizes_some_with_scales)
     auto str = "1280x1024^.9:600x600:30x750^12";
     auto parsed = mg::X::Platform::parse_output_sizes(str);
 
-    EXPECT_THAT(*parsed, ElementsAre(
+    EXPECT_THAT(parsed, ElementsAre(
         mgx::X11OutputConfig{{1280, 1024}, 0.9},
         mgx::X11OutputConfig{{600, 600}},
         mgx::X11OutputConfig{{30, 750}, 12}));

--- a/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
@@ -30,7 +30,22 @@
 #include "mir_test_framework/executable_path.h"
 #include "mir_test_framework/udev_environment.h"
 
+namespace mir
+{
+namespace graphics
+{
+namespace X
+{
+auto operator==(X11OutputConfig const& a, X11OutputConfig const& b) -> bool
+{
+    return a.size == b.size;
+}
+}
+}
+}
+
 namespace mg = mir::graphics;
+namespace mgx = mir::graphics::X;
 namespace mtd = mir::test::doubles;
 namespace mtf = mir_test_framework;
 
@@ -49,6 +64,7 @@ public:
 
     std::shared_ptr<mg::Platform> create_platform()
     {
+        std::vector<mg::X::X11OutputConfig> const output_config{{{1280, 1024}}};
         return std::make_shared<mg::X::Platform>(
             std::shared_ptr<::Display>(
                 XOpenDisplay(nullptr),
@@ -56,7 +72,7 @@ public:
                 {
                     XCloseDisplay(display);
                 }),
-            std::vector<mir::geometry::Size>{{1280, 1024}},
+            std::make_unique<std::vector<mg::X::X11OutputConfig>>(output_config),
             std::make_shared<mir::report::null::DisplayReport>());
     }
 
@@ -139,7 +155,7 @@ TEST_F(X11GraphicsPlatformTest, parses_simple_output_size)
     auto str = "1280x720";
     auto parsed = mg::X::Platform::parse_output_sizes(str);
 
-    EXPECT_THAT(parsed, Eq(std::vector<mir::geometry::Size>{{1280, 720}}));
+    EXPECT_THAT(*parsed, Eq(std::vector<mgx::X11OutputConfig>{{{1280, 720}}}));
 }
 
 TEST_F(X11GraphicsPlatformTest, parses_multiple_output_size)
@@ -149,7 +165,7 @@ TEST_F(X11GraphicsPlatformTest, parses_multiple_output_size)
     auto str = "1280x1024:600x600:30x750";
     auto parsed = mg::X::Platform::parse_output_sizes(str);
 
-    EXPECT_THAT(parsed, Eq(std::vector<mir::geometry::Size>{{1280, 1024}, {600, 600}, {30, 750}}));
+    EXPECT_THAT(*parsed, Eq(std::vector<mgx::X11OutputConfig>{{{1280, 1024}}, {{600, 600}}, {{30, 750}}}));
 }
 
 TEST_F(X11GraphicsPlatformTest, output_size_parsing_throws_on_bad_input)

--- a/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_platform.cpp
@@ -41,6 +41,11 @@ auto operator==(X11OutputConfig const& a, X11OutputConfig const& b) -> bool
     return a.size == b.size &&
            testing::Value(a.scale, testing::FloatEq(b.scale));
 }
+
+auto operator<<(std::ostream& os, X11OutputConfig const& config) -> std::ostream&
+{
+    return os << "size: " << config.size << ", scale: " << config.scale;
+}
 }
 }
 }
@@ -156,17 +161,54 @@ TEST_F(X11GraphicsPlatformTest, parses_simple_output_size)
     auto str = "1280x720";
     auto parsed = mg::X::Platform::parse_output_sizes(str);
 
-    EXPECT_THAT(*parsed, Eq(std::vector<mgx::X11OutputConfig>{{{1280, 720}}}));
+    EXPECT_THAT(*parsed, ElementsAre(mgx::X11OutputConfig{{1280, 720}}));
 }
 
-TEST_F(X11GraphicsPlatformTest, parses_multiple_output_size)
+TEST_F(X11GraphicsPlatformTest, parses_output_size_with_whole_number_scale)
+{
+    using namespace ::testing;
+
+    auto str = "1280x720^2";
+    auto parsed = mg::X::Platform::parse_output_sizes(str);
+
+    EXPECT_THAT(*parsed, ElementsAre(mgx::X11OutputConfig{{1280, 720}, 2}));
+}
+
+TEST_F(X11GraphicsPlatformTest, parses_output_size_with_fractional_scale)
+{
+    using namespace ::testing;
+
+    auto str = "1280x720^0.8";
+    auto parsed = mg::X::Platform::parse_output_sizes(str);
+
+    // X11OutputConfig equality operator does not do exact float comparison
+    EXPECT_THAT(*parsed, ElementsAre(mgx::X11OutputConfig{{1280, 720}, 0.8}));
+}
+
+TEST_F(X11GraphicsPlatformTest, parses_multiple_output_sizes)
 {
     using namespace ::testing;
 
     auto str = "1280x1024:600x600:30x750";
     auto parsed = mg::X::Platform::parse_output_sizes(str);
 
-    EXPECT_THAT(*parsed, Eq(std::vector<mgx::X11OutputConfig>{{{1280, 1024}}, {{600, 600}}, {{30, 750}}}));
+    EXPECT_THAT(*parsed, ElementsAre(
+        mgx::X11OutputConfig{{1280, 1024}},
+        mgx::X11OutputConfig{{600, 600}},
+        mgx::X11OutputConfig{{30, 750}}));
+}
+
+TEST_F(X11GraphicsPlatformTest, parses_multiple_output_sizes_some_with_scales)
+{
+    using namespace ::testing;
+
+    auto str = "1280x1024^.9:600x600:30x750^12";
+    auto parsed = mg::X::Platform::parse_output_sizes(str);
+
+    EXPECT_THAT(*parsed, ElementsAre(
+        mgx::X11OutputConfig{{1280, 1024}, 0.9},
+        mgx::X11OutputConfig{{600, 600}},
+        mgx::X11OutputConfig{{30, 750}, 12}));
 }
 
 TEST_F(X11GraphicsPlatformTest, output_size_parsing_throws_on_bad_input)
@@ -178,6 +220,7 @@ TEST_F(X11GraphicsPlatformTest, output_size_parsing_throws_on_bad_input)
     EXPECT_THROW(mg::X::Platform::parse_output_sizes("=20x40"), std::runtime_error) << "Random equals";
     EXPECT_THROW(mg::X::Platform::parse_output_sizes("20x30x40"), std::runtime_error) << "Too many dimensions";
     EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x720:"), std::runtime_error) << "Ends with delim";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280.5x720"), std::runtime_error) << "Fractional size";
     EXPECT_THROW(mg::X::Platform::parse_output_sizes(":1280x720"), std::runtime_error) << "Starts with delim";
     EXPECT_THROW(mg::X::Platform::parse_output_sizes("1280x720:500"), std::runtime_error) << "No height or x on 2nd size";
     EXPECT_THROW(mg::X::Platform::parse_output_sizes("50x50:x20:50x50"), std::runtime_error) << "No width on 2nd size";
@@ -185,4 +228,8 @@ TEST_F(X11GraphicsPlatformTest, output_size_parsing_throws_on_bad_input)
     EXPECT_THROW(mg::X::Platform::parse_output_sizes("0x0"), std::runtime_error) << "Zero size";
     EXPECT_THROW(mg::X::Platform::parse_output_sizes("0x200"), std::runtime_error) << "Zero width";
     EXPECT_THROW(mg::X::Platform::parse_output_sizes("200x-300"), std::runtime_error) << "Negative height";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("200x300^"), std::runtime_error) << "Ends with ^";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("200x^2"), std::runtime_error) << "Scale but no height";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("200x300^2^2"), std::runtime_error) << "Multiple scales";
+    EXPECT_THROW(mg::X::Platform::parse_output_sizes("200x300^2..8"), std::runtime_error) << "Multiple scale decimal points";
 }


### PR DESCRIPTION
We already have an option that allows creating multiple X11 windows that act as outputs of different sizes. This adds the additional functionality of optionally specifying a scale for each output with the syntax `^SCALE`.

For example, `--x11-output 640x480:1020x720^2.5` would result in two "outputs", a 640x480 one with a scale of 1 and a 1020x720 one with a scale of 2.5.

This aims to make testing HiDPI much easier.