### PR TITLE
WindowManagerTools::force_close is unsafe, document it

### DIFF
--- a/include/miral/miral/window_manager_tools.h
+++ b/include/miral/miral/window_manager_tools.h
@@ -129,8 +129,15 @@ public:
     /// Send close request to the window
     void ask_client_to_close(Window const& window);
 
-    /// Close the window by force
-    /// \note ask_client_to_close() is the polite way
+    /// Immediately remove all references to the window from the server's
+    /// internal data structures, invalidating any held client or server
+    /// references.
+    /// \warning This method is only safe to use if you can guarantee the
+    ///     Window will not be reused by server or client. Otherwise, it may
+    ///     lead to a use-after-delete. As an alternative, consider using
+    ///     ask_client_to_close(), then terminating the client if that
+    ///     does not work.
+    /// \deprecated WindowManager should not close windows directly.
     MIRAL_FOR_REMOVAL_IN_VERSION_3("Window Manager should not close windows directly")
     void force_close(Window const& window);
 


### PR DESCRIPTION
It's also deprecated. Both of these things should be reflected in its documentation.

This produces the following documentation:

![image](https://user-images.githubusercontent.com/21966173/78998288-e8474e80-7b0d-11ea-8876-0b53f8296dea.png)

It also adds force_close to the list of deprecations at 'deprecated.html'.