### PR TITLE
More XWayland cleanup

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -187,21 +187,6 @@ mf::XCBConnection::~XCBConnection()
     xcb_disconnect(xcb_connection);
 }
 
-mf::XCBConnection::operator xcb_connection_t*() const
-{
-    return xcb_connection;
-}
-
-auto mf::XCBConnection::screen() const -> xcb_screen_t*
-{
-    return xcb_screen;
-}
-
-auto mf::XCBConnection::root_window() const -> xcb_window_t
-{
-    return xcb_screen->root;
-}
-
 auto mf::XCBConnection::query_name(xcb_atom_t atom) const -> std::string
 {
     std::lock_guard<std::mutex>{atom_name_cache_mutex};

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -94,9 +94,9 @@ public:
     explicit XCBConnection(Fd const& fd);
     ~XCBConnection();
 
-    operator xcb_connection_t*() const;
-    auto screen() const -> xcb_screen_t*;
-    auto root_window() const -> xcb_window_t;
+    operator xcb_connection_t*() const { return xcb_connection; }
+    auto screen() const -> xcb_screen_t* { return xcb_screen; }
+    auto root_window() const -> xcb_window_t { return xcb_screen->root; }
 
     /// Looks up an atom's name, or requests it from the X server if it is not already cached
     auto query_name(xcb_atom_t atom) const -> std::string;

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -98,6 +98,18 @@ void check_xfixes(mf::XCBConnection const& connection)
 
     free(xfixes_reply);
 }
+
+auto focus_mode_to_string(uint32_t focus_mode) -> std::string
+{
+    switch (focus_mode)
+    {
+    case XCB_NOTIFY_MODE_NORMAL:        return "normal focus";
+    case XCB_NOTIFY_MODE_GRAB:          return "focus grabbed";
+    case XCB_NOTIFY_MODE_UNGRAB:        return "focus ungrabbed";
+    case XCB_NOTIFY_MODE_WHILE_GRABBED: return "focus while grabbed";
+    }
+    return "unknown focus mode " + std::to_string(focus_mode);
+}
 }
 
 class mf::XWaylandSceneObserver
@@ -764,16 +776,10 @@ void mf::XWaylandWM::handle_focus_in(xcb_focus_in_event_t* event)
 {
     if (verbose_xwayland_logging_enabled())
     {
-        std::string mode_str;
-        switch (event->mode)
-        {
-        case XCB_NOTIFY_MODE_NORMAL:        mode_str = "normal focus"; break;
-        case XCB_NOTIFY_MODE_GRAB:          mode_str = "focus grabbed"; break;
-        case XCB_NOTIFY_MODE_UNGRAB:        mode_str = "focus ungrabbed"; break;
-        case XCB_NOTIFY_MODE_WHILE_GRABBED: mode_str = "focus while grabbed"; break;
-        default: mode_str = "unknown focus mode " + std::to_string(event->mode); break;
-        }
-        log_debug("XCB_FOCUS_IN %s on %s", mode_str.c_str(), connection->window_debug_string(event->event).c_str());
+        log_debug(
+            "XCB_FOCUS_IN %s on %s",
+            focus_mode_to_string(event->mode).c_str(),
+            connection->window_debug_string(event->event).c_str());
     }
 
     // Ignore grabs

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -201,6 +201,9 @@ mf::XWaylandWM::~XWaylandWM()
     if (verbose_xwayland_logging_enabled())
         log_debug("...done closing surfaces");
 
+    xcb_destroy_window(*connection, wm_window);
+    connection->flush();
+
     dispatcher->remove_watch(wm_dispatcher);
 }
 

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -43,7 +43,6 @@ namespace dispatch
 {
 class ReadableFd;
 class ThreadedDispatcher;
-class MultiplexingDispatchable;
 }
 namespace frontend
 {
@@ -94,7 +93,6 @@ private:
     void handle_focus_in(xcb_focus_in_event_t* event);
 
     std::shared_ptr<WaylandConnector> const wayland_connector;
-    std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
     wl_client* const wayland_client;
     std::shared_ptr<XWaylandWMShell> const wm_shell;
     std::unique_ptr<XWaylandCursors> const cursors;


### PR DESCRIPTION
Please note that I remove a `MultiplexingDispatchable` that we don't appear to need. If there is any purpose for the indirection, let me know.