### PR TITLE
Stack X11 surfaces correctly on the XWayland server

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -659,6 +659,7 @@ mf::WaylandConnector::WaylandConnector(
     std::shared_ptr<mi::Seat> const& seat,
     std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
     std::shared_ptr<mf::SessionAuthorizer> const& session_authorizer,
+    std::shared_ptr<SurfaceStack> const& surface_stack,
     bool arw_socket,
     std::unique_ptr<WaylandExtensions> extensions_,
     WaylandProtocolExtensionFilter const& extension_filter)
@@ -718,7 +719,12 @@ mf::WaylandConnector::WaylandConnector(
 
     data_device_manager_global = mf::create_data_device_manager(display.get());
 
-    extensions->init(WaylandExtensions::Context{display.get(), shell, seat_global.get(), output_manager.get()});
+    extensions->init(WaylandExtensions::Context{
+        display.get(),
+        shell,
+        seat_global.get(),
+        output_manager.get(),
+        surface_stack});
 
     wl_display_init_shm(display.get());
 

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -66,6 +66,7 @@ class MirDisplay;
 class SessionAuthorizer;
 class DataDeviceManager;
 class WlSurface;
+class SurfaceStack;
 
 class WaylandExtensions
 {
@@ -77,6 +78,7 @@ public:
         std::shared_ptr<shell::Shell> shell;
         WlSeat* seat;
         OutputManager* output_manager;
+        std::shared_ptr<SurfaceStack> surface_stack;
     };
 
     WaylandExtensions() = default;
@@ -111,6 +113,7 @@ public:
         std::shared_ptr<input::Seat> const& seat,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
         std::shared_ptr<SessionAuthorizer> const& session_authorizer,
+        std::shared_ptr<SurfaceStack> const& surface_stack,
         bool arw_socket,
         std::unique_ptr<WaylandExtensions> extensions,
         WaylandProtocolExtensionFilter const& extension_filter);

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -75,7 +75,7 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
 
 ExtensionBuilder const xwayland_builder {
     "x11-support", [](auto const& ctx) -> std::shared_ptr<void>
-        { return std::make_shared<mf::XWaylandWMShell>(ctx.shell, *ctx.seat, ctx.output_manager); }
+        { return std::make_shared<mf::XWaylandWMShell>(ctx.shell, *ctx.seat); }
 };
 
 struct WaylandExtensions : mf::WaylandExtensions

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -75,7 +75,7 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
 
 ExtensionBuilder const xwayland_builder {
     "x11-support", [](auto const& ctx) -> std::shared_ptr<void>
-        { return std::make_shared<mf::XWaylandWMShell>(ctx.shell, *ctx.seat); }
+        { return std::make_shared<mf::XWaylandWMShell>(ctx.shell, *ctx.seat, ctx.surface_stack); }
 };
 
 struct WaylandExtensions : mf::WaylandExtensions
@@ -194,6 +194,7 @@ std::shared_ptr<mf::Connector>
                 the_seat(),
                 the_buffer_allocator(),
                 the_session_authorizer(),
+                the_frontend_surface_stack(),
                 arw_socket,
                 configure_wayland_extensions(
                     wayland_extensions,

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -254,6 +254,11 @@ void mf::XWaylandSurface::close()
         surface_observer = std::experimental::nullopt;
     }
 
+    if (scene_surface)
+    {
+        xwm->forget_scene_surface(scene_surface);
+    }
+
     connection->delete_property(window, connection->net_wm_desktop);
 
     state.withdrawn = true;
@@ -603,6 +608,8 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
         std::lock_guard<std::mutex> lock{mutex};
         weak_scene_surface = surface;
     }
