### PR TITLE
mesa-kms: Handle EOPNOTSUPP from drmModeGetResources.

### DIFF
--- a/src/platforms/mesa/server/kms/display.cpp
+++ b/src/platforms/mesa/server/kms/display.cpp
@@ -142,21 +142,30 @@ void log_drm_details(std::vector<std::shared_ptr<mgm::helpers::DRMHelper>> const
             version->version_patchlevel,
             version->date);
 
-        mg::kms::DRMModeResources resources{device->fd};
-        for (auto const& connector : resources.connectors())
+        try
         {
-            mir::log_info(
-                "\tOutput: %s (%s)",
-                mg::kms::connector_name(connector).c_str(),
-                describe_connection_status(*connector));
-            for (auto i = 0; i < connector->count_modes; ++i)
+            mg::kms::DRMModeResources resources{device->fd};
+            for (auto const& connector : resources.connectors())
             {
                 mir::log_info(
-                    "\t\tMode: %i×%i@%.2f",
-                    connector->modes[i].hdisplay,
-                    connector->modes[i].vdisplay,
-                    calculate_vrefresh_hz(connector->modes[i]));
+                    "\tOutput: %s (%s)",
+                    mg::kms::connector_name(connector).c_str(),
+                    describe_connection_status(*connector));
+                for (auto i = 0; i < connector->count_modes; ++i)
+                {
+                    mir::log_info(
+                        "\t\tMode: %i×%i@%.2f",
+                        connector->modes[i].hdisplay,
+                        connector->modes[i].vdisplay,
+                        calculate_vrefresh_hz(connector->modes[i]));
+                }
             }
+        }
+        catch (std::exception const& error)
+        {
+            mir::log_info(
+                "\tKMS not supported (%s)",
+                error.what());
         }
     }
 }


### PR DESCRIPTION
DRM will return `EOPNOTSUPP` when attempting to access the KMS APIs on a device
node which does not support KMS.

We can hit this if `drmCheckModesettingSupported` is inconclusve (because, for example,
we're on an ARM device where the GPU has no PCI address).

This is the case on the Raspberry Pi 4. `drmCheckModesettingSupported` is inconclusive,
because of course it is, but the V3D DRM node does not support modesetting.