### PR TITLE
Delete copy constructors and asignment operators for XWayland classes

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -78,7 +78,6 @@ public:
 
     private:
         Atom(Atom&) = delete;
-        Atom(Atom&&) = delete;
         Atom& operator=(Atom&) = delete;
 
         XCBConnection* const connection;
@@ -249,7 +248,6 @@ public:
 
 private:
     XCBConnection(XCBConnection&) = delete;
-    XCBConnection(XCBConnection&&) = delete;
     XCBConnection& operator=(XCBConnection&) = delete;
 
     auto xcb_type_atom(XCBType type) const -> xcb_atom_t;

--- a/src/server/frontend_xwayland/xwayland_cursors.h
+++ b/src/server/frontend_xwayland/xwayland_cursors.h
@@ -39,6 +39,9 @@ public:
     void apply_default_to(xcb_window_t window) const;
 
 private:
+    XWaylandCursors(XWaylandCursors const&) = delete;
+    XWaylandCursors& operator=(XWaylandCursors const&) = delete;
+
     struct Cursor
     {
         Cursor(std::shared_ptr<XCBConnection> const& connection, xcb_cursor_t xcb_cursor);

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -48,6 +48,9 @@ public:
     auto x11_display() const -> std::string;
 
 private:
+    XWaylandServer(XWaylandServer const&) = delete;
+    XWaylandServer& operator=(XWaylandServer const&) = delete;
+
     /// Forks off the XWayland process
     void spawn();
     /// Called after fork() if we should turn into XWayland

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -68,6 +68,9 @@ public:
     void move_resize(uint32_t detail);
 
 private:
+    XWaylandSurface(XWaylandSurface const&) = delete;
+    XWaylandSurface& operator=(XWaylandSurface const&) = delete;
+
     /// contains more information than just a MirWindowState
     /// (for example if a minimized window would otherwise be maximized)
     struct WindowState

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -68,9 +68,6 @@ public:
     void move_resize(uint32_t detail);
 
 private:
-    XWaylandSurface(XWaylandSurface const&) = delete;
-    XWaylandSurface& operator=(XWaylandSurface const&) = delete;
-
     /// contains more information than just a MirWindowState
     /// (for example if a minimized window would otherwise be maximized)
     struct WindowState

--- a/src/server/frontend_xwayland/xwayland_surface_observer_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface_observer_surface.h
@@ -32,6 +32,9 @@ namespace frontend
 class XWaylandSurfaceObserverSurface
 {
 public:
+    XWaylandSurfaceObserverSurface() = default;
+    virtual ~XWaylandSurfaceObserverSurface() = default;
+
     virtual void scene_surface_focus_set(bool has_focus) = 0;
     virtual void scene_surface_state_set(MirWindowState new_state) = 0;
     virtual void scene_surface_resized(geometry::Size const& new_size) = 0;
@@ -39,7 +42,9 @@ public:
     virtual void scene_surface_close_requested() = 0;
     virtual void run_on_wayland_thread(std::function<void()>&& work) = 0;
 
-    virtual ~XWaylandSurfaceObserverSurface() = default;
+private:
+    XWaylandSurfaceObserverSurface(XWaylandSurfaceObserverSurface const&) = delete;
+    XWaylandSurfaceObserverSurface& operator=(XWaylandSurfaceObserverSurface const&) = delete;
 };
 }
 }

--- a/src/server/frontend_xwayland/xwayland_surface_role_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface_role_surface.h
@@ -36,10 +36,15 @@ class WlSurface;
 class XWaylandSurfaceRoleSurface
 {
 public:
+    XWaylandSurfaceRoleSurface() = default;
+    virtual ~XWaylandSurfaceRoleSurface() = default;
+
     virtual void wl_surface_destroyed() = 0;
     virtual auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> = 0;
 
-    virtual ~XWaylandSurfaceRoleSurface() = default;
+private:
+    XWaylandSurfaceRoleSurface(XWaylandSurfaceRoleSurface const&) = delete;
+    XWaylandSurfaceRoleSurface& operator=(XWaylandSurfaceRoleSurface const&) = delete;
 };
 }
 }

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -72,6 +72,9 @@ public:
     void surfaces_reordered(scene::SurfaceSet const& affected_surfaces);
 
 private:
+    XWaylandWM(XWaylandWM const&) = delete;
+    XWaylandWM& operator=(XWaylandWM const&) = delete;
+
     void restack_surfaces();
 
     // Event handeling


### PR DESCRIPTION
This wasn't causing any problems, but I noticed we weren't doing it. I also removed the explicit delete of some move constructors, as I believe they are deleted by default when the copy constructor is.