### PR TITLE
immediately activate surface with a buffer

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -157,11 +157,18 @@ auto miral::BasicWindowManager::add_surface(
     policy->advise_new_window(window_info);
 
     std::shared_ptr<scene::Surface> const scene_surface = window_info.window();
-    scene_surface->add_observer(std::make_shared<shell::SurfaceReadyObserver>(
-        [this, &window_info](std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&)
-            { Locker lock{this}; policy->handle_window_ready(window_info); },
-        session,
-        scene_surface));
+    if (scene_surface->visible())
+    {
+        policy->handle_window_ready(window_info);
+    }
+    else
+    {
+        scene_surface->add_observer(std::make_shared<shell::SurfaceReadyObserver>(
+            [this, &window_info](std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&)
+                { Locker lock{this}; policy->handle_window_ready(window_info); },
+            session,
+            scene_surface));
+    }
 
     if (parent && spec.aux_rect().is_set() && spec.placement_hints().is_set())
     {

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -453,9 +453,12 @@ void mf::WindowWlSurfaceRole::create_scene_surface()
     if (params->max_height) committed_max_size.height = params->max_height.value();
 
     // The shell isn't guaranteed to respect the requested size
+    // TODO: make initial updates atomic somehow
     auto const content_size = scene_surface->content_size();
     if (content_size != params->size)
         observer->content_resized_to(scene_surface.get(), content_size);
+    if (is_active())
+        observer->attrib_changed(scene_surface.get(), mir_window_attrib_focus, 1);
 
     // Send wl_surface.enter events for every output
     // TODO: send enter/leave when the surface actually enters and leaves outputs


### PR DESCRIPTION
Activates a surface immediately if is has a buffer on first commit. Fixes #936. Tested by https://github.com/MirServer/wlcs/pull/160.