### PR TITLE
Mesa/KMS: position cursor correctly when output scaled

### DIFF
--- a/src/platforms/mesa/server/kms/cursor.cpp
+++ b/src/platforms/mesa/server/kms/cursor.cpp
@@ -333,7 +333,7 @@ void mgm::Cursor::hide()
 }
 
 void mgm::Cursor::for_each_used_output(
-    std::function<void(KMSOutput&, geom::Rectangle const&, MirOrientation orientation)> const& f)
+    std::function<void(KMSOutput& output, DisplayConfigurationOutput const& conf)> const& f)
 {
     current_configuration->with_current_configuration_do(
         [&f](KMSDisplayConfiguration const& kms_conf)
@@ -343,8 +343,7 @@ void mgm::Cursor::for_each_used_output(
                 if (conf_output.used)
                 {
                     auto output = kms_conf.get_output_for(conf_output.id);
-
-                    f(*output, conf_output.extents(), conf_output.orientation);
+                    f(*output, conf_output);
                 }
             });
         });
@@ -371,8 +370,11 @@ void mgm::Cursor::place_cursor_at_locked(
 
     bool set_on_all_outputs = true;
 
-    for_each_used_output([&](KMSOutput& output, geom::Rectangle const& output_rect, MirOrientation orientation)
+    for_each_used_output([&](KMSOutput& output, DisplayConfigurationOutput const& conf)
     {
+        auto const output_rect = conf.extents();
+        auto const orientation = conf.orientation;
+
         if (output_rect.contains(position))
         {
             auto dp = transform(output_rect, position - output_rect.top_left, orientation);

--- a/src/platforms/mesa/server/kms/cursor.cpp
+++ b/src/platforms/mesa/server/kms/cursor.cpp
@@ -388,7 +388,7 @@ void mgm::Cursor::place_cursor_at_locked(
                 relative_to_extants_vec.x / output_rect.size.width.as_int(),
                 relative_to_extants_vec.y / output_rect.size.height.as_int()} * 2.0f - glm::vec2{1};
 
-            // Cursor position with the output transform applied on the same (-1, -1) to (1, 1) coordinates
+            // Cursor position on the same (-1, -1) to (1, 1) coordinate system, but with the output transform applied
             auto const transformed_vec = scaled_vec * conf.transformation();
 
             auto const output_size_vec = glm::vec2{output.size().width.as_int(), output.size().height.as_int()};
@@ -398,7 +398,6 @@ void mgm::Cursor::place_cursor_at_locked(
 
             auto const position_on_output = geom::Point{roundf(output_space_vec.x), roundf(output_space_vec.y)};
 
-            //geom::Point const hotspot_position_on_output = transform(output_rect, position - output_rect.top_left, orientation);
             auto const hotspot_displacement = transform(geom::Rectangle{{}, size}, hotspot, orientation);
 
             // It's a little strange that we implement hotspot this way as there is

--- a/src/platforms/mesa/server/kms/cursor.h
+++ b/src/platforms/mesa/server/kms/cursor.h
@@ -43,6 +43,7 @@ struct Rectangle;
 namespace graphics
 {
 class CursorImage;
+class DisplayConfigurationOutput;
 
 namespace mesa
 {
@@ -85,7 +86,7 @@ public:
 private:
     enum ForceCursorState { UpdateState, ForceState };
     struct GBMBOWrapper;
-    void for_each_used_output(std::function<void(KMSOutput&, geometry::Rectangle const&, MirOrientation orientation)> const& f);
+    void for_each_used_output(std::function<void(KMSOutput& output, DisplayConfigurationOutput const& conf)> const& f);
     void place_cursor_at(geometry::Point position, ForceCursorState force_state);
     void place_cursor_at_locked(std::lock_guard<std::mutex> const&, geometry::Point position, ForceCursorState force_state);
     void write_buffer_data_locked(


### PR DESCRIPTION
This correctly applies output transform and scale when positioning the hardware cursor