### PR TITLE
(when verbose logging) warn on X11 errors

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -535,6 +535,48 @@ auto mf::XCBConnection::window_debug_string(xcb_window_t window) const -> std::s
         return "window " + number_to_readable_name(window);
 }
 
+auto mf::XCBConnection::error_debug_string(xcb_generic_error_t* error) const -> std::string
+{
+    std::string result;
+
+    switch (error->error_code)
+    {
+    case XCB_REQUEST:
+        result = "not a valid request";
+        break;
+
+    case XCB_VALUE:
+    {
+        auto const value_error{reinterpret_cast<xcb_value_error_t*>(error)};
+        result += std::to_string(value_error->bad_value) + " is an invalid value";
+        break;
+    }
+
+    case XCB_WINDOW:
+    {
+        auto const window_error{reinterpret_cast<xcb_window_error_t*>(error)};
+        result +=
+            window_debug_string(window_error->bad_value) +
+            " (ID " + std::to_string(window_error->bad_value) + ") does not exist";
+        break;
+    }
+    case XCB_ATOM:
+    {
+        auto const atom_error{reinterpret_cast<xcb_atom_error_t*>(error)};
+        result += "atom " + std::to_string(atom_error->bad_value) + " does not exist";
+        break;
+    }
+    default:
+        break;
+    }
+
+    result +=
+        " (error code " + std::to_string(error->error_code) +
+        ", opcode " + std::to_string(error->major_code) + "." + std::to_string(error->minor_code) + ")";
+
+    return result;
+}
+
 auto mf::XCBConnection::xcb_type_atom(XCBType type) const -> xcb_atom_t
 {
     switch (type)

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -202,6 +202,7 @@ public:
     auto reply_debug_string(xcb_get_property_reply_t* reply) const -> std::string;
     auto client_message_debug_string(xcb_client_message_event_t* event) const -> std::string;
     auto window_debug_string(xcb_window_t window) const -> std::string;
+    auto error_debug_string(xcb_generic_error_t* error) const -> std::string;
     /// @}
 
     Atom const wm_protocols;

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -390,6 +390,9 @@ void mf::XWaylandWM::handle_events()
 
 void mf::XWaylandWM::handle_event(xcb_generic_event_t* event)
 {
+    // see https://www.systutorials.com/docs/linux/man/3-xcb-requests/
+    int const xcb_error_type = 0;
+
     int type = event->response_type & ~0x80;
     switch (type)
     {
@@ -453,6 +456,8 @@ void mf::XWaylandWM::handle_event(xcb_generic_event_t* event)
         break;
     case XCB_FOCUS_IN:
         handle_focus_in(reinterpret_cast<xcb_focus_in_event_t*>(event));
+    case xcb_error_type:
+        handle_error(reinterpret_cast<xcb_generic_error_t*>(event));
     default:
         break;
     }
@@ -789,5 +794,13 @@ void mf::XWaylandWM::handle_focus_in(xcb_focus_in_event_t* event)
         focused_window = event->event;
         // We might want to keep X11 focus and Mir focus in sync
         // (either by requesting a focus change in Mir, reverting this X11 focus change or both)
+    }
+}
+
+void mf::XWaylandWM::handle_error(xcb_generic_error_t* event)
+{
+    if (verbose_xwayland_logging_enabled())
+    {
+        log_warning("XWayland XCB error: %s", connection->error_debug_string(event).c_str());
     }
 }

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -456,8 +456,10 @@ void mf::XWaylandWM::handle_event(xcb_generic_event_t* event)
         break;
     case XCB_FOCUS_IN:
         handle_focus_in(reinterpret_cast<xcb_focus_in_event_t*>(event));
+        break;
     case xcb_error_type:
         handle_error(reinterpret_cast<xcb_generic_error_t*>(event));
+        break;
     default:
         break;
     }

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -91,6 +91,7 @@ private:
     void handle_unmap_notify(xcb_unmap_notify_event_t *event);
     void handle_destroy_notify(xcb_destroy_notify_event_t *event);
     void handle_focus_in(xcb_focus_in_event_t* event);
+    void handle_error(xcb_generic_error_t* event);
 
     std::shared_ptr<WaylandConnector> const wayland_connector;
     wl_client* const wayland_client;


### PR DESCRIPTION
Error logging is hidden behind the verbose X11 flag because there are a number of errors in normal use and showing them isn't particularly useful. Still something we should have for debugging purposes.