+
+    xwm->remember_scene_surface(surface, window);
 }
 
 void mf::XWaylandSurface::move_resize(uint32_t detail)

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -712,14 +712,6 @@ auto mf::XWaylandSurface::WindowState::updated_from(MirWindowState state) const 
 void mf::XWaylandSurface::scene_surface_focus_set(bool has_focus)
 {
     xwm->set_focus(window, has_focus);
-    // HACK: A window being focused does not necessarily mean it's on top
-    // TODO: plumb through access to the real stacking order
-    connection->configure_window(
-        window,
-        std::experimental::nullopt,
-        std::experimental::nullopt,
-        std::experimental::nullopt,
-        XCB_STACK_MODE_ABOVE);
 }
 
 void mf::XWaylandSurface::scene_surface_state_set(MirWindowState new_state)

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -285,7 +285,67 @@ void mf::XWaylandWM::run_on_wayland_thread(std::function<void()>&& work)
 
 void mf::XWaylandWM::surfaces_reordered(scene::SurfaceSet const& affected_surfaces)
 {
-    (void)affected_surfaces;
+    bool our_surfaces_affected = false;
+
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        for (auto const& surface : affected_surfaces)
+        {
+            if (scene_surfaces.find(surface) != scene_surfaces.end())
+            {
+                our_surfaces_affected = true;
+                break;
+            }
+        }
+    }
+
+    if (our_surfaces_affected)
+    {
+        restack_surfaces();
+    }
+}
+
+void mf::XWaylandWM::restack_surfaces()
+{
+    std::vector<xcb_window_t> new_order;
+
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        auto const new_surface_order = wm_shell->surface_stack->stacking_order_of(scene_surface_set);
+        for (auto const& surface : new_surface_order)
+        {
+            auto const surface_window = scene_surfaces.find(surface);
+            if (surface_window != scene_surfaces.end())
+            {
+                new_order.push_back(surface_window->second);
+            }
+        }
+    }
+
+    xcb_window_t window_below = 0;
+    for (auto const& window : new_order)
+    {
+        if (window_below)
+        {
+            if (verbose_xwayland_logging_enabled())
+            {
+                log_debug(
+                    "Stacking %s on top of %s",
+                    connection->window_debug_string(window).c_str(),
+                    connection->window_debug_string(window_below).c_str());
+            }
+
+            connection->configure_window(
+                window,
+                std::experimental::nullopt,
+                std::experimental::nullopt,
+                window_below,
+                XCB_STACK_MODE_ABOVE);
+        }
+        window_below = window;
+    }
+
+    connection->flush();
 }
 
 /* Events */

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -264,6 +264,20 @@ void mf::XWaylandWM::set_focus(xcb_window_t xcb_window, bool should_be_focused)
     connection->flush();
 }
 
