### PR TITLE
Allow Fedora 30 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,4 +124,5 @@ jobs:
   allow_failures:
     - env: TASK=google:ubuntu-devel-proposed-64:spread/build/ubuntu:amd64
     - env: TASK=google:fedora-rawhide-64:spread/build/fedora:amd64
+    - env: TASK=google:fedora-30-64:spread/build/fedora:amd64
   fast_finish: true


### PR DESCRIPTION
Fedora 30 has been failing consistently throught the day. Ignore it. (For now.)