### PR TITLE
Fix performance tests

### DIFF
--- a/src/server/frontend_xwayland/xwayland_default_configuration.cpp
+++ b/src/server/frontend_xwayland/xwayland_default_configuration.cpp
@@ -71,9 +71,9 @@ std::shared_ptr<mf::Connector> mir::DefaultServerConfiguration::the_xwayland_con
                     wayland_connector,
                     options->get<std::string>("xwayland-path"));
             }
-            catch (...)
+            catch (std::exception& x)
             {
-                mir::fatal_error("Invalid x11 display value provided, must be number only!");
+                mir::fatal_error("Failed to start XWaylandConnector: %s", x.what());
             }
         }
 

--- a/tests/performance-tests/test_glmark2-es2-mir.cpp
+++ b/tests/performance-tests/test_glmark2-es2-mir.cpp
@@ -17,6 +17,7 @@
 #include "mir_test_framework/async_server_runner.h"
 #include "mir/test/popen.h"
 #include <mir_test_framework/executable_path.h>
+#include <miral/x11_support.h>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -96,10 +97,19 @@ struct AbstractGLMark2Test : testing::Test, mtf::AsyncServerRunner {
 
 struct GLMark2Xwayland : AbstractGLMark2Test
 {
+    GLMark2Xwayland()
+    {
+        // This is a slightly awkward method of enabling X11 support,
+        // but refactoring these tests to use MirAL can wait.
+        miral::X11Support{}(server);
+        add_to_environment("MIR_SERVER_ENABLE_X11", "1");
+    }
+
     char const* command() override
     {
-        static auto command = mir_test_framework::executable_path() + "/miral-xrun -Xwayland glmark2-es2";
-        return command.c_str();
+        add_to_environment("DISPLAY", server.x11_display().value().c_str());
+        static char const* const command = "glmark2-es2-wayland";
+        return command;
     }
 };
 

--- a/tests/performance-tests/test_glmark2-es2-mir.cpp
+++ b/tests/performance-tests/test_glmark2-es2-mir.cpp
@@ -50,10 +50,7 @@ struct AbstractGLMark2Test : testing::Test, mtf::AsyncServerRunner {
     int run_glmark2(char const *args) {
         ResultFileType file_type = raw; // Should this still be selectable?
 
-        auto const cmd = "MIR_SOCKET=" + new_connection() + " "
-                         + command()
-                         + " -b build "
-                         + args;
+        auto const cmd = std::string{} + command() + " -b build " + args;
         mir::test::Popen p(cmd);
 
         const ::testing::TestInfo *const test_info =


### PR DESCRIPTION
Fix performance tests.

Drop MIR_SOCKET legacy, use integrated X11 support 