### PR TITLE
DisplayConfiguration respect scale

### DIFF
--- a/src/platform/graphics/display_configuration.cpp
+++ b/src/platform/graphics/display_configuration.cpp
@@ -236,12 +236,13 @@ mir::geometry::Rectangle extents_of(
     std::vector<mg::DisplayConfigurationMode> const& modes,
     size_t current_mode_index,
     MirOrientation orientation,
-    mir::geometry::Point top_left)
+    mir::geometry::Point top_left,
+    float scale)
 {
     if (current_mode_index >= modes.size())
         return mir::geometry::Rectangle();
 
-    auto const& size = modes[current_mode_index].size;
+    auto const& size = modes[current_mode_index].size * (1.0f / scale);
 
     if (orientation == mir_orientation_normal ||
         orientation == mir_orientation_inverted)
@@ -260,7 +261,7 @@ mir::geometry::Rectangle mg::DisplayConfigurationOutput::extents() const
 {
     return custom_logical_size.is_set() ?
            mir::geometry::Rectangle(top_left, custom_logical_size.value()) :
-           extents_of(modes, current_mode_index, orientation, top_left);
+           extents_of(modes, current_mode_index, orientation, top_left, scale);
 }
 
 glm::mat2 mg::DisplayConfigurationOutput::transformation() const
@@ -334,7 +335,7 @@ mir::geometry::Rectangle mg::UserDisplayConfigurationOutput::extents() const
 {
     return custom_logical_size.is_set() ?
            mir::geometry::Rectangle(top_left, custom_logical_size.value()) :
-           extents_of(modes, current_mode_index, orientation, top_left);
+           extents_of(modes, current_mode_index, orientation, top_left, scale);
 }
 
 

--- a/src/platforms/mesa/server/kms/real_kms_display_configuration.cpp
+++ b/src/platforms/mesa/server/kms/real_kms_display_configuration.cpp
@@ -213,7 +213,7 @@ bool mgm::compatible(mgm::RealKMSDisplayConfiguration const& conf1, mgm::RealKMS
                 compatible &= (conf1.outputs[i].first == clone);
             }
             else
-            	break;
+                break;
         }
     }
 

--- a/src/platforms/mesa/server/x11/graphics/display_configuration.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display_configuration.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<mg::DisplayConfigurationOutput> mgx::DisplayConfiguration::build
     MirPixelFormat pf,
     geom::Size const pixels,
     geom::Point const top_left,
-    geom::Size const size,
+    geom::Size const physical_size_mm,
     const float scale,
     MirOrientation orientation)
 {
@@ -44,7 +44,7 @@ std::shared_ptr<mg::DisplayConfigurationOutput> mgx::DisplayConfiguration::build
             //TODO: query fps
             {mg::DisplayConfigurationMode{pixels, 60.0}},
             0,
-            size,
+            physical_size_mm,
             true,
             true,
             top_left,

--- a/src/platforms/mesa/server/x11/graphics/display_configuration.h
+++ b/src/platforms/mesa/server/x11/graphics/display_configuration.h
@@ -37,7 +37,7 @@ public:
         MirPixelFormat pf,
         geometry::Size const pixels,
         geometry::Point const top_left,
-        geometry::Size const size_mm,
+        geometry::Size const physical_size_mm,
         float const scale,
         MirOrientation orientation);
 

