### PR TITLE
Make various texture bind() functions threadsafe

### DIFF
--- a/src/platforms/common/server/buffer_from_wl_shm.cpp
+++ b/src/platforms/common/server/buffer_from_wl_shm.cpp
@@ -339,6 +339,7 @@ public:
                 });
             on_consumed();
             on_consumed = [](){};
+            uploaded = true;
         }
     }
 

--- a/src/platforms/common/server/shm_buffer.cpp
+++ b/src/platforms/common/server/shm_buffer.cpp
@@ -223,7 +223,12 @@ void mgc::ShmBuffer::bind()
 void mgc::MemoryBackedShmBuffer::bind()
 {
     mgc::ShmBuffer::bind();
-    upload_to_texture(pixels.get(), stride_);
+    std::lock_guard<decltype(uploaded_mutex)> lock{uploaded_mutex};
+    if (!uploaded)
+    {
+        upload_to_texture(pixels.get(), stride_);
+        uploaded = true;
+    }
 }
 
 auto mgc::MemoryBackedShmBuffer::native_buffer_handle() const -> std::shared_ptr<mg::NativeBuffer>

--- a/src/platforms/common/server/shm_buffer.cpp
+++ b/src/platforms/common/server/shm_buffer.cpp
@@ -203,6 +203,7 @@ mg::NativeBufferBase* mgc::ShmBuffer::native_buffer_base()
 
 void mgc::ShmBuffer::bind()
 {
+    std::lock_guard<decltype(tex_id_mutex)> lock{tex_id_mutex};
     bool const needs_initialisation = tex_id == 0;
     if (needs_initialisation)
     {

--- a/src/platforms/common/server/shm_buffer.h
+++ b/src/platforms/common/server/shm_buffer.h
@@ -31,6 +31,8 @@
 
 #include MIR_SERVER_GL_H
 
+#include <mutex>
+
 namespace mir
 {
 class ShmFile;
@@ -71,6 +73,7 @@ private:
     geometry::Size const size_;
     MirPixelFormat const pixel_format_;
     std::shared_ptr<EGLContextExecutor> const egl_delegate;
+    std::mutex tex_id_mutex;
     GLuint tex_id{0};
 };
 

--- a/src/platforms/common/server/shm_buffer.h
+++ b/src/platforms/common/server/shm_buffer.h
@@ -100,6 +100,8 @@ public:
 private:
     geometry::Stride const stride_;
     std::unique_ptr<unsigned char[]> const pixels;
+    std::mutex uploaded_mutex;
+    bool uploaded{false};
 };
 
 }

--- a/src/platforms/mesa/server/gbm_buffer.cpp
+++ b/src/platforms/mesa/server/gbm_buffer.cpp
@@ -165,6 +165,7 @@ void mgm::GBMBuffer::add_syncpoint()
 
 void mgm::GBMBuffer::tex_bind()
 {
+    std::lock_guard<decltype(tex_id_mutex)> lock{tex_id_mutex};
     bool const needs_initialisation = tex_id == 0;
     if (needs_initialisation)
     {

--- a/src/platforms/mesa/server/gbm_buffer.h
+++ b/src/platforms/mesa/server/gbm_buffer.h
@@ -29,6 +29,7 @@
 #include MIR_SERVER_GL_H
 
 #include <memory>
+#include <mutex>
 #include <limits>
 
 namespace mir
@@ -113,6 +114,8 @@ private:
     uint32_t bo_flags;
     std::unique_ptr<common::BufferTextureBinder> const texture_binder;
     int prime_fd;
+
+    std::mutex tex_id_mutex;
     GLuint tex_id{0};
 };
 


### PR DESCRIPTION
Make various texture bind() functions threadsafe. (Fixes: #1332)

The one that was actually causing #1332 was re-uploading a texture on multiple threads.