### PR TITLE
If the `wayland-host` is not configured do not try connecting

### DIFF
--- a/src/platforms/wayland/platform_symbols.cpp
+++ b/src/platforms/wayland/platform_symbols.cpp
@@ -65,7 +65,6 @@ mg::PlatformPriority probe_graphics_platform(
     mir::assert_entry_point_signature<mg::PlatformProbe>(&probe_graphics_platform);
 
     return mpw::connection_options_supplied(options) ? mg::PlatformPriority::best :
-           mpw::connection(options)                  ? mg::PlatformPriority::supported :
            mg::PlatformPriority::unsupported;
 }
 


### PR DESCRIPTION
If the `wayland-host` is not configured do not try connecting to a Wayland server, and do not return `PlatformPriority::supported` if that succeeds. (Fixes: #1395)

Note: if `WAYLAND_DISPLAY` is set and provided by an existing server Mir will fail to start anyway (as it cannot provide `WAYLAND_DISPLAY`). Only if both `WAYLAND_DISPLAY` is unset and the default wayland-0 socket is provided by an existing server could Mir start with with Mir-on-Wayland.