--- a/src/platforms/wayland/cursor.cpp
+++ b/src/platforms/wayland/cursor.cpp
@@ -90,18 +90,16 @@ void mpw::Cursor::show(graphics::CursorImage const& cursor_image)
     {
         std::lock_guard<decltype(mutex)> lock{mutex};
         if (buffer) wl_buffer_destroy(buffer);
-        hotspot = cursor_image.hotspot();
 
         auto const width = cursor_image.size().width.as_uint32_t();
         auto const height = cursor_image.size().height.as_uint32_t();
-        auto const hotspot_x = hotspot.dx.as_uint32_t()/scale_factor;
-        auto const hotspot_y = hotspot.dy.as_uint32_t()/scale_factor;
+        auto const hotspot_x = cursor_image.hotspot().dx.as_uint32_t();
+        auto const hotspot_y = cursor_image.hotspot().dy.as_uint32_t();
         void* data_buffer;
         auto const shm_pool = make_shm_pool(shm, 4 * width * height, &data_buffer);
         memcpy(data_buffer, cursor_image.as_argb_8888(), 4 * width * height);
         buffer = wl_shm_pool_create_buffer(shm_pool, 0, width, height, 4 * width, WL_SHM_FORMAT_ARGB8888);
         wl_surface_attach(surface, buffer, 0, 0);
-        wl_surface_set_buffer_scale(surface, scale_factor);
         wl_surface_commit(surface);
         wl_shm_pool_destroy(shm_pool);
         if (pointer) wl_pointer_set_cursor(pointer, 0, surface, hotspot_x, hotspot_y);
@@ -127,15 +125,4 @@ void mir::platform::wayland::Cursor::leave(wl_pointer* /*pointer*/)
 {
     std::lock_guard<decltype(mutex)> lock{mutex};
     pointer = nullptr;
-}
-
-void mir::platform::wayland::Cursor::scale(int factor)
-{
-    std::lock_guard<decltype(mutex)> lock{mutex};
-    scale_factor = factor;
-    auto const hotspot_x = hotspot.dx.as_uint32_t()/scale_factor;
-    auto const hotspot_y = hotspot.dy.as_uint32_t()/scale_factor;
-    wl_surface_set_buffer_scale(surface, factor);
-    wl_surface_commit(surface);
-    if (pointer) wl_pointer_set_cursor(pointer, 0, surface, hotspot_x, hotspot_y);
 }

--- a/src/platforms/wayland/cursor.h
+++ b/src/platforms/wayland/cursor.h
@@ -50,15 +50,12 @@ public:
 
     void enter(wl_pointer* pointer);
     void leave(wl_pointer* pointer);
-    void scale(int factor);
 
 private:
     wl_display* const display;
     wl_shm* const shm;
 
     wl_surface* surface;
-    geometry::Displacement hotspot;
-    int scale_factor = 1;
 
     std::mutex mutable mutex;
     wl_buffer* buffer{nullptr};

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -325,7 +325,7 @@ void mir::graphics::wayland::Display::pointer_motion(wl_pointer* pointer, uint32
 {
     {
         std::lock_guard<decltype(sink_mutex)> lock{sink_mutex};
-        geom::Point const new_pointer{wl_fixed_to_int(x)*pointer_scale, wl_fixed_to_int(y)*pointer_scale};
+        geom::Point const new_pointer{wl_fixed_to_int(x), wl_fixed_to_int(y)};
         pointer_pos = new_pointer + pointer_displacement;
         pointer_time = std::chrono::milliseconds{time};
     }
@@ -395,8 +395,8 @@ void mir::graphics::wayland::Display::touch_down(
 
         touch_time = std::chrono::milliseconds{time};
         contact->action = mir_touch_action_down;
-        contact->x = touch_scale*wl_fixed_to_double(x) + touch_displacement.dx.as_int();
-        contact->y = touch_scale*wl_fixed_to_double(y) + touch_displacement.dy.as_int();
+        contact->x = wl_fixed_to_double(x) + touch_displacement.dx.as_int();
+        contact->y = wl_fixed_to_double(y) + touch_displacement.dy.as_int();
     }
 }
 
@@ -424,8 +424,8 @@ void mir::graphics::wayland::Display::touch_motion(wl_touch* touch, uint32_t tim
 
         touch_time = std::chrono::milliseconds{time};
         contact->action = mir_touch_action_change;
-        contact->x = touch_scale*wl_fixed_to_double(x) + touch_displacement.dx.as_int();
-        contact->y = touch_scale*wl_fixed_to_double(y) + touch_displacement.dy.as_int();
+        contact->x = wl_fixed_to_double(x) + touch_displacement.dx.as_int();
+        contact->y = wl_fixed_to_double(y) + touch_displacement.dy.as_int();
     }
 
     DisplayClient::touch_motion(touch, time, id, x, y);
@@ -525,12 +525,8 @@ auto mir::graphics::wayland::Display::get_touch_contact(int32_t id) -> decltype(
 void mir::graphics::wayland::Display::pointer_enter(
     wl_pointer* pointer, uint32_t serial, wl_surface* surface, wl_fixed_t x, wl_fixed_t y)
 {
+    if (cursor) cursor->enter(pointer);
     DisplayClient::pointer_enter(pointer, serial, surface, x, y);
-    if (cursor)
-    {
-        cursor->enter(pointer);
-        cursor->scale(pointer_scale);
-    }
 }
 
 void mir::graphics::wayland::Display::pointer_leave(wl_pointer* pointer, uint32_t serial, wl_surface* surface)

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -211,7 +211,6 @@ void mgw::DisplayClient::Output::scale(void* data, wl_output* /*wl_output*/, int
     auto const output = static_cast<Output*>(data);
     auto& dcout = output->dcout;
     dcout.scale = factor;
-    wl_surface_set_buffer_scale(output->surface, factor);
 }
 
 mgw::DisplayClient::Output::Output(
@@ -568,7 +567,6 @@ void mgw::DisplayClient::pointer_enter(
         if (surface == out.second->surface)
         {
             pointer_displacement = out.second->dcout.top_left - geometry::Point{};
-            pointer_scale = out.second->dcout.scale;
             break;
         }
     }
@@ -637,7 +635,6 @@ void mgw::DisplayClient::touch_down(
         if (surface == out.second->surface)
         {
             touch_displacement = out.second->dcout.top_left - geometry::Point{};
-            touch_scale = out.second->dcout.scale;
             break;
         }
     }

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -159,9 +159,7 @@ protected:
     xkb_state* keyboard_state_ = nullptr;
     bool fake_pointer_frame = false;
     geometry::Displacement pointer_displacement; // Position of current output
-    int pointer_scale = 1;
     geometry::Displacement touch_displacement;   // Position of current output
-    int touch_scale = 1;
 
     std::unique_ptr<wl_registry, decltype(&wl_registry_destroy)> registry;
 

--- a/tests/unit-tests/graphics/test_display_configuration.cpp
+++ b/tests/unit-tests/graphics/test_display_configuration.cpp
@@ -391,3 +391,37 @@ TEST(DisplayConfiguration, output_extents_empty_when_there_are_no_modes)
     geom::Rectangle empty{};
     EXPECT_EQ(empty, out.extents());
 }
+
+TEST(DisplayConfiguration, output_extents_are_scaled)
+{
+    mg::DisplayConfigurationOutput out = tmpl_output;
+    out.scale = 2.0f;
+
+    EXPECT_EQ(out.modes[out.current_mode_index].size * 0.5, out.extents().size);
+}
+
+TEST(DisplayConfiguration, output_extents_are_scaled_fractionally)
+{
+    mg::DisplayConfigurationOutput out = tmpl_output;
+    out.scale = 0.8f;
+
+    EXPECT_EQ(out.modes[out.current_mode_index].size * 1.25, out.extents().size);
+}
+
+TEST(DisplayConfiguration, user_display_configuration_output_extents_are_scaled)
+{
+    mg::DisplayConfigurationOutput out = tmpl_output;
+    mg::UserDisplayConfigurationOutput user{out};
+    user.scale = 2.0f;
+
+    EXPECT_EQ(user.modes[user.current_mode_index].size * 0.5, user.extents().size);
+}
+
+TEST(DisplayConfiguration, user_display_configuration_output_extents_are_scaled_fractionally)
+{
+    mg::DisplayConfigurationOutput out = tmpl_output;
+    mg::UserDisplayConfigurationOutput user{out};
+    user.scale = 0.8f;
+
+    EXPECT_EQ(user.modes[user.current_mode_index].size * 1.25, user.extents().size);
+}

--- a/tests/unit-tests/graphics/test_display_configuration.cpp
+++ b/tests/unit-tests/graphics/test_display_configuration.cpp
@@ -22,6 +22,7 @@
 
 namespace mg = mir::graphics;
 namespace geom = mir::geometry;
+using namespace testing;
 
 namespace
 {
@@ -67,9 +68,9 @@ TEST(DisplayConfiguration, same_cards_compare_equal)
     mg::DisplayConfigurationCard const card1{id, max_outputs};
     mg::DisplayConfigurationCard const card2 = card1;
 
-    EXPECT_EQ(card1, card1);
-    EXPECT_EQ(card1, card2);
-    EXPECT_EQ(card2, card1);
+    EXPECT_THAT(card1, Eq(card1));
+    EXPECT_THAT(card1, Eq(card2));
+    EXPECT_THAT(card2, Eq(card1));
 }
 
 TEST(DisplayConfiguration, different_cards_compare_unequal)
@@ -83,12 +84,12 @@ TEST(DisplayConfiguration, different_cards_compare_unequal)
     mg::DisplayConfigurationCard const card2{id1, max_outputs2};
     mg::DisplayConfigurationCard const card3{id2, max_outputs1};
 
-    EXPECT_NE(card1, card2);
-    EXPECT_NE(card2, card1);
-    EXPECT_NE(card2, card3);
-    EXPECT_NE(card3, card2);
-    EXPECT_NE(card1, card3);
-    EXPECT_NE(card3, card1);
+    EXPECT_THAT(card1, Ne(card2));
+    EXPECT_THAT(card2, Ne(card1));
+    EXPECT_THAT(card2, Ne(card3));
+    EXPECT_THAT(card3, Ne(card2));
+    EXPECT_THAT(card1, Ne(card3));
+    EXPECT_THAT(card3, Ne(card1));
 }
 
 TEST(DisplayConfiguration, same_modes_compare_equal)
@@ -99,9 +100,9 @@ TEST(DisplayConfiguration, same_modes_compare_equal)
     mg::DisplayConfigurationMode const mode1{size, vrefresh};
     mg::DisplayConfigurationMode const mode2 = mode1;
 
-    EXPECT_EQ(mode1, mode1);
-    EXPECT_EQ(mode1, mode2);
-    EXPECT_EQ(mode2, mode1);
+    EXPECT_THAT(mode1, Eq(mode1));
+    EXPECT_THAT(mode1, Eq(mode2));
+    EXPECT_THAT(mode2, Eq(mode1));
 }
 
 TEST(DisplayConfiguration, different_modes_compare_unequal)
@@ -115,12 +116,12 @@ TEST(DisplayConfiguration, different_modes_compare_unequal)
     mg::DisplayConfigurationMode const mode2{size1, vrefresh2};
     mg::DisplayConfigurationMode const mode3{size2, vrefresh1};
 
-    EXPECT_NE(mode1, mode2);
-    EXPECT_NE(mode2, mode1);
-    EXPECT_NE(mode2, mode3);
-    EXPECT_NE(mode3, mode2);
-    EXPECT_NE(mode1, mode3);
-    EXPECT_NE(mode3, mode1);
+    EXPECT_THAT(mode1, Ne(mode2));
+    EXPECT_THAT(mode2, Ne(mode1));
+    EXPECT_THAT(mode2, Ne(mode3));
+    EXPECT_THAT(mode3, Ne(mode2));
+    EXPECT_THAT(mode1, Ne(mode3));
+    EXPECT_THAT(mode3, Ne(mode1));
 }
 
 TEST(DisplayConfiguration, same_outputs_compare_equal)
