### PR TITLE
Fix launching gnome-terminal from "Mir Shell"

### DIFF
--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -90,8 +90,6 @@ int main(int argc, char const* argv[])
                     {
                         // gnome-terminal is a horrid wrapper script on Ubuntu that needs frigging
                         command_line.emplace_back("--disable-factory");
-                        command_line.emplace_back("--app-id");
-                        command_line.emplace_back("com.canonical.miral.Terminal");
                     }
 
                     external_client_launcher.launch(command_line);


### PR DESCRIPTION
Fix launching gnome-terminal from "Mir Shell".

We should not supply both --disable-factory and --app-id, as that spawns multiple terminal servers. (Which eventually leads to madness.).