### PR TITLE
[Mir-on-X] hide the X11 cursor when over the Mir window

### DIFF
--- a/src/platforms/mesa/server/x11/CMakeLists.txt
+++ b/src/platforms/mesa/server/x11/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
   ${EGL_LDFLAGS} ${EGL_LIBRARIES}
   ${GL_LDFLAGS} ${GL_LIBRARIES}
   X11
+  Xfixes
   mirsharedmesaservercommon-static
   ${Boost_PROGRAM_OPTIONS_LIBRARY}
   ${DRM_LDFLAGS} ${DRM_LIBRARIES}

--- a/src/platforms/mesa/server/x11/input/input_platform.cpp
+++ b/src/platforms/mesa/server/x11/input/input_platform.cpp
@@ -28,6 +28,7 @@
 #define MIR_LOG_COMPONENT "x11-input"
 #include "mir/log.h"
 
+#include <X11/extensions/Xfixes.h>
 #include <X11/Xutil.h>
 #include <X11/Xlib.h>
 #include <linux/input.h>
@@ -153,6 +154,7 @@ void mix::XInputPlatform::process_input_event()
                         auto const& xenev = xev.xcrossing;
                         XGrabPointer(xenev.display, xenev.window, True, 0, GrabModeAsync,
                                      GrabModeAsync, None, None, CurrentTime);
+                        XFixesHideCursor(xenev.display, xenev.window);
                         ptr_grabbed = true;
                     }
                     break;
@@ -164,6 +166,7 @@ void mix::XInputPlatform::process_input_event()
                     {
                         auto const& xlnev = xev.xcrossing;
                         XUngrabPointer(xlnev.display, CurrentTime);
+                        XFixesShowCursor(xlnev.display, xlnev.window);
                         ptr_grabbed = false;
                     }
                     break;

--- a/tests/include/mir/test/doubles/mock_x11.h
+++ b/tests/include/mir/test/doubles/mock_x11.h
@@ -90,6 +90,8 @@ public:
     MOCK_METHOD3(XInternAtom, Atom(Display*, const char*, Bool));
     MOCK_METHOD4(XSetWMProtocols, Status(Display*, Window, Atom*, int));
     MOCK_METHOD9(XGetGeometry, Status(Display*, Drawable, Window*, int*, int*, unsigned int*, unsigned int*, unsigned int*, unsigned int*));
+    MOCK_METHOD2(XFixesHideCursor, void(Display *dpy, Window win));
+    MOCK_METHOD2(XFixesShowCursor, void(Display *dpy, Window win));
 
     FakeX11Resources fake_x11;
 };

--- a/tests/mir_test_doubles/mock_x11.cpp
+++ b/tests/mir_test_doubles/mock_x11.cpp
@@ -254,3 +254,13 @@ Status XGetGeometry(Display* display, Drawable d,
                                      width_return, height_return,
                                      border_width_return, depth_return);
 }
+
+extern "C" void XFixesHideCursor(Display *dpy, Window win)
+{
+    global_mock->XFixesHideCursor(dpy, win);
+}
+
+extern "C" void XFixesShowCursor(Display *dpy, Window win)
+{
+    global_mock->XFixesShowCursor(dpy, win);
+}

--- a/tests/unit-tests/input/test_x11_platform.cpp
+++ b/tests/unit-tests/input/test_x11_platform.cpp
@@ -395,7 +395,7 @@ TEST_F(X11PlatformTest, enter_hides_X_cursor)
     auto const* next_event = std::begin(events);
 
     ON_CALL(mock_x11, XNextEvent(_,_))
-        .WillByDefault(Invoke([this, &next_event](Display*, XEvent* xev)
+        .WillByDefault(Invoke([&next_event](Display*, XEvent* xev)
         {
             *xev = *next_event++;
 


### PR DESCRIPTION
[Mir-on-X] hide the X11 cursor when over the Mir window. (Fixes: #1352)