### PR TITLE
cmake: Handle tests which also set LD_PRELOAD in their environment.

### DIFF
--- a/cmake/MirCommon.cmake
+++ b/cmake/MirCommon.cmake
@@ -125,7 +125,7 @@ function (mir_discover_tests_internal EXECUTABLE TEST_ENV_OPTIONS DETECT_FD_LEAK
     endforeach()
 
     # Now construct a single LD_PRELOAD=first:second:…:last string
-    list(JOIN preload_values ":" coalesced_values)
+    string(REPLACE ";" ":" coalesced_values "${preload_values}")
     set(coalesced_preload "LD_PRELOAD=${coalesced_values}")
 
     # Add the LD_PRELOAD=… to the end of the non-LD_PRELOAD list…

--- a/cmake/MirCommon.cmake
+++ b/cmake/MirCommon.cmake
@@ -170,10 +170,6 @@ function (mir_discover_tests_with_fd_leak_detection EXECUTABLE)
   mir_discover_tests_internal(${EXECUTABLE} "" TRUE ${ARGN})
 endfunction()
 
-function (mir_discover_tests_with_fd_leak_detection_and_env EXECUTABLE TEST_ENV_OPTION)
-  mir_discover_tests_internal(${EXECUTABLE} ${TEST_ENV_OPTION} TRUE ${ARGN})
-endfunction()
-
 function (mir_discover_external_gtests)
   set(one_value_args NAME WORKING_DIRECTORY)
   set(multi_value_args COMMAND EXCLUDE_FILTER)

--- a/tools/discover_gtests.sh
+++ b/tools/discover_gtests.sh
@@ -23,7 +23,7 @@ print_help_and_exit()
 
 add_env()
 {
-    env="$env \"$1\""
+    env="$env ENVIRONMENT \"$1\""
 }
 
 add_cmd()
@@ -76,5 +76,5 @@ tests=$($test_binary --gtest_list_tests $filter | grep -v '^ ' | cut -d' ' -f1 |
 for t in $tests;
 do
     echo "add_test($testname.$t $cmd \"--gtest_filter=$t\")"
-    echo "set_tests_properties($testname.$t PROPERTIES ENVIRONMENT $env)"
+    echo "set_tests_properties($testname.$t PROPERTIES $env)"
 done


### PR DESCRIPTION
The umockdev tests work by LD_PRELOADing libumockdev-preload.so.0. Unfortunately, the
LD_PRELOAD of liblttng-ust-fork.so overrides this, causing the tests to fail.

Instead coalesce all the LD_PRELOADs in the environment into a single call, so
both libumockdev-preload.so.0 and liblttng-ust-fork.so get loaded.