### PR TITLE
Fix hybrid config chosing

### DIFF
--- a/src/platforms/mesa/server/display_helpers.cpp
+++ b/src/platforms/mesa/server/display_helpers.cpp
@@ -333,7 +333,7 @@ mgmh::GBMHelper::GBMHelper(mir::Fd const& drm_fd)
 mgm::GBMSurfaceUPtr mgmh::GBMHelper::create_scanout_surface(
     uint32_t width,
     uint32_t height,
-    bool sharable)
+    bool sharable) const
 {
     auto format_flags = GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT;
 

--- a/src/platforms/mesa/server/display_helpers.h
+++ b/src/platforms/mesa/server/display_helpers.h
@@ -92,7 +92,7 @@ public:
     GBMHelper(const GBMHelper&) = delete;
     GBMHelper& operator=(const GBMHelper&) = delete;
 
-    GBMSurfaceUPtr create_scanout_surface(uint32_t width, uint32_t height, bool sharable);
+    GBMSurfaceUPtr create_scanout_surface(uint32_t width, uint32_t height, bool sharable) const;
 
     gbm_device* const device;
 };

--- a/src/platforms/mesa/server/kms/egl_helper.cpp
+++ b/src/platforms/mesa/server/kms/egl_helper.cpp
@@ -45,7 +45,7 @@ mgmh::EGLHelper::EGLHelper(
     EGLContext shared_context)
     : EGLHelper(gl_config)
 {
-    setup(gbm, surface, shared_context);
+    setup(gbm, surface, shared_context, false);
 }
 
 mgmh::EGLHelper::EGLHelper(EGLHelper&& from)
@@ -101,8 +101,11 @@ void mgmh::EGLHelper::setup(GBMHelper const& gbm, EGLContext shared_context)
         BOOST_THROW_EXCEPTION(mg::egl_error("Failed to create EGL context"));
 }
 
-void mgmh::EGLHelper::setup(GBMHelper const& gbm, gbm_surface* surface_gbm,
-                            EGLContext shared_context)
+void mgmh::EGLHelper::setup(
+    GBMHelper const& gbm,
+    gbm_surface* surface_gbm,
+    EGLContext shared_context,
+    bool owns_egl)
 {
     eglBindAPI(MIR_SERVER_EGL_OPENGL_API);
 
@@ -114,7 +117,7 @@ void mgmh::EGLHelper::setup(GBMHelper const& gbm, gbm_surface* surface_gbm,
     };
 
     // TODO: Take the required format as a parameter, so we can select the framebuffer format.
-    setup_internal(gbm, false, GBM_FORMAT_XRGB8888);
+    setup_internal(gbm, owns_egl, GBM_FORMAT_XRGB8888);
 
     egl_surface = platform_base.eglCreatePlatformWindowSurface(
         egl_display,

--- a/src/platforms/mesa/server/kms/egl_helper.h
+++ b/src/platforms/mesa/server/kms/egl_helper.h
@@ -49,8 +49,7 @@ public:
 
     void setup(GBMHelper const& gbm);
     void setup(GBMHelper const& gbm, EGLContext shared_context);
-    void setup(GBMHelper const& gbm, gbm_surface* surface_gbm,
-               EGLContext shared_context);
+    void setup(GBMHelper const& gbm, gbm_surface* surface_gbm, EGLContext shared_context, bool owns_egl);
 
     bool swap_buffers();
     bool make_current() const;


### PR DESCRIPTION
`mgmh::EGLHelper` got a fix for when mesa started supporting `rgba_1010102` visuals, resulting in `eglChooseConfig` picking a config incompatible with our `rgba_8888` GBM buffers.

The hybrid bounce-buffer code did not get updated at the same time, so suffers the same problem.

Fix this by using the `EGLHelper` code in `EGLBufferCopier`. Convenenly, this also eliminates quite a lot of code from `EGLBufferCopier`. Score!"
