### PR TITLE
WaylandTexBuffer: call on_consumed() after uploading the texture

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -756,7 +756,6 @@ mf::WaylandConnector::WaylandConnector(
 
     pause_source = wl_event_loop_add_fd(wayland_loop, pause_signal, WL_EVENT_READABLE, &halt_eventloop, display.get());
 }
-
 mf::WaylandConnector::~WaylandConnector()
 {
     if (dispatch_thread.joinable())


### PR DESCRIPTION
WaylandTexBuffer: call on_consumed() after uploading the texture. (Fixes: #1377, Fixes: #1100)

Also addresses the underlying problem that lead to #1338.