### PR TITLE
Wayland platform display config

### DIFF
--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -50,6 +50,8 @@ class TouchInput;
 }
 namespace graphics
 {
+class DisplayConfigurationPolicy;
+
 namespace wayland
 {
 class Display : public mir::graphics::Display, public mir::graphics::NativeDisplay,
@@ -59,6 +61,7 @@ public:
     Display(
         wl_display* const wl_display,
         std::shared_ptr<GLConfig> const& gl_config,
+        std::shared_ptr<DisplayConfigurationPolicy> const& policy,
         std::shared_ptr<DisplayReport> const& report);
 
     ~Display();

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -833,6 +833,21 @@ void mgw::DisplayClient::for_each_display_sync_group(const std::function<void(Di
     }
 }
 
+void mir::graphics::wayland::DisplayClient::apply(mir::graphics::DisplayConfiguration const& config)
+{
+    std::lock_guard<decltype(outputs_mutex)> lock{outputs_mutex};
+
+    // There's no way for the underlying outputs to change, so these iterations will zip
+    auto bound_output = bound_outputs.begin();
+    config.for_each_output([&bound_output](DisplayConfigurationOutput const& output)
+    {
+        bound_output->second->dcout.used = output.used;
+        bound_output->second->dcout.top_left = output.top_left;
+        bound_output->second->dcout.current_mode_index = output.current_mode_index;
+        ++bound_output;
+    });
+}
+
 mgw::WaylandDisplayConfiguration::WaylandDisplayConfiguration(std::vector<DisplayConfigurationOutput> && outputs) :
     outputs{outputs}
 {

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -58,6 +58,7 @@ protected:
     wl_display* const display;
 
     auto display_configuration() const -> std::unique_ptr<DisplayConfiguration>;
+    void apply(DisplayConfiguration const& config);
     void for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f);
 
     virtual void keyboard_keymap(wl_keyboard* keyboard, uint32_t format, int32_t fd, uint32_t size);

--- a/src/platforms/wayland/platform.cpp
+++ b/src/platforms/wayland/platform.cpp
@@ -46,10 +46,10 @@ mgw::Platform::Platform(struct wl_display* const wl_display, std::shared_ptr<mg:
 }
 
 mir::UniqueModulePtr<mg::Display> mgw::Platform::create_display(
-    std::shared_ptr<DisplayConfigurationPolicy> const&,
+    std::shared_ptr<DisplayConfigurationPolicy> const& policy,
     std::shared_ptr<GLConfig> const& gl_config)
 {
-  return mir::make_module_ptr<mgw::Display>(wl_display, gl_config, report);
+  return mir::make_module_ptr<mgw::Display>(wl_display, gl_config, policy, report);
 }
 
 mg::NativeDisplayPlatform* mgw::Platform::native_display_platform()


### PR DESCRIPTION
Apply the display configuration to the Wayland platform.

This enables, for example, setting clone mode for a hosted shell.