### PR TITLE
Split out and refactor xcursor loading

### DIFF
--- a/src/server/frontend_xwayland/CMakeLists.txt
+++ b/src/server/frontend_xwayland/CMakeLists.txt
@@ -6,6 +6,7 @@ set(
   xwayland_server.cpp     xwayland_server.h
   xcb_connection.cpp      xcb_connection.h
   xwayland_wm.cpp         xwayland_wm.h
+  xwayland_cursors.cpp    xwayland_cursors.h
   xwayland_surface.cpp    xwayland_surface.h
   xwayland_surface_role.cpp xwayland_surface_role.h
                           xwayland_surface_role_surface.h

--- a/src/server/frontend_xwayland/xwayland_cursors.cpp
+++ b/src/server/frontend_xwayland/xwayland_cursors.cpp
@@ -101,11 +101,6 @@ auto mf::XWaylandCursors::Loader::query_formats(std::shared_ptr<XCBConnection> c
                 continue;
             }
 
-            // if (formats[i].type == XCB_RENDER_PICT_TYPE_DIRECT && formats[i].depth == 24)
-            // {
-            //    result.rgb = formats[i];
-            // }
-
             if (formats[i].type == XCB_RENDER_PICT_TYPE_DIRECT && formats[i].depth == 32 &&
                 formats[i].direct.alpha_mask == 0xff && formats[i].direct.alpha_shift == 24)
             {

--- a/src/server/frontend_xwayland/xwayland_cursors.cpp
+++ b/src/server/frontend_xwayland/xwayland_cursors.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2018 Marius Gripsgard <marius@ubports.com>
+ * Copyright (C) 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Written with alot of help of Weston Xwm
+ *
+ */
+
+#include "xcb_connection.h"
+#include "xwayland_cursors.h"
+#include "xwayland_log.h"
+
+#include <cstring>
+#include <boost/throw_exception.hpp>
+
+namespace
+{
+template<typename T, size_t length>
+constexpr size_t length_of(T(&)[length])
+{
+    return length;
+}
+}
+
+#ifndef ARRAY_LENGTH
+#define ARRAY_LENGTH(a) length_of(a)
+#endif
+
+#define CURSOR_ENTRY(x)        \
+    {                          \
+        (x), ARRAY_LENGTH((x)) \
+    }
+
+static const char *bottom_left_corners[] = {"bottom_left_corner", "sw-resize", "size_bdiag"};
+
+static const char *bottom_right_corners[] = {"bottom_right_corner", "se-resize", "size_fdiag"};
+
+static const char *bottom_sides[] = {"bottom_side", "s-resize", "size_ver"};
+
+static const char *left_ptrs[] = {"left_ptr", "default", "top_left_arrow", "left-arrow"};
+
+static const char *left_sides[] = {"left_side", "w-resize", "size_hor"};
+
+static const char *right_sides[] = {"right_side", "e-resize", "size_hor"};
+
+static const char *top_left_corners[] = {"top_left_corner", "nw-resize", "size_fdiag"};
+
+static const char *top_right_corners[] = {"top_right_corner", "ne-resize", "size_bdiag"};
+
+static const char *top_sides[] = {"top_side", "n-resize", "size_ver"};
+
+struct cursor_alternatives
+{
+    const char **names;
+    size_t count;
+};
+
+static const struct cursor_alternatives cursors[] = {
+    CURSOR_ENTRY(top_sides),           CURSOR_ENTRY(bottom_sides),         CURSOR_ENTRY(left_sides),
+    CURSOR_ENTRY(right_sides),         CURSOR_ENTRY(top_left_corners),     CURSOR_ENTRY(top_right_corners),
+    CURSOR_ENTRY(bottom_left_corners), CURSOR_ENTRY(bottom_right_corners), CURSOR_ENTRY(left_ptrs)};
+
+namespace mf = mir::frontend;
+
+mf::XWaylandCursors::XWaylandCursors(std::shared_ptr<XCBConnection> const& connection)
+    : connection{connection}
+{
+    auto const formats_cookie = xcb_render_query_pict_formats(*connection);
+    auto const formats_reply = xcb_render_query_pict_formats_reply(*connection, formats_cookie, 0);
+    if (formats_reply)
+    {
+        auto const formats = xcb_render_query_pict_formats_formats(formats_reply);
+        for (unsigned i = 0; i < formats_reply->num_formats; i++)
+        {
+            if (formats[i].direct.red_mask != 0xff && formats[i].direct.red_shift != 16)
+                continue;
+            if (formats[i].type == XCB_RENDER_PICT_TYPE_DIRECT && formats[i].depth == 24)
+                xcb_format_rgb = formats[i];
+            if (formats[i].type == XCB_RENDER_PICT_TYPE_DIRECT && formats[i].depth == 32 &&
+                formats[i].direct.alpha_mask == 0xff && formats[i].direct.alpha_shift == 24)
+                xcb_format_rgba = formats[i];
+        }
+
+        free(formats_reply);
+    }
+    else
+    {
+        log_warning("Could not get color formats from the X server");
+    }
+
+    create_wm_cursor();
+    set_cursor(connection->root_window(), CursorLeftPointer);
+}
+
+mf::XWaylandCursors::~XWaylandCursors()
+{
+    for (auto xcb_cursor : xcb_cursors)
+    {
+        xcb_free_cursor(*connection, xcb_cursor);
+    }
+}
+
+void mf::XWaylandCursors::set_cursor(xcb_window_t id, const CursorType &cursor)
+{
+    if (xcb_cursor == cursor)
+        return;
+
+    xcb_cursor = cursor;
+    uint32_t cursor_value_list = xcb_cursors[cursor];
+    xcb_change_window_attributes(*connection, id, XCB_CW_CURSOR, &cursor_value_list);
+    connection->flush();
+}
+
+void mf::XWaylandCursors::create_wm_cursor()
+{
+    const char *name;
+    int count = ARRAY_LENGTH(cursors);
+
+    xcb_cursors.clear();
+    xcb_cursors.reserve(count);
+
+    for (int i = 0; i < count; i++)
+    {
+        for (size_t j = 0; j < cursors[i].count; j++)
+        {
+            name = cursors[i].names[j];
+            xcb_cursors.push_back(xcb_cursor_library_load_cursor(name));
+            if (xcb_cursors[i] != static_cast<xcb_cursor_t>(-1))
+                break;
+        }
+    }
+}
+
+// Cursor
+xcb_cursor_t mf::XWaylandCursors::xcb_cursor_image_load_cursor(const XcursorImage *img)
+{
+    xcb_connection_t *c = *connection;
+    xcb_screen_iterator_t s = xcb_setup_roots_iterator(xcb_get_setup(c));
+    xcb_screen_t *screen = s.data;
+    xcb_gcontext_t gc;
+    xcb_pixmap_t pix;
+    xcb_render_picture_t pic;
+    xcb_cursor_t cursor;
+    int stride = img->width * 4;
+
+    pix = xcb_generate_id(c);
+    xcb_create_pixmap(c, 32, pix, screen->root, img->width, img->height);
+
+    pic = xcb_generate_id(c);
+    xcb_render_create_picture(c, pic, pix, xcb_format_rgba.id, 0, 0);
+
+    gc = xcb_generate_id(c);
+    xcb_create_gc(c, gc, pix, 0, 0);
+
+    xcb_put_image(c, XCB_IMAGE_FORMAT_Z_PIXMAP, pix, gc, img->width, img->height, 0, 0, 0, 32, stride * img->height,
+                  (uint8_t *)img->pixels);
+    xcb_free_gc(c, gc);
+
+    cursor = xcb_generate_id(c);
+    xcb_render_create_cursor(c, cursor, pic, img->xhot, img->yhot);
+
+    xcb_render_free_picture(c, pic);
+    xcb_free_pixmap(c, pix);
+
+    return cursor;
+}
+
+xcb_cursor_t mf::XWaylandCursors::xcb_cursor_images_load_cursor(const XcursorImages *images)
+{
+    if (images->nimage != 1)
+        return -1;
+
+    return xcb_cursor_image_load_cursor(images->images[0]);
+}
+
+xcb_cursor_t mf::XWaylandCursors::xcb_cursor_library_load_cursor(const char *file)
+{
+    xcb_cursor_t cursor;
+    XcursorImages *images;
+    char *v = NULL;
+    int size = 0;
+
+    if (!file)
+        return 0;
+
+    v = getenv("XCURSOR_SIZE");
+    if (v)
+        size = atoi(v);
+
+    if (!size)
+        size = 32;
+
+    images = XcursorLibraryLoadImages(file, NULL, size);
+    if (!images)
+        return -1;
+
+    cursor = xcb_cursor_images_load_cursor(images);
+    XcursorImagesDestroy(images);
+
+    return cursor;
+}

--- a/src/server/frontend_xwayland/xwayland_cursors.h
+++ b/src/server/frontend_xwayland/xwayland_cursors.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 Marius Gripsgard <marius@ubports.com>
+ * Copyright (C) 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MIR_FRONTEND_XWAYLAND_CURSORS_H
+#define MIR_FRONTEND_XWAYLAND_CURSORS_H
+
+#include <memory>
+#include <vector>
+#include <X11/Xcursor/Xcursor.h>
+#include <xcb/composite.h>
+#include <xcb/xcb.h>
+
+namespace mir
+{
+namespace frontend
+{
+class XCBConnection;
+
+class XWaylandCursors
+{
+public:
+    XWaylandCursors(std::shared_ptr<XCBConnection> const& connection);
+    ~XWaylandCursors();
+
+private:
+    enum CursorType
+    {
+        CursorUnset = -1,
+        CursorTop,
+        CursorBottom,
+        CursorLeft,
+        CursorRight,
+        CursorTopLeft,
+        CursorTopRight,
+        CursorBottomLeft,
+        CursorBottomRight,
+        CursorLeftPointer
+    };
+
+    void set_cursor(xcb_window_t id, const CursorType &cursor);
+    void create_wm_cursor();
+
+    // Cursor
+    xcb_cursor_t xcb_cursor_image_load_cursor(const XcursorImage *img);
+    xcb_cursor_t xcb_cursor_images_load_cursor(const XcursorImages *images);
+    xcb_cursor_t xcb_cursor_library_load_cursor(const char *file);
+
+    std::shared_ptr<XCBConnection> const connection;
+    xcb_render_pictforminfo_t xcb_format_rgb, xcb_format_rgba;
+    std::vector<xcb_cursor_t> xcb_cursors;
+    int xcb_cursor;
+};
+}
+}
+
+#endif // MIR_FRONTEND_XWAYLAND_CURSORS_H

--- a/src/server/frontend_xwayland/xwayland_cursors.h
+++ b/src/server/frontend_xwayland/xwayland_cursors.h
@@ -56,7 +56,6 @@ private:
     struct Loader
     {
         struct Formats {
-            // std::experimental::optional<xcb_render_pictforminfo_t> rgb;
             std::experimental::optional<xcb_render_pictforminfo_t> rgba;
         };
 

--- a/src/server/frontend_xwayland/xwayland_cursors.h
+++ b/src/server/frontend_xwayland/xwayland_cursors.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <vector>
+#include <experimental/optional>
 #include <X11/Xcursor/Xcursor.h>
 #include <xcb/composite.h>
 #include <xcb/xcb.h>
@@ -35,35 +36,46 @@ class XWaylandCursors
 {
 public:
     XWaylandCursors(std::shared_ptr<XCBConnection> const& connection);
-    ~XWaylandCursors();
+    void apply_default_to(xcb_window_t window) const;
 
 private:
-    enum CursorType
+    struct Cursor
     {
-        CursorUnset = -1,
-        CursorTop,
-        CursorBottom,
-        CursorLeft,
-        CursorRight,
-        CursorTopLeft,
-        CursorTopRight,
-        CursorBottomLeft,
-        CursorBottomRight,
-        CursorLeftPointer
+        Cursor(std::shared_ptr<XCBConnection> const& connection, xcb_cursor_t xcb_cursor);
+        ~Cursor();
+
+        Cursor(Cursor const&) = delete;
+        auto operator=(Cursor const&) -> bool = delete;
+
+        void apply_to(xcb_window_t window) const;
+
+        std::shared_ptr<XCBConnection> const connection;
+        xcb_cursor_t const xcb_cursor;
     };
 
-    void set_cursor(xcb_window_t id, const CursorType &cursor);
-    void create_wm_cursor();
+    struct Loader
+    {
+        struct Formats {
+            // std::experimental::optional<xcb_render_pictforminfo_t> rgb;
+            std::experimental::optional<xcb_render_pictforminfo_t> rgba;
+        };
 
-    // Cursor
-    xcb_cursor_t xcb_cursor_image_load_cursor(const XcursorImage *img);
-    xcb_cursor_t xcb_cursor_images_load_cursor(const XcursorImages *images);
-    xcb_cursor_t xcb_cursor_library_load_cursor(const char *file);
+        Loader(std::shared_ptr<XCBConnection> const& connection);
+        static auto query_formats(std::shared_ptr<XCBConnection> const& connection) -> Loader::Formats;
+        static auto get_xcursor_size() -> int;
 
-    std::shared_ptr<XCBConnection> const connection;
-    xcb_render_pictforminfo_t xcb_format_rgb, xcb_format_rgba;
-    std::vector<xcb_cursor_t> xcb_cursors;
-    int xcb_cursor;
+        /// Can return null
+        auto load_cursor(std::string const& name) const -> std::unique_ptr<Cursor>;
+        /// Can return null
+        auto load_default() const -> std::unique_ptr<Cursor>;
+
+        std::shared_ptr<XCBConnection> const connection;
+        Formats const formats;
+        int const cursor_size;
+    };
+
+    Loader const loader;
+    std::unique_ptr<Cursor> const default_cursor; ///< Can be null
 };
 }
 }

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -35,44 +35,6 @@
 #include <unistd.h>
 #include <boost/throw_exception.hpp>
 
-#ifndef ARRAY_LENGTH
-#define ARRAY_LENGTH(a) mir::frontend::length_of(a)
-#endif
-
-#define CURSOR_ENTRY(x)        \
-    {                          \
-        (x), ARRAY_LENGTH((x)) \
-    }
-
-static const char *bottom_left_corners[] = {"bottom_left_corner", "sw-resize", "size_bdiag"};
-
-static const char *bottom_right_corners[] = {"bottom_right_corner", "se-resize", "size_fdiag"};
-
-static const char *bottom_sides[] = {"bottom_side", "s-resize", "size_ver"};
-
-static const char *left_ptrs[] = {"left_ptr", "default", "top_left_arrow", "left-arrow"};
-
-static const char *left_sides[] = {"left_side", "w-resize", "size_hor"};
-
-static const char *right_sides[] = {"right_side", "e-resize", "size_hor"};
-
-static const char *top_left_corners[] = {"top_left_corner", "nw-resize", "size_fdiag"};
-
-static const char *top_right_corners[] = {"top_right_corner", "ne-resize", "size_bdiag"};
-
-static const char *top_sides[] = {"top_side", "n-resize", "size_ver"};
-
-struct cursor_alternatives
-{
-    const char **names;
-    size_t count;
-};
-
-static const struct cursor_alternatives cursors[] = {
-    CURSOR_ENTRY(top_sides),           CURSOR_ENTRY(bottom_sides),         CURSOR_ENTRY(left_sides),
-    CURSOR_ENTRY(right_sides),         CURSOR_ENTRY(top_left_corners),     CURSOR_ENTRY(top_right_corners),
-    CURSOR_ENTRY(bottom_left_corners), CURSOR_ENTRY(bottom_right_corners), CURSOR_ENTRY(left_ptrs)};
-
 namespace mf = mir::frontend;
 
 mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, wl_client* wayland_client, int fd)
