### PR TITLE
Clean up Wayland extension building

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -625,9 +625,9 @@ auto mf::create_wl_shell(wl_display* display, std::shared_ptr<msh::Shell> const&
     return std::make_shared<mf::WlShell>(display, shell, *seat, output_manager);
 }
 
-void mf::WaylandExtensions::init(wl_display* display, std::shared_ptr<msh::Shell> const& shell, WlSeat* seat, OutputManager* const output_manager)
+void mf::WaylandExtensions::init(Context const& context)
 {
-    custom_extensions(display, shell, seat, output_manager);
+    custom_extensions(context);
 }
 
 void mf::WaylandExtensions::add_extension(std::string const name, std::shared_ptr<void> implementation)
@@ -635,7 +635,7 @@ void mf::WaylandExtensions::add_extension(std::string const name, std::shared_pt
     extension_protocols[std::move(name)] = std::move(implementation);
 }
 
-void mf::WaylandExtensions::custom_extensions(wl_display*, std::shared_ptr<msh::Shell> const&, WlSeat*, OutputManager* const)
+void mf::WaylandExtensions::custom_extensions(Context const&)
 {
 }
 
@@ -718,7 +718,7 @@ mf::WaylandConnector::WaylandConnector(
 
     data_device_manager_global = mf::create_data_device_manager(display.get());
 
-    extensions->init(display.get(), shell, seat_global.get(), output_manager.get());
+    extensions->init(WaylandExtensions::Context{display.get(), shell, seat_global.get(), output_manager.get()});
 
     wl_display_init_shm(display.get());
 

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -70,6 +70,15 @@ class WlSurface;
 class WaylandExtensions
 {
 public:
+    /// The resources needed to init Wayland extensions
+    struct Context
+    {
+        wl_display* display;
+        std::shared_ptr<shell::Shell> shell;
+        WlSeat* seat;
+        OutputManager* output_manager;
+    };
+
     WaylandExtensions() = default;
     virtual ~WaylandExtensions() = default;
     WaylandExtensions(WaylandExtensions const&) = delete;
@@ -77,14 +86,14 @@ public:
 
     virtual void run_builders(wl_display* display, std::function<void(std::function<void()>&& work)> const& run_on_wayland_mainloop);
 
-    void init(wl_display* display, std::shared_ptr<shell::Shell> const& shell, WlSeat* seat, OutputManager* const output_manager);
+    void init(Context const& context);
 
     auto get_extension(std::string const& name) const -> std::shared_ptr<void>;
 
 protected:
 
     void add_extension(std::string const name, std::shared_ptr<void> implementation);
-    virtual void custom_extensions(wl_display* display, std::shared_ptr<shell::Shell> const& shell, WlSeat* seat, OutputManager* const output_manager);
+    virtual void custom_extensions(Context const& context);
 
 private:
     std::unordered_map<std::string, std::shared_ptr<void>> extension_protocols;

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -79,39 +79,35 @@ auto configure_wayland_extensions(
             extension{extension}, x11_enabled{x11_enabled}, wayland_extension_hooks{wayland_extension_hooks} {}
 
     protected:
-        void custom_extensions(
-            wl_display* display,
-            std::shared_ptr<msh::Shell> const& shell,
-            mf::WlSeat* seat,
-            mf::OutputManager* const output_manager) override
+        void custom_extensions(Context const& context) override
         {
             if (extension.find(mw::Shell::interface_name) != extension.end())
                 add_extension(
                     mw::Shell::interface_name,
-                    mf::create_wl_shell(display, shell, seat, output_manager));
+                    mf::create_wl_shell(context.display, context.shell, context.seat, context.output_manager));
 
             if (extension.find(mw::XdgShellV6::interface_name) != extension.end())
                 add_extension(
                     mw::XdgShellV6::interface_name,
-                    std::make_shared<mf::XdgShellV6>(display, shell, *seat, output_manager));
+                    std::make_shared<mf::XdgShellV6>(context.display, context.shell, *context.seat, context.output_manager));
 
             if (extension.find(mw::XdgWmBase::interface_name) != extension.end())
                 add_extension(
                     mw::XdgWmBase::interface_name,
-                    std::make_shared<mf::XdgShellStable>(display, shell, *seat, output_manager));
+                    std::make_shared<mf::XdgShellStable>(context.display, context.shell, *context.seat, context.output_manager));
 
             if (extension.find(mw::LayerShellV1::interface_name) != extension.end())
                 add_extension(
                     mw::LayerShellV1::interface_name,
-                    std::make_shared<mf::LayerShellV1>(display, shell, *seat, output_manager));
+                    std::make_shared<mf::LayerShellV1>(context.display, context.shell, *context.seat, context.output_manager));
 
             if (extension.find(mw::XdgOutputManagerV1::interface_name) != extension.end())
                 add_extension(
                     mw::XdgOutputManagerV1::interface_name,
-                    create_xdg_output_manager_v1(display, output_manager));
+                    create_xdg_output_manager_v1(context.display, context.output_manager));
 
             if (x11_enabled)
-                add_extension("x11-support", std::make_shared<mf::XWaylandWMShell>(shell, *seat, output_manager));
+                add_extension("x11-support", std::make_shared<mf::XWaylandWMShell>(context.shell, *context.seat, context.output_manager));
         }
 
         void run_builders(


### PR DESCRIPTION
## Problems that this PR addresses
- We have to pass the display, shell, seat, output manager through a number of functions to create Wayland extensions
- When an extension requires a new global, all these signatures have to be updated
- `mf::get_supported_extensions()` can fall out of sync with actual supported extensions
- Creating the right extensions if the correct names are enabled is manual
- Somewhat convoluted code structure with a class inside a function

## This PR will
- Add a `WaylandExtensions::Context` that can be more easily passed around and added to
- Add `internal_extension_builders`. This is used both to build extensions and to return the list of supported extensions
- Flatten and clean up the code