### PR TITLE
rpi-dispmanx: Use DispmanX overlays when possible

### DIFF
--- a/src/platforms/rpi-dispmanx/CMakeLists.txt
+++ b/src/platforms/rpi-dispmanx/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(mirplatformgraphicsrpidispmanxobjects OBJECT
   display.h
   display_buffer.cpp
   display_buffer.h
-)
+  helpers.h helpers.cpp)
 
 target_include_directories(
   mirplatformgraphicsrpidispmanxobjects

--- a/src/platforms/rpi-dispmanx/buffer_allocator.cpp
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.cpp
@@ -124,7 +124,7 @@ public:
         std::shared_ptr<mg::common::EGLContextExecutor> egl_executor)
         : ShmBuffer(size, format, std::move(egl_executor)),
           stride_{stride},
-          handle{mg::rpi::dispmanx_resource_for(size, format)}
+          handle{mg::rpi::dispmanx_resource_for(size, stride_, format)}
     {
     }
 

--- a/src/platforms/rpi-dispmanx/buffer_allocator.cpp
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.cpp
@@ -152,7 +152,7 @@ public:
                 vc_dispmanx_rect_set(
                     &rect,
                     0, row,
-                    size().width.as_uint32_t(), row + 1);
+                    size().width.as_uint32_t(), 1);
                 vc_dispmanx_resource_write_data(
                     handle,
                     vc_format,

--- a/src/platforms/rpi-dispmanx/buffer_allocator.cpp
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.cpp
@@ -138,43 +138,17 @@ public:
         auto const vc_format = mg::rpi::vc_image_type_from_mir_pf(pixel_format());
 
         VC_RECT_T rect;
-        if (stride_.as_uint32_t() % 64)
-        {
-            // Surprise! DispmanX seems to require buffers to have a stride divisible by 64.
+        vc_dispmanx_rect_set(
+            &rect,
+            0, 0,
+            size().width.as_uint32_t(), size().height.as_uint32_t());
 
-            // TODO: Having to pad like this means we need to handle opaque buffer formats differently
-/*            size_t const padding_size = 16 - (stride_.as_uint32_t() % 16);
-            auto const padding_bytes = std::make_unique<unsigned char>(padding_size);
-            std::fill(padding_bytes.get(), padding_bytes.get() + padding_size, 0);
-*/
-            for(uint32_t row = 0; row < size().height.as_uint32_t(); ++row)
-            {
-                vc_dispmanx_rect_set(
-                    &rect,
-                    0, row,
-                    size().width.as_uint32_t(), 1);
-                vc_dispmanx_resource_write_data(
-                    handle,
-                    vc_format,
-                    stride().as_uint32_t(),
-                    const_cast<unsigned char*>(pixels + (stride_.as_uint32_t() * row)),
-                    &rect);
-            }
-        }
-        else
-        {
-            vc_dispmanx_rect_set(
-                &rect,
-                0, 0,
-                size().width.as_uint32_t(), size().height.as_uint32_t());
-
-            vc_dispmanx_resource_write_data(
-                handle,
-                vc_format,
-                stride().as_uint32_t(),
-                const_cast<unsigned char*>(pixels),
-                &rect);
-        }
+        vc_dispmanx_resource_write_data(
+            handle,
+            vc_format,
+            stride().as_uint32_t(),
+            const_cast<unsigned char*>(pixels),
+            &rect);
     }
 
     void read(std::function<void(unsigned char const*)> const& do_with_pixels) override

--- a/src/platforms/rpi-dispmanx/buffer_allocator.cpp
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.cpp
@@ -338,7 +338,6 @@ public:
             glTexImage2D(GL_TEXTURE_2D, 0, gl_format, width, height,
                 0, gl_format, gl_type, bounce_buffer.get());
 
-            on_consumed();
             uploaded = true;
         }
     }
@@ -350,6 +349,8 @@ public:
 
     explicit operator DISPMANX_RESOURCE_HANDLE_T() const override
     {
+        on_consumed();
+        const_cast<WlDispmanxBuffer*>(this)->on_consumed = [](){};
         return vc_dispmanx_get_handle_from_wl_buffer(buffer);
     }
 

--- a/src/platforms/rpi-dispmanx/buffer_allocator.cpp
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.cpp
@@ -25,6 +25,7 @@
 #include <interface/vmcs_host/vc_vchi_dispmanx.h>
 #undef BUILD_WAYLAND
 
+#include "helpers.h"
 #include "mir/raii.h"
 #include "mir/anonymous_shm_file.h"
 #include "mir/graphics/egl_extensions.h"

