### PR TITLE
Support scaled buffers

### DIFF
--- a/src/gl/tessellation_helpers.cpp
+++ b/src/gl/tessellation_helpers.cpp
@@ -26,7 +26,6 @@ namespace geom = mir::geometry;
 mgl::Primitive mgl::tessellate_renderable_into_rectangle(
     mg::Renderable const& renderable, geom::Displacement const& offset)
 {
-    auto const& buf_size = renderable.buffer()->size();
     auto rect = renderable.screen_position();
     rect.top_left = rect.top_left - offset;
     GLfloat left = rect.top_left.x.as_int();
@@ -37,10 +36,8 @@ mgl::Primitive mgl::tessellate_renderable_into_rectangle(
     mgl::Primitive rectangle;
     rectangle.type = GL_TRIANGLE_STRIP;
 
-    GLfloat tex_right = static_cast<GLfloat>(rect.size.width.as_int()) /
-                        buf_size.width.as_int();
-    GLfloat tex_bottom = static_cast<GLfloat>(rect.size.height.as_int()) /
-                         buf_size.height.as_int();
+    GLfloat const tex_right = 1.0f;
+    GLfloat const tex_bottom = 1.0f;
 
     auto& vertices = rectangle.vertices;
     vertices[0] = {{left,  top,    0.0f}, {0.0f,      0.0f}};

--- a/src/include/server/mir/compositor/buffer_stream.h
+++ b/src/include/server/mir/compositor/buffer_stream.h
@@ -43,6 +43,7 @@ public:
     virtual ~BufferStream() = default;
 
     virtual auto lock_compositor_buffer(void const* user_id) -> std::shared_ptr<graphics::Buffer> = 0;
+    /// Logical size of the stream (may be different than buffer sizes if scaled)
     virtual auto stream_size() -> geometry::Size = 0;
     virtual auto buffers_ready_for_compositor(void const* user_id) const -> int = 0;
     virtual void drop_old_buffers() = 0;

--- a/src/server/compositor/stream.h
+++ b/src/server/compositor/stream.h
@@ -65,7 +65,8 @@ private:
     ScheduleMode schedule_mode;
     std::shared_ptr<Schedule> schedule;
     std::shared_ptr<MultiMonitorArbiter> const arbiter;
-    geometry::Size size; 
+    geometry::Size latest_buffer_size;
+    float scale_{1.0f};
     MirPixelFormat pf;
     bool first_frame_posted;
 

--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -150,7 +150,7 @@ void mf::Output::send_initial_config(wl_resource* client_resource, mg::DisplayCo
     }
 
     if (wl_resource_get_version(client_resource) >= WL_OUTPUT_SCALE_SINCE_VERSION)
-        wl_output_send_scale(client_resource, 1);
+        wl_output_send_scale(client_resource, ceil(config.scale));
 
     if (wl_resource_get_version(client_resource) >= WL_OUTPUT_DONE_SINCE_VERSION)
         wl_output_send_done(client_resource);

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -57,6 +57,9 @@ void mf::WlSurfaceState::update_from(WlSurfaceState const& source)
     if (source.buffer)
         buffer = source.buffer;
 
+    if (source.scale)
+        scale = source.scale;
+
     if (source.offset)
         offset = source.offset;
 
@@ -313,6 +316,9 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
     if (state.input_shape)
         input_shape = state.input_shape.value();
 
+    if (state.scale)
+        stream->set_scale(state.scale.value());
+
     if (state.buffer)
     {
         wl_resource * buffer = *state.buffer;
@@ -418,8 +424,7 @@ void mf::WlSurface::set_buffer_transform(int32_t transform)
 
 void mf::WlSurface::set_buffer_scale(int32_t scale)
 {
-    (void)scale;
-    // TODO
+    pending.scale = scale;
 }
 
 mf::NullWlSurfaceRole::NullWlSurfaceRole(WlSurface* surface) :

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -371,12 +371,15 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
                     mir_buffer->id().as_value());
             }
 
-            if (!input_shape && (!buffer_size_ || mir_buffer->size() != buffer_size_.value()))
+            stream->submit_buffer(mir_buffer);
+            auto const new_buffer_size = stream->stream_size();
+
+            if (!input_shape && std::experimental::make_optional(new_buffer_size) != buffer_size_)
             {
                 state.invalidate_surface_data(); // input shape needs to be recalculated for the new size
             }
-            buffer_size_ = mir_buffer->size();
-            stream->submit_buffer(mir_buffer);
+
+            buffer_size_ = new_buffer_size;
         }
     }
     else

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -80,6 +80,7 @@ struct WlSurfaceState
     // if it's nullptr, there is a new buffer and it is a null buffer, which should replace the current buffer
     std::experimental::optional<wl_resource*> buffer;
 
+    std::experimental::optional<int> scale;
     std::experimental::optional<geometry::Displacement> offset;
     std::experimental::optional<std::experimental::optional<std::vector<geometry::Rectangle>>> input_shape;
     std::vector<std::shared_ptr<Callback>> frame_callbacks;


### PR DESCRIPTION
Renders scaled buffers at correct size, and sends correct output scales so clients know to render scaled buffers. Clients will not start sending scaled buffers until #1363 has also landed, as they do not know they're on a scaled output.