### PR TITLE
frontend::SurfaceStack: add stacking_order_of()

### DIFF
--- a/src/include/server/mir/frontend/surface_stack.h
+++ b/src/include/server/mir/frontend/surface_stack.h
@@ -20,12 +20,17 @@
 #define MIR_FRONTEND_SURFACE_STACK_H_
 
 #include <memory>
+#include <set>
+#include <vector>
 
 namespace mir
 {
 namespace scene
 {
 class Observer;
+class Surface;
+using SurfaceSet = std::set<std::weak_ptr<scene::Surface>, std::owner_less<std::weak_ptr<scene::Surface>>>;
+using SurfaceList = std::vector<std::weak_ptr<scene::Surface>>;
 }
 namespace frontend
 {
@@ -37,6 +42,10 @@ public:
 
     virtual void add_observer(std::shared_ptr<scene::Observer> const& observer) = 0;
     virtual void remove_observer(std::weak_ptr<scene::Observer> const& observer) = 0;
+
+    /// Returns the stacking order of the given surfaces, bottom to top
+    /// If a surface is not known to the surface stack it will not be in the returned list
+    virtual auto stacking_order_of(scene::SurfaceSet const& surfaces) const -> scene::SurfaceList = 0;
 
 private:
     SurfaceStack(SurfaceStack const&) = delete;

--- a/src/include/server/mir/shell/surface_stack.h
+++ b/src/include/server/mir/shell/surface_stack.h
@@ -33,6 +33,7 @@ class Surface;
 struct SurfaceCreationParameters;
 class SurfaceObserver;
 class Session;
+using SurfaceSet = std::set<std::weak_ptr<scene::Surface>, std::owner_less<std::weak_ptr<scene::Surface>>>;
 }
 
 namespace shell
@@ -40,15 +41,13 @@ namespace shell
 class SurfaceStack
 {
 public:
-    using SurfaceSet = std::set<std::weak_ptr<scene::Surface>, std::owner_less<std::weak_ptr<scene::Surface>>>;
-
     virtual void add_surface(
         std::shared_ptr<scene::Surface> const&,
         input::InputReceptionMode new_mode) = 0;
 
     virtual void raise(std::weak_ptr<scene::Surface> const& surface) = 0;
 
-    virtual void raise(SurfaceSet const& surfaces) = 0;
+    virtual void raise(scene::SurfaceSet const& surfaces) = 0;
 
     virtual void remove_surface(std::weak_ptr<scene::Surface> const& surface) = 0;
 

--- a/src/include/server/mir/shell/surface_stack_wrapper.h
+++ b/src/include/server/mir/shell/surface_stack_wrapper.h
@@ -36,7 +36,7 @@ public:
 
     void raise(std::weak_ptr<scene::Surface> const& surface) override;
 
-    void raise(SurfaceSet const& surfaces) override;
+    void raise(scene::SurfaceSet const& surfaces) override;
 
     void remove_surface(std::weak_ptr<scene::Surface> const& surface) override;
 

--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -478,6 +478,24 @@ void ms::SurfaceStack::remove_observer(std::weak_ptr<ms::Observer> const& observ
     observers.remove(o);
 }
 
+auto ms::SurfaceStack::stacking_order_of(SurfaceSet const& surfaces) const -> SurfaceList
+{
+    SurfaceList result;
+
+    RecursiveReadLock lk(guard);
+    for (auto const& layer : surface_layers)
+    {
+        for (auto const& surface : layer)
+        {
+            if (surfaces.find(surface) != surfaces.end())
+            {
+                result.push_back(surface);
+            }
+        }
+    }
+    return result;
+}
+
 void ms::Observers::surface_added(std::shared_ptr<Surface> const& surface)
 {
     for_each([&](std::shared_ptr<Observer> const& observer)

--- a/src/server/scene/surface_stack.h
+++ b/src/server/scene/surface_stack.h
@@ -101,6 +101,8 @@ public:
     void add_observer(std::shared_ptr<Observer> const& observer) override;
     void remove_observer(std::weak_ptr<Observer> const& observer) override;
 
+    auto stacking_order_of(SurfaceSet const& surfaces) const -> SurfaceList override;
+
     // Intended for input overlays, as described in mir::input::Scene documentation.
     void add_input_visualization(std::shared_ptr<graphics::Renderable> const& overlay) override;
     void remove_input_visualization(std::weak_ptr<graphics::Renderable> const& overlay) override;

--- a/src/server/shell/surface_stack_wrapper.cpp
+++ b/src/server/shell/surface_stack_wrapper.cpp
@@ -40,7 +40,7 @@ void msh::SurfaceStackWrapper::raise(std::weak_ptr<scene::Surface> const& surfac
     wrapped->raise(surface);
 }
 
-void msh::SurfaceStackWrapper::raise(SurfaceSet const& surfaces)
+void msh::SurfaceStackWrapper::raise(scene::SurfaceSet const& surfaces)
 {
     wrapped->raise(surfaces);
 }

--- a/tests/include/mir/test/doubles/mock_surface_stack.h
+++ b/tests/include/mir/test/doubles/mock_surface_stack.h
@@ -35,7 +35,7 @@ namespace doubles
 struct MockSurfaceStack : public shell::SurfaceStack
 {
     MOCK_METHOD1(raise, void(std::weak_ptr<scene::Surface> const&));
-    MOCK_METHOD1(raise, void(SurfaceSet const&));
+    MOCK_METHOD1(raise, void(scene::SurfaceSet const&));
 
     MOCK_METHOD2(add_surface, void(std::shared_ptr<scene::Surface> const&, input::InputReceptionMode new_mode));
 

--- a/tests/integration-tests/session_management.cpp
+++ b/tests/integration-tests/session_management.cpp
@@ -59,7 +59,7 @@ struct TestSurfaceStack : public msh::SurfaceStack
     MOCK_METHOD1(raise, void(
         std::weak_ptr<ms::Surface> const& surface));
 
-    void raise(SurfaceSet const& surfaces) override
+    void raise(ms::SurfaceSet const& surfaces) override
     {
         wrapped->raise(surfaces);
     }

--- a/tests/unit-tests/scene/test_application_session.cpp
+++ b/tests/unit-tests/scene/test_application_session.cpp
@@ -114,7 +114,7 @@ struct StubSurfaceStack : public msh::SurfaceStack
     void raise(std::weak_ptr<ms::Surface> const&) override
     {
     }
-    void raise(SurfaceSet const&) override
+    void raise(ms::SurfaceSet const&) override
     {
     }
     void add_surface(std::shared_ptr<ms::Surface> const&, mi::InputReceptionMode) override

--- a/tests/unit-tests/scene/test_surface_stack.cpp
+++ b/tests/unit-tests/scene/test_surface_stack.cpp
@@ -68,6 +68,11 @@ MATCHER_P(SceneElementForStream, stream, "")
     return arg->renderable()->id() == stream.get();
 }
 
+MATCHER_P(LockedEq, value, "")
+{
+    return arg.lock() == value;
+}
+
 struct MockCallback
 {
     MOCK_METHOD0(call, void());

--- a/tests/unit-tests/scene/test_surface_stack.cpp
+++ b/tests/unit-tests/scene/test_surface_stack.cpp
@@ -505,7 +505,7 @@ TEST_F(SurfaceStack, remove_scene_observer)
 }
 
 // Many clients of the scene observer wish to install surface observers to monitor surface
-// notifications. We offer them a surface_added event for existing surfaces to give them
+// notifications. We offer them a surface_exists event for existing surfaces to give them
 // a chance to do this.
 TEST_F(SurfaceStack, scene_observer_informed_of_existing_surfaces)
 {
@@ -597,6 +597,20 @@ TEST_F(SurfaceStack, surfaces_reordered)
     stack.add_surface(stub_surface1, default_params.input_mode);
     stack.add_surface(stub_surface2, default_params.input_mode);
     stack.raise(stub_surface1);
+}
+
+TEST_F(SurfaceStack, surface_stacking_order)
+{
+    using namespace ::testing;
+
+    stack.add_surface(stub_surface1, default_params.input_mode);
+    stack.add_surface(stub_surface2, default_params.input_mode);
+    stack.add_surface(stub_surface3, default_params.input_mode);
+    stack.raise(stub_surface2);
+
+    EXPECT_THAT(
+        stack.stacking_order_of({stub_surface2, stub_surface3}),
+        ElementsAre(LockedEq(stub_surface3), LockedEq(stub_surface2)));
 }
 
 TEST_F(SurfaceStack, scene_elements_hold_snapshot_of_positioning_info)


### PR DESCRIPTION
This allows a user of the fronted surface to query the stacking order of a specific set of surfaces. This API will be used by the X11 window manager to inform the X server of the correct window stacking order (which is necessary for correct input dispatch).