### PR TITLE
mir_demo_client_wayland_egl_spinner: Return a value from main()

### DIFF
--- a/examples/client/spinner.cpp
+++ b/examples/client/spinner.cpp
@@ -41,4 +41,6 @@ int main()
     spinner(display);
 
     wl_display_disconnect(display);
+
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
For some reason nothing complained that we didn't have a `return` statement
in a function declared as returning an int?!