### PR TITLE
Bump libmirplatform soname

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -96,7 +96,7 @@ Description: Display server for Ubuntu - server library
  .
  Contains the shared library needed by server applications for Mir.
 
-Package: libmirplatform17
+Package: libmirplatform18
 Section: libs
 Architecture: linux-any
 Multi-Arch: same
@@ -145,7 +145,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirplatform17 (= ${binary:Version}),
+Depends: libmirplatform18 (= ${binary:Version}),
          libmircommon-dev (= ${binary:Version}),
          libboost-program-options-dev,
          ${misc:Depends},

--- a/debian/libmirplatform17.install
+++ b/debian/libmirplatform17.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmirplatform.so.17

--- a/debian/libmirplatform18.install
+++ b/debian/libmirplatform18.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmirplatform.so.18

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # We need MIRPLATFORM_ABI in both libmirplatform and the platform implementations.
-set(MIRPLATFORM_ABI 17)
+set(MIRPLATFORM_ABI 18)
 
 set(MIRAL_VERSION_MAJOR 2)
 set(MIRAL_VERSION_MINOR 9)

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -1,4 +1,4 @@
-MIRPLATFORM_1.6 {
+MIRPLATFORM_1.8 {
  global:
   extern "C++" {
 # The following symbols come from running a script over the generated docs. Vis:


### PR DESCRIPTION
Bump libmirplatform soname.

We changed ProgramFactory::compile_fragment_shader(). This will conflict with "master", as that already used `MIRPLATFORM_ABI 18` for a different ABI break. I'll deal with that when we get there.