@@ -80,7 +42,8 @@ mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, 
       wayland_connector(wayland_connector),
       dispatcher{std::make_shared<mir::dispatch::MultiplexingDispatchable>()},
       wayland_client{wayland_client},
-      wm_shell{std::static_pointer_cast<XWaylandWMShell>(wayland_connector->get_extension("x11-support"))}
+      wm_shell{std::static_pointer_cast<XWaylandWMShell>(wayland_connector->get_extension("x11-support"))},
+      cursors{connection}
 {
     wm_dispatcher =
         std::make_shared<mir::dispatch::ReadableFd>(mir::Fd{mir::IntOwnedFd{fd}}, [this]() { handle_events(); });
@@ -116,9 +79,6 @@ mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, 
 
     connection->flush();
 
-    create_wm_cursor();
-    set_cursor(connection->root_window(), CursorLeftPointer);
-
     create_wm_window();
     connection->flush();
 }
@@ -153,14 +113,6 @@ mf::XWaylandWM::~XWaylandWM()
         dispatcher->remove_watch(wm_dispatcher);
         event_thread.reset();
     }
-
-    // xcb_cursors == 2 when its empty
-    if (xcb_cursors.size() != 2)
-    {
-        mir::log_info("Cleaning cursors");
-        for (auto xcb_cursor : xcb_cursors)
-        xcb_free_cursor(*connection, xcb_cursor);
-    }
 }
 
 void mf::XWaylandWM::wm_selector()
