### PR TITLE
Wayland: move visibility() logic into commit()

### DIFF
--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -367,16 +367,15 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
 
     if (auto const scene_surface = weak_scene_surface.lock())
     {
-        if (scene_surface->visible() != static_cast<bool>(surface->buffer_size()))
+        bool const is_mapped = scene_surface->visible();
+        bool const should_be_mapped = static_cast<bool>(surface->buffer_size());
+        if (!is_mapped && should_be_mapped)
         {
-            if (surface->buffer_size() && scene_surface->state() == mir_window_state_hidden)
-            {
-                spec().state = mir_window_state_restored;
-            }
-            else if (!surface->buffer_size() && scene_surface->state() != mir_window_state_hidden)
-            {
-                spec().state = mir_window_state_hidden;
-            }
+            spec().state = mir_window_state_restored;
+        }
+        else if (is_mapped && !should_be_mapped)
+        {
+            spec().state = mir_window_state_hidden;
         }
 
         if (!committed_size || size != committed_size.value())

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -417,10 +417,6 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
     pending_explicit_height = std::experimental::nullopt;
 }
 
-void mf::WindowWlSurfaceRole::visiblity(bool)
-{
-}
-
 mir::shell::SurfaceSpecification& mf::WindowWlSurfaceRole::spec()
 {
     if (!pending_changes)

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -367,6 +367,18 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
 
     if (auto const scene_surface = weak_scene_surface.lock())
     {
+        if (scene_surface->visible() != static_cast<bool>(surface->buffer_size()))
+        {
+            if (surface->buffer_size() && scene_surface->state() == mir_window_state_hidden)
+            {
+                spec().state = mir_window_state_restored;
+            }
+            else if (!surface->buffer_size() && scene_surface->state() != mir_window_state_hidden)
+            {
+                spec().state = mir_window_state_hidden;
+            }
+        }
+
         if (!committed_size || size != committed_size.value())
         {
             spec().width = size.width;
@@ -405,25 +417,8 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
     pending_explicit_height = std::experimental::nullopt;
 }
 
-void mf::WindowWlSurfaceRole::visiblity(bool visible)
+void mf::WindowWlSurfaceRole::visiblity(bool)
 {
-    auto const scene_surface = weak_scene_surface.lock();
-    if (!scene_surface)
-        return;
-
-    if (scene_surface->visible() == visible)
-        return;
-
-    if (visible)
-    {
-        if (scene_surface->state() == mir_window_state_hidden)
-            spec().state = mir_window_state_restored;
-    }
-    else
-    {
-        if (scene_surface->state() != mir_window_state_hidden)
-            spec().state = mir_window_state_hidden;
-    }
 }
 
 mir::shell::SurfaceSpecification& mf::WindowWlSurfaceRole::spec()

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -151,8 +151,6 @@ private:
 
     std::unique_ptr<shell::SurfaceSpecification> pending_changes;
 
-    void visiblity(bool visible) override;
-
     shell::SurfaceSpecification& spec();
 };
 

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -94,7 +94,11 @@ void mf::WlSubsurface::populate_surface_data(std::vector<shell::StreamSpecificat
                                              std::vector<mir::geometry::Rectangle>& input_shape_accumulator,
                                              geometry::Displacement const& parent_offset) const
 {
-    surface->populate_surface_data(buffer_streams, input_shape_accumulator, parent_offset);
+    if (surface->buffer_size())
+    {
+        // surface is mapped
+        surface->populate_surface_data(buffer_streams, input_shape_accumulator, parent_offset);
+    }
 }
 
 bool mf::WlSubsurface::synchronized() const

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -193,9 +193,3 @@ void mf::WlSubsurface::commit(WlSurfaceState const& state)
         cached_state = std::experimental::nullopt;
     }
 }
-
-void mf::WlSubsurface::visiblity(bool visible)
-{
-    (void)visible;
-    log_warning("TODO: wl_subsurface.visiblity not implemented");
-}

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -170,6 +170,16 @@ void mf::WlSubsurface::commit(WlSurfaceState const& state)
 
     cached_state.value().update_from(state);
 
