### PR TITLE
Make WaylandInputDispatcher only take input events (fixes #1047)

### DIFF
--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -70,27 +70,13 @@ void mf::WaylandInputDispatcher::set_focus(bool has_focus)
         });
 }
 
-void mf::WaylandInputDispatcher::handle_event(MirEvent const* event)
-{
-    if (*wl_surface_destroyed)
-        return;
-
-    if (mir_event_get_type(event) != mir_event_type_input)
-    {
-        log_warning(
-            "WaylandInputDispatcher::input_consumed() got non-input event type %d",
-            mir_event_get_type(event));
-        return;
-    }
-
-    auto const input_ev = mir_event_get_input_event(event);
-    handle_input_event(input_ev);
-}
-
-void mf::WaylandInputDispatcher::handle_input_event(MirInputEvent const* event)
+void mf::WaylandInputDispatcher::handle_event(MirInputEvent const* event)
 {
     auto const ns = std::chrono::nanoseconds{mir_input_event_get_event_time(event)};
     auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(ns);
+
+    if (*wl_surface_destroyed)
+        return;
 
     // Remember the timestamp of any events "signed" with a cookie
     if (mir_input_event_has_cookie(event))

--- a/src/server/frontend_wayland/wayland_input_dispatcher.h
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.h
@@ -52,7 +52,7 @@ public:
 
     void set_keymap(input::Keymap const& keymap);
     void set_focus(bool has_focus);
-    void handle_event(MirEvent const* event);
+    void handle_event(MirInputEvent const* event);
 
     auto latest_timestamp() const -> std::chrono::nanoseconds { return timestamp; }
 
@@ -71,7 +71,6 @@ private:
 
     /// Handle user input events
     ///@{
-    void handle_input_event(MirInputEvent const* event);
     void handle_keyboard_event(std::chrono::milliseconds const& ms, MirKeyboardEvent const* event);
     void handle_pointer_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
     void handle_pointer_button_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);

--- a/src/server/frontend_wayland/wayland_surface_observer.cpp
+++ b/src/server/frontend_wayland/wayland_surface_observer.cpp
@@ -128,13 +128,17 @@ void mf::WaylandSurfaceObserver::placed_relative(ms::Surface const*, geometry::R
 
 void mf::WaylandSurfaceObserver::input_consumed(ms::Surface const*, MirEvent const* event)
 {
-    std::shared_ptr<MirEvent> owned_event = mev::clone_event(*event);
+    if (mir_event_get_type(event) == mir_event_type_input)
+    {
+        std::shared_ptr<MirEvent> owned_event = mev::clone_event(*event);
 
-    run_on_wayland_thread_unless_destroyed(
-        [this, owned_event]()
-        {
-            input_dispatcher->handle_event(owned_event.get());
-        });
+        run_on_wayland_thread_unless_destroyed(
+            [this, owned_event]()
+            {
+                auto const input_event = mir_event_get_input_event(owned_event.get());
+                input_dispatcher->handle_event(input_event);
+            });
+    }
 }
 
 auto mf::WaylandSurfaceObserver::latest_timestamp() const -> std::chrono::nanoseconds

--- a/src/server/frontend_xwayland/xwayland_surface_observer.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.cpp
@@ -111,13 +111,17 @@ void mf::XWaylandSurfaceObserver::keymap_changed(
 
 void mf::XWaylandSurfaceObserver::input_consumed(ms::Surface const*, MirEvent const* event)
 {
-    std::shared_ptr<MirEvent> owned_event = mev::clone_event(*event);
+    if (mir_event_get_type(event) == mir_event_type_input)
+    {
+        std::shared_ptr<MirEvent> owned_event = mev::clone_event(*event);
 
-    aquire_input_dispatcher(
-        [owned_event](auto input_dispatcher)
-        {
-            input_dispatcher->handle_event(owned_event.get());
-        });
+        aquire_input_dispatcher(
+            [owned_event](auto input_dispatcher)
+            {
+                auto const input_event = mir_event_get_input_event(owned_event.get());
+                input_dispatcher->handle_event(input_event);
+            });
+    }
 }
 
 auto mf::XWaylandSurfaceObserver::latest_timestamp() const -> std::chrono::nanoseconds


### PR DESCRIPTION
Finally got around to fixing the useless `non-input event type 11` warnings