### PR TITLE
Add wayland::Handle (.with() interface)

### DIFF
--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -19,6 +19,8 @@
 #ifndef MIR_WAYLAND_OBJECT_H_
 #define MIR_WAYLAND_OBJECT_H_
 
+#include <memory>
+
 struct wl_resource;
 struct wl_global;
 struct wl_client;
@@ -37,10 +39,15 @@ public:
     };
 
     Resource();
-    virtual ~Resource() = default;
+    ~Resource();
 
     Resource(Resource const&) = delete;
     Resource& operator=(Resource const&) = delete;
+
+    auto destroyed_flag() const -> std::shared_ptr<bool>;
+
+private:
+    std::shared_ptr<bool> mutable destroyed;
 };
 
 class Global

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -58,8 +58,8 @@ public:
                                std::vector<mir::geometry::Rectangle>& input_shape_accumulator,
                                geometry::Displacement const& parent_offset) const;
 
-    geometry::Displacement total_offset() const override { return parent->total_offset(); }
-    bool synchronized() const override;
+    auto total_offset() const -> geometry::Displacement override;
+    auto synchronized() const -> bool override;
     auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
 
     void parent_has_committed();
@@ -80,8 +80,7 @@ private:
 
     WlSurface* const surface;
     /// This class is responsible for removing itself from the parent's children list when needed
-    WlSurface* const parent;
-    std::shared_ptr<bool> const parent_destroyed;
+    wayland::Handle<WlSurface> const parent;
     bool synchronized_;
     std::experimental::optional<WlSurfaceState> cached_state;
 };

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -341,14 +341,15 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
         }
         else
         {
-            auto const executor_send_frame_callbacks = [this, executor = executor, destroyed = destroyed_flag()]()
+            auto const executor_send_frame_callbacks = [executor = executor, handle = mw::make_handle(this)]()
                 {
-                    executor->spawn(run_unless(
-                        destroyed,
-                        [this]()
+                    executor->spawn([handle]()
                         {
-                            send_frame_callbacks();
-                        }));
+                            handle.with([](auto self)
+                                {
+                                    self->send_frame_callbacks();
+                                });
+                        });
                 };
 
             std::shared_ptr<graphics::Buffer> mir_buffer;

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -115,7 +115,6 @@ public:
 
     ~WlSurface();
 
-    std::shared_ptr<bool> destroyed_flag() const { return destroyed; }
     geometry::Displacement offset() const { return offset_; }
     geometry::Displacement total_offset() const { return offset_ + role->total_offset(); }
     std::experimental::optional<geometry::Size> buffer_size() const { return buffer_size_; }
@@ -157,7 +156,6 @@ private:
     std::vector<std::shared_ptr<WlSurfaceState::Callback>> frame_callbacks;
     std::experimental::optional<std::vector<mir::geometry::Rectangle>> input_shape;
     std::map<void const*, std::function<void()>> destroy_listeners;
-    std::shared_ptr<bool> const destroyed;
 
     void send_frame_callbacks();
 

--- a/src/wayland/wayland_base.cpp
+++ b/src/wayland/wayland_base.cpp
@@ -25,7 +25,25 @@
 namespace mw = mir::wayland;
 
 mw::Resource::Resource()
+    : destroyed{nullptr}
 {
+}
+
+mw::Resource::~Resource()
+{
+    if (destroyed)
+    {
+        *destroyed = true;
+    }
+}
+
+auto mw::Resource::destroyed_flag() const -> std::shared_ptr<bool>
+{
+    if (!destroyed)
+    {
+        destroyed = std::make_shared<bool>(false);
+    }
+    return destroyed;
 }
 
 mw::Global::Global(wl_global* global)


### PR DESCRIPTION
Stacked on #1512 

Alternative to #1514 

Makes the destroyed flag part of `wayland::Resource` and adds a `wayland::Handle` class which uses it to allow objects to hold a weak handle to a Wayland object.

`std::shared_ptr<bool>`s are kept around so that `wayland::Resource` can manage them. If instead they were replaced by some sort of strongly typed pointer, the implementation would be messier and every derived class would need to be modified. With this system, new code should only use the destroyed flag indirectly via `wayland::Handle`.

This PR has one of two possible interfaces for `wayland::Handle`. This one has `.with()` and `.with_opt()` methods to access the underlying class. The other has an optional-like interface. I think the other is cleaner than this one, but I'm not going to put up a fight either way.

[this commit](https://github.com/MirServer/mir/pull/1514/commits/55527a84cf031a79c5dcab22c41fb804e2d5e85f) shows the difference between the two interfaces.