### PR TITLE
Simplify adding and removing subsurfaces

### DIFF
--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -74,18 +74,21 @@ void mf::WlSubcompositorInstance::get_subsurface(
 mf::WlSubsurface::WlSubsurface(wl_resource* new_subsurface, WlSurface* surface, WlSurface* parent_surface)
     : wayland::Subsurface(new_subsurface, Version<1>()),
       surface{surface},
-      parent{parent_surface->add_child(this)},
+      parent{parent_surface},
       parent_destroyed{parent_surface->destroyed_flag()},
       synchronized_{true}
 {
+    parent->add_subsurface(this);
     surface->set_role(this);
     surface->pending_invalidate_surface_data();
 }
 
 mf::WlSubsurface::~WlSubsurface()
 {
-    // unique pointer automatically removes `this` from parent child list
-
+    if (!*parent_destroyed)
+    {
+        parent->remove_subsurface(this);
+    }
     surface->clear_role();
     refresh_surface_data_now();
 }

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -79,8 +79,7 @@ private:
     virtual void commit(WlSurfaceState const& state) override;
 
     WlSurface* const surface;
-    // manages parent/child relationship, but does not manage parent's memory
-    // see WlSurface::add_child() for details
+    /// This class is responsible for removing itself from the parent's children list when needed
     std::unique_ptr<WlSurface, std::function<void(WlSurface*)>> const parent;
     std::shared_ptr<bool> const parent_destroyed;
     bool synchronized_;

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -164,22 +164,25 @@ void mf::WlSurface::set_pending_offset(std::experimental::optional<geom::Displac
     pending.offset = offset;
 }
 
-std::unique_ptr<mf::WlSurface, std::function<void(mf::WlSurface*)>> mf::WlSurface::add_child(WlSubsurface* child)
+void mf::WlSurface::add_subsurface(WlSubsurface* child)
 {
-    children.push_back(child);
+    if (std::find(children.begin(), children.end(), child) != children.end())
+    {
+        log_warning("Subsurface %p added to surface %p multiple times", child, this);
+        return;
+    }
 
-    return std::unique_ptr<WlSurface, std::function<void(WlSurface*)>>(
-        this,
-        [child=child, destroyed=destroyed](WlSurface* self)
-        {
-            if (*destroyed)
-                return;
-            // remove the child from the vector
-            self->children.erase(std::remove(self->children.begin(),
-                                             self->children.end(),
-                                             child),
-                                 self->children.end());
-        });
+    children.push_back(child);
+}
+
+void mf::WlSurface::remove_subsurface(WlSubsurface* child)
+{
+    children.erase(
+        std::remove(
+            children.begin(),
+            children.end(),
+            child),
+        children.end());
 }
 
 void mf::WlSurface::refresh_surface_data_now()

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -127,7 +127,8 @@ public:
     void set_role(WlSurfaceRole* role_);
     void clear_role();
     void set_pending_offset(std::experimental::optional<geometry::Displacement> const& offset);
-    std::unique_ptr<WlSurface, std::function<void(WlSurface*)>> add_child(WlSubsurface* child);
+    void add_subsurface(WlSubsurface* child);
+    void remove_subsurface(WlSubsurface* child);
     void refresh_surface_data_now();
     void pending_invalidate_surface_data() { pending.invalidate_surface_data(); }
     void populate_surface_data(std::vector<shell::StreamSpecification>& buffer_streams,


### PR DESCRIPTION
The only time we ever want to add a subsurface is in the subsurface constructor and the only time we remove one is in the subsurface destructor. For this reason, the fancy custom unique pointer "solution" is over-engineering.