### PR TITLE
Refactor Wayland output interface

### DIFF
--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -89,7 +89,7 @@ public:
     LayerSurfaceV1(
         wl_resource* new_resource,
         WlSurface* surface,
-        optional_value<graphics::DisplayConfigurationOutputId> output_id,
+        std::experimental::optional<graphics::DisplayConfigurationOutputId> output_id,
         LayerShellV1 const& layer_shell,
         MirDepthLayer layer);
 
@@ -200,7 +200,9 @@ void mf::LayerShellV1::Instance::get_layer_surface(
 {
     (void)namespace_; // TODO
 
-    auto output_id = shell->output_manager->output_id_for(client, output);
+    auto const output_id = output ?
+        shell->output_manager->output_id_for(client, output.value()) :
+        std::experimental::nullopt;
 
     new LayerSurfaceV1(
         new_layer_surface,
@@ -215,7 +217,7 @@ void mf::LayerShellV1::Instance::get_layer_surface(
 mf::LayerSurfaceV1::LayerSurfaceV1(
     wl_resource* new_resource,
     WlSurface* surface,
-    optional_value<graphics::DisplayConfigurationOutputId> output_id,
+    std::experimental::optional<graphics::DisplayConfigurationOutputId> output_id,
     LayerShellV1 const& layer_shell,
     MirDepthLayer layer)
     : mw::LayerSurfaceV1(new_resource, Version<1>()),
@@ -230,7 +232,8 @@ mf::LayerSurfaceV1::LayerSurfaceV1(
     shell::SurfaceSpecification spec;
     spec.state = mir_window_state_attached;
     spec.depth_layer = layer;
-    spec.output_id = output_id;
+    if (output_id)
+        spec.output_id = output_id.value();
     apply_spec(spec);
 }
 

--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -242,6 +242,15 @@ auto mf::OutputManager::output_id_for(wl_client* client, wl_resource* output) co
     return std::experimental::nullopt;
 }
 
+auto mf::OutputManager::output_for(graphics::DisplayConfigurationOutputId id) -> std::experimental::optional<Output*>
+{
+    auto const result = outputs.find(id);
+    if (result != outputs.end())
+        return result->second.get();
+    else
+        return std::experimental::nullopt;
+}
+
 void mf::OutputManager::create_output(mg::DisplayConfigurationOutput const& initial_config)
 {
     if (initial_config.used)

--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -225,29 +225,14 @@ mf::OutputManager::~OutputManager()
     display_config_->unregister_interest(this);
 }
 
-auto mf::OutputManager::output_id_for(
-    wl_client* client,
-    std::experimental::optional<struct wl_resource*> const& output) const
-    -> mir::optional_value<graphics::DisplayConfigurationOutputId>
-{
-    if (output)
-    {
-        return output_id_for(client, output.value());
-    }
-    else
-    {
-        return {};
-    }
-}
-
-auto mf::OutputManager::output_id_for(wl_client* client, struct wl_resource* output) const
-    -> mir::graphics::DisplayConfigurationOutputId
+auto mf::OutputManager::output_id_for(wl_client* client, wl_resource* output) const
+    -> std::experimental::optional<graphics::DisplayConfigurationOutputId>
 {
     for (auto const& dd: outputs)
         if (dd.second->matches_client_resource(client, output))
-            return {dd.first};
+            return dd.first;
 
-    return {};
+    return std::experimental::nullopt;
 }
 
 void mf::OutputManager::create_output(mg::DisplayConfigurationOutput const& initial_config)

--- a/src/server/frontend_wayland/output_manager.h
+++ b/src/server/frontend_wayland/output_manager.h
@@ -47,7 +47,7 @@ public:
 
     void handle_configuration_changed(graphics::DisplayConfigurationOutput const& /*config*/);
 
-    bool matches_client_resource(wl_client* client, struct wl_resource* resource) const;
+    void for_each_output_resource_bound_by(wl_client* client, std::function<void(wl_resource*)> const& functor);
 
 private:
     static void send_initial_config(wl_resource* client_resource, graphics::DisplayConfigurationOutput const& config);

--- a/src/server/frontend_wayland/output_manager.h
+++ b/src/server/frontend_wayland/output_manager.h
@@ -70,11 +70,8 @@ public:
     OutputManager(wl_display* display, std::shared_ptr<MirDisplay> const& display_config, std::shared_ptr<Executor> const& executor);
     ~OutputManager();
 
-    auto output_id_for(wl_client* client, std::experimental::optional<struct wl_resource*> const& /*output*/) const
-        -> optional_value<graphics::DisplayConfigurationOutputId>;
-
-    auto output_id_for(wl_client* client, struct wl_resource* /*output*/) const
-        -> graphics::DisplayConfigurationOutputId;
+    auto output_id_for(wl_client* client, wl_resource* output) const
+        -> std::experimental::optional<graphics::DisplayConfigurationOutputId>;
 
     auto display_config() const -> std::shared_ptr<MirDisplay> {return display_config_;}
 

--- a/src/server/frontend_wayland/output_manager.h
+++ b/src/server/frontend_wayland/output_manager.h
@@ -73,6 +73,8 @@ public:
     auto output_id_for(wl_client* client, wl_resource* output) const
         -> std::experimental::optional<graphics::DisplayConfigurationOutputId>;
 
+    auto output_for(graphics::DisplayConfigurationOutputId id) -> std::experimental::optional<Output*>;
+
     auto display_config() const -> std::shared_ptr<MirDisplay> {return display_config_;}
 
 private:

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -264,14 +264,21 @@ void mf::WindowWlSurfaceRole::set_fullscreen(std::experimental::optional<struct 
     {
         shell::SurfaceSpecification mods;
         mods.state = mir_window_state_fullscreen;
-        mods.output_id = output_manager->output_id_for(client, output);
+        auto const output_id = output ?
+            output_manager->output_id_for(client, output.value()) :
+            std::experimental::nullopt;
+        if (output_id)
+            mods.output_id = output_id.value();
         shell->modify_surface(session, scene_surface, mods);
     }
     else
     {
         params->state = mir_window_state_fullscreen;
-        if (output)
-            params->output_id = output_manager->output_id_for(client, output.value());
+        auto const output_id = output ?
+            output_manager->output_id_for(client, output.value()) :
+            std::experimental::nullopt;
+        if (output_id)
+            params->output_id = output_id.value();
         create_scene_surface();
     }
 }

--- a/src/server/frontend_wayland/xdg_output_v1.cpp
+++ b/src/server/frontend_wayland/xdg_output_v1.cpp
@@ -104,7 +104,14 @@ void mf::XdgOutputManagerV1::Instance::destroy()
 void mf::XdgOutputManagerV1::Instance::get_xdg_output(wl_resource* new_output, wl_resource* output)
 {
     bool found = false;
-    auto const output_id = output_manager->output_id_for(client, output);
+    auto const output_id_opt = output_manager->output_id_for(client, output);
+    if (!output_id_opt)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error(
+            "No output for wl_output@" + std::to_string(wl_resource_get_id(output))));
+    }
+    auto const output_id = output_id_opt.value();
+
     output_manager->display_config()->for_each_output(
         [&found, output, output_id, new_output](mg::DisplayConfigurationOutput const& config)
         {


### PR DESCRIPTION
Improve the interface to the output and output manager classes. `OutputManager::output_for()` will be needed by upcoming HiDPI code.