@@ -128,9 +129,9 @@ TEST(DisplayConfiguration, same_outputs_compare_equal)
     mg::DisplayConfigurationOutput const output1 = tmpl_output;
     mg::DisplayConfigurationOutput output2 = tmpl_output;
 
-    EXPECT_EQ(output1, output1);
-    EXPECT_EQ(output1, output2);
-    EXPECT_EQ(output2, output1);
+    EXPECT_THAT(output1, Eq(output1));
+    EXPECT_THAT(output1, Eq(output2));
+    EXPECT_THAT(output2, Eq(output1));
 }
 
 TEST(DisplayConfiguration, outputs_with_different_ids_compare_unequal)
@@ -142,12 +143,12 @@ TEST(DisplayConfiguration, outputs_with_different_ids_compare_unequal)
     output2.id = mg::DisplayConfigurationOutputId{15};
     output3.card_id = mg::DisplayConfigurationCardId{12};
 
-    EXPECT_NE(output1, output2);
-    EXPECT_NE(output2, output1);
-    EXPECT_NE(output2, output3);
-    EXPECT_NE(output3, output2);
-    EXPECT_NE(output1, output3);
-    EXPECT_NE(output3, output1);
+    EXPECT_THAT(output1, Ne(output2));
+    EXPECT_THAT(output2, Ne(output1));
+    EXPECT_THAT(output2, Ne(output3));
+    EXPECT_THAT(output3, Ne(output2));
+    EXPECT_THAT(output1, Ne(output3));
+    EXPECT_THAT(output3, Ne(output1));
 }
 
 TEST(DisplayConfiguration, outputs_with_different_modes_compare_unequal)
