### PR TITLE
Handle XCB startup errors better

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -117,7 +117,8 @@ mf::XCBConnection::Atom::operator xcb_atom_t() const
 }
 
 mf::XCBConnection::XCBConnection(int fd)
-    : xcb_connection{connect_to_fd(fd)},
+    : fd{fd},
+      xcb_connection{connect_to_fd(fd)},
       xcb_screen{xcb_setup_roots_iterator(xcb_get_setup(xcb_connection)).data},
       atom_name_cache{{XCB_ATOM_NONE, "None/Any"}},
       wm_protocols{"WM_PROTOCOLS", this},
@@ -167,6 +168,7 @@ mf::XCBConnection::XCBConnection(int fd)
 mf::XCBConnection::~XCBConnection()
 {
     xcb_disconnect(xcb_connection);
+    close(fd);
 }
 
 mf::XCBConnection::operator xcb_connection_t*() const

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -70,14 +70,32 @@ auto number_to_readable_name(uint32_t number) -> std::string
     return ss.str();
 }
 
+auto xcb_error_to_string(int error) -> std::string
+{
+    // see https://xcb.freedesktop.org/manual/group__XCB__Core__API.html#ga70a6bade94bd2824db552abcf5fbdbe3
+    switch (error)
+    {
+        case 0: return "no error";
+        case XCB_CONN_ERROR: return "XCB_CONN_ERROR";
+        case XCB_CONN_CLOSED_EXT_NOTSUPPORTED: return "XCB_CONN_CLOSED_EXT_NOTSUPPORTED";
+        case XCB_CONN_CLOSED_MEM_INSUFFICIENT: return "XCB_CONN_CLOSED_MEM_INSUFFICIENT";
+        case XCB_CONN_CLOSED_REQ_LEN_EXCEED: return "XCB_CONN_CLOSED_REQ_LEN_EXCEED";
+        case XCB_CONN_CLOSED_PARSE_ERR: return "XCB_CONN_CLOSED_PARSE_ERR";
+        case XCB_CONN_CLOSED_INVALID_SCREEN: return "XCB_CONN_CLOSED_INVALID_SCREEN";
+        case XCB_CONN_CLOSED_FDPASSING_FAILED: return "XCB_CONN_CLOSED_FDPASSING_FAILED";
+        default:;
+    }
+    return "unknwon XCB error " + std::to_string(error);
+}
+
 auto connect_to_fd(int fd) -> xcb_connection_t*
 {
     xcb_connection_t* connection = xcb_connect_to_fd(fd, nullptr);
-    if (xcb_connection_has_error(connection))
+    if (auto const error = xcb_connection_has_error(connection))
     {
         xcb_disconnect(connection);
         close(fd);
-        BOOST_THROW_EXCEPTION(std::runtime_error("xcb_connect_to_fd() failed"));
+        BOOST_THROW_EXCEPTION(std::runtime_error("xcb_connect_to_fd() failed: " + xcb_error_to_string(error)));
     }
     else
     {

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -60,6 +60,7 @@ template<> struct NativeXCBType<XCBType::WM_PROTOCOLS>  { typedef uint32_t type;
 class XCBConnection
 {
 private:
+    int const fd;
     xcb_connection_t* const xcb_connection;
     xcb_screen_t* const xcb_screen;
 
@@ -89,6 +90,7 @@ public:
         std::atomic<xcb_atom_t> mutable atom{XCB_ATOM_NONE};
     };
 
+    /// Takes ownership of the given FD
     explicit XCBConnection(int fd);
     ~XCBConnection();
 

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -83,13 +83,6 @@ mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, 
       wayland_client{wayland_client},
       wm_shell{std::static_pointer_cast<XWaylandWMShell>(wayland_connector->get_extension("x11-support"))}
 {
-    if (xcb_connection_has_error(*connection))
-    {
-        mir::log_error("XWAYLAND: xcb_connect_to_fd failed");
-        close(wm_fd);
-        return;
-    }
-
     wm_dispatcher =
         std::make_shared<mir::dispatch::ReadableFd>(mir::Fd{mir::IntOwnedFd{wm_fd}}, [this]() { handle_events(); });
     dispatcher->add_watch(wm_dispatcher);

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -76,15 +76,14 @@ static const struct cursor_alternatives cursors[] = {
 namespace mf = mir::frontend;
 
 mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, wl_client* wayland_client, int fd)
-    : wm_fd{fd},
-      connection{std::make_shared<XCBConnection>(fd)},
+    : connection{std::make_shared<XCBConnection>(fd)},
       wayland_connector(wayland_connector),
       dispatcher{std::make_shared<mir::dispatch::MultiplexingDispatchable>()},
       wayland_client{wayland_client},
       wm_shell{std::static_pointer_cast<XWaylandWMShell>(wayland_connector->get_extension("x11-support"))}
 {
     wm_dispatcher =
-        std::make_shared<mir::dispatch::ReadableFd>(mir::Fd{mir::IntOwnedFd{wm_fd}}, [this]() { handle_events(); });
+        std::make_shared<mir::dispatch::ReadableFd>(mir::Fd{mir::IntOwnedFd{fd}}, [this]() { handle_events(); });
     dispatcher->add_watch(wm_dispatcher);
 
     event_thread = std::make_unique<mir::dispatch::ThreadedDispatcher>(
@@ -162,8 +161,6 @@ mf::XWaylandWM::~XWaylandWM()
         for (auto xcb_cursor : xcb_cursors)
         xcb_free_cursor(*connection, xcb_cursor);
     }
-
-    close(wm_fd);
 }
 
 void mf::XWaylandWM::wm_selector()

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -57,10 +57,10 @@ constexpr size_t length_of(T(&)[length])
 class XWaylandWM
 {
 private:
-    int const wm_fd;
     std::shared_ptr<XCBConnection> const connection;
 
 public:
+    /// Takes ownership of the given FD
     XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, wl_client* wayland_client, int fd);
     ~XWaylandWM();
 


### PR DESCRIPTION
We're supposed to check if the XCB connection has errors immediately after creating it, but instead we were initializing the rest of the wm before making the check. If the check failed, the wm was left in-tact with an invalid connection.

With this PR the connection checks itself before doing anything, and throws if there's an error. The exception is caught by `XWaylandServer::connect_wm_to_xwayland()` and treated like other XWayland errors. The logic for retrying a few times and then giving up is already implemented (change `connect_to_fd()` to always throw if you want to test this out).