@@ -193,37 +145,6 @@ void mf::XWaylandWM::wm_selector()
         XCB_XFIXES_SELECTION_EVENT_MASK_SELECTION_CLIENT_CLOSE;
 
     xcb_xfixes_select_selection_input(*connection, xcb_selection_window, connection->clipboard, mask);
-}
-
-void mf::XWaylandWM::set_cursor(xcb_window_t id, const CursorType &cursor)
-{
-    if (xcb_cursor == cursor)
-        return;
-
-    xcb_cursor = cursor;
-    uint32_t cursor_value_list = xcb_cursors[cursor];
-    xcb_change_window_attributes(*connection, id, XCB_CW_CURSOR, &cursor_value_list);
-    connection->flush();
-}
-
-void mf::XWaylandWM::create_wm_cursor()
-{
-    const char *name;
-    int count = ARRAY_LENGTH(cursors);
-
-    xcb_cursors.clear();
-    xcb_cursors.reserve(count);
-
-    for (int i = 0; i < count; i++)
-    {
-        for (size_t j = 0; j < cursors[i].count; j++)
-        {
-            name = cursors[i].names[j];
-            xcb_cursors.push_back(xcb_cursor_library_load_cursor(name));
-            if (xcb_cursors[i] != static_cast<xcb_cursor_t>(-1))
-                break;
-        }
-    }
 }
 
 void mf::XWaylandWM::create_wm_window()
