### PR TITLE
Use const where possible

### DIFF
--- a/src/common/dispatch/threaded_dispatcher.cpp
+++ b/src/common/dispatch/threaded_dispatcher.cpp
@@ -159,7 +159,7 @@ public:
     }
 
 private:
-    mir::Fd event_semaphore;
+    mir::Fd const event_semaphore;
 
     std::mutex terminating_thread_mutex;
     std::condition_variable thread_terminating;


### PR DESCRIPTION
Use const where possible