### PR TITLE
Remove the mirclient related configuration options

### DIFF
--- a/examples/miral-shell/desktop/mir-shell.sh
+++ b/examples/miral-shell/desktop/mir-shell.sh
@@ -30,12 +30,6 @@ if [ "${bindir}" != "" ]; then bindir="${bindir}/"; fi
 
 unset QT_QPA_PLATFORMTHEME
 
-if [ "$(lsb_release -c -s)" == "xenial" ]
-then
-  export MIR_SERVER_APP_ENV="GDK_BACKEND=x11:QT_QPA_PLATFORM=ubuntumirclient:SDL_VIDEODRIVER=mir:NO_AT_BRIDGE=1"
-  export MIR_SERVER_ENABLE_MIRCLIENT=
-fi
-
 if which gsettings > /dev/null
 then
   keymap_index=$(gsettings get org.gnome.desktop.input-sources current | cut -d\  -f 2)

--- a/examples/miral-shell/desktop/mir-shell.sh
+++ b/examples/miral-shell/desktop/mir-shell.sh
@@ -30,6 +30,12 @@ if [ "${bindir}" != "" ]; then bindir="${bindir}/"; fi
 
 unset QT_QPA_PLATFORMTHEME
 
+# On Xenial fall back to X11 for all the toolkits
+if [ "$(lsb_release -c -s)" == "xenial" ]
+then
+  export MIR_SERVER_APP_ENV="GDK_BACKEND=x11:QT_QPA_PLATFORM=xcb:SDL_VIDEODRIVER=x11:-QT_QPA_PLATFORMTHEME:NO_AT_BRIDGE=1:QT_ACCESSIBILITY:QT_LINUX_ACCESSIBILITY_ALWAYS_ON:_JAVA_AWT_WM_NONREPARENTING=1:-GTK_MODULES:-OOO_FORCE_DESKTOP:-GNOME_ACCESSIBILITY:"
+fi
+
 if which gsettings > /dev/null
 then
   keymap_index=$(gsettings get org.gnome.desktop.input-sources current | cut -d\  -f 2)

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -147,11 +147,7 @@ mo::DefaultConfiguration::DefaultConfiguration(
     namespace po = boost::program_options;
 
     add_options()
-        (server_socket_opt, po::value<std::string>()->default_value(::mir::default_server_socket),
-            "Socket filename [string:default=$XDG_RUNTIME_DIR/mir_socket or /tmp/mir_socket]")
-        (no_server_socket_opt, "Do not provide a socket filename for client connections")
         (arw_server_socket_opt, "Make socket filename globally rw (equivalent to chmod a=rw)")
-        (prompt_socket_opt, "Provide a \"..._trusted\" filename for prompt helper connections")
         (platform_graphics_lib, po::value<std::string>(),
             "Library to use for platform graphics support (default: autodetect)")
         (platform_input_lib, po::value<std::string>(),
@@ -202,7 +198,6 @@ mo::DefaultConfiguration::DefaultConfiguration(
             "in unexpected ways] throw an exception (instead of a core dump)")
         (debug_opt, "Enable extra development debugging. "
             "This is only interesting for people doing Mir server or client development.")
-        (enable_mirclient_opt, "Enable deprecated mirclient socket (for running old clients)")
         (console_provider,
             po::value<std::string>()->default_value("auto"),
             "Console device handling\n"

--- a/tests/mir_test_framework/async_server_runner.cpp
+++ b/tests/mir_test_framework/async_server_runner.cpp
@@ -20,9 +20,11 @@
 #include "mir_test_framework/command_line_server_configuration.h"
 #include "mir_test_framework/canonical_window_manager_policy.h"
 
+#include "mir/default_configuration.h"
 #include "mir/fd.h"
 #include "mir/main_loop.h"
 #include "mir/geometry/rectangle.h"
+#include "mir/options/configuration.h"
 #include "mir/options/option.h"
 #include <mir/thread_name.h>
 #include "mir/test/doubles/null_logger.h"
@@ -35,6 +37,7 @@
 
 namespace geom = mir::geometry;
 namespace ml = mir::logging;
+namespace mo = mir::options;
 namespace msh = mir::shell;
 namespace mtd = mir::test::doubles;
 namespace mtf = mir_test_framework;
@@ -48,6 +51,16 @@ std::chrono::seconds const timeout{20};
 mtf::AsyncServerRunner::AsyncServerRunner() :
     set_window_management_policy{[](auto&){}}
 {
+    // These options are needed to test through the legacy mirclient API
+    server.add_configuration_option(mo::enable_mirclient_opt, "Enable deprecated mirclient socket", mir::OptionType::null);
+    server.add_configuration_option(mo::no_server_socket_opt,
+                                    "Do not provide a socket filename for client connections", mir::OptionType::null);
+    server.add_configuration_option(mo::prompt_socket_opt,
+                                    "Provide a \"..._trusted\" filename for prompt helper connections", mir::OptionType::null);
+    server.add_configuration_option(mo::server_socket_opt,
+                                    "Socket filename [string:default=$XDG_RUNTIME_DIR/mir_socket or /tmp/mir_socket]",
+                                    mir::default_server_socket);
+
     unsetenv("WAYLAND_DISPLAY");    // We don't want to conflict with any existing Wayland server
     add_to_environment("MIR_SERVER_ENABLE_MIRCLIENT", "");
     configure_from_commandline(server);

--- a/tests/mir_test_framework/stubbed_server_configuration.cpp
+++ b/tests/mir_test_framework/stubbed_server_configuration.cpp
@@ -21,6 +21,8 @@
 
 #include "mir_test_framework/stub_server_platform_factory.h"
 
+#include <mir/default_configuration.h>
+#include <mir/options/configuration.h>
 #include "mir/options/default_configuration.h"
 #include "mir/graphics/cursor.h"
 #include "mir/shell/canonical_window_manager.h"
@@ -74,6 +76,14 @@ mtf::StubbedServerConfiguration::StubbedServerConfiguration(
           result->add_options()
                   (mtd::logging_opt, po::value<bool>()->default_value(false), mtd::logging_descr)
                   ("tests-use-real-input", po::value<bool>()->default_value(false), "Use real input in tests.");
+
+          // These options are needed to test through the legacy mirclient API
+          result->add_options()
+              (mo::server_socket_opt, po::value<std::string>()->default_value(mir::default_server_socket),
+               "Socket filename [string:default=$XDG_RUNTIME_DIR/mir_socket or /tmp/mir_socket]")
+              (mo::no_server_socket_opt, "Do not provide a socket filename for client connections")
+              (mo::prompt_socket_opt, "Provide a \"..._trusted\" filename for prompt helper connections")
+              (mo::enable_mirclient_opt, "Enable deprecated mirclient socket (for running old clients)");
 
           return result;
       }()),

--- a/tests/mir_test_framework/test_display_server.cpp
+++ b/tests/mir_test_framework/test_display_server.cpp
@@ -28,9 +28,11 @@
 #include <mir_test_framework/headless_display_buffer_compositor_factory.h>
 #include <mir/test/doubles/null_logger.h>
 
+#include <mir/default_configuration.h>
 #include <mir/fd.h>
 #include <mir/main_loop.h>
 #include <mir/server.h>
+#include <mir/options/configuration.h>
 #include <mir/options/option.h>
 
 #include <boost/throw_exception.hpp>
@@ -40,6 +42,7 @@ using namespace std::chrono_literals;
 namespace mtf = mir_test_framework;
 namespace msh = mir::shell;
 namespace ml = mir::logging;
+namespace mo = mir::options;
 namespace mtd = mir::test::doubles;
 
 namespace
@@ -88,6 +91,17 @@ void miral::TestDisplayServer::start_server()
                 {
                     server.add_configuration_option(trace_option, "log trace message", mir::OptionType::null);
                     server.add_configuration_option(mtd::logging_opt, mtd::logging_descr, false);
+
+                    // These options are needed to test through the legacy mirclient API
+                    server.add_configuration_option(mo::server_socket_opt,
+                                                    "Socket filename [string:default=$XDG_RUNTIME_DIR/mir_socket or /tmp/mir_socket]",
+                                                    mir::default_server_socket);
+                    server.add_configuration_option(mo::no_server_socket_opt,
+                                                    "Do not provide a socket filename for client connections", mir::OptionType::null);
+                    server.add_configuration_option(mo::prompt_socket_opt,
+                                                    "Provide a \"..._trusted\" filename for prompt helper connections", mir::OptionType::null);
+                    server.add_configuration_option(mo::enable_mirclient_opt,
+                                                    "Enable deprecated mirclient socket", mir::OptionType::null);
 
                     server.add_init_callback([&]
                         {

--- a/tools/mir-smoke-test-runner.sh
+++ b/tools/mir-smoke-test-runner.sh
@@ -27,15 +27,15 @@ echo "I: client_list=" ${client_list}
 # Start with eglinfo for the system
 echo Running eglinfo client
 date --utc --iso-8601=seconds | xargs echo "[timestamp] Start :" ${client}
-echo MIR_SERVER_ENABLE_MIRCLIENT= WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client eglinfo
-MIR_SERVER_ENABLE_MIRCLIENT= WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client eglinfo
+echo WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client eglinfo
+WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client eglinfo
 date --utc --iso-8601=seconds | xargs echo "[timestamp] End :" ${client}
 
 for client in ${client_list}; do
     echo running client ${client}
     date --utc --iso-8601=seconds | xargs echo "[timestamp] Start :" ${client}
-    echo MIR_SERVER_ENABLE_MIRCLIENT= WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client ${root}/${client}
-    if   MIR_SERVER_ENABLE_MIRCLIENT= WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client ${root}/${client}
+    echo WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client ${root}/${client}
+    if   WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client ${root}/${client}
     then
       echo "I: [PASSED]" ${root}/${client}
     else


### PR DESCRIPTION
Remove the mirclient related configuration options from the standard configuration and add them to the test configurations.

(We can't yet remove them for the tests, as we still use the mirclient API for a lot of end-end tests.)