### PR TITLE
platform: Ensure each rendering thread has a separate gl::Program.

### DIFF
--- a/include/platform/mir/graphics/program_factory.h
+++ b/include/platform/mir/graphics/program_factory.h
@@ -41,10 +41,12 @@ public:
     /**
      * Compile and link a fragment-shader fragment into a full shader Program
      *
-     * \note    As the id needs to be globally unique, we suggest using the address of a local
-     *          static variable as the id.
+     * \note    The ID is used to identify this shader program for caching purposes. Accidentally
+     *          using an ID which is already used by another shader will result in incorrect rendering.
+     *          We recommend using the address of a static local variable as the ID to guarantee
+     *          uniqueness.
      *
-     * \param id [in]                   An opaque ID for this shader. This *must* be globally unique
+     * \param id [in]                   An opaque ID for this shader.
      * \param extension_fragment [in]   Fragment to include necessary extensions
      * \param fragment_fragment [in]    The fragment-shader fragment. This must be a GLSL
      *                                  fragment defining a function:

--- a/include/platform/mir/graphics/program_factory.h
+++ b/include/platform/mir/graphics/program_factory.h
@@ -41,16 +41,21 @@ public:
     /**
      * Compile and link a fragment-shader fragment into a full shader Program
      *
-     * \param extension_fragment [in]    Fragment to include necessary extensions
+     * \note    As the id needs to be globally unique, we suggest using the address of a local
+     *          static variable as the id.
+     *
+     * \param id [in]                   An opaque ID for this shader. This *must* be globally unique
+     * \param extension_fragment [in]   Fragment to include necessary extensions
      * \param fragment_fragment [in]    The fragment-shader fragment. This must be a GLSL
-     *                                          fragment defining a function:
-     *                                          vec4 sample_to_rgba(in vec2 texcoord)
-     *                                          returning a vector containing the RGBA value at texcoord.
-     *                                          The elements of the uniform array tex[n] will be bound to
-     *                                          GL_TEXTURE0, GL_TEXTURE1, …, GL_TEXTURE(n-1). (n <= 8)
-     * \return  A fully compiled and linked Program
+     *                                  fragment defining a function:
+     *                                  vec4 sample_to_rgba(in vec2 texcoord)
+     *                                  returning a vector containing the RGBA value at texcoord.
+     *                                  The elements of the uniform array tex[n] will be bound to
+     *                                  GL_TEXTURE0, GL_TEXTURE1, …, GL_TEXTURE(n-1). (n <= 8)
+     * \return  A reference to the fully compiled and linked Program
      */
-    virtual std::unique_ptr<Program> compile_fragment_shader(
+    virtual Program& compile_fragment_shader(
+        void* id,
         char const* extension_fragment,
         char const* fragment_fragment) = 0;
 };

--- a/src/platform/graphics/egl_wayland_allocator.cpp
+++ b/src/platform/graphics/egl_wayland_allocator.cpp
@@ -218,18 +218,15 @@ public:
 
     mir::graphics::gl::Program const& shader(mir::graphics::gl::ProgramFactory& cache) const override
     {
-        static std::unique_ptr<mg::gl::Program> shader;
-        if (!shader)
-        {
-            shader = cache.compile_fragment_shader(
-                "",
-                "uniform sampler2D tex;\n"
-                "vec4 sample_to_rgba(in vec2 texcoord)\n"
-                "{\n"
-                "    return texture2D(tex, texcoord);\n"
-                "}\n");
-        }
-        return *shader;
+        static int argb_shader{0};
+        return cache.compile_fragment_shader(
+            &argb_shader,
+            "",
+            "uniform sampler2D tex;\n"
+            "vec4 sample_to_rgba(in vec2 texcoord)\n"
+            "{\n"
+            "    return texture2D(tex, texcoord);\n"
+            "}\n");
     }
 
     Layout layout() const override

--- a/src/platforms/common/server/shm_buffer.cpp
+++ b/src/platforms/common/server/shm_buffer.cpp
@@ -232,15 +232,15 @@ auto mgc::MemoryBackedShmBuffer::native_buffer_handle() const -> std::shared_ptr
 
 mg::gl::Program const& mgc::ShmBuffer::shader(mg::gl::ProgramFactory& cache) const
 {
-    static auto const program = cache.compile_fragment_shader(
+    static int argb_shader{0};
+    return cache.compile_fragment_shader(
+        &argb_shader,
         "",
         "uniform sampler2D tex;\n"
         "vec4 sample_to_rgba(in vec2 texcoord)\n"
         "{\n"
         "    return texture2D(tex, texcoord);\n"
         "}\n");
-
-    return *program;
 }
 
 auto mgc::ShmBuffer::layout() const -> Layout

--- a/src/platforms/mesa/server/gbm_buffer.cpp
+++ b/src/platforms/mesa/server/gbm_buffer.cpp
@@ -141,15 +141,16 @@ void mgm::GBMBuffer::bind_for_write()
 mg::gl::Program const& mgm::GBMBuffer::shader(
     mg::gl::ProgramFactory& cache) const
 {
-    static auto const program = cache.compile_fragment_shader(
+    static int argb_program{0};
+
+    return cache.compile_fragment_shader(
+        &argb_program,
         "",
         "uniform sampler2D tex;\n"
         "vec4 sample_to_rgba(in vec2 texcoord)\n"
         "{\n"
         "    return texture2D(tex, texcoord);\n"
         "}\n");
-
-    return *program;
 }
 
 mir::graphics::gl::Texture::Layout mgm::GBMBuffer::layout() const

--- a/src/platforms/rpi-dispmanx/buffer_allocator.cpp
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.cpp
@@ -212,18 +212,15 @@ public:
 
     auto shader(mg::gl::ProgramFactory& factory) const -> mg::gl::Program const& override
     {
-        static std::unique_ptr<mg::gl::Program> shader;
-        if (!shader)
-        {
-            shader = factory.compile_fragment_shader(
-                "",
-                "uniform sampler2D tex;\n"
-                "vec4 sample_to_rgba(in vec2 texcoord)\n"
-                "{\n"
-                "    return texture2D(tex, texcoord);\n"
-                "}\n");
-        }
-        return *shader;
+        static int rgba_shader_tag{0};
+        return factory.compile_fragment_shader(
+            &rgba_shader_tag,
+            "",
+            "uniform sampler2D tex;\n"
+            "vec4 sample_to_rgba(in vec2 texcoord)\n"
+            "{\n"
+            "    return texture2D(tex, texcoord);\n"
+            "}\n");
     }
 
     auto layout() const -> Layout override


### PR DESCRIPTION
The GL uniforms (such as, for example, screen position) are per Program state, *not*
per context state, so when there were multiple rendering threads they would race.

Fix this by generating a `Program` per `ProgramFactory`; we already had a `ProgramFactory`
per thread.

Fixes: #1332, #1317