@@ -771,88 +692,13 @@ void mf::XWaylandWM::handle_focus_in(xcb_focus_in_event_t* event)
     }
 }
 
-// Cursor
-xcb_cursor_t mf::XWaylandWM::xcb_cursor_image_load_cursor(const XcursorImage *img)
-{
-    xcb_connection_t *c = *connection;
-    xcb_screen_iterator_t s = xcb_setup_roots_iterator(xcb_get_setup(c));
-    xcb_screen_t *screen = s.data;
-    xcb_gcontext_t gc;
-    xcb_pixmap_t pix;
-    xcb_render_picture_t pic;
-    xcb_cursor_t cursor;
-    int stride = img->width * 4;
-
-    pix = xcb_generate_id(c);
-    xcb_create_pixmap(c, 32, pix, screen->root, img->width, img->height);
-
-    pic = xcb_generate_id(c);
-    xcb_render_create_picture(c, pic, pix, xcb_format_rgba.id, 0, 0);
-
-    gc = xcb_generate_id(c);
-    xcb_create_gc(c, gc, pix, 0, 0);
-
-    xcb_put_image(c, XCB_IMAGE_FORMAT_Z_PIXMAP, pix, gc, img->width, img->height, 0, 0, 0, 32, stride * img->height,
-                  (uint8_t *)img->pixels);
-    xcb_free_gc(c, gc);
-
-    cursor = xcb_generate_id(c);
-    xcb_render_create_cursor(c, cursor, pic, img->xhot, img->yhot);
-
-    xcb_render_free_picture(c, pic);
-    xcb_free_pixmap(c, pix);
-
-    return cursor;
-}
-
-xcb_cursor_t mf::XWaylandWM::xcb_cursor_images_load_cursor(const XcursorImages *images)
-{
-    if (images->nimage != 1)
-        return -1;
-
-    return xcb_cursor_image_load_cursor(images->images[0]);
-}
-
-xcb_cursor_t mf::XWaylandWM::xcb_cursor_library_load_cursor(const char *file)
-{
-    xcb_cursor_t cursor;
-    XcursorImages *images;
-    char *v = NULL;
-    int size = 0;
-
-    if (!file)
-        return 0;
-
-    v = getenv("XCURSOR_SIZE");
-    if (v)
-        size = atoi(v);
-
-    if (!size)
-        size = 32;
-
-    images = XcursorLibraryLoadImages(file, NULL, size);
-    if (!images)
-        return -1;
-
-    cursor = xcb_cursor_images_load_cursor(images);
-    XcursorImagesDestroy(images);
-
-    return cursor;
-}
-
 void mf::XWaylandWM::wm_get_resources()
 {
     xcb_xfixes_query_version_cookie_t xfixes_cookie;
     xcb_xfixes_query_version_reply_t *xfixes_reply;
-    xcb_render_query_pict_formats_reply_t *formats_reply;
-    xcb_render_query_pict_formats_cookie_t formats_cookie;
-    xcb_render_pictforminfo_t *formats;
-    uint32_t i;
 
     xcb_prefetch_extension_data(*connection, &xcb_xfixes_id);
     xcb_prefetch_extension_data(*connection, &xcb_composite_id);
-
-    formats_cookie = xcb_render_query_pict_formats(*connection);
 
     xfixes = xcb_get_extension_data(*connection, &xcb_xfixes_id);
     if (!xfixes || !xfixes->present)
@@ -865,22 +711,4 @@ void mf::XWaylandWM::wm_get_resources()
         log_debug("xfixes version: %d.%d", xfixes_reply->major_version, xfixes_reply->minor_version);
 
     free(xfixes_reply);
-
-    formats_reply = xcb_render_query_pict_formats_reply(*connection, formats_cookie, 0);
-    if (formats_reply == NULL)
-        return;
-
-    formats = xcb_render_query_pict_formats_formats(formats_reply);
-    for (i = 0; i < formats_reply->num_formats; i++)
-    {
-        if (formats[i].direct.red_mask != 0xff && formats[i].direct.red_shift != 16)
-            continue;
-        if (formats[i].type == XCB_RENDER_PICT_TYPE_DIRECT && formats[i].depth == 24)
-            xcb_format_rgb = formats[i];
-        if (formats[i].type == XCB_RENDER_PICT_TYPE_DIRECT && formats[i].depth == 32 &&
-            formats[i].direct.alpha_mask == 0xff && formats[i].direct.alpha_shift == 24)
-            xcb_format_rgba = formats[i];
-    }
-
-    free(formats_reply);
 }

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -23,6 +23,7 @@
 #include "xwayland_surface.h"
 #include "xwayland_wm_shell.h"
 #include "xwayland_surface_role.h"