--- a/src/platforms/rpi-dispmanx/buffer_allocator.cpp
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.cpp
@@ -108,6 +108,118 @@ auto mg::rpi::BufferAllocator::alloc_buffer(
     BOOST_THROW_EXCEPTION((std::runtime_error{"Platform does not support mirclient"}));
 }
 
+namespace
+{
+
+class DispmanxShmBuffer
+    : public mg::common::ShmBuffer,
+      public mir::renderer::software::PixelSource,
+      public mg::rpi::DispmanXBuffer
+{
+public:
+    DispmanxShmBuffer(
+        geom::Size const& size,
+        geom::Stride const& stride,
+        MirPixelFormat format,
+        std::shared_ptr<mg::common::EGLContextExecutor> egl_executor)
+        : ShmBuffer(size, format, std::move(egl_executor)),
+          stride_{stride},
+          handle{mg::rpi::dispmanx_resource_for(size, format)}
+    {
+    }
+
+    auto native_buffer_handle() const -> std::shared_ptr<mg::NativeBuffer> override
+    {
+        BOOST_THROW_EXCEPTION((std::runtime_error{"mirclient not supported"}));
+    }
+
+    void write(unsigned char const* pixels, size_t /*size*/) override
+    {
+        auto const vc_format = mg::rpi::vc_image_type_from_mir_pf(pixel_format());
+
+        VC_RECT_T rect;
+        if (stride_.as_uint32_t() % 64)
+        {
+            // Surprise! DispmanX seems to require buffers to have a stride divisible by 64.
+
+            // TODO: Having to pad like this means we need to handle opaque buffer formats differently
+/*            size_t const padding_size = 16 - (stride_.as_uint32_t() % 16);
+            auto const padding_bytes = std::make_unique<unsigned char>(padding_size);
+            std::fill(padding_bytes.get(), padding_bytes.get() + padding_size, 0);
+*/
+            for(uint32_t row = 0; row < size().height.as_uint32_t(); ++row)
+            {
+                vc_dispmanx_rect_set(
+                    &rect,
+                    0, row,
+                    size().width.as_uint32_t(), row + 1);
+                vc_dispmanx_resource_write_data(
+                    handle,
+                    vc_format,
+                    stride().as_uint32_t(),
+                    const_cast<unsigned char*>(pixels + (stride_.as_uint32_t() * row)),
+                    &rect);
+            }
+        }
+        else
+        {
+            vc_dispmanx_rect_set(
+                &rect,
+                0, 0,
+                size().width.as_uint32_t(), size().height.as_uint32_t());
+
+            vc_dispmanx_resource_write_data(
+                handle,
+                vc_format,
+                stride().as_uint32_t(),
+                const_cast<unsigned char*>(pixels),
+                &rect);
+        }
+    }
+
+    void read(std::function<void(unsigned char const*)> const& do_with_pixels) override
+    {
+        auto const width = size().width.as_int();
+        auto const height = size().height.as_int();
+
+        VC_RECT_T const rect{0, 0, width, height};
+
+        auto const bounce_buffer = std::make_unique<unsigned char[]>(
+            stride().as_uint32_t() * height);
+
+        vc_dispmanx_resource_read_data(
+            static_cast<DISPMANX_RESOURCE_HANDLE_T>(*this),
+            &rect,
+            bounce_buffer.get(),
+            stride().as_uint32_t());
+
+        do_with_pixels(bounce_buffer.get());
+    }
+
+    mir::geometry::Stride stride() const override
+    {
+        return stride_;
+    }
+
+    void bind() override
+    {
+        ShmBuffer::bind();
+
+        /*
+         * Slowpath: we download from VideoCore memory before uploading again
+         */
+        read([this](auto pixels) { upload_to_texture(pixels, stride()); });
+    }
+
+    explicit operator DISPMANX_RESOURCE_HANDLE_T() const override
+    {
+        return handle;
+    }
+private:
+    geom::Stride const stride_;
+    DISPMANX_RESOURCE_HANDLE_T const handle;
+};
+}
 auto mg::rpi::BufferAllocator::alloc_software_buffer(
     mir::geometry::Size size, MirPixelFormat format)
     -> std::shared_ptr<Buffer>
@@ -118,7 +230,11 @@ auto mg::rpi::BufferAllocator::alloc_software_buffer(
             std::runtime_error{"Trying to create SHM buffer with unsupported pixel format"}));
     }
 