@@ -171,12 +172,12 @@ TEST(DisplayConfiguration, outputs_with_different_modes_compare_unequal)
     output2.modes = modes2;
     output3.modes = modes3;
 
-    EXPECT_NE(output1, output2);
-    EXPECT_NE(output2, output1);
-    EXPECT_NE(output2, output3);
-    EXPECT_NE(output3, output2);
-    EXPECT_NE(output1, output3);
-    EXPECT_NE(output3, output1);
+    EXPECT_THAT(output1, Ne(output2));
+    EXPECT_THAT(output2, Ne(output1));
+    EXPECT_THAT(output2, Ne(output3));
+    EXPECT_THAT(output3, Ne(output2));
+    EXPECT_THAT(output1, Ne(output3));
+    EXPECT_THAT(output3, Ne(output1));
 }
 
 TEST(DisplayConfiguration, outputs_with_different_physical_size_compare_unequal)
@@ -188,8 +189,8 @@ TEST(DisplayConfiguration, outputs_with_different_physical_size_compare_unequal)
 
     output2.physical_size_mm = physical_size2;
 
-    EXPECT_NE(output1, output2);
-    EXPECT_NE(output2, output1);
+    EXPECT_THAT(output1, Ne(output2));
+    EXPECT_THAT(output2, Ne(output1));
 }
 
 TEST(DisplayConfiguration, outputs_with_different_connected_status_compare_unequal)