+    if (cached_state.value().buffer)
+    {
+        auto const currently_mapped = static_cast<bool>(surface->buffer_size());
+        auto const pending_mapped = cached_state.value().buffer.value() != nullptr;
+        if (currently_mapped != pending_mapped)
+        {
+            cached_state.value().invalidate_surface_data();
+        }
+    }
+
     if (synchronized())
     {
         if (cached_state.value().surface_data_needs_refresh() && !*parent_destroyed)

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -77,7 +77,6 @@ private:
 
     void refresh_surface_data_now() override;
     virtual void commit(WlSurfaceState const& state) override;
-    virtual void visiblity(bool visible) override;
 
     WlSurface* const surface;
     // manages parent/child relationship, but does not manage parent's memory

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -263,8 +263,6 @@ void mf::WlSurface::attach(std::experimental::optional<wl_resource*> const& buff
         mir::log_warning("Client requested unimplemented non-zero attach offset. Rendering will be incorrect.");
     }
 
-    role->visiblity(!!buffer);
-
     pending.buffer = buffer.value_or(nullptr);
 }
 
@@ -447,5 +445,4 @@ auto mf::NullWlSurfaceRole::scene_surface() const -> std::experimental::optional
 }
 void mf::NullWlSurfaceRole::refresh_surface_data_now() {}
 void mf::NullWlSurfaceRole::commit(WlSurfaceState const& state) { surface->commit(state); }
-void mf::NullWlSurfaceRole::visiblity(bool /*visible*/) {}
 void mf::NullWlSurfaceRole::destroy() {}

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -100,7 +100,6 @@ public:
     auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
     void refresh_surface_data_now() override;
     void commit(WlSurfaceState const& state) override;
-    void visiblity(bool /*visible*/) override;
     void destroy() override;
 
 private:

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -45,7 +45,6 @@ public:
     virtual auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> = 0;
     virtual void refresh_surface_data_now() = 0;
     virtual void commit(WlSurfaceState const& state) = 0;
-    virtual void visiblity(bool visible) = 0;
     virtual void destroy() = 0;
     virtual ~WlSurfaceRole() = default;
 };

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -97,6 +97,17 @@ void mf::XWaylandSurfaceRole::commit(WlSurfaceState const& state)
     {
         shell::SurfaceSpecification spec;
 
+        bool const is_mapped = surface.value()->state() != mir_window_state_hidden;
+        bool const should_be_mapped = static_cast<bool>(wl_surface->buffer_size());
+        if (!is_mapped && should_be_mapped)
+        {
+            spec.state = mir_window_state_restored;
+        }
+        else if (is_mapped && !should_be_mapped)
+        {
+            spec.state = mir_window_state_hidden;
+        }
+
         if (state.surface_data_needs_refresh())
         {
             spec.streams = std::vector<shell::StreamSpecification>();

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -97,7 +97,7 @@ void mf::XWaylandSurfaceRole::commit(WlSurfaceState const& state)
     {
         shell::SurfaceSpecification spec;
 
-        bool const is_mapped = surface.value()->state() != mir_window_state_hidden;
+        bool const is_mapped = surface.value()->visible();
         bool const should_be_mapped = static_cast<bool>(wl_surface->buffer_size());
         if (!is_mapped && should_be_mapped)
         {

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -122,11 +122,6 @@ void mf::XWaylandSurfaceRole::commit(WlSurfaceState const& state)
     }
 }
 
-void mf::XWaylandSurfaceRole::visiblity(bool /*visible*/)
-{
-    // TODO?
-}
-
 void mf::XWaylandSurfaceRole::destroy()
 {
     if (auto const wm_surface = weak_wm_surface.lock())

--- a/src/server/frontend_xwayland/xwayland_surface_role.h
+++ b/src/server/frontend_xwayland/xwayland_surface_role.h
@@ -59,7 +59,6 @@ private:
     auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
     void refresh_surface_data_now() override;
     void commit(WlSurfaceState const& state) override;
-    void visiblity(bool visible) override;
     void destroy() override;
     /// @}
 };


### PR DESCRIPTION
This fixes some problems with subsurfaces mapping and unmapping, and removes the now-unneeded `visibility()` function from the window role interface. This should get simpler once we sort out buffer streams.