### PR TITLE
Allow tests to coexist with existing Wayland compositor

### DIFF
--- a/tests/mir_test_framework/test_display_server.cpp
+++ b/tests/mir_test_framework/test_display_server.cpp
@@ -57,7 +57,7 @@ miral::TestDisplayServer::TestDisplayServer() :
 miral::TestDisplayServer::TestDisplayServer(int argc, char const** argv) :
     runner{argc, argv}
 {
-    unsetenv("WAYLAND_DISPLAY");    // We don't want to conflict with any existing server
+    add_to_environment("WAYLAND_DISPLAY", "wayland-mir-test"); // We don't want to conflict with any existing server
     add_to_environment("MIR_SERVER_PLATFORM_GRAPHICS_LIB", mtf::server_platform("graphics-dummy.so").c_str());
     add_to_environment("MIR_SERVER_PLATFORM_INPUT_LIB", mtf::server_platform("input-stub.so").c_str());
     add_to_environment("MIR_SERVER_NO_FILE", "on");


### PR DESCRIPTION
Running `miral-test` on sway I get a lot of `unable to lock lockfile /run/user/1000/wayland-0.lock, maybe another compositor is running`, and setting `WAYLAND_DISPLAY` on the command line doesn't help (because the variable is unset, as you can see).