+#include "xwayland_cursors.h"
 
 #include "mir/dispatch/multiplexing_dispatchable.h"
 #include "mir/dispatch/readable_fd.h"
@@ -43,7 +44,7 @@ mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, 
       dispatcher{std::make_shared<mir::dispatch::MultiplexingDispatchable>()},
       wayland_client{wayland_client},
       wm_shell{std::static_pointer_cast<XWaylandWMShell>(wayland_connector->get_extension("x11-support"))},
-      cursors{connection}
+      cursors{std::make_unique<XWaylandCursors>(connection)}
 {
     wm_dispatcher =
         std::make_shared<mir::dispatch::ReadableFd>(mir::Fd{mir::IntOwnedFd{fd}}, [this]() { handle_events(); });
@@ -76,6 +77,7 @@ mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, 
         connection->net_active_window,
         static_cast<xcb_window_t>(XCB_WINDOW_NONE));
     wm_selector();
+    cursors->apply_default_to(connection->root_window());
 
     connection->flush();
 

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -22,6 +22,7 @@
 #include "mir/dispatch/threaded_dispatcher.h"
 #include "wayland_connector.h"
 #include "xcb_connection.h"
+#include "xwayland_cursors.h"
 
 #include <map>
 #include <thread>
@@ -29,10 +30,6 @@
 #include <mutex>
 
 #include <wayland-server-core.h>
