### PR TITLE
[MirAL] Implement a "no active window" state

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -213,7 +213,7 @@ void miral::BasicWindowManager::remove_surface(
 
 void miral::BasicWindowManager::remove_window(Application const& application, miral::WindowInfo const& info)
 {
-    bool const is_active_window{mru_active_windows.top() == info.window()};
+    bool const is_active_window{active_window() == info.window()};
     auto const workspaces_containing_window = workspaces_containing(info.window());
 
     {

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -547,7 +547,7 @@ void miral::BasicWindowManager::force_close(Window const& window)
 
 auto miral::BasicWindowManager::active_window() const -> Window
 {
-    return mru_active_windows.top();
+    return allow_active_window ? mru_active_windows.top() : Window{};
 }
 
 void miral::BasicWindowManager::focus_next_application()
@@ -1532,6 +1532,9 @@ void miral::BasicWindowManager::invoke_under_lock(std::function<void()> const& c
 auto miral::BasicWindowManager::select_active_window(Window const& hint) -> miral::Window
 {
     auto const prev_window = active_window();
+
+    // Lomiri "selects" a null Window to implicitly disable the active window
+    allow_active_window = hint;
 
     if (!hint)
     {

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -245,6 +245,7 @@ private:
     uint64_t last_input_event_timestamp{0};
     MirEvent const* last_input_event{nullptr};
     miral::MRUWindowList mru_active_windows;
+    bool allow_active_window = true;
     std::set<Window> fullscreen_surfaces;
     std::vector<std::shared_ptr<DisplayArea>> display_areas; ///< For now these will map 1:1 to outputs, but this should not be assumed
 

--- a/tests/miral/active_window.cpp
+++ b/tests/miral/active_window.cpp
@@ -489,3 +489,21 @@ TEST_F(ActiveWindow, when_focus_changes_parents_gain_focus_first)
 
     EXPECT_TRUE(sync3.signal_raised());
 }
+
+TEST_F(ActiveWindow, when_null_window_is_active_dont_refocus_on_last_active_window_hidden)
+{
+    char const* const test_name = __PRETTY_FUNCTION__;
+    auto const connection = connect_client(test_name);
+
+    auto const first_window = create_window(connection, test_name, sync1);
+    auto const second_window = create_window(connection, another_name, sync2);
+
+    sync2.exec([&]{ invoke_tools([&](WindowManagerTools& tools){ tools.select_active_window(miral::Window{}); }); });
+    EXPECT_TRUE(sync2.signal_raised());
+    assert_no_active_window();
+
+    // Expect this to timeout: the first window should not receive focus
+    sync1.exec([&]{ mir_window_set_state(second_window, mir_window_state_hidden); });
+    EXPECT_FALSE(sync1.signal_raised());
+    assert_no_active_window();
+}

--- a/tests/miral/active_window.cpp
+++ b/tests/miral/active_window.cpp
@@ -507,3 +507,21 @@ TEST_F(ActiveWindow, when_null_window_is_active_dont_refocus_on_last_active_wind
     EXPECT_FALSE(sync1.signal_raised());
     assert_no_active_window();
 }
+
+TEST_F(ActiveWindow, when_null_window_is_active_dont_refocus_on_last_active_window_removed)
+{
+    char const* const test_name = __PRETTY_FUNCTION__;
+    auto const connection = connect_client(test_name);
+
+    auto const first_window = create_window(connection, test_name, sync1);
+    auto second_window = create_window(connection, another_name, sync2);
+
+    sync2.exec([&]{ invoke_tools([&](WindowManagerTools& tools){ tools.select_active_window(miral::Window{}); }); });
+    EXPECT_TRUE(sync2.signal_raised());
+    assert_no_active_window();
+
+    // Expect this to timeout: the first window should not receive focus
+    sync1.exec([&]{ second_window = Window{}; });
+    EXPECT_FALSE(sync1.signal_raised());
+    assert_no_active_window();
+}


### PR DESCRIPTION
When setting the active window to a null window, mru_active_windows
won't be updated. This commit add the `allow_active_window` flag which
will be false when a null window is set, disabling the active window.

This is used by Lomiri during spreads and other effects and animations.

Co-authored-by: Alan Griffiths <alan@octopull.co.uk>