-    return std::make_shared<common::MemoryBackedShmBuffer>(size, format, egl_executor);
+    return std::make_shared<DispmanxShmBuffer>(
+        size,
+        geom::Stride{MIR_BYTES_PER_PIXEL(format) * size.width.as_uint32_t()},
+        format,
+        egl_executor);
 }
 
 namespace
@@ -309,15 +425,92 @@ std::shared_ptr<mg::Buffer> mg::rpi::BufferAllocator::buffer_from_resource(
         std::move(on_release));
 }
 
-auto mg::rpi::BufferAllocator::buffer_from_shm(
-    wl_resource* buffer,
-    std::shared_ptr<mir::Executor> wayland_executor,
-    std::function<void()>&& on_consumed) -> std::shared_ptr<Buffer>
+namespace
 {
-    return mg::wayland::buffer_from_wl_shm(
-        buffer,
-        std::move(wayland_executor),
-        egl_executor,
-        std::move(on_consumed));
+MirPixelFormat wl_format_to_mir_format(uint32_t format)
+{
+    switch (format)
+    {
+        case WL_SHM_FORMAT_ARGB8888:
+            return mir_pixel_format_argb_8888;
+        case WL_SHM_FORMAT_XRGB8888:
+            return mir_pixel_format_xrgb_8888;
+        case WL_SHM_FORMAT_RGBA4444:
+            return mir_pixel_format_rgba_4444;
+        case WL_SHM_FORMAT_RGBA5551:
+            return mir_pixel_format_rgba_5551;
+        case WL_SHM_FORMAT_RGB565:
+            return mir_pixel_format_rgb_565;
+        case WL_SHM_FORMAT_RGB888:
+            return mir_pixel_format_rgb_888;
+        case WL_SHM_FORMAT_BGR888:
+            return mir_pixel_format_bgr_888;
+        case WL_SHM_FORMAT_XBGR8888:
+            return mir_pixel_format_xbgr_8888;
+        case WL_SHM_FORMAT_ABGR8888:
+            return mir_pixel_format_abgr_8888;
+        default:
+            return mir_pixel_format_invalid;
+    }
 }
 
+class DispmanxWlShmBuffer : public DispmanxShmBuffer
+{
+public:
+    DispmanxWlShmBuffer(
+        wl_shm_buffer* buffer,
+        std::shared_ptr<mg::common::EGLContextExecutor> egl_executor,
+        std::function<void()>&& on_consumed)
+        : DispmanxShmBuffer(
+            geom::Size{wl_shm_buffer_get_width(buffer), wl_shm_buffer_get_height(buffer)},
+            geom::Stride{wl_shm_buffer_get_stride(buffer)},
+            wl_format_to_mir_format(wl_shm_buffer_get_format(buffer)),
+            std::move(egl_executor)),
+          on_consumed(std::move(on_consumed))
+    {
+        wl_shm_buffer_begin_access(buffer);
+        write(
+            static_cast<unsigned char*>(wl_shm_buffer_get_data(buffer)),
+            stride().as_uint32_t() * size().height.as_uint32_t());
+        wl_shm_buffer_end_access(buffer);
+    }
+
+    void bind() override
+    {
+        ShmBuffer::bind();
+
+        std::lock_guard<std::mutex> lock{consumption_mutex};
+        if (on_consumed)
+        {
+            read([this](auto pixels) { upload_to_texture(pixels, stride()); });
+            on_consumed();
+            on_consumed = nullptr;
+        }
+    }
+
+private:
+    std::mutex consumption_mutex;
+    std::function<void()> on_consumed;
+};
+}
+
+auto mg::rpi::BufferAllocator::buffer_from_shm(
+    wl_resource* buffer,
+    std::shared_ptr<mir::Executor> /*wayland_executor*/,
+    std::function<void()>&& on_consumed) -> std::shared_ptr<Buffer>
+{
+    auto shm_buffer = wl_shm_buffer_get(buffer);
+    if (shm_buffer == nullptr)
+    {
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Attempt to allocate Shm buffer from non-shm wl_resource"}));
+    }
+
+    auto const mir_buffer = std::make_shared<DispmanxWlShmBuffer>(
+        shm_buffer,
+        egl_executor,
+        std::move(on_consumed));
+
+    // DispmanxWlShmBuffer eagerly copies out of the wl_shm_buffer, so we're done with it here.
+    wl_resource_post_event(buffer, WL_BUFFER_RELEASE);
+    return mir_buffer;
+}

--- a/src/platforms/rpi-dispmanx/buffer_allocator.cpp
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.cpp
@@ -352,8 +352,6 @@ public:
                 bounce_buffer.get(),
                 stride);
 
-
-
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);

