### PR TITLE
Wayland: dispatch pointer and touch input more correctly

### DIFF
--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -139,9 +139,9 @@ void mf::WaylandInputDispatcher::handle_pointer_event(std::chrono::milliseconds 
             geom::Point const position{
                 mir_pointer_event_axis_value(event, mir_pointer_axis_x),
                 mir_pointer_event_axis_value(event, mir_pointer_axis_y)};
-            seat->for_each_listener(client, [wl_surface = wl_surface, &position](WlPointer* pointer)
+            seat->for_each_listener(client, [wl_surface = wl_surface, &position, &ms](WlPointer* pointer)
                 {
-                    pointer->enter(wl_surface, position);
+                    pointer->enter(ms, wl_surface, position);
                     pointer->frame();
                 });
             break;

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -21,6 +21,7 @@
 #include "wayland_utils.h"
 #include "wl_surface.h"
 
+#include "mir/log.h"
 #include "mir/executor.h"
 #include "mir/frontend/wayland.h"
 #include "mir/scene/surface.h"
@@ -138,6 +139,29 @@ void mf::WlPointer::leave()
 
 void mf::WlPointer::button(std::chrono::milliseconds const& ms, uint32_t button, bool pressed)
 {
+    if (pressed)
+    {
+        if (!pressed_buttons.insert(button).second)
+        {
+            log_warning(
+                "Got pressed event for wl_pointer@%d button %d when already down",
+                wl_resource_get_id(resource),
+                button);
+            return;
+        }
+    }
+    else
+    {
+        if (!pressed_buttons.erase(button))
+        {
+            log_warning(
+                "Got unpressed event for wl_pointer@%d button %d when already up",
+                wl_resource_get_id(resource),
+                button);
+            return;
+        }
+    }
+
     auto const serial = wl_display_next_serial(display);
     auto const state = pressed ? ButtonState::pressed : ButtonState::released;
 

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -57,13 +57,16 @@ public:
 
     /// Handles finding the correct subsurface and position on that subsurface if needed
     /// Giving it an already transformed surface and position is also fine
-    void enter(WlSurface* parent_surface, geometry::Point const& position_on_parent);
+    void enter(
+        std::chrono::milliseconds const& ms,
+        WlSurface* root_surface,
+        geometry::Point const& root_position);
     void leave();
     void button(std::chrono::milliseconds const& ms, uint32_t button, bool pressed);
     void motion(
         std::chrono::milliseconds const& ms,
-        WlSurface* parent_surface,
-        geometry::Point const& position_on_parent);
+        WlSurface* root_surface,
+        geometry::Point const& root_position);
     void axis(std::chrono::milliseconds const& ms, geometry::Displacement const& scroll);
     void frame();
 
@@ -76,7 +79,10 @@ private:
     bool can_send_frame{false};
     std::experimental::optional<WlSurface*> surface_under_cursor;
 
-    void enter_internal(WlSurface* surface, geometry::Point const& position);
+    void send_update(
+        std::chrono::milliseconds const& ms,
+        WlSurface* target_surface,
+        geometry::Point const& root_position);
 
     /// Wayland request handlers
     ///@{

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -27,6 +27,7 @@
 
 #include <functional>
 #include <chrono>
+#include <set>
 
 struct MirInputEvent;
 typedef unsigned int MirPointerButtons;
@@ -87,6 +88,7 @@ private:
     void release() override;
     ///@}
 
+    std::set<uint32_t> pressed_buttons;
     std::unique_ptr<Cursor> cursor;
 };
 

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -75,6 +75,8 @@ private:
     bool can_send_frame{false};
     std::experimental::optional<WlSurface*> surface_under_cursor;
 
+    void enter_internal(WlSurface* surface, geometry::Point const& position);
+
     /// Wayland request handlers
     ///@{
     void set_cursor(

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -116,9 +116,9 @@ void mf::WlSubsurface::parent_has_committed()
     }
 }
 
-mf::WlSurface::Position mf::WlSubsurface::transform_point(geom::Point point)
+auto mf::WlSubsurface::subsurface_at(geom::Point point) -> std::experimental::optional<WlSurface*>
 {
-    return surface->transform_point(point);
+    return surface->subsurface_at(point);
 }
 
 void mf::WlSubsurface::set_position(int32_t x, int32_t y)

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -64,7 +64,7 @@ public:
 
     void parent_has_committed();
 
