### PR TITLE
Report affected surfaces in the surfaces_reordered() call

### DIFF
--- a/src/include/server/mir/scene/legacy_scene_change_notification.h
+++ b/src/include/server/mir/scene/legacy_scene_change_notification.h
@@ -50,7 +50,7 @@ public:
 
     void surface_added(std::shared_ptr<Surface> const& surface) override;
     void surface_removed(std::shared_ptr<Surface> const& surface) override;
-    void surfaces_reordered() override;
+    void surfaces_reordered(SurfaceSet const& affected_surfaces) override;
     
     void scene_changed() override;
 

--- a/src/include/server/mir/scene/null_observer.h
+++ b/src/include/server/mir/scene/null_observer.h
@@ -33,7 +33,7 @@ public:
 
     void surface_added(std::shared_ptr<Surface> const& surface) override;
     void surface_removed(std::shared_ptr<Surface> const& surface) override;
-    void surfaces_reordered() override;
+    void surfaces_reordered(SurfaceSet const& affected_surfaces) override;
 
     // Used to indicate the scene has changed in some way beyond the present surfaces
     // and will require full recomposition.

--- a/src/include/server/mir/scene/observer.h
+++ b/src/include/server/mir/scene/observer.h
@@ -20,22 +20,32 @@
 #define MIR_SCENE_OBSERVER_H_
 
 #include <memory>
