### PR TITLE
Merge #1356

### DIFF
--- a/src/platforms/common/server/shm_buffer.cpp
+++ b/src/platforms/common/server/shm_buffer.cpp
@@ -207,6 +207,7 @@ void mir::graphics::common::ShmBuffer::commit()
 
 void mgc::ShmBuffer::tex_bind()
 {
+    std::lock_guard<decltype(tex_id_mutex)> lock{tex_id_mutex};
     bool const needs_initialisation = tex_id == 0;
     if (needs_initialisation)
     {

--- a/src/platforms/common/server/shm_buffer.h
+++ b/src/platforms/common/server/shm_buffer.h
@@ -32,6 +32,8 @@
 
 #include MIR_SERVER_GL_H
 
+#include <mutex>
+
 namespace mir
 {
 class ShmFile;
@@ -125,6 +127,7 @@ private:
     MirPixelFormat const pixel_format_;
     geometry::Stride const stride_;
     void* const pixels;
+    std::mutex tex_id_mutex;
     GLuint tex_id{0};
 };
 

--- a/src/platforms/mesa/server/gbm_buffer.cpp
+++ b/src/platforms/mesa/server/gbm_buffer.cpp
@@ -165,6 +165,7 @@ void mgm::GBMBuffer::add_syncpoint()
 
 void mgm::GBMBuffer::tex_bind()
 {
+    std::lock_guard<decltype(tex_id_mutex)> lock{tex_id_mutex};
     bool const needs_initialisation = tex_id == 0;
     if (needs_initialisation)
     {

--- a/src/platforms/mesa/server/gbm_buffer.h
+++ b/src/platforms/mesa/server/gbm_buffer.h
@@ -29,6 +29,7 @@
 #include MIR_SERVER_GL_H
 
 #include <memory>
+#include <mutex>
 #include <limits>
 
 namespace mir
@@ -113,6 +114,8 @@ private:
     uint32_t bo_flags;
     std::unique_ptr<common::BufferTextureBinder> const texture_binder;
     int prime_fd;
+
+    std::mutex tex_id_mutex;
     GLuint tex_id{0};
 };
 


### PR DESCRIPTION
1356: Make various texture bind() functions threadsafe r=wmww a=AlanGriffiths

Make various texture bind() functions threadsafe. (Fixes: #1332)

The one that was actually causing #1332 was re-uploading a texture on multiple threads.