### PR TITLE
Have wl_surfaces enter all outputs

### DIFF
--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -456,5 +456,19 @@ void mf::WindowWlSurfaceRole::create_scene_surface()
     auto const content_size = scene_surface->content_size();
     if (content_size != params->size)
         observer->content_resized_to(scene_surface.get(), content_size);
+
+    // Send wl_surface.enter events for every output
+    // TODO: send enter/leave when the surface actually enters and leaves outputs
+    output_manager->display_config()->for_each_output([&](graphics::DisplayConfigurationOutput const& conf)
+        {
+            auto const output = output_manager->output_for(conf.id);
+            if (output)
+            {
+                output.value()->for_each_output_resource_bound_by(client, [&](wl_resource* resource)
+                    {
+                        surface->send_enter_event(resource);
+                    });
+            }
+        });
 }
 


### PR DESCRIPTION
Is not a full fix of #342, but accomplishes 80% of the functionality that would with 20% of the work. Sends `wl_surface.enter` for every output when a surface is created. This allows surfaces to scale to the highest scale output.

Will cause the buffers of some clients (such as weston-terminal) to have an incorrect transform on transformed outputs until #1362 lands