### PR TITLE
Disable display configuration on Wayland platform

### DIFF
--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -22,7 +22,6 @@
 
 #include <mir/fatal.h>
 #include <mir/graphics/display_configuration.h>
-#include <mir/graphics/display_configuration_policy.h>
 #include <mir/graphics/egl_error.h>
 #include <mir/graphics/virtual_output.h>
 #include <mir/log.h>
@@ -85,7 +84,6 @@ mgw::Display* the_display = nullptr;
 mgw::Display::Display(
     wl_display* const wl_display,
     std::shared_ptr<GLConfig> const& gl_config,
-    std::shared_ptr<DisplayConfigurationPolicy> const& policy,
     std::shared_ptr<DisplayReport> const& report) :
     DisplayClient{wl_display, gl_config},
     report{report},
@@ -98,9 +96,6 @@ mgw::Display::Display(
 
     std::lock_guard<decltype(the_display_mtx)> lock{the_display_mtx};
     the_display = this;
-    auto const display_config = DisplayClient::display_configuration();
-    policy->apply_to(*display_config);
-    configure(*display_config);
 }
 
 auto mgw::Display::configuration() const -> std::unique_ptr<DisplayConfiguration>
@@ -108,9 +103,8 @@ auto mgw::Display::configuration() const -> std::unique_ptr<DisplayConfiguration
     return DisplayClient::display_configuration();
 }
 
-void mgw::Display::configure(DisplayConfiguration const& conf)
+void mgw::Display::configure(DisplayConfiguration const& /*conf*/)
 {
-    DisplayClient::apply(conf);
 }
 
 void mgw::Display::register_configuration_change_handler(

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -50,8 +50,6 @@ class TouchInput;
 }
 namespace graphics
 {
-class DisplayConfigurationPolicy;
-
 namespace wayland
 {
 class Display : public mir::graphics::Display, public mir::graphics::NativeDisplay,
@@ -61,7 +59,6 @@ public:
     Display(
         wl_display* const wl_display,
         std::shared_ptr<GLConfig> const& gl_config,
-        std::shared_ptr<DisplayConfigurationPolicy> const& policy,
         std::shared_ptr<DisplayReport> const& report);
 
     ~Display();

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -830,21 +830,6 @@ void mgw::DisplayClient::for_each_display_sync_group(const std::function<void(Di
     }
 }
 
-void mir::graphics::wayland::DisplayClient::apply(mir::graphics::DisplayConfiguration const& config)
-{
-    std::lock_guard<decltype(outputs_mutex)> lock{outputs_mutex};
-
-    // There's no way for the underlying outputs to change, so these iterations will zip
-    auto bound_output = bound_outputs.begin();
-    config.for_each_output([&bound_output](DisplayConfigurationOutput const& output)
-    {
-        bound_output->second->dcout.used = output.used;
-        bound_output->second->dcout.top_left = output.top_left;
-        bound_output->second->dcout.current_mode_index = output.current_mode_index;
-        ++bound_output;
-    });
-}
-
 mgw::WaylandDisplayConfiguration::WaylandDisplayConfiguration(std::vector<DisplayConfigurationOutput> && outputs) :
     outputs{outputs}
 {

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -58,7 +58,6 @@ protected:
     wl_display* const display;
 
     auto display_configuration() const -> std::unique_ptr<DisplayConfiguration>;
-    void apply(DisplayConfiguration const& config);
     void for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f);
 
     virtual void keyboard_keymap(wl_keyboard* keyboard, uint32_t format, int32_t fd, uint32_t size);

--- a/src/platforms/wayland/platform.cpp
+++ b/src/platforms/wayland/platform.cpp
@@ -46,10 +46,10 @@ mgw::Platform::Platform(struct wl_display* const wl_display, std::shared_ptr<mg:
 }
 
 mir::UniqueModulePtr<mg::Display> mgw::Platform::create_display(
-    std::shared_ptr<DisplayConfigurationPolicy> const& policy,
+    std::shared_ptr<DisplayConfigurationPolicy> const&,
     std::shared_ptr<GLConfig> const& gl_config)
 {
-  return mir::make_module_ptr<mgw::Display>(wl_display, gl_config, policy, report);
+  return mir::make_module_ptr<mgw::Display>(wl_display, gl_config, report);
 }
 
 mg::NativeDisplayPlatform* mgw::Platform::native_display_platform()


### PR DESCRIPTION
This reverts commit b248f5282eaba79f639a82eca42962337941aadf, reversing
changes made to 2fb3523b6e2285527a55c52e4a8ee53ee7c1a4a2. (Fixes: #1376)

The reverted changes were simplistic: Display configuration changes cannot ignore the host configuration.