### PR TITLE
Unhiding window takes focus if active window is same app

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1472,11 +1472,13 @@ void miral::BasicWindowManager::set_state(miral::WindowInfo& window_info, MirWin
         break;
 
     default:
-        auto const none_active = !active_window();
+        bool const can_become_active =
+            !active_window() ||
+            active_window().application() == window_info.window().application();
         window_info.state(value);
         mir_surface->configure(mir_window_attrib_state, value);
         mir_surface->show();
-        if (was_hidden && none_active)
+        if (was_hidden && can_become_active)
         {
             select_active_window(window);
         }

--- a/tests/miral/active_window.cpp
+++ b/tests/miral/active_window.cpp
@@ -233,7 +233,7 @@ TEST_F(ActiveWindow, a_second_window_hiding_makes_first_active)
     assert_active_window_is(test_name);
 }
 
-TEST_F(ActiveWindow, a_second_window_unhiding_leaves_first_active)
+TEST_F(ActiveWindow, a_second_window_of_same_app_becomes_active_when_unhiding)
 {
     char const* const test_name = __PRETTY_FUNCTION__;
     auto const connection = connect_client(test_name);
@@ -243,10 +243,26 @@ TEST_F(ActiveWindow, a_second_window_unhiding_leaves_first_active)
 
     sync1.exec([&]{ mir_window_set_state(window, mir_window_state_hidden); });
 
-    // Expect this to timeout
     sync2.exec([&]{ mir_window_set_state(window, mir_window_state_restored); });
 
-    EXPECT_THAT(sync2.signal_raised(), Eq(false));
+    EXPECT_THAT(sync2.signal_raised(), Eq(true));
+    assert_active_window_is(another_name);
+}
+
+TEST_F(ActiveWindow, a_second_window_of_different_app_leaves_first_active_when_unhiding)
+{
+    char const* const test_name = __PRETTY_FUNCTION__;
+    auto const connection_a = connect_client(test_name);
+    auto const connection_b = connect_client(another_name);
+
+    auto const window_a = create_window(connection_a, test_name, sync1);
+    auto const window_b = create_window(connection_b, another_name, sync2);
+
+    sync1.exec([&]{ mir_window_set_state(window_b, mir_window_state_hidden); });
+
+    // Expect this to timeout
+    sync2.exec([&]{ mir_window_set_state(window_b, mir_window_state_restored); });
+
     assert_active_window_is(test_name);
 }
 


### PR DESCRIPTION
As discussed with @AlanGriffiths this morning. This fixes a new WLCS test that needs to depend on unmapping/mapping a surface not changing it's stacking order. It also just makes sense.