@@ -199,8 +200,8 @@ TEST(DisplayConfiguration, outputs_with_different_connected_status_compare_unequ
 
     output2.connected = false;
 
-    EXPECT_NE(output1, output2);
-    EXPECT_NE(output2, output1);
+    EXPECT_THAT(output1, Ne(output2));
+    EXPECT_THAT(output2, Ne(output1));
 }
 
 TEST(DisplayConfiguration, outputs_with_different_current_mode_index_compare_unequal)
@@ -210,8 +211,8 @@ TEST(DisplayConfiguration, outputs_with_different_current_mode_index_compare_une
 
     output2.current_mode_index = 0;
 
-    EXPECT_NE(output1, output2);
-    EXPECT_NE(output2, output1);
+    EXPECT_THAT(output1, Ne(output2));
+    EXPECT_THAT(output2, Ne(output1));
 }
 
 TEST(DisplayConfiguration, outputs_with_different_preferred_mode_index_compare_unequal)
@@ -221,8 +222,8 @@ TEST(DisplayConfiguration, outputs_with_different_preferred_mode_index_compare_u
 
     output2.preferred_mode_index = 1;
 
-    EXPECT_NE(output1, output2);
-    EXPECT_NE(output2, output1);
+    EXPECT_THAT(output1, Ne(output2));
+    EXPECT_THAT(output2, Ne(output1));
 }
 
 TEST(DisplayConfiguration, outputs_with_different_orientation_compare_unequal)