--- a/src/platforms/rpi-dispmanx/buffer_allocator.cpp
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.cpp
@@ -128,6 +128,11 @@ public:
     {
     }
 
+    ~DispmanxShmBuffer() override
+    {
+        vc_dispmanx_resource_delete(handle);
+    }
+
     auto native_buffer_handle() const -> std::shared_ptr<mg::NativeBuffer> override
     {
         BOOST_THROW_EXCEPTION((std::runtime_error{"mirclient not supported"}));

--- a/src/platforms/rpi-dispmanx/buffer_allocator.cpp
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.cpp
@@ -194,6 +194,11 @@ public:
     {
         return handle;
     }
+
+    auto resource_transform() const -> DISPMANX_TRANSFORM_T override
+    {
+        return DISPMANX_NO_ROTATE;
+    }
 private:
     geom::Stride const stride_;
     DISPMANX_RESOURCE_HANDLE_T const handle;
@@ -366,6 +371,10 @@ public:
         return vc_dispmanx_get_handle_from_wl_buffer(buffer);
     }
 
+    auto resource_transform() const -> DISPMANX_TRANSFORM_T override
+    {
+        return static_cast<DISPMANX_TRANSFORM_T>(DISPMANX_NO_ROTATE | DISPMANX_FLIP_VERT);
+    }
 private:
     wl_resource* buffer;
     mir::geometry::Size const size_;

--- a/src/platforms/rpi-dispmanx/buffer_allocator.h
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.h
@@ -55,6 +55,7 @@ public:
     virtual ~DispmanXBuffer() = default;
 
     virtual explicit operator DISPMANX_RESOURCE_HANDLE_T() const = 0;
+    virtual DISPMANX_TRANSFORM_T resource_transform() const = 0;
 };
 
 class BufferAllocator :

--- a/src/platforms/rpi-dispmanx/display_buffer.cpp
+++ b/src/platforms/rpi-dispmanx/display_buffer.cpp
@@ -317,6 +317,7 @@ bool mg::rpi::DisplayBuffer::overlay(mg::RenderableList const& renderlist)
 
     return true;
 }
+
 glm::mat2 mg::rpi::DisplayBuffer::transformation() const
 {
     return glm::mat2(1);

--- a/src/platforms/rpi-dispmanx/display_buffer.cpp
+++ b/src/platforms/rpi-dispmanx/display_buffer.cpp
@@ -208,6 +208,13 @@ auto dispmanx_handle_for_renderable(mg::Renderable const& renderable)
             std::runtime_error{"We accidentally tried to use overlays without checking the buffers are overlay-capable"}));
     }
 }
+
+auto transform_for_renderable(mg::Renderable const& renderable) -> DISPMANX_TRANSFORM_T
+{
+    // TODO: Handle rotations etc
+    return dynamic_cast<mg::rpi::DispmanXBuffer const&>(*renderable.buffer())
+        .resource_transform();
+}
 }
 
 bool mg::rpi::DisplayBuffer::overlay(mg::RenderableList const& renderlist)
@@ -279,6 +286,8 @@ bool mg::rpi::DisplayBuffer::overlay(mg::RenderableList const& renderlist)
             0
         };
 
