### PR TITLE
A few minor test cleanups

### DIFF
--- a/tests/mir_test_framework/process.cpp
+++ b/tests/mir_test_framework/process.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "mir_test_framework/process.h"
+#include "mir/log.h"
 
 #include <errno.h>
 #include <signal.h>
@@ -95,9 +96,13 @@ mtf::Process::~Process()
             terminate();
             wait_for_termination();
         }
-        catch (std::exception const &)
+        catch (std::exception const&)
         {
-            // Ignore a failure to signal the process.
+            mir::log(
+                mir::logging::Severity::error,
+               "mir_test_framework",
+               std::current_exception(),
+               "Failed to signal process");
         }
     }
 }

--- a/tests/unit-tests/console/test_logind_console_services.cpp
+++ b/tests/unit-tests/console/test_logind_console_services.cpp
@@ -1193,6 +1193,7 @@ TEST_F(LogindConsoleServices, device_activated_callback_called_on_activate)
     add_take_device_to_session(
         session_path.c_str(),
         "ret = (os.open('/dev/zero', os.O_RDONLY), True)");
+    add_release_device_to_session(session_path.c_str());
 
     mir::LogindConsoleServices services{the_main_loop()};
 
@@ -1245,6 +1246,8 @@ TEST_F(LogindConsoleServices, device_suspended_callback_called_on_suspend)
     add_take_device_to_session(
         session_path.c_str(),
         "ret = (os.open('/dev/zero', os.O_RDONLY), False)");
+    add_release_device_to_session(session_path.c_str());
+    add_pause_device_complete_to_session(session_path.c_str());
 
     mir::LogindConsoleServices services{the_main_loop()};
 
@@ -1284,6 +1287,7 @@ TEST_F(LogindConsoleServices, acks_device_suspend_signal)
         session_path.c_str(),
         "ret = (os.open('/dev/zero', os.O_RDONLY), False)");
     add_pause_device_complete_to_session(session_path.c_str());
+    add_release_device_to_session(session_path.c_str());
 
     mir::LogindConsoleServices services{the_main_loop()};
 
@@ -1322,6 +1326,7 @@ TEST_F(LogindConsoleServices, handles_ack_device_suspend_failure)
     add_pause_device_complete_to_session(
         session_path.c_str(),
         "raise dbus.exceptions.DBusException('Device or resource busy (36)', name='System.Error.EBUSY')");
+    add_release_device_to_session(session_path.c_str());
 
     mir::LogindConsoleServices services{the_main_loop()};
 
@@ -1624,6 +1629,7 @@ TEST_F(LogindConsoleServices, can_acquire_device_without_running_main_loop)
     add_take_device_to_session(
         session_path.c_str(),
         "ret = (os.open('/dev/zero', os.O_RDONLY), False)");
+    add_release_device_to_session(session_path.c_str());
 
     auto not_running_main_loop =
         std::make_shared<mir::GLibMainLoop>(std::make_shared<mir::time::SteadyClock>());


### PR DESCRIPTION
 * Log when mtf::Process fails to terminate the process, rather than silently leave a process hanging around
 * Capture `dbusmock`'s stderr in `LogindConsoleServices` tests
 * Provide a more complete mock environment in some `LogindConsoleServices` tests so the code doesn't needlessly spew errors to the log