### PR TITLE
Tests: Make LTTNG fork()-safe

### DIFF
--- a/cmake/MirCommon.cmake
+++ b/cmake/MirCommon.cmake
@@ -98,6 +98,10 @@ function (mir_discover_tests_internal EXECUTABLE TEST_ENV_OPTIONS DETECT_FD_LEAK
       set(test_exclusion_filter "${test_exclusion_filter}:AnonymousShmFile.*:MesaBufferAllocatorTest.software_buffers_dont_bypass:MesaBufferAllocatorTest.creates_software_rendering_buffer")
   endif()
 
+  # liblttng-ust is unsafe if you fork() without exec(), such as we do in the test suite
+  # We need to load liblttng-ust-fork.so to make this work reliably.
+  list(APPEND test_env "LD_PRELOAD=liblttng-ust-fork.so")
+
   # Final commands
   set(test_cmd "${test_cmd}" "--gtest_filter=-${test_no_memcheck_filter}:${test_exclusion_filter}")
   set(test_cmd_no_memcheck "${test_cmd_no_memcheck}" "--gtest_death_test_style=threadsafe" "--gtest_filter=${test_no_memcheck_filter}:-${test_exclusion_filter}")

--- a/tests/unit-tests/graphics/test_display_configuration.cpp
+++ b/tests/unit-tests/graphics/test_display_configuration.cpp
@@ -19,6 +19,7 @@
 #include "mir/graphics/display_configuration.h"
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 namespace mg = mir::graphics;
 namespace geom = mir::geometry;


### PR DESCRIPTION
[LTTNG documentation](https://lttng.org/man/3/lttng-ust/v2.12/#doc-_using_lttng_ust_with_daemons) makes it clear that using `fork()` without `exec()` in applications linked to `liblttng-ust` is unsafe unless you preload `liblttng-ust-fork.so`. Do so! (Fixes #1405)

This fixes a test failure where running `ThreadedDispatcherSignalTest` immediately after the `Logind` tests would fail.