+#include <set>
 
 namespace mir
 {
 namespace scene
 {
 class Surface;
+using SurfaceSet = std::set<std::weak_ptr<Surface>, std::owner_less<std::weak_ptr<Surface>>>;
 
 /// An observer for top level notifications of scene changes. In order
 /// to receive more granular change notifications a user may install
-/// mir::scene::SurfaceObserver in surface_added.
+/// mir::scene::SurfaceObserver in surface_added() and surface_exists().
 class Observer
 {
 public:
+    /// A new surface has been added to the scene
+    /// Not called for existing surfaces, see surface_exists()
     virtual void surface_added(std::shared_ptr<Surface> const& surface) = 0;
+
+    /// The surface has been removed from the scene
     virtual void surface_removed(std::shared_ptr<Surface> const& surface) = 0;
-    virtual void surfaces_reordered() = 0;
+
+    /// The stacking order of surfaces has changed
+    /// Affected surfaces may or may not have changed order relative to each other, and they may be at any position
+    /// Non-affected surfaces will not have changed order relative to each other
+    virtual void surfaces_reordered(SurfaceSet const& affected_surfaces) = 0;
 
     /// Used to indicate the scene has changed in some way beyond the present surfaces
     /// and will require full recomposition.

--- a/src/include/server/mir/shell/surface_stack.h
+++ b/src/include/server/mir/shell/surface_stack.h
@@ -33,6 +33,7 @@ class Surface;
 struct SurfaceCreationParameters;
 class SurfaceObserver;
 class Session;
+using SurfaceSet = std::set<std::weak_ptr<scene::Surface>, std::owner_less<std::weak_ptr<scene::Surface>>>;
 }
 
 namespace shell
@@ -40,15 +41,13 @@ namespace shell
 class SurfaceStack
 {
 public:
-    using SurfaceSet = std::set<std::weak_ptr<scene::Surface>, std::owner_less<std::weak_ptr<scene::Surface>>>;
-
     virtual void add_surface(
         std::shared_ptr<scene::Surface> const&,
         input::InputReceptionMode new_mode) = 0;
 
     virtual void raise(std::weak_ptr<scene::Surface> const& surface) = 0;
 
-    virtual void raise(SurfaceSet const& surfaces) = 0;
+    virtual void raise(scene::SurfaceSet const& surfaces) = 0;
 
     virtual void remove_surface(std::weak_ptr<scene::Surface> const& surface) = 0;
 

--- a/src/include/server/mir/shell/surface_stack_wrapper.h
+++ b/src/include/server/mir/shell/surface_stack_wrapper.h
@@ -36,7 +36,7 @@ public:
 
     void raise(std::weak_ptr<scene::Surface> const& surface) override;
 
-    void raise(SurfaceSet const& surfaces) override;
+    void raise(scene::SurfaceSet const& surfaces) override;
 
     void remove_surface(std::weak_ptr<scene::Surface> const& surface) override;
 

--- a/src/server/input/cursor_controller.cpp
+++ b/src/server/input/cursor_controller.cpp
@@ -142,7 +142,7 @@ struct UpdateCursorOnSceneChanges : ms::Observer
         cursor_controller->update_cursor_image();
     }
 
-    void surfaces_reordered() override
+    void surfaces_reordered(ms::SurfaceSet const&) override
     {
         cursor_controller->update_cursor_image();
     }

--- a/src/server/scene/legacy_scene_change_notification.cpp
+++ b/src/server/scene/legacy_scene_change_notification.cpp
@@ -145,7 +145,7 @@ void ms::LegacySceneChangeNotification::surface_removed(std::shared_ptr<ms::Surf
         scene_notify_change();
 }
 
-void ms::LegacySceneChangeNotification::surfaces_reordered()
+void ms::LegacySceneChangeNotification::surfaces_reordered(SurfaceSet const&)
 {
     scene_notify_change();
 }

--- a/src/server/scene/null_observer.cpp
+++ b/src/server/scene/null_observer.cpp
@@ -22,7 +22,7 @@ namespace ms = mir::scene;
 
 void ms::NullObserver::surface_added(std::shared_ptr<ms::Surface> const& /* surface */) {}
 void ms::NullObserver::surface_removed(std::shared_ptr<ms::Surface> const& /* surface */) {}
-void ms::NullObserver::surfaces_reordered() {}
+void ms::NullObserver::surfaces_reordered(SurfaceSet const& /* affected_surfaces */) {}
 void ms::NullObserver::scene_changed() {}
 void ms::NullObserver::surface_exists(std::shared_ptr<ms::Surface> const& /* surface */) {}
 void ms::NullObserver::end_observation() {}

--- a/src/server/scene/surface_stack.h
+++ b/src/server/scene/surface_stack.h
@@ -57,7 +57,7 @@ public:
    // ms::Observer
    void surface_added(std::shared_ptr<Surface> const& surface) override;
    void surface_removed(std::shared_ptr<Surface> const& surface) override;
-   void surfaces_reordered() override;
+   void surfaces_reordered(SurfaceSet const& affected_surfaces) override;
    void scene_changed() override;
    void surface_exists(std::shared_ptr<Surface> const& surface) override;
    void end_observation() override;

--- a/src/server/shell/surface_stack_wrapper.cpp
+++ b/src/server/shell/surface_stack_wrapper.cpp
@@ -40,7 +40,7 @@ void msh::SurfaceStackWrapper::raise(std::weak_ptr<scene::Surface> const& surfac
     wrapped->raise(surface);
 }
 
-void msh::SurfaceStackWrapper::raise(SurfaceSet const& surfaces)
+void msh::SurfaceStackWrapper::raise(scene::SurfaceSet const& surfaces)
 {
     wrapped->raise(surfaces);
 }

--- a/tests/include/mir/test/doubles/mock_surface_stack.h
+++ b/tests/include/mir/test/doubles/mock_surface_stack.h
@@ -35,7 +35,7 @@ namespace doubles
 struct MockSurfaceStack : public shell::SurfaceStack
 {
     MOCK_METHOD1(raise, void(std::weak_ptr<scene::Surface> const&));
-    MOCK_METHOD1(raise, void(SurfaceSet const&));
+    MOCK_METHOD1(raise, void(scene::SurfaceSet const&));
 
     MOCK_METHOD2(add_surface, void(std::shared_ptr<scene::Surface> const&, input::InputReceptionMode new_mode));
 

--- a/tests/integration-tests/session_management.cpp
+++ b/tests/integration-tests/session_management.cpp
@@ -59,7 +59,7 @@ struct TestSurfaceStack : public msh::SurfaceStack
     MOCK_METHOD1(raise, void(
         std::weak_ptr<ms::Surface> const& surface));
 
-    void raise(SurfaceSet const& surfaces) override
+    void raise(ms::SurfaceSet const& surfaces) override
     {
         wrapped->raise(surfaces);
     }

--- a/tests/unit-tests/compositor/test_multi_threaded_compositor.cpp
+++ b/tests/unit-tests/compositor/test_multi_threaded_compositor.cpp
@@ -122,10 +122,10 @@ public:
     {
         {
             std::lock_guard<std::mutex> lock{observer_mutex};
-            
+
             // Any old event will do.
             if (observer)
-                observer->surfaces_reordered();
+                observer->surfaces_reordered({});
         }
         /* Reduce run-time under valgrind */
         std::this_thread::yield();

--- a/tests/unit-tests/scene/test_application_session.cpp
+++ b/tests/unit-tests/scene/test_application_session.cpp
@@ -114,7 +114,7 @@ struct StubSurfaceStack : public msh::SurfaceStack
     void raise(std::weak_ptr<ms::Surface> const&) override
     {
     }
-    void raise(SurfaceSet const&) override
+    void raise(ms::SurfaceSet const&) override
     {
     }
     void add_surface(std::shared_ptr<ms::Surface> const&, mi::InputReceptionMode) override

--- a/tests/unit-tests/scene/test_legacy_scene_change_notification.cpp
+++ b/tests/unit-tests/scene/test_legacy_scene_change_notification.cpp
@@ -62,7 +62,7 @@ TEST_F(LegacySceneChangeNotificationTest, fowards_all_observations_to_callback)
     ms::LegacySceneChangeNotification observer(scene_change_callback, buffer_change_callback);
     observer.surface_added(surface);
     observer.surface_removed(surface);
-    observer.surfaces_reordered();
+    observer.surfaces_reordered({});
 }
 
 TEST_F(LegacySceneChangeNotificationTest, registers_observer_with_surfaces)

--- a/tests/unit-tests/scene/test_surface_stack.cpp
+++ b/tests/unit-tests/scene/test_surface_stack.cpp
@@ -68,6 +68,11 @@ MATCHER_P(SceneElementForStream, stream, "")
     return arg->renderable()->id() == stream.get();
 }
 
+MATCHER_P(LockedEq, value, "")
+{
+    return arg.lock() == value;
+}
+
 struct MockCallback
 {
     MOCK_METHOD0(call, void());


### PR DESCRIPTION
Gives a scene observer the set of surfaces a reorder affected. This will improve performance in some cases (for example, the XWayland window manager can ignore notifications about Wayland surfaces being raised)