-
-#include <X11/Xcursor/Xcursor.h>
-#include <xcb/composite.h>
-#include <xcb/xcb.h>
 #include <xcb/xfixes.h>
 
 namespace mir
@@ -47,12 +44,6 @@ namespace frontend
 {
 class XWaylandSurface;
 class XWaylandWMShell;
-
-template<typename T, size_t length>
-constexpr size_t length_of(T(&)[length])
-{
-    return length;
-}
 
 class XWaylandWM
 {
@@ -70,25 +61,10 @@ public:
     void run_on_wayland_thread(std::function<void()>&& work);
 
 private:
-    enum CursorType
-    {
-        CursorUnset = -1,
-        CursorTop,
-        CursorBottom,
-        CursorLeft,
-        CursorRight,
-        CursorTopLeft,
-        CursorTopRight,
-        CursorBottomLeft,
-        CursorBottomRight,
-        CursorLeftPointer
-    };
-
     void create_wm_window();
     void wm_selector();
 
     void create_window(xcb_window_t id);
-    void set_cursor(xcb_window_t id, const CursorType &cursor);
     void create_wm_cursor();
     void wm_get_resources();
 
@@ -112,25 +88,18 @@ private:
 
     std::mutex mutex;
 
-    // Cursor
-    xcb_cursor_t xcb_cursor_image_load_cursor(const XcursorImage *img);
-    xcb_cursor_t xcb_cursor_images_load_cursor(const XcursorImages *images);
-    xcb_cursor_t xcb_cursor_library_load_cursor(const char *file);
-
     std::shared_ptr<WaylandConnector> const wayland_connector;
     std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
     wl_client* const wayland_client;
     std::shared_ptr<XWaylandWMShell> const wm_shell;
+    XWaylandCursors const cursors;
 
     xcb_window_t wm_window;
     std::map<xcb_window_t, std::shared_ptr<XWaylandSurface>> surfaces;
     std::experimental::optional<xcb_window_t> focused_window;
     std::shared_ptr<dispatch::ReadableFd> wm_dispatcher;
-    int xcb_cursor;
-    std::vector<xcb_cursor_t> xcb_cursors;
     xcb_window_t xcb_selection_window;
     xcb_selection_request_event_t xcb_selection_request;
-    xcb_render_pictforminfo_t xcb_format_rgb, xcb_format_rgba;
     const xcb_query_extension_reply_t *xfixes;
     std::unique_ptr<dispatch::ThreadedDispatcher> event_thread;
 };

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -22,7 +22,6 @@
 #include "mir/dispatch/threaded_dispatcher.h"
 #include "wayland_connector.h"
 #include "xcb_connection.h"
-#include "xwayland_cursors.h"
 
 #include <map>
 #include <thread>
@@ -44,6 +43,7 @@ namespace frontend
 {
 class XWaylandSurface;
 class XWaylandWMShell;
+class XWaylandCursors;
 
 class XWaylandWM
 {
@@ -92,7 +92,7 @@ private:
     std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
     wl_client* const wayland_client;
     std::shared_ptr<XWaylandWMShell> const wm_shell;
-    XWaylandCursors const cursors;
+    std::unique_ptr<XWaylandCursors> const cursors;
 
     xcb_window_t wm_window;
     std::map<xcb_window_t, std::shared_ptr<XWaylandSurface>> surfaces;


### PR DESCRIPTION
We were loading a number of cursors with xcursor but only using the default pointer. We need to load the pointer and set it as the cursor for the root window or else an ugly X will appear as the cursor in some apps (such as GTK apps). This splits the cursor loading logic into its own file, and only loads the default cursor that we need. If we need additional cursors in the future for whatever reason extending it to do more would be easy.