### PR TITLE
Revert "Enable `--display-config` for Mir-on-X"

### DIFF
--- a/src/platforms/mesa/server/x11/graphics/display.cpp
+++ b/src/platforms/mesa/server/x11/graphics/display.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2020 Canonical Ltd.
+ * Copyright © 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 2 or 3,
@@ -19,7 +19,6 @@
 #include "mir/graphics/platform.h"
 #include "mir/graphics/display_report.h"
 #include "mir/graphics/display_configuration.h"
-#include <mir/graphics/display_configuration_policy.h>
 #include "mir/graphics/egl_error.h"
 #include "mir/graphics/virtual_output.h"
 #include "mir/renderer/gl/context.h"
@@ -237,7 +236,6 @@ unsigned long mgx::X11Window::red_mask() const
 
 mgx::Display::Display(::Display* x_dpy,
                       std::vector<X11OutputConfig> const& requested_sizes,
-                      std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
                       std::shared_ptr<GLConfig> const& gl_config,
                       std::shared_ptr<DisplayReport> const& report)
     : shared_egl{*gl_config},
@@ -283,9 +281,6 @@ mgx::Display::Display(::Display* x_dpy,
 
     shared_egl.make_current();
 
-    auto const display_config = configuration();
-    initial_conf_policy->apply_to(*display_config);
-    configure(*display_config);
     report->report_successful_display_construction();
 }
 

--- a/src/platforms/mesa/server/x11/graphics/display.h
+++ b/src/platforms/mesa/server/x11/graphics/display.h
@@ -40,7 +40,6 @@ class AtomicFrame;
 class GLConfig;
 class DisplayReport;
 struct DisplayConfigurationOutput;
-class DisplayConfigurationPolicy;
 
 namespace X
 {
@@ -73,7 +72,6 @@ class Display : public graphics::Display,
 public:
     explicit Display(::Display* x_dpy,
                      std::vector<X11OutputConfig> const& requested_size,
-                     std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
                      std::shared_ptr<GLConfig> const& gl_config,
                      std::shared_ptr<DisplayReport> const& report);
     ~Display() noexcept;

--- a/src/platforms/mesa/server/x11/graphics/platform.cpp
+++ b/src/platforms/mesa/server/x11/graphics/platform.cpp
@@ -124,10 +124,10 @@ mir::UniqueModulePtr<mg::GraphicBufferAllocator> mgx::Platform::create_buffer_al
 }
 
 mir::UniqueModulePtr<mg::Display> mgx::Platform::create_display(
-    std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
+    std::shared_ptr<DisplayConfigurationPolicy> const& /*initial_conf_policy*/,
     std::shared_ptr<GLConfig> const& gl_config)
 {
-    return make_module_ptr<mgx::Display>(x11_connection.get(), output_sizes, initial_conf_policy, gl_config, report);
+    return make_module_ptr<mgx::Display>(x11_connection.get(), output_sizes, gl_config, report);
 }
 
 mg::NativeDisplayPlatform* mgx::Platform::native_display_platform()

--- a/tests/unit-tests/platforms/mesa/x11/test_display.cpp
+++ b/tests/unit-tests/platforms/mesa/x11/test_display.cpp
@@ -25,7 +25,6 @@
 
 #include "mir/graphics/display_configuration.h"
 
-#include "mir/test/doubles/null_display_configuration_policy.h"
 #include "mir/test/doubles/mock_egl.h"
 #include "mir/test/doubles/mock_x11.h"
 #include "mir/test/doubles/mock_gl_config.h"
@@ -112,12 +111,10 @@ public:
         return std::make_shared<mgx::Display>(
                    mock_x11.fake_x11.display,
                    sizes,
-                   mt::fake_shared(null_display_configuration_policy),
                    mt::fake_shared(mock_gl_config),
                    std::make_shared<mir::report::null::DisplayReport>());
     }
 
-    mtd::NullDisplayConfigurationPolicy null_display_configuration_policy;
     ::testing::NiceMock<mtd::MockEGL> mock_egl;
     ::testing::NiceMock<mtd::MockX11> mock_x11;
     mtd::MockGLConfig mock_gl_config;


### PR DESCRIPTION
This reverts commit cd4ca37d05518ed1947d76916f6f20329a531036. (Fixes: #1338)

I'm not convinced that "Enable `--display-config` for Mir-on-X" is the real problem, but let's first fix the issue it introduced.