-    WlSurface::Position transform_point(geometry::Point point);
+    auto subsurface_at(geometry::Point point) -> std::experimental::optional<WlSurface*>;
 
 private:
     void set_position(int32_t x, int32_t y) override;

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -122,6 +122,11 @@ bool mf::WlSurface::synchronized() const
 mf::WlSurface::Position mf::WlSurface::transform_point(geom::Point point)
 {
     point = point - offset_;
+    if (!buffer_size_)
+    {
+        // surface not mapped
+        return {point, this, false};
+    }
     // loop backwards so the first subsurface we find that accepts the input is the topmost one
     for (auto child_it = children.rbegin(); child_it != children.rend(); ++child_it)
     {
@@ -130,7 +135,7 @@ mf::WlSurface::Position mf::WlSurface::transform_point(geom::Point point)
             return result;
     }
     geom::Rectangle surface_rect = {geom::Point{}, buffer_size_.value_or(geom::Size{})};
-    for (auto& rect : input_shape.value_or(std::vector<geom::Rectangle>{{{}, buffer_size_.value_or(geom::Size{})}}))
+    for (auto& rect : input_shape.value_or(std::vector<geom::Rectangle>{surface_rect}))
     {
         if (rect.intersection_with(surface_rect).contains(point))
             return {point, this, true};

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -110,13 +110,6 @@ private:
 class WlSurface : public wayland::Surface
 {
 public:
-    struct Position
-    {
-        mir::geometry::Point position;
-        WlSurface* surface;
-        bool is_in_input_region;
-    };
-
     WlSurface(wl_resource* new_resource,
               std::shared_ptr<mir::Executor> const& executor,
               std::shared_ptr<mir::graphics::WaylandAllocator> const& allocator);
@@ -128,7 +121,7 @@ public:
     geometry::Displacement total_offset() const { return offset_ + role->total_offset(); }
     std::experimental::optional<geometry::Size> buffer_size() const { return buffer_size_; }
     bool synchronized() const;
-    Position transform_point(geometry::Point point);
+    auto subsurface_at(geometry::Point point) -> std::experimental::optional<WlSurface*>;
     wl_resource* raw_resource() const { return resource; }
     auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>;
 

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -78,7 +78,7 @@ void mf::WlTouch::motion(
 
     if (final_surface == focused_surface_for_ids.end())
     {
-        log_warning("WlTouch::motion() called with invalid ID");
+        log_warning("WlTouch::motion() called with invalid ID %d", touch_id);
         return;
     }
 
@@ -97,13 +97,18 @@ void mf::WlTouch::up(std::chrono::milliseconds const& ms, int32_t touch_id)
 {
     auto const serial = wl_display_next_serial(wl_client_get_display(client));
 
-    focused_surface_for_ids.erase(touch_id);
-
-    send_up_event(
-        serial,
-        ms.count(),
-        touch_id);
-    can_send_frame = true;
+    if (focused_surface_for_ids.erase(touch_id))
+    {
+        send_up_event(
+            serial,
+            ms.count(),
+            touch_id);
+        can_send_frame = true;
+    }
+    else
+    {
+        log_warning("WlTouch::up() called with invalid ID %d", touch_id);
+    }
 }
 
 void mf::WlTouch::frame()

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -47,13 +47,13 @@ public:
     void down(
         std::chrono::milliseconds const& ms,
         int32_t touch_id,
-        WlSurface* parent,
-        geometry::Point const& position_on_parent);
+        WlSurface* root_surface,
+        geometry::Point const& root_position);
     void motion(
         std::chrono::milliseconds const& ms,
         int32_t touch_id,
-        WlSurface* parent,
-        geometry::Point const& position_on_parent);
+        WlSurface* root_surface,
+        geometry::Point const& root_position);
     void up(std::chrono::milliseconds const& ms, int32_t touch_id);
     void frame();
 


### PR DESCRIPTION
First of all, once we make each buffer stream an input surface, all of this nonsense will go away. What we have now is a whole input dispatch system separate from the main input dispatch system just for giving input events to the right subsurface. That being said, we might as well do it right. When combined with #1462, all tests added in https://github.com/MirServer/wlcs/pull/156 should now pass.