### PR TITLE
Set default DisplayConfigurationOutput.scale

### DIFF
--- a/include/platform/mir/graphics/display_configuration.h
+++ b/include/platform/mir/graphics/display_configuration.h
@@ -119,7 +119,7 @@ struct DisplayConfigurationOutput
     MirOrientation orientation;
 
     /** Requested scale factor for this output, for HiDPI support */
-    float scale;
+    float scale{1.0f};
     /** Form factor of this output; phone display, tablet, monitor, TV, projector... */
     MirFormFactor form_factor;
 


### PR DESCRIPTION
1.0 is a much more reasonable default output scale than 0.0. Normal code paths do not rely on the default scale, but some tests do.