### PR TITLE
Clear wl_resource implementation on destroy

### DIFF
--- a/src/wayland/generated/wayland_wrapper.cpp
+++ b/src/wayland/generated/wayland_wrapper.cpp
@@ -80,6 +80,11 @@ mw::Callback::Callback(struct wl_resource* resource, Version<1>)
     }
 }
 
+mw::Callback::~Callback()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 void mw::Callback::send_done_event(uint32_t callback_data) const
 {
     wl_resource_post_event(resource, Opcode::done, callback_data);
@@ -189,6 +194,11 @@ mw::Compositor::Compositor(struct wl_resource* resource, Version<4>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::Compositor::~Compositor()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 bool mw::Compositor::is_instance(wl_resource* resource)
@@ -310,6 +320,11 @@ mw::ShmPool::ShmPool(struct wl_resource* resource, Version<1>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::ShmPool::~ShmPool()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 bool mw::ShmPool::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &wl_shm_pool_interface_data, Thunks::request_vtable);
@@ -417,6 +432,11 @@ mw::Shm::Shm(struct wl_resource* resource, Version<1>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::Shm::~Shm()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 void mw::Shm::send_format_event(uint32_t format) const
 {
     wl_resource_post_event(resource, Opcode::format, format);
@@ -506,6 +526,11 @@ mw::Buffer::Buffer(struct wl_resource* resource, Version<1>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::Buffer::~Buffer()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 void mw::Buffer::send_release_event() const
@@ -637,6 +662,11 @@ mw::DataOffer::DataOffer(DataDevice const& parent)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::DataOffer::~DataOffer()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 void mw::DataOffer::send_offer_event(std::string const& mime_type) const
 {
     const char* mime_type_resolved = mime_type.c_str();
@@ -763,6 +793,11 @@ mw::DataSource::DataSource(struct wl_resource* resource, Version<3>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::DataSource::~DataSource()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 void mw::DataSource::send_target_event(std::experimental::optional<std::string> const& mime_type) const
@@ -936,6 +971,11 @@ mw::DataDevice::DataDevice(struct wl_resource* resource, Version<3>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::DataDevice::~DataDevice()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 void mw::DataDevice::send_data_offer_event(struct wl_resource* id) const
@@ -1131,6 +1171,11 @@ mw::DataDeviceManager::DataDeviceManager(struct wl_resource* resource, Version<3
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::DataDeviceManager::~DataDeviceManager()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 bool mw::DataDeviceManager::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &wl_data_device_manager_interface_data, Thunks::request_vtable);
@@ -1246,6 +1291,11 @@ mw::Shell::Shell(struct wl_resource* resource, Version<1>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::Shell::~Shell()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 bool mw::Shell::is_instance(wl_resource* resource)
@@ -1461,6 +1511,11 @@ mw::ShellSurface::ShellSurface(struct wl_resource* resource, Version<1>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::ShellSurface::~ShellSurface()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 void mw::ShellSurface::send_ping_event(uint32_t serial) const
@@ -1740,6 +1795,11 @@ mw::Surface::Surface(struct wl_resource* resource, Version<4>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::Surface::~Surface()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 void mw::Surface::send_enter_event(struct wl_resource* output) const
 {
     wl_resource_post_event(resource, Opcode::enter, output);
@@ -1941,6 +2001,11 @@ mw::Seat::Seat(struct wl_resource* resource, Version<6>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::Seat::~Seat()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 void mw::Seat::send_capabilities_event(uint32_t capabilities) const
 {
     wl_resource_post_event(resource, Opcode::capabilities, capabilities);
@@ -2073,6 +2138,11 @@ mw::Pointer::Pointer(struct wl_resource* resource, Version<6>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::Pointer::~Pointer()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 void mw::Pointer::send_enter_event(uint32_t serial, struct wl_resource* surface, double surface_x, double surface_y) const
@@ -2239,6 +2309,11 @@ mw::Keyboard::Keyboard(struct wl_resource* resource, Version<6>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::Keyboard::~Keyboard()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 void mw::Keyboard::send_keymap_event(uint32_t format, mir::Fd fd, uint32_t size) const
 {
     int32_t fd_resolved{fd};
@@ -2354,6 +2429,11 @@ mw::Touch::Touch(struct wl_resource* resource, Version<6>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::Touch::~Touch()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 void mw::Touch::send_down_event(uint32_t serial, uint32_t time, struct wl_resource* surface, int32_t id, double x, double y) const
@@ -2512,6 +2592,11 @@ mw::Output::Output(struct wl_resource* resource, Version<3>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::Output::~Output()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 void mw::Output::send_geometry_event(int32_t x, int32_t y, int32_t physical_width, int32_t physical_height, int32_t subpixel, std::string const& make, std::string const& model, int32_t transform) const
 {
     const char* make_resolved = make.c_str();
@@ -2663,6 +2748,11 @@ mw::Region::Region(struct wl_resource* resource, Version<1>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::Region::~Region()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 bool mw::Region::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &wl_region_interface_data, Thunks::request_vtable);
@@ -2771,6 +2861,11 @@ mw::Subcompositor::Subcompositor(struct wl_resource* resource, Version<1>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::Subcompositor::~Subcompositor()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 bool mw::Subcompositor::is_instance(wl_resource* resource)
@@ -2922,6 +3017,11 @@ mw::Subsurface::Subsurface(struct wl_resource* resource, Version<1>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::Subsurface::~Subsurface()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 bool mw::Subsurface::is_instance(wl_resource* resource)

--- a/src/wayland/generated/wayland_wrapper.h
+++ b/src/wayland/generated/wayland_wrapper.h
@@ -49,7 +49,7 @@ public:
     static Callback* from(struct wl_resource*);
 
     Callback(struct wl_resource* resource, Version<1>);
-    virtual ~Callback() = default;
+    virtual ~Callback();
 
     void send_done_event(uint32_t callback_data) const;
 
@@ -78,7 +78,7 @@ public:
     static Compositor* from(struct wl_resource*);
 
     Compositor(struct wl_resource* resource, Version<4>);
-    virtual ~Compositor() = default;
+    virtual ~Compositor();
 
     void destroy_wayland_object() const;
 
@@ -114,7 +114,7 @@ public:
     static ShmPool* from(struct wl_resource*);
 
     ShmPool(struct wl_resource* resource, Version<1>);
-    virtual ~ShmPool() = default;
+    virtual ~ShmPool();
 
     void destroy_wayland_object() const;
 
@@ -139,7 +139,7 @@ public:
     static Shm* from(struct wl_resource*);
 
     Shm(struct wl_resource* resource, Version<1>);
-    virtual ~Shm() = default;
+    virtual ~Shm();
 
     void send_format_event(uint32_t format) const;
 
@@ -250,7 +250,7 @@ public:
     static Buffer* from(struct wl_resource*);
 
     Buffer(struct wl_resource* resource, Version<1>);
-    virtual ~Buffer() = default;
+    virtual ~Buffer();
 
     void send_release_event() const;
 
@@ -280,7 +280,7 @@ public:
     static DataOffer* from(struct wl_resource*);
 
     DataOffer(DataDevice const& parent);
-    virtual ~DataOffer() = default;
+    virtual ~DataOffer();
 
     void send_offer_event(std::string const& mime_type) const;
     bool version_supports_source_actions();
@@ -328,7 +328,7 @@ public:
     static DataSource* from(struct wl_resource*);
 
     DataSource(struct wl_resource* resource, Version<3>);
-    virtual ~DataSource() = default;
+    virtual ~DataSource();
 
     void send_target_event(std::experimental::optional<std::string> const& mime_type) const;
     void send_send_event(std::string const& mime_type, mir::Fd fd) const;
@@ -379,7 +379,7 @@ public:
     static DataDevice* from(struct wl_resource*);
 
     DataDevice(struct wl_resource* resource, Version<3>);
-    virtual ~DataDevice() = default;
+    virtual ~DataDevice();
 
     void send_data_offer_event(struct wl_resource* id) const;
     void send_enter_event(uint32_t serial, struct wl_resource* surface, double x, double y, std::experimental::optional<struct wl_resource*> const& id) const;
@@ -426,7 +426,7 @@ public:
     static DataDeviceManager* from(struct wl_resource*);
 
     DataDeviceManager(struct wl_resource* resource, Version<3>);
-    virtual ~DataDeviceManager() = default;
+    virtual ~DataDeviceManager();
 
     void destroy_wayland_object() const;
 
@@ -470,7 +470,7 @@ public:
     static Shell* from(struct wl_resource*);
 
     Shell(struct wl_resource* resource, Version<1>);
-    virtual ~Shell() = default;
+    virtual ~Shell();
 
     void destroy_wayland_object() const;
 
@@ -510,7 +510,7 @@ public:
     static ShellSurface* from(struct wl_resource*);
 
     ShellSurface(struct wl_resource* resource, Version<1>);
-    virtual ~ShellSurface() = default;
+    virtual ~ShellSurface();
 
     void send_ping_event(uint32_t serial) const;
     void send_configure_event(uint32_t edges, int32_t width, int32_t height) const;
@@ -579,7 +579,7 @@ public:
     static Surface* from(struct wl_resource*);
 
     Surface(struct wl_resource* resource, Version<4>);
-    virtual ~Surface() = default;
+    virtual ~Surface();
 
     void send_enter_event(struct wl_resource* output) const;
     void send_leave_event(struct wl_resource* output) const;
@@ -626,7 +626,7 @@ public:
     static Seat* from(struct wl_resource*);
 
     Seat(struct wl_resource* resource, Version<6>);
-    virtual ~Seat() = default;
+    virtual ~Seat();
 
     void send_capabilities_event(uint32_t capabilities) const;
     bool version_supports_name();
@@ -681,7 +681,7 @@ public:
     static Pointer* from(struct wl_resource*);
 
     Pointer(struct wl_resource* resource, Version<6>);
-    virtual ~Pointer() = default;
+    virtual ~Pointer();
 
     void send_enter_event(uint32_t serial, struct wl_resource* surface, double surface_x, double surface_y) const;
     void send_leave_event(uint32_t serial, struct wl_resource* surface) const;
@@ -757,7 +757,7 @@ public:
     static Keyboard* from(struct wl_resource*);
 
     Keyboard(struct wl_resource* resource, Version<6>);
-    virtual ~Keyboard() = default;
+    virtual ~Keyboard();
 
     void send_keymap_event(uint32_t format, mir::Fd fd, uint32_t size) const;
     void send_enter_event(uint32_t serial, struct wl_resource* surface, struct wl_array* keys) const;
@@ -810,7 +810,7 @@ public:
     static Touch* from(struct wl_resource*);
 
     Touch(struct wl_resource* resource, Version<6>);
-    virtual ~Touch() = default;
+    virtual ~Touch();
 
     void send_down_event(uint32_t serial, uint32_t time, struct wl_resource* surface, int32_t id, double x, double y) const;
     void send_up_event(uint32_t serial, uint32_t time, int32_t id) const;
@@ -854,7 +854,7 @@ public:
     static Output* from(struct wl_resource*);
 
     Output(struct wl_resource* resource, Version<3>);
-    virtual ~Output() = default;
+    virtual ~Output();
 
     void send_geometry_event(int32_t x, int32_t y, int32_t physical_width, int32_t physical_height, int32_t subpixel, std::string const& make, std::string const& model, int32_t transform) const;
     void send_mode_event(uint32_t flags, int32_t width, int32_t height, int32_t refresh) const;
@@ -932,7 +932,7 @@ public:
     static Region* from(struct wl_resource*);
 
     Region(struct wl_resource* resource, Version<1>);
-    virtual ~Region() = default;
+    virtual ~Region();
 
     void destroy_wayland_object() const;
 
@@ -957,7 +957,7 @@ public:
     static Subcompositor* from(struct wl_resource*);
 
     Subcompositor(struct wl_resource* resource, Version<1>);
-    virtual ~Subcompositor() = default;
+    virtual ~Subcompositor();
 
     void destroy_wayland_object() const;
 
@@ -998,7 +998,7 @@ public:
     static Subsurface* from(struct wl_resource*);
 
     Subsurface(struct wl_resource* resource, Version<1>);
-    virtual ~Subsurface() = default;
+    virtual ~Subsurface();
 
     void destroy_wayland_object() const;
 

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
@@ -121,6 +121,11 @@ mw::LayerShellV1::LayerShellV1(struct wl_resource* resource, Version<1>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::LayerShellV1::~LayerShellV1()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 bool mw::LayerShellV1::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &zwlr_layer_shell_v1_interface_data, Thunks::request_vtable);
@@ -296,6 +301,11 @@ mw::LayerSurfaceV1::LayerSurfaceV1(struct wl_resource* resource, Version<1>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::LayerSurfaceV1::~LayerSurfaceV1()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 void mw::LayerSurfaceV1::send_configure_event(uint32_t serial, uint32_t width, uint32_t height) const

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
@@ -31,7 +31,7 @@ public:
     static LayerShellV1* from(struct wl_resource*);
 
     LayerShellV1(struct wl_resource* resource, Version<1>);
-    virtual ~LayerShellV1() = default;
+    virtual ~LayerShellV1();
 
     void destroy_wayland_object() const;
 
@@ -81,7 +81,7 @@ public:
     static LayerSurfaceV1* from(struct wl_resource*);
 
     LayerSurfaceV1(struct wl_resource* resource, Version<1>);
-    virtual ~LayerSurfaceV1() = default;
+    virtual ~LayerSurfaceV1();
 
     void send_configure_event(uint32_t serial, uint32_t width, uint32_t height) const;
     void send_closed_event() const;

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
@@ -127,6 +127,11 @@ mw::XdgOutputManagerV1::XdgOutputManagerV1(struct wl_resource* resource, Version
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::XdgOutputManagerV1::~XdgOutputManagerV1()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 bool mw::XdgOutputManagerV1::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &zxdg_output_manager_v1_interface_data, Thunks::request_vtable);
@@ -209,6 +214,11 @@ mw::XdgOutputV1::XdgOutputV1(struct wl_resource* resource, Version<3>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::XdgOutputV1::~XdgOutputV1()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 void mw::XdgOutputV1::send_logical_position_event(int32_t x, int32_t y) const

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
@@ -31,7 +31,7 @@ public:
     static XdgOutputManagerV1* from(struct wl_resource*);
 
     XdgOutputManagerV1(struct wl_resource* resource, Version<3>);
-    virtual ~XdgOutputManagerV1() = default;
+    virtual ~XdgOutputManagerV1();
 
     void destroy_wayland_object() const;
 
@@ -67,7 +67,7 @@ public:
     static XdgOutputV1* from(struct wl_resource*);
 
     XdgOutputV1(struct wl_resource* resource, Version<3>);
-    virtual ~XdgOutputV1() = default;
+    virtual ~XdgOutputV1();
 
     void send_logical_position_event(int32_t x, int32_t y) const;
     void send_logical_size_event(int32_t width, int32_t height) const;

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
@@ -167,6 +167,11 @@ mw::XdgShellV6::XdgShellV6(struct wl_resource* resource, Version<1>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::XdgShellV6::~XdgShellV6()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 void mw::XdgShellV6::send_ping_event(uint32_t serial) const
 {
     wl_resource_post_event(resource, Opcode::ping, serial);
@@ -343,6 +348,11 @@ mw::XdgPositionerV6::XdgPositionerV6(struct wl_resource* resource, Version<1>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::XdgPositionerV6::~XdgPositionerV6()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 bool mw::XdgPositionerV6::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &zxdg_positioner_v6_interface_data, Thunks::request_vtable);
@@ -484,6 +494,11 @@ mw::XdgSurfaceV6::XdgSurfaceV6(struct wl_resource* resource, Version<1>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::XdgSurfaceV6::~XdgSurfaceV6()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 void mw::XdgSurfaceV6::send_configure_event(uint32_t serial) const
@@ -757,6 +772,11 @@ mw::XdgToplevelV6::XdgToplevelV6(struct wl_resource* resource, Version<1>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::XdgToplevelV6::~XdgToplevelV6()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 void mw::XdgToplevelV6::send_configure_event(int32_t width, int32_t height, struct wl_array* states) const
 {
     wl_resource_post_event(resource, Opcode::configure, width, height, states);
@@ -893,6 +913,11 @@ mw::XdgPopupV6::XdgPopupV6(struct wl_resource* resource, Version<1>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::XdgPopupV6::~XdgPopupV6()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 void mw::XdgPopupV6::send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -34,7 +34,7 @@ public:
     static XdgShellV6* from(struct wl_resource*);
 
     XdgShellV6(struct wl_resource* resource, Version<1>);
-    virtual ~XdgShellV6() = default;
+    virtual ~XdgShellV6();
 
     void send_ping_event(uint32_t serial) const;
 
@@ -89,7 +89,7 @@ public:
     static XdgPositionerV6* from(struct wl_resource*);
 
     XdgPositionerV6(struct wl_resource* resource, Version<1>);
-    virtual ~XdgPositionerV6() = default;
+    virtual ~XdgPositionerV6();
 
     void destroy_wayland_object() const;
 
@@ -152,7 +152,7 @@ public:
     static XdgSurfaceV6* from(struct wl_resource*);
 
     XdgSurfaceV6(struct wl_resource* resource, Version<1>);
-    virtual ~XdgSurfaceV6() = default;
+    virtual ~XdgSurfaceV6();
 
     void send_configure_event(uint32_t serial) const;
 
@@ -193,7 +193,7 @@ public:
     static XdgToplevelV6* from(struct wl_resource*);
 
     XdgToplevelV6(struct wl_resource* resource, Version<1>);
-    virtual ~XdgToplevelV6() = default;
+    virtual ~XdgToplevelV6();
 
     void send_configure_event(int32_t width, int32_t height, struct wl_array* states) const;
     void send_close_event() const;
@@ -259,7 +259,7 @@ public:
     static XdgPopupV6* from(struct wl_resource*);
 
     XdgPopupV6(struct wl_resource* resource, Version<1>);
-    virtual ~XdgPopupV6() = default;
+    virtual ~XdgPopupV6();
 
     void send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const;
     void send_popup_done_event() const;

--- a/src/wayland/generated/xdg-shell_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell_wrapper.cpp
@@ -167,6 +167,11 @@ mw::XdgWmBase::XdgWmBase(struct wl_resource* resource, Version<1>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::XdgWmBase::~XdgWmBase()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 void mw::XdgWmBase::send_ping_event(uint32_t serial) const
 {
     wl_resource_post_event(resource, Opcode::ping, serial);
@@ -343,6 +348,11 @@ mw::XdgPositioner::XdgPositioner(struct wl_resource* resource, Version<1>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::XdgPositioner::~XdgPositioner()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 bool mw::XdgPositioner::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &xdg_positioner_interface_data, Thunks::request_vtable);
@@ -489,6 +499,11 @@ mw::XdgSurface::XdgSurface(struct wl_resource* resource, Version<1>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::XdgSurface::~XdgSurface()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 void mw::XdgSurface::send_configure_event(uint32_t serial) const
@@ -762,6 +777,11 @@ mw::XdgToplevel::XdgToplevel(struct wl_resource* resource, Version<1>)
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
+mw::XdgToplevel::~XdgToplevel()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
+}
+
 void mw::XdgToplevel::send_configure_event(int32_t width, int32_t height, struct wl_array* states) const
 {
     wl_resource_post_event(resource, Opcode::configure, width, height, states);
@@ -898,6 +918,11 @@ mw::XdgPopup::XdgPopup(struct wl_resource* resource, Version<1>)
         BOOST_THROW_EXCEPTION((std::bad_alloc{}));
     }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
+}
+
+mw::XdgPopup::~XdgPopup()
+{
+    wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
 void mw::XdgPopup::send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const

--- a/src/wayland/generated/xdg-shell_wrapper.h
+++ b/src/wayland/generated/xdg-shell_wrapper.h
@@ -34,7 +34,7 @@ public:
     static XdgWmBase* from(struct wl_resource*);
 
     XdgWmBase(struct wl_resource* resource, Version<1>);
-    virtual ~XdgWmBase() = default;
+    virtual ~XdgWmBase();
 
     void send_ping_event(uint32_t serial) const;
 
@@ -89,7 +89,7 @@ public:
     static XdgPositioner* from(struct wl_resource*);
 
     XdgPositioner(struct wl_resource* resource, Version<1>);
-    virtual ~XdgPositioner() = default;
+    virtual ~XdgPositioner();
 
     void destroy_wayland_object() const;
 
@@ -160,7 +160,7 @@ public:
     static XdgSurface* from(struct wl_resource*);
 
     XdgSurface(struct wl_resource* resource, Version<1>);
-    virtual ~XdgSurface() = default;
+    virtual ~XdgSurface();
 
     void send_configure_event(uint32_t serial) const;
 
@@ -201,7 +201,7 @@ public:
     static XdgToplevel* from(struct wl_resource*);
 
     XdgToplevel(struct wl_resource* resource, Version<1>);
-    virtual ~XdgToplevel() = default;
+    virtual ~XdgToplevel();
 
     void send_configure_event(int32_t width, int32_t height, struct wl_array* states) const;
     void send_close_event() const;
@@ -267,7 +267,7 @@ public:
     static XdgPopup* from(struct wl_resource*);
 
     XdgPopup(struct wl_resource* resource, Version<1>);
-    virtual ~XdgPopup() = default;
+    virtual ~XdgPopup();
 
     void send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const;
     void send_popup_done_event() const;

--- a/src/wayland/generator/interface.cpp
+++ b/src/wayland/generator/interface.cpp
@@ -132,6 +132,7 @@ Emitter Interface::implementation() const
             },
             thunks_impl(),
             constructor_impl(),
+            destructor_impl(),
             event_impls(),
             is_instance_impl(),
             Lines{
@@ -246,7 +247,17 @@ Emitter Interface::constructor_args(std::string const& parent_interface) const
 
 Emitter Interface::destructor_prototype() const
 {
-    return Line{"virtual ~", generated_name, "() = default;"};
+    return Line{"virtual ~", generated_name, "();"};
+}
+
+Emitter Interface::destructor_impl() const
+{
+    return Lines{
+        {nmspace, "~", generated_name, "()"},
+        Block{
+            "wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);"
+        }
+    };
 }
 
 Emitter Interface::virtual_request_prototypes() const

--- a/src/wayland/generator/interface.h
+++ b/src/wayland/generator/interface.h
@@ -58,6 +58,7 @@ private:
     Emitter constructor_args() const;
     Emitter constructor_args(std::string const& parent_interface) const;
     Emitter destructor_prototype() const;
+    Emitter destructor_impl() const;
     Emitter virtual_request_prototypes() const;
     Emitter event_prototypes() const;
     Emitter event_impls() const;


### PR DESCRIPTION
Fixes #1438 (see that for description of the problem). The fix is to unlink the `wl_resource` from the object when the object is destroyed. This should eliminate this and potential future bugs involving wayland objects getting destroyed early.

I've looked at libwayland to verify that:
-  `wl_resource_set_implementation()` is  extremely low cost (just 3 assignments)
- libwayland doesn't assume these values are non-null