### PR TITLE
Add XWaylandSpawner class

### DIFF
--- a/src/server/frontend_xwayland/CMakeLists.txt
+++ b/src/server/frontend_xwayland/CMakeLists.txt
@@ -3,6 +3,7 @@ set(
 
   xwayland_default_configuration.cpp
   xwayland_connector.cpp  xwayland_connector.h
+  xwayland_spawner.cpp    xwayland_spawner.h
   xwayland_server.cpp     xwayland_server.h
   xcb_connection.cpp      xcb_connection.h
   xwayland_wm.cpp         xwayland_wm.h

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -38,6 +38,7 @@ class MultiplexingDispatchable;
 namespace frontend
 {
 class WaylandConnector;
+class XWaylandSpawner;
 
 class XWaylandServer
 {
@@ -59,15 +60,6 @@ private:
         std::unique_lock<std::mutex>& spawn_thread_lock);
     void new_spawn_thread();
 
-    struct SocketFd
-    {
-        int const xdisplay;
-        std::vector<Fd> fd;
-
-        SocketFd();
-        ~SocketFd();
-    };
-
     enum Status {
         STARTING = 1,
         RUNNING = 2,
@@ -78,9 +70,9 @@ private:
     std::shared_ptr<WaylandConnector> const wayland_connector;
     std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
     std::unique_ptr<dispatch::ThreadedDispatcher> const xserver_thread;
-    SocketFd const sockets;
     std::vector<std::shared_ptr<dispatch::ReadableFd>> dispatcher_fd;
     std::string const xwayland_path;
+    std::unique_ptr<XWaylandSpawner> const spawner;
 
     std::mutex mutable spawn_thread_mutex;
     std::thread spawn_thread;

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -68,9 +68,6 @@ private:
     };
 
     std::shared_ptr<WaylandConnector> const wayland_connector;
-    std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
-    std::unique_ptr<dispatch::ThreadedDispatcher> const xserver_thread;
-    std::vector<std::shared_ptr<dispatch::ReadableFd>> dispatcher_fd;
     std::string const xwayland_path;
     std::unique_ptr<XWaylandSpawner> const spawner;
 

--- a/src/server/frontend_xwayland/xwayland_spawner.cpp
+++ b/src/server/frontend_xwayland/xwayland_spawner.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2018 Marius Gripsgard <marius@ubports.com>
+ * Copyright (C) 2019-2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "xwayland_spawner.h"
+
+#include "mir/dispatch/multiplexing_dispatchable.h"
+#include "mir/dispatch/threaded_dispatcher.h"
+#include "mir/dispatch/readable_fd.h"
+#include "mir/fd.h"
+#include "mir/log.h"
+#include "mir/fatal.h"
+#include "mir/thread_name.h"
+
+#include <csignal>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace mf = mir::frontend;
+namespace md = mir::dispatch;
+
+namespace
+{
+auto const x11_lock_fmt = "/tmp/.X%d-lock";
+auto const x11_socket_fmt = "/tmp/.X11-unix/X%d";
+
+// TODO this can be written with more modern c++
+int create_lockfile(int xdisplay)
+{
+    char lockfile[256];
+
+    snprintf(lockfile, sizeof lockfile, x11_lock_fmt, xdisplay);
+
+    mir::Fd const fd{open(lockfile, O_WRONLY | O_CLOEXEC | O_CREAT | O_EXCL, 0444)};
+    if (fd < 0)
+        return EEXIST;
+
+    // We format for consistency with the corresponding code in xorg-server (os/utils.c) which
+    // requires 11 characters. Vis:
+    //
+    //    snprintf(pid_str, sizeof(pid_str), "%10lu\n", (unsigned long) getpid());
+    //    if (write(lfd, pid_str, 11) != 11)
+    bool const success_writing_to_lock_file = dprintf(fd, "%10lu\n", (unsigned long) getpid()) == 11;
+
+    // Check if anyone else has created the socket (even though we have the lockfile)
+    char x11_socket[256];
+    snprintf(x11_socket, sizeof x11_socket, x11_socket_fmt, xdisplay);
+
+    if (!success_writing_to_lock_file || access(x11_socket, F_OK) == 0)
+    {
+        unlink(lockfile);
+        return EEXIST;
+    }
+
+    return 0;
+}
+
+auto choose_display() -> int
+{
+    for (auto xdisplay = 0; xdisplay != 10000; ++xdisplay)
+    {
+        if (create_lockfile(xdisplay) == 0) return xdisplay;
+    }
+
+    mir::fatal_error("Cannot create X11 lockfile!");
+    return -1;
+}
+
+auto create_socket(std::vector<mir::Fd>& fds, struct sockaddr_un *addr, size_t path_size)
+{
+    int fd;
+    socklen_t size = offsetof(struct sockaddr_un, sun_path) + path_size + 1;
+
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0)
+    {
+        mir::log_warning(
+            "Failed to create socket %c%s", addr->sun_path[0] ? addr->sun_path[0] : '@', addr->sun_path + 1);
+        return;
+    }
+    if (!mf::XWaylandSpawner::set_cloexec(fd, true))
+    {
+        close(fd);
+        return;
+    }
+
+    if (addr->sun_path[0])
+    {
+        unlink(addr->sun_path);
+    }
+
+    if (bind(fd, (struct sockaddr*)addr, size) < 0)
+    {
+        mir::log_warning("Failed to bind socket %c%s", addr->sun_path[0] ? addr->sun_path[0] : '@', addr->sun_path + 1);
+        close(fd);
+        if (addr->sun_path[0])
+            unlink(addr->sun_path);
+        return;
+    }
+    if (listen(fd, 1) < 0)
+    {
+        mir::log_warning(
+            "Failed to listen to socket %c%s", addr->sun_path[0] ? addr->sun_path[0] : '@', addr->sun_path + 1);
+        close(fd);
+        if (addr->sun_path[0])
+            unlink(addr->sun_path);
+        return;
+    }
+
+    fds.push_back(mir::Fd{fd});
+}
+
+auto create_sockets(int xdisplay) -> std::vector<mir::Fd>
+{
+    std::vector<mir::Fd> result;
+    struct sockaddr_un addr;
+    size_t path_size;
+
+    addr.sun_family = AF_UNIX;
+    addr.sun_path[0] = 0;
+    path_size = snprintf(addr.sun_path + 1, sizeof(addr.sun_path) - 1, x11_socket_fmt, xdisplay);
+    create_socket(result, &addr, path_size);
+
+    path_size = snprintf(addr.sun_path, sizeof(addr.sun_path), x11_socket_fmt, xdisplay);
+    create_socket(result, &addr, path_size);
+
+    return result;
+}
+}
+
+mf::XWaylandSpawner::XWaylandSpawner()
+    : xdisplay{choose_display()},
+      fds{create_sockets(xdisplay)}
+{
+}
+
+mf::XWaylandSpawner::~XWaylandSpawner()
+{
+    char path[256];
+    snprintf(path, sizeof path, x11_lock_fmt, xdisplay);
+    unlink(path);
+    snprintf(path, sizeof path, x11_socket_fmt, xdisplay);
+    unlink(path);
+}
+
+auto mf::XWaylandSpawner::x11_display() const -> std::string
+{
+    return std::string(":") + std::to_string(xdisplay);
+}
+
+auto mf::XWaylandSpawner::socket_fds() const -> std::vector<Fd> const&
+{
+    return fds;
+}
+
+bool mf::XWaylandSpawner::set_cloexec(int fd, bool cloexec)
+{
+    int flags = fcntl(fd, F_GETFD);
+    if (flags == -1) {
+        mir::fatal_error("fcntl failed");
+        return false;
+    }
+    if (cloexec) {
+        flags = flags | FD_CLOEXEC;
+    } else {
+        flags = flags & ~FD_CLOEXEC;
+    }
+    if (fcntl(fd, F_SETFD, flags) == -1) {
+        mir::fatal_error("fcntl failed");
+        return false;
+    }
+    return true;
+}

--- a/src/server/frontend_xwayland/xwayland_spawner.h
+++ b/src/server/frontend_xwayland/xwayland_spawner.h
@@ -27,13 +27,19 @@
 namespace mir
 {
 class Fd;
+namespace dispatch
+{
+class ReadableFd;
+class ThreadedDispatcher;
+class MultiplexingDispatchable;
+}
 namespace frontend
 {
 
 class XWaylandSpawner
 {
 public:
-    XWaylandSpawner();
+    XWaylandSpawner(std::function<void()> spawn);
     ~XWaylandSpawner();
 
     XWaylandSpawner(XWaylandSpawner const&) = delete;
@@ -48,6 +54,9 @@ public:
 private:
     int const xdisplay;
     std::vector<Fd> const fds;
+    std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
+    std::unique_ptr<dispatch::ThreadedDispatcher> const spawn_thread;
+    std::vector<std::shared_ptr<dispatch::ReadableFd>> const dispatcher_fd;
 };
 
 }

--- a/src/server/frontend_xwayland/xwayland_spawner.h
+++ b/src/server/frontend_xwayland/xwayland_spawner.h
@@ -55,7 +55,7 @@ public:
 
     /// Enables or disables the CLOEXEC flag for the given fd
     /// \returns if the operation succeeded
-    static bool set_cloexec(int fd, bool cloexec);
+    static bool set_cloexec(mir::Fd const& fd, bool cloexec);
 
 private:
     int const xdisplay;

--- a/src/server/frontend_xwayland/xwayland_spawner.h
+++ b/src/server/frontend_xwayland/xwayland_spawner.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018 Marius Gripsgard <marius@ubports.com>
+ * Copyright (C) 2019-2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MIR_FRONTEND_XWAYLAND_SPAWNER_H
+#define MIR_FRONTEND_XWAYLAND_SPAWNER_H
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <functional>
+
+namespace mir
+{
+class Fd;
+namespace frontend
+{
+
+class XWaylandSpawner
+{
+public:
+    XWaylandSpawner();
+    ~XWaylandSpawner();
+
+    XWaylandSpawner(XWaylandSpawner const&) = delete;
+    XWaylandSpawner& operator=(XWaylandSpawner const&) = delete;
+
+    auto x11_display() const -> std::string;
+    auto socket_fds() const -> std::vector<Fd> const&;
+
+    /// Returns if the operation succeeded
+    static bool set_cloexec(int fd, bool cloexec);
+
+private:
+    int const xdisplay;
+    std::vector<Fd> const fds;
+};
+
+}
+}
+
+#endif // MIR_FRONTEND_XWAYLAND_SPAWNER_H

--- a/src/server/frontend_xwayland/xwayland_spawner.h
+++ b/src/server/frontend_xwayland/xwayland_spawner.h
@@ -36,6 +36,8 @@ class MultiplexingDispatchable;
 namespace frontend
 {
 
+/// Responsible for finding an available X11 display and waiting for connections on it
+/// Calls the spawn callback when a client tries to connect
 class XWaylandSpawner
 {
 public:
@@ -45,10 +47,14 @@ public:
     XWaylandSpawner(XWaylandSpawner const&) = delete;
     XWaylandSpawner& operator=(XWaylandSpawner const&) = delete;
 
+    /// The name of the X11 display (such as ":0")
     auto x11_display() const -> std::string;
+    /// \returns whatever sockets we're waiting on
+    /// (on construction we try to open both an abstract and non-abstrack socket)
     auto socket_fds() const -> std::vector<Fd> const&;
 
-    /// Returns if the operation succeeded
+    /// Enables or disables the CLOEXEC flag for the given fd
+    /// \returns if the operation succeeded
     static bool set_cloexec(int fd, bool cloexec);
 
 private:


### PR DESCRIPTION
This new class is responsible for waiting for X11 clients to connect, and calling a callback when they do which starts the server. This simplifies logic in `XWaylandServer`. For now the spawner is owned by the server, but later ownership of it will get moved to the connector.