### PR TITLE
Example clients: use configured size instead of output size

### DIFF
--- a/examples/example-server-lib/wayland_helpers.cpp
+++ b/examples/example-server-lib/wayland_helpers.cpp
@@ -105,8 +105,8 @@ namespace
 void output_geometry(
     void* data,
     struct wl_output* /*wl_output*/,
-    int32_t x,
-    int32_t y,
+    int32_t /*x*/,
+    int32_t /*y*/,
     int32_t /*physical_width*/,
     int32_t /*physical_height*/,
     int32_t /*subpixel*/,
@@ -116,27 +116,19 @@ void output_geometry(
 {
     auto output = static_cast<Output*>(data);
 
-    output->x = x;
-    output->y = y;
     output->transform = transform;
 }
-
 
 void output_mode(
     void *data,
     struct wl_output* /*wl_output*/,
-    uint32_t flags,
-    int32_t width,
-    int32_t height,
+    uint32_t /*flags*/,
+    int32_t /*width*/,
+    int32_t /*height*/,
     int32_t /*refresh*/)
 {
-    if (!(WL_OUTPUT_MODE_CURRENT & flags))
-        return;
-
     auto output = static_cast<Output*>(data);
-
-    output->width = width,
-    output->height = height;
+    (void)output;
 }
 
 void output_scale(void* data, struct wl_output* wl_output, int32_t factor)

--- a/examples/example-server-lib/wayland_helpers.h
+++ b/examples/example-server-lib/wayland_helpers.h
@@ -48,8 +48,6 @@ public:
     Output& operator=(Output const&) = delete;
     Output& operator=(Output&&) = delete;
 
-    int32_t x, y;
-    int32_t width, height;
     int32_t transform;
     wl_output* output;
 private:

--- a/examples/miral-shell/spinner/miregl.h
+++ b/examples/miral-shell/spinner/miregl.h
@@ -31,7 +31,7 @@ std::vector<std::shared_ptr<MirEglSurface>> mir_surface_init(std::shared_ptr<Mir
 class MirEglSurface
 {
 public:
-    MirEglSurface(std::shared_ptr<MirEglApp> const& mir_egl_app, struct wl_output* wl_output, int width, int height);
+    MirEglSurface(std::shared_ptr<MirEglApp> const& mir_egl_app, struct wl_output* wl_output);
 
     ~MirEglSurface();
 
@@ -65,8 +65,8 @@ private:
     bool waiting_for_buffer = true;
 
     EGLSurface eglsurface;
-    int width_;
-    int height_;
+    int width_{640};
+    int height_{480};
 
     static void shell_surface_ping(void *data, struct wl_shell_surface *wl_shell_surface, uint32_t serial);
 


### PR DESCRIPTION
__problem:__ When rendering example clients (such as the spinner, splash and background), we previously used the size from the current output mode for each output. This is not a robust system, as raw output size is not necessarily the size the surface should be to fill the screen (for example, raw output size does not reflect transforms including scaling).

Some of these transforms can be detected and compensated for, but this results in a complicated and fragile system. Others, such as fractional scaling, can not be compensated for in this way as the protocol does not supply enough information.

__Alternative Solution:__ The `xdg_output_unstable_v1` protocol (which we implement) has a `.logical_size` event. This would work, but would have added the complication of generating/updating a non-core protocol, plus the code to actually use it. I found this to be unnecessary, but worth mentioning here in case my current approach turns out to have problems I'm unaware of.

__Selected Solution:__ Since we're already making the client windows full screen, they're already getting configured with the size the compositor wants them to be. Here, I add the logic to use the sizes from those `wl_surface.configure` events. This should make these components work reliably without modification as the way Mir handles transformations and scaling change.