@@ -230,12 +231,12 @@ TEST(DisplayConfiguration, outputs_with_different_orientation_compare_unequal)
     mg::DisplayConfigurationOutput a = tmpl_output;
     mg::DisplayConfigurationOutput b = tmpl_output;
 
-    EXPECT_EQ(a, b);
-    EXPECT_EQ(b, a);
+    EXPECT_THAT(a, Eq(b));
+    EXPECT_THAT(b, Eq(a));
     a.orientation = mir_orientation_left;
     b.orientation = mir_orientation_inverted;
-    EXPECT_NE(a, b);
-    EXPECT_NE(b, a);
+    EXPECT_THAT(a, Ne(b));
+    EXPECT_THAT(b, Ne(a));
 }
 
 TEST(DisplayConfiguration, outputs_with_different_power_mode_compare_equal)
@@ -243,12 +244,12 @@ TEST(DisplayConfiguration, outputs_with_different_power_mode_compare_equal)
     mg::DisplayConfigurationOutput a = tmpl_output;
     mg::DisplayConfigurationOutput b = tmpl_output;
 
-    EXPECT_EQ(a, b);
-    EXPECT_EQ(b, a);
+    EXPECT_THAT(a, Eq(b));
+    EXPECT_THAT(b, Eq(a));
     a.power_mode = mir_power_mode_on;
     b.power_mode = mir_power_mode_off;
-    EXPECT_EQ(a, b);
-    EXPECT_EQ(b, a);
+    EXPECT_THAT(a, Eq(b));
+    EXPECT_THAT(b, Eq(a));
 }
 
 TEST(DisplayConfiguration, outputs_with_different_scaling_factors_compare_unequal)
@@ -256,12 +257,12 @@ TEST(DisplayConfiguration, outputs_with_different_scaling_factors_compare_unequa
     mg::DisplayConfigurationOutput a = tmpl_output;
     mg::DisplayConfigurationOutput b = tmpl_output;
 
-    EXPECT_EQ(a, b);
-    EXPECT_EQ(b, a);
+    EXPECT_THAT(a, Eq(b));
+    EXPECT_THAT(b, Eq(a));
     a.scale = 2.0f;
     b.scale = 3.0f;
-    EXPECT_NE(a, b);
-    EXPECT_NE(b, a);
+    EXPECT_THAT(a, Ne(b));
+    EXPECT_THAT(b, Ne(a));
 }
 
 TEST(DisplayConfiguration, outputs_with_different_form_factors_compare_unequal)
@@ -269,12 +270,12 @@ TEST(DisplayConfiguration, outputs_with_different_form_factors_compare_unequal)
     mg::DisplayConfigurationOutput a = tmpl_output;
     mg::DisplayConfigurationOutput b = tmpl_output;
 
-    EXPECT_EQ(a, b);
-    EXPECT_EQ(b, a);
+    EXPECT_THAT(a, Eq(b));
+    EXPECT_THAT(b, Eq(a));
     a.form_factor = mir_form_factor_monitor;
     b.form_factor = mir_form_factor_projector;
-    EXPECT_NE(a, b);
-    EXPECT_NE(b, a);
+    EXPECT_THAT(a, Ne(b));
+    EXPECT_THAT(b, Ne(a));
 }
 
 TEST(DisplayConfiguration, output_extents_uses_current_mode)
@@ -282,9 +283,9 @@ TEST(DisplayConfiguration, output_extents_uses_current_mode)
     mg::DisplayConfigurationOutput out = tmpl_output;
 
     out.current_mode_index = 2;
-    ASSERT_NE(out.modes[0], out.modes[2]);
+    ASSERT_THAT(out.modes[0], Ne(out.modes[2]));
 
-    EXPECT_EQ(out.modes[out.current_mode_index].size, out.extents().size);
+    EXPECT_THAT(out.modes[out.current_mode_index].size, Eq(out.extents().size));
 }
 
 TEST(DisplayConfiguration, output_extents_are_customizable)
@@ -294,7 +295,7 @@ TEST(DisplayConfiguration, output_extents_are_customizable)
     geom::Size const custom_size{1234, 9876};
     out.custom_logical_size = custom_size;
 
