### PR TITLE
XWaylandWM::handle_events(): make sure there is no XCB error

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -187,6 +187,14 @@ mf::XCBConnection::~XCBConnection()
     xcb_disconnect(xcb_connection);
 }
 
+void mf::XCBConnection::verify_not_in_error_state() const
+{
+    if (auto const error = xcb_connection_has_error(xcb_connection))
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("XCB connection shut down: " + xcb_error_to_string(error)));
+    }
+}
+
 auto mf::XCBConnection::query_name(xcb_atom_t atom) const -> std::string
 {
     std::lock_guard<std::mutex>{atom_name_cache_mutex};

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -94,6 +94,9 @@ public:
     explicit XCBConnection(Fd const& fd);
     ~XCBConnection();
 
+    /// Throws if the connection has been shut down
+    void verify_not_in_error_state() const;
+
     operator xcb_connection_t*() const { return xcb_connection; }
     auto screen() const -> xcb_screen_t* { return xcb_screen; }
     auto root_window() const -> xcb_window_t { return xcb_screen->root; }

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -362,6 +362,8 @@ void mf::XWaylandWM::handle_events()
 {
     bool got_events = false;
 
+    connection->verify_not_in_error_state();
+
     while (xcb_generic_event_t* const event = xcb_poll_for_event(*connection))
     {
         try


### PR DESCRIPTION
Handling fatal XCB errors is trickier because we don't have the infrastructure to stop the X server. Both the current code and this PR will result in fatal Mir errors, but at least here the problem is made obvious.