### PR TITLE
[miral-shell] Use a better default terminal emulator

### DIFF
--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char const* argv[])
 
     ExternalClientLauncher external_client_launcher;
 
-    std::string terminal_cmd{"weston-terminal"};
+    std::string terminal_cmd{"miral-terminal"};
 
     auto const quit_on_ctrl_alt_bksp = [&](MirEvent const* event)
         {


### PR DESCRIPTION
[miral-shell] Use a better default for --shell-terminal-emulator

(It is *possible* that miral-terminal isn't installed, but weston-terminal is even less likely to be found!)