-    EXPECT_EQ(custom_size, out.extents().size);
+    EXPECT_THAT(custom_size, Eq(out.extents().size));
 }
 
 TEST(DisplayConfiguration, output_extents_rotates_with_orientation)
@@ -305,22 +306,22 @@ TEST(DisplayConfiguration, output_extents_rotates_with_orientation)
     int w = size.width.as_int();
     int h = size.height.as_int();
 
-    ASSERT_NE(w, h);
+    ASSERT_THAT(w, Ne(h));
 
     geom::Rectangle normal{out.top_left, {w, h}};
     geom::Rectangle swapped{out.top_left, {h, w}};
 
     out.orientation = mir_orientation_normal;
-    EXPECT_EQ(normal, out.extents());
+    EXPECT_THAT(normal, Eq(out.extents()));
 
     out.orientation = mir_orientation_inverted;
-    EXPECT_EQ(normal, out.extents());
+    EXPECT_THAT(normal, Eq(out.extents()));
 
     out.orientation = mir_orientation_left;
-    EXPECT_EQ(swapped, out.extents());
+    EXPECT_THAT(swapped, Eq(out.extents()));
 
     out.orientation = mir_orientation_right;
-    EXPECT_EQ(swapped, out.extents());
+    EXPECT_THAT(swapped, Eq(out.extents()));
 }
 
 TEST(DisplayConfiguration, default_valid)
@@ -389,7 +390,7 @@ TEST(DisplayConfiguration, output_extents_empty_when_there_are_no_modes)
     out.current_mode_index = 0;
 
     geom::Rectangle empty{};
-    EXPECT_EQ(empty, out.extents());
+    EXPECT_THAT(empty, Eq(out.extents()));
 }
 
 TEST(DisplayConfiguration, output_extents_are_scaled)
@@ -397,7 +398,7 @@ TEST(DisplayConfiguration, output_extents_are_scaled)
     mg::DisplayConfigurationOutput out = tmpl_output;
     out.scale = 2.0f;
 
-    EXPECT_EQ(out.modes[out.current_mode_index].size * 0.5, out.extents().size);
+    EXPECT_THAT(out.modes[out.current_mode_index].size * 0.5, Eq(out.extents().size));
 }
 
 TEST(DisplayConfiguration, output_extents_are_scaled_fractionally)
@@ -405,7 +406,7 @@ TEST(DisplayConfiguration, output_extents_are_scaled_fractionally)
     mg::DisplayConfigurationOutput out = tmpl_output;
     out.scale = 0.8f;
 
-    EXPECT_EQ(out.modes[out.current_mode_index].size * 1.25, out.extents().size);
+    EXPECT_THAT(out.modes[out.current_mode_index].size * 1.25, Eq(out.extents().size));
 }
 
 TEST(DisplayConfiguration, user_display_configuration_output_extents_are_scaled)
@@ -414,7 +415,7 @@ TEST(DisplayConfiguration, user_display_configuration_output_extents_are_scaled)
     mg::UserDisplayConfigurationOutput user{out};
     user.scale = 2.0f;
 
-    EXPECT_EQ(user.modes[user.current_mode_index].size * 0.5, user.extents().size);
+    EXPECT_THAT(user.modes[user.current_mode_index].size * 0.5, Eq(user.extents().size));
 }
 
 TEST(DisplayConfiguration, user_display_configuration_output_extents_are_scaled_fractionally)
@@ -423,5 +424,5 @@ TEST(DisplayConfiguration, user_display_configuration_output_extents_are_scaled_
     mg::UserDisplayConfigurationOutput user{out};
     user.scale = 0.8f;
 
-    EXPECT_EQ(user.modes[user.current_mode_index].size * 1.25, user.extents().size);
+    EXPECT_THAT(user.modes[user.current_mode_index].size * 1.25, Eq(user.extents().size));
 }


### PR DESCRIPTION
Make `DisplayConfiguration::extents_of()` return the scaled logical size, instead of the pixel size of the mode