+void mf::XWaylandWM::remember_scene_surface(std::weak_ptr<scene::Surface> const& scene_surface, xcb_window_t window)
+{
+    std::lock_guard<std::mutex> lock{mutex};
+    scene_surfaces.insert(std::make_pair(scene_surface, window));
+    scene_surface_set.insert(scene_surface);
+}
+
+void mf::XWaylandWM::forget_scene_surface(std::weak_ptr<scene::Surface> const& scene_surface)
+{
+    std::lock_guard<std::mutex> lock{mutex};
+    scene_surfaces.erase(scene_surface);
+    scene_surface_set.erase(scene_surface);
+}
+
 void mf::XWaylandWM::run_on_wayland_thread(std::function<void()>&& work)
 {
     wayland_connector->run_on_wayland_display([work = move(work)](auto){ work(); });

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -73,7 +73,7 @@ public:
     void surfaces_reordered(scene::SurfaceSet const& affected_surfaces);
 
 private:
-    void create_window(xcb_window_t id);
+    void restack_surfaces();
 
     // Event handeling
     void handle_events();

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -24,6 +24,7 @@
 #include "xcb_connection.h"
 
 #include <map>
+#include <set>
 #include <thread>
 #include <experimental/optional>
 #include <mutex>
@@ -33,6 +34,10 @@
 
 namespace mir
 {
+namespace scene
+{
+using SurfaceSet = std::set<std::weak_ptr<Surface>, std::owner_less<std::weak_ptr<Surface>>>;
+}
 namespace dispatch
 {
 class ReadableFd;
@@ -44,6 +49,8 @@ namespace frontend
 class XWaylandSurface;
 class XWaylandWMShell;
 class XWaylandCursors;
+
+class XWaylandSceneObserver;
 
 class XWaylandWM
 {
@@ -59,6 +66,8 @@ public:
     auto get_focused_window() -> std::experimental::optional<xcb_window_t>;
     void set_focus(xcb_window_t xcb_window, bool should_be_focused);
     void run_on_wayland_thread(std::function<void()>&& work);
+
+    void surfaces_reordered(scene::SurfaceSet const& affected_surfaces);
 
 private:
     void create_window(xcb_window_t id);
@@ -89,6 +98,7 @@ private:
     xcb_window_t const wm_window;
     std::shared_ptr<dispatch::ReadableFd> const wm_dispatcher;
     std::unique_ptr<dispatch::ThreadedDispatcher> const event_thread;
+    std::shared_ptr<XWaylandSceneObserver> const scene_observer;
 
     std::mutex mutex;
     std::map<xcb_window_t, std::shared_ptr<XWaylandSurface>> surfaces;

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -37,6 +37,7 @@ namespace mir
 namespace scene
 {
 using SurfaceSet = std::set<std::weak_ptr<Surface>, std::owner_less<std::weak_ptr<Surface>>>;
+class Surface;
 }
 namespace dispatch
 {
@@ -65,6 +66,8 @@ public:
     auto get_wm_surface(xcb_window_t xcb_window) -> std::experimental::optional<std::shared_ptr<XWaylandSurface>>;
     auto get_focused_window() -> std::experimental::optional<xcb_window_t>;
     void set_focus(xcb_window_t xcb_window, bool should_be_focused);
+    void remember_scene_surface(std::weak_ptr<scene::Surface> const& scene_surface, xcb_window_t window);
+    void forget_scene_surface(std::weak_ptr<scene::Surface> const& scene_surface);
     void run_on_wayland_thread(std::function<void()>&& work);
 
     void surfaces_reordered(scene::SurfaceSet const& affected_surfaces);
@@ -102,6 +105,12 @@ private:
 
     std::mutex mutex;
     std::map<xcb_window_t, std::shared_ptr<XWaylandSurface>> surfaces;
+    std::map<std::weak_ptr<
+        scene::Surface>,
+        xcb_window_t,
+        std::owner_less<std::weak_ptr<scene::Surface>>> scene_surfaces;
+    /// Could be regenerated from scene_surfaces at any time, but more efficient to keep this up to date
+    std::set<std::weak_ptr<scene::Surface>, std::owner_less<std::weak_ptr<scene::Surface>>> scene_surface_set;
     std::experimental::optional<xcb_window_t> focused_window;
 };
 } /* frontend */

--- a/src/server/frontend_xwayland/xwayland_wm_shell.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_shell.cpp
@@ -30,10 +30,8 @@ namespace msh = mir::shell;
 
 mf::XWaylandWMShell::XWaylandWMShell(
     std::shared_ptr<msh::Shell> const& shell,
-    mf::WlSeat& seat,
-    OutputManager* const output_manager)
+    mf::WlSeat& seat)
     : shell{shell},
-      seat{seat},
-      output_manager{output_manager}
+      seat{seat}
 {
 }

--- a/src/server/frontend_xwayland/xwayland_wm_shell.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm_shell.cpp
@@ -18,20 +18,4 @@
 
 #include "xwayland_wm_shell.h"
 
-#include "mir/log.h"
-
-#include "mir/frontend/shell.h"
-#include "wl_seat.h"
-#include "wl_surface.h"
-
 namespace mf = mir::frontend;
-namespace ms = mir::scene;
-namespace msh = mir::shell;
-
-mf::XWaylandWMShell::XWaylandWMShell(
-    std::shared_ptr<msh::Shell> const& shell,
-    mf::WlSeat& seat)
-    : shell{shell},
-      seat{seat}
-{
-}

--- a/src/server/frontend_xwayland/xwayland_wm_shell.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shell.h
@@ -39,12 +39,10 @@ class XWaylandWMShell
 public:
     XWaylandWMShell(
         std::shared_ptr<shell::Shell> const& shell,
-        WlSeat& seat,
-        OutputManager* const output_manager);
+        WlSeat& seat);
 
     std::shared_ptr<shell::Shell> const shell;
     WlSeat& seat;
-    OutputManager* const output_manager;
 };
 
 } /* frontend*/

--- a/src/server/frontend_xwayland/xwayland_wm_shell.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shell.h
@@ -30,6 +30,7 @@ class Shell;
 namespace frontend
 {
 class OutputManager;
+class SurfaceStack;
 class WlSeat;
 class WlSurface;
 class XWaylandSurface;
@@ -39,10 +40,17 @@ class XWaylandWMShell
 public:
     XWaylandWMShell(
         std::shared_ptr<shell::Shell> const& shell,
-        WlSeat& seat);
+        WlSeat& seat,
+        std::shared_ptr<SurfaceStack> const& surface_stack)
+        : shell{shell},
+          seat{seat},
+          surface_stack{surface_stack}
+    {
+    }
 
     std::shared_ptr<shell::Shell> const shell;
     WlSeat& seat;
+    std::shared_ptr<SurfaceStack> const surface_stack;
 };
 
 } /* frontend*/


### PR DESCRIPTION
If the XWayland server is not told the correct surface stacking order, the desktop will look correct but input will go to the wrong surfaces. Our current solution is to raise a surface when it gains focus, but this is  a bug waiting to happen when someone uses X apps on a desktop that, for example, has focus follow pointer.

To get the correct stacking order we need to plumb the `frontend::SurfaceStack` all the way through to the XWayland window manager, so it can add a scene observer. The wm also has to maintain a map of scene surfaces to XCB windows, and methods are added to allow XWayland surfaces to update that mapping when scene surfaces are created or destroyed. A set of scene surfaces is also added, which is not strictly necessary but prevents us from having to build and destroy it every time we want to call `surface_stack->stacking_order_of()`