### PR TITLE
mir-smoke-test-runner: Start with Mir's eglinfo

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -231,7 +231,8 @@ Recommends: mir-demos,
             xwayland,
             glmark2-es2,
             glmark2-es2-mir,
-            glmark2-es2-wayland
+            glmark2-es2-wayland,
+            mesa-utils-extra,
 Description: Display Server for Ubuntu - stress tests and other test tools
  Mir is a display server running on linux systems, with a focus on efficiency,
  robust operation and a well-defined driver model.

--- a/tools/mir-smoke-test-runner.sh
+++ b/tools/mir-smoke-test-runner.sh
@@ -24,6 +24,13 @@ echo "I: client_list=" ${client_list}
 
 ### Run Tests ###
 
+# Start with eglinfo for the system
+echo Running eglinfo client
+date --utc --iso-8601=seconds | xargs echo "[timestamp] Start :" ${client}
+echo MIR_SERVER_ENABLE_MIRCLIENT= WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client eglinfo
+MIR_SERVER_ENABLE_MIRCLIENT= WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client eglinfo
+date --utc --iso-8601=seconds | xargs echo "[timestamp] End :" ${client}
+
 for client in ${client_list}; do
     echo running client ${client}
     date --utc --iso-8601=seconds | xargs echo "[timestamp] Start :" ${client}


### PR DESCRIPTION
For the moment we don't use the return value to PASS/FAIL the test, as
eglinfo doesn't support selecting the platform to test.

There's an upstream branch which supports dumping the info for a specific
platform; should that land we can then gate on the Wayland and X11 EGL
platforms being supported.

Even before that, the output can be helpful for understanding the rest of
the mir-smoke-test-runner output.