### PR TITLE
miral-shell background support scaling

### DIFF
--- a/examples/example-server-lib/decoration_provider.cpp
+++ b/examples/example-server-lib/decoration_provider.cpp
@@ -116,7 +116,7 @@ struct BackgroundInfo
         Size const unscaled = (rotated ?
             Size{output.height, output.width} :
             Size{output.width, output.height});
-        return unscaled;
+        return unscaled * (1.0f / output.scale);
     }
 
     // Screen description

--- a/examples/example-server-lib/decoration_provider.cpp
+++ b/examples/example-server-lib/decoration_provider.cpp
@@ -110,6 +110,15 @@ struct BackgroundInfo
             wl_surface_destroy(surface);
     }
 
+    auto content_size() const -> Size
+    {
+        bool const rotated = output.transform == WL_OUTPUT_TRANSFORM_90 || output.transform == WL_OUTPUT_TRANSFORM_270;
+        Size const unscaled = (rotated ?
+            Size{output.height, output.width} :
+            Size{output.width, output.height});
+        return unscaled;
+    }
+
     // Screen description
     Output const& output;
 
@@ -125,10 +134,7 @@ void Printer::printhelp(BackgroundInfo const& region)
     if (!working)
         return;
 
-    bool rotated = region.output.transform == WL_OUTPUT_TRANSFORM_90 || region.output.transform == WL_OUTPUT_TRANSFORM_270;
-    auto const region_size = rotated ?
-        Size{region.output.height, region.output.width} :
-        Size{region.output.width, region.output.height};
+    auto const region_size = region.content_size();
 
     static char const* const helptext[] =
         {
@@ -292,9 +298,9 @@ void DecorationProviderClient::on_new_output(Output const* output)
 
 void DecorationProviderClient::draw_background(BackgroundInfo& ctx) const
 {
-    bool rotated = ctx.output.transform == WL_OUTPUT_TRANSFORM_90 || ctx.output.transform == WL_OUTPUT_TRANSFORM_270;
-    auto const width = rotated ? ctx.output.height : ctx.output.width;
-    auto const height = rotated ? ctx.output.width : ctx.output.height;
+    Size const size = ctx.content_size();
+    int const width = size.width.as_int();
+    int const height = size.height.as_int();
 
     if (width <= 0 || height <= 0)
         return;

--- a/examples/example-server-lib/wayland_helpers.cpp
+++ b/examples/example-server-lib/wayland_helpers.cpp
@@ -139,11 +139,11 @@ void output_mode(
     output->height = height;
 }
 
-void output_scale(void* data, struct wl_output* wl_output, int32_t factor)
+void output_scale(void* data, struct wl_output* /*wl_output*/, int32_t factor)
 {
-    (void)data;
-    (void)wl_output;
-    (void)factor;
+    auto const output = static_cast<Output*>(data);
+
+    output->scale = factor;
 }
 
 }

--- a/examples/example-server-lib/wayland_helpers.h
+++ b/examples/example-server-lib/wayland_helpers.h
@@ -51,6 +51,7 @@ public:
     int32_t x, y;
     int32_t width, height;
     int32_t transform;
+    int32_t scale{1};
     wl_output* output;
 private:
     static void output_done(void* data, wl_output* output);

--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -151,7 +151,7 @@ void mf::Output::send_initial_config(wl_resource* client_resource, mg::DisplayCo
     }
 
     if (wl_resource_get_version(client_resource) >= WL_OUTPUT_SCALE_SINCE_VERSION)
-        wl_output_send_scale(client_resource, 1);
+        wl_output_send_scale(client_resource, ceil(config.scale));
 
     if (wl_resource_get_version(client_resource) >= WL_OUTPUT_DONE_SINCE_VERSION)
         wl_output_send_done(client_resource);


### PR DESCRIPTION
Because Wayland only supports integer scaling the miral-shell background is too small on outputs with fractional scaling. In the future this could be fixed by using the logical size from `xdg_output`.