+        auto const buffer_transform = transform_for_renderable(*renderable);
+
         current_elements.emplace_back(
             vc_dispmanx_element_add(
                 update_handle,
@@ -290,7 +299,7 @@ bool mg::rpi::DisplayBuffer::overlay(mg::RenderableList const& renderlist)
                 DISPMANX_PROTECTION_NONE,
                 &alpha_flags,
                 0,
-                DISPMANX_NO_ROTATE));
+                buffer_transform));
         if (current_elements.back() == DISPMANX_NO_HANDLE)
         {
             // TODO: We should probably back out to GL rendering here

--- a/src/platforms/rpi-dispmanx/display_buffer.cpp
+++ b/src/platforms/rpi-dispmanx/display_buffer.cpp
@@ -17,10 +17,19 @@
  */
 
 #include "display_buffer.h"
+#include "buffer_allocator.h"
 
 #include "mir/graphics/egl_error.h"
+#include "mir/renderer/sw/pixel_source.h"
 
 #include <boost/throw_exception.hpp>
+#include <algorithm>
+
+#ifndef GLM_ENABLE_EXPERIMENTAL
+#define GLM_ENABLE_EXPERIMENTAL
+#endif
+#include <glm/gtx/matrix_decompose.hpp>
+#include <mir/fatal.h>
 
 namespace mg = mir::graphics;
 
@@ -32,12 +41,9 @@ typedef struct {
     int height;
 } EGL_DISPMANX_WINDOW_T;
 
-
-auto surface_for_display(
+auto create_fullscreen_dispmanx_element(
     DISPMANX_DISPLAY_HANDLE_T display,
-    mir::geometry::Size const& size,
-    EGLDisplay dpy,
-    EGLConfig config) -> EGLSurface
+    mir::geometry::Size const& size) -> DISPMANX_ELEMENT_HANDLE_T
 {
     VC_RECT_T source_rect, dest_rect;
 
@@ -74,6 +80,15 @@ auto surface_for_display(
 
     vc_dispmanx_update_submit_sync(update);
 
+    return display_element;
+}
+
+auto surface_for_element(
+    DISPMANX_ELEMENT_HANDLE_T display_element,
+    mir::geometry::Size const& size,
+    EGLDisplay dpy,
+    EGLConfig config) -> EGLSurface
+{
     static EGL_DISPMANX_WINDOW_T native_window {
         display_element,
         size.width.as_int(),
@@ -104,7 +119,10 @@ mg::rpi::DisplayBuffer::DisplayBuffer(
     : view{{0, 0}, size},
       dpy{dpy},
       ctx{ctx},
-      surface{surface_for_display(display, size, dpy, config)}
+      config{config},
+      display_handle{display},
+      egl_target_element{DISPMANX_NO_HANDLE},
+      surface{EGL_NO_SURFACE}
 {
 }
 
@@ -125,9 +143,151 @@ mir::geometry::Rectangle mg::rpi::DisplayBuffer::view_area() const
 {
     return view;
 }
-bool mg::rpi::DisplayBuffer::overlay(mg::RenderableList const& /*renderlist*/)
+
+namespace
 {
-    return false;
+bool is_dispmanx_capable_buffer(mg::Buffer const& buffer)
+{
+    return
+        dynamic_cast<mg::rpi::DispmanXBuffer const*>(&buffer) ||
+        dynamic_cast<mir::renderer::software::PixelSource const*>(&buffer);
+}
+
+bool transform_is_representable(glm::mat4 const& transform)
+{
+    // TODO: We can handle arbitrary scaling, 90° rotations, and mirroring
+    // For now, just bail on *any* transformation.
+    return transform == glm::mat4{1};
+}
+
+bool renderable_is_overlay_candidate(std::shared_ptr<mg::Renderable> const& renderable)
+{
+    return
+        transform_is_representable(renderable->transformation()) &&
+        is_dispmanx_capable_buffer(*renderable->buffer());
+}
+
+auto vc_image_type_from_mir_pf(MirPixelFormat format) -> VC_IMAGE_TYPE_T
+{
+    switch(format)
+    {
+    case mir_pixel_format_xbgr_8888:
+        return VC_IMAGE_XRGB8888;
+    default:
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Unexpected pixel format"}));
+    }
+}
+
+auto dispmanx_handle_for_renderable(mg::Renderable const& renderable)
+    -> DISPMANX_RESOURCE_HANDLE_T
+{
+    auto const buffer = renderable.buffer().get();
+    if (auto dispmanx_buffer = dynamic_cast<mg::rpi::DispmanXBuffer const*>(buffer))
+    {
+        return static_cast<DISPMANX_RESOURCE_HANDLE_T>(*dispmanx_buffer);
+    }
+    else if (auto const pixel_source = dynamic_cast<mir::renderer::software::PixelSource*>(buffer))
+    {
+        uint32_t dummy;
+        auto const vc_format = vc_image_type_from_mir_pf(buffer->pixel_format());
+        auto const width = buffer->size().width.as_uint32_t();
+        auto const height = buffer->size().height.as_uint32_t();
+        auto handle = vc_dispmanx_resource_create(vc_format, width, height, &dummy);
+
+        pixel_source->read(
+            [handle, vc_format, stride = pixel_source->stride().as_uint32_t(), width, height]
+            (unsigned char const* data)
+            {
+                VC_RECT_T rect;
+                vc_dispmanx_rect_set(&rect, 0, 0, width, height);
+
+                vc_dispmanx_resource_write_data(
+                    handle,
+                    vc_format,
+                    stride,
+                    const_cast<unsigned char*>(data),
+                    &rect);
+            });
+
+        return handle;
+    }
+    else
+    {
+        BOOST_THROW_EXCEPTION((
+            std::runtime_error{"We accidentally tried to use overlays without checking the buffers are overlay-capable"}));
+    }
+}
+}
+
+bool mg::rpi::DisplayBuffer::overlay(mg::RenderableList const& renderlist)
+{
+    if (!std::all_of(
+        renderlist.begin(),
+        renderlist.end(),
+        &renderable_is_overlay_candidate))
+    {
+        return false;
+    }
+
+    auto update_handle = vc_dispmanx_update_start(0);
+
+    // TODO: Better algorithm than “remove everything from last frame, add everything from this”
+
+    // First, remove everything
+    for (auto const& element : current_elements)
+    {
+        vc_dispmanx_element_remove(update_handle, element);
+    }
+    current_elements.clear();
+
+    // Now, add the renderables
+    for (uint32_t layer = 0; layer < renderlist.size(); ++layer)
+    {
+        auto const renderable = renderlist[layer];
+        VC_RECT_T dest_rect, src_rect;
+
+        // Destination rect coördinates are in integer pixels…
+        vc_dispmanx_rect_set(
+            &dest_rect,
+            renderable->screen_position().top_left.x.as_uint32_t(),
+            renderable->screen_position().top_left.y.as_uint32_t(),
+            renderable->screen_position().size.width.as_uint32_t(),
+            renderable->screen_position().size.height.as_uint32_t());
+
+        // …but source rect coödinates are in 16.16 fixed point.
+        vc_dispmanx_rect_set(
+            &src_rect,
+            0, 0,
+            renderable->buffer()->size().width.as_uint32_t() << 16,
+            renderable->buffer()->size().height.as_uint32_t() << 16);
+
+        VC_DISPMANX_ALPHA_T alpha_flags = {
+            static_cast<DISPMANX_FLAGS_ALPHA_T>(DISPMANX_FLAGS_ALPHA_FROM_SOURCE | DISPMANX_FLAGS_ALPHA_MIX),
+            static_cast<uint8_t>(renderable->alpha() * 255),
+            0
+        };
+
+        current_elements.push_back(
+            vc_dispmanx_element_add(
+                update_handle,
+                display_handle,
+                layer,
+                &dest_rect,
+                dispmanx_handle_for_renderable(*renderlist[layer]),
+                &src_rect,
+                DISPMANX_PROTECTION_NONE,
+                &alpha_flags,
+                0,
+                DISPMANX_NO_ROTATE));
+        if (current_elements.back() == DISPMANX_NO_HANDLE)
+        {
+            BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to add element to DispmanX display list"}));
+        }
+    }
+
+    vc_dispmanx_update_submit_sync(update_handle);
+
+    return true;
 }
 glm::mat2 mg::rpi::DisplayBuffer::transformation() const
 {
@@ -140,6 +300,21 @@ mg::NativeDisplayBuffer* mg::rpi::DisplayBuffer::native_display_buffer()
 
 void mg::rpi::DisplayBuffer::make_current()
 {
+    if (current_elements.size() != 1 || current_elements.front() != egl_target_element)
+    {
+        auto update_handle = vc_dispmanx_update_start(0);
+
+        for (auto const& element : current_elements)
+        {
+            vc_dispmanx_element_remove(update_handle, element);
+        }
+        current_elements.clear();
+
+        egl_target_element = create_fullscreen_dispmanx_element(display_handle, view.size);
+        current_elements.push_back(egl_target_element);
+        surface = surface_for_element(egl_target_element, view.size, dpy, config);
+    }
+
     if (eglMakeCurrent(dpy, surface, surface, ctx) != EGL_TRUE)
     {
         BOOST_THROW_EXCEPTION(mg::egl_error("Failed to make context current"));

--- a/src/platforms/rpi-dispmanx/display_buffer.cpp
+++ b/src/platforms/rpi-dispmanx/display_buffer.cpp
@@ -183,7 +183,12 @@ auto dispmanx_handle_for_renderable(mg::Renderable const& renderable)
         auto const vc_format = mg::rpi::vc_image_type_from_mir_pf(buffer->pixel_format());
         auto const width = buffer->size().width.as_uint32_t();
         auto const height = buffer->size().height.as_uint32_t();
-        auto handle = vc_dispmanx_resource_create(vc_format, width, height, &dummy);
+        auto handle = vc_dispmanx_resource_create(
+            vc_format,
+            width | (pixel_source->stride().as_uint32_t() << 16),
+            height | (height << 16),
+            &dummy);
+
 
         pixel_source->read(
             [handle, vc_format, stride = pixel_source->stride().as_uint32_t(), width, height]

--- a/src/platforms/rpi-dispmanx/display_buffer.cpp
+++ b/src/platforms/rpi-dispmanx/display_buffer.cpp
@@ -18,6 +18,7 @@
 
 #include "display_buffer.h"
 #include "buffer_allocator.h"
+#include "helpers.h"
 
 #include "mir/graphics/egl_error.h"
 #include "mir/renderer/sw/pixel_source.h"
@@ -168,17 +169,6 @@ bool renderable_is_overlay_candidate(std::shared_ptr<mg::Renderable> const& rend
         is_dispmanx_capable_buffer(*renderable->buffer());
 }
 
-auto vc_image_type_from_mir_pf(MirPixelFormat format) -> VC_IMAGE_TYPE_T
-{
-    switch(format)
-    {
-    case mir_pixel_format_xbgr_8888:
-        return VC_IMAGE_XRGB8888;
-    default:
-        BOOST_THROW_EXCEPTION((std::runtime_error{"Unexpected pixel format"}));
-    }
-}
-
 auto dispmanx_handle_for_renderable(mg::Renderable const& renderable)
     -> DISPMANX_RESOURCE_HANDLE_T
 {
@@ -190,7 +180,7 @@ auto dispmanx_handle_for_renderable(mg::Renderable const& renderable)
     else if (auto const pixel_source = dynamic_cast<mir::renderer::software::PixelSource*>(buffer))
     {
         uint32_t dummy;
-        auto const vc_format = vc_image_type_from_mir_pf(buffer->pixel_format());
+        auto const vc_format = mg::rpi::vc_image_type_from_mir_pf(buffer->pixel_format());
         auto const width = buffer->size().width.as_uint32_t();
         auto const height = buffer->size().height.as_uint32_t();
         auto handle = vc_dispmanx_resource_create(vc_format, width, height, &dummy);

--- a/src/platforms/rpi-dispmanx/display_buffer.h
+++ b/src/platforms/rpi-dispmanx/display_buffer.h
@@ -64,7 +64,11 @@ private:
     geometry::Rectangle const view;
     EGLDisplay const dpy;
     EGLContext const ctx;
-    EGLSurface const surface;
+    EGLConfig const config;
+    DISPMANX_DISPLAY_HANDLE_T const display_handle;
+    DISPMANX_ELEMENT_HANDLE_T egl_target_element;
+    EGLSurface surface;
+    std::vector<DISPMANX_ELEMENT_HANDLE_T> current_elements;
 };
 }
 }

--- a/src/platforms/rpi-dispmanx/display_buffer.h
+++ b/src/platforms/rpi-dispmanx/display_buffer.h
@@ -64,10 +64,9 @@ private:
     geometry::Rectangle const view;
     EGLDisplay const dpy;
     EGLContext const ctx;
-    EGLConfig const config;
     DISPMANX_DISPLAY_HANDLE_T const display_handle;
-    DISPMANX_ELEMENT_HANDLE_T egl_target_element;
-    EGLSurface surface;
+    DISPMANX_ELEMENT_HANDLE_T const egl_target_element;
+    EGLSurface const surface;
     std::vector<DISPMANX_ELEMENT_HANDLE_T> current_elements;
 };
 }

--- a/src/platforms/rpi-dispmanx/helpers.cpp
+++ b/src/platforms/rpi-dispmanx/helpers.cpp
@@ -47,13 +47,15 @@ auto mg::rpi::vc_image_type_from_mir_pf(MirPixelFormat format) -> VC_IMAGE_TYPE_
 
 auto mg::rpi::dispmanx_resource_for(
     geom::Size const& size,
-    MirPixelFormat format) -> DISPMANX_RESOURCE_HANDLE_T
+    geom::Stride stride,
+    MirPixelFormat format)
+    -> DISPMANX_RESOURCE_HANDLE_T
 {
     uint32_t dummy;
     auto const handle = vc_dispmanx_resource_create(
         vc_image_type_from_mir_pf(format),
-        size.width.as_uint32_t(),
-        size.height.as_uint32_t(),
+        size.width.as_uint32_t() | stride.as_uint32_t() << 16,
+        size.height.as_uint32_t() | size.height.as_uint32_t() << 16,
         &dummy);
     if (handle == DISPMANX_NO_HANDLE)
     {

--- a/src/platforms/rpi-dispmanx/helpers.cpp
+++ b/src/platforms/rpi-dispmanx/helpers.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#include "helpers.h"
+#include "mir/geometry/size.h"
+#include "mir/geometry/dimensions.h"
+
+#include <interface/vmcs_host/vc_dispmanx.h>
+
+#include <stdexcept>
+#include <boost/throw_exception.hpp>
+
+namespace mg = mir::graphics;
+namespace geom = mir::geometry;
+
+auto mg::rpi::vc_image_type_from_mir_pf(MirPixelFormat format) -> VC_IMAGE_TYPE_T
+{
+    switch(format)
+    {
+    case mir_pixel_format_xbgr_8888:
+        return VC_IMAGE_BGRX8888;
+    case mir_pixel_format_argb_8888:
+        return VC_IMAGE_ARGB8888;
+    case mir_pixel_format_xrgb_8888:
+        return VC_IMAGE_RGBX8888;
+    case mir_pixel_format_rgb_565:
+        return VC_IMAGE_RGB565;
+    default:
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Unexpected pixel format"}));
+    }
+}
+
+auto mg::rpi::dispmanx_resource_for(
+    geom::Size const& size,
+    MirPixelFormat format) -> DISPMANX_RESOURCE_HANDLE_T
+{
+    uint32_t dummy;
+    auto const handle = vc_dispmanx_resource_create(
+        vc_image_type_from_mir_pf(format),
+        size.width.as_uint32_t(),
+        size.height.as_uint32_t(),
+        &dummy);
+    if (handle == DISPMANX_NO_HANDLE)
+    {
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to allocate DispmanX resource"}));
+    }
+    return handle;
+}
+
+auto mg::rpi::dispmanx_resource_from_pixels(
+    void const* pixels,
+    geom::Size const& size,
+    geom::Stride const& stride,
+    MirPixelFormat format) -> DISPMANX_RESOURCE_HANDLE_T
+{
+    uint32_t dummy;
+    auto const vc_format = mg::rpi::vc_image_type_from_mir_pf(format);
+    auto const width = size.width.as_uint32_t();
+    auto const height = size.height.as_uint32_t();
+    auto handle = vc_dispmanx_resource_create(vc_format, width, height, &dummy);
+
+    VC_RECT_T rect;
+    vc_dispmanx_rect_set(&rect, 0, 0, width, height);
+
+    vc_dispmanx_resource_write_data(
+        handle,
+        vc_format,
+        stride.as_uint32_t(),
+        const_cast<unsigned char*>(static_cast<unsigned char const*>(pixels)),
+        &rect);
+
+    return handle;
+}

--- a/src/platforms/rpi-dispmanx/helpers.h
+++ b/src/platforms/rpi-dispmanx/helpers.h
@@ -19,8 +19,9 @@
 #ifndef MIR_RPI_DISPMANX_HELPERS_H_
 #define MIR_RPI_DISPMANX_HELPERS_H_
 
-#include "mir_toolkit/common.h"
+#include "mir/geometry/dimensions.h"
 #include "mir/geometry/size.h"
+#include "mir_toolkit/common.h"
 #include "mir/geometry/dimensions.h"
 
 #include "interface/vctypes/vc_image_types.h"
@@ -36,7 +37,9 @@ auto vc_image_type_from_mir_pf(MirPixelFormat format) -> VC_IMAGE_TYPE_T;
 
 auto dispmanx_resource_for(
     geometry::Size const& size,
-    MirPixelFormat format) -> DISPMANX_RESOURCE_HANDLE_T;
+    geometry::Stride stride,
+    MirPixelFormat format)
+    -> DISPMANX_RESOURCE_HANDLE_T;
 
 auto dispmanx_resource_from_pixels(
     void const* pixels,

--- a/src/platforms/rpi-dispmanx/helpers.h
+++ b/src/platforms/rpi-dispmanx/helpers.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef MIR_RPI_DISPMANX_HELPERS_H_
+#define MIR_RPI_DISPMANX_HELPERS_H_
+
+#include "mir_toolkit/common.h"
+#include "mir/geometry/size.h"
+#include "mir/geometry/dimensions.h"
+
+#include "interface/vctypes/vc_image_types.h"
+#include "interface/vmcs_host/vc_dispmanx_types.h"
+
+namespace mir
+{
+namespace graphics
+{
+namespace rpi
+{
+auto vc_image_type_from_mir_pf(MirPixelFormat format) -> VC_IMAGE_TYPE_T;
+
+auto dispmanx_resource_for(
+    geometry::Size const& size,
+    MirPixelFormat format) -> DISPMANX_RESOURCE_HANDLE_T;
+
+auto dispmanx_resource_from_pixels(
+    void const* pixels,
+    geometry::Size const& size,
+    geometry::Stride const& stride,
+    MirPixelFormat format) -> DISPMANX_RESOURCE_HANDLE_T;
+}
+}
+}
+
+#endif //MIR_RPI_DISPMANX_HELPERS_H_


### PR DESCRIPTION
This provides an immense performance improvement, so Mir is actually useable.