### PR TITLE
Forget Xenial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,8 +300,6 @@ include(CheckCXXSymbolExists)
 list(APPEND CMAKE_REQUIRED_INCLUDES ${DRM_INCLUDE_DIRS})
 list(APPEND CMAKE_REQUIRED_LIBRARIES ${DRM_LIBRARIES})
 
-check_cxx_symbol_exists("drmIsMaster" "xf86drm.h" MIR_LIBDRM_HAS_IS_MASTER)
-
 # Add USDT hooks to all LTTNG tracepoints
 #
 # This might be gnarly; this tweaks an LTTNG header to enable its

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # Authored by: Thomas Voss <thomas.voss@canonical.com>,
 #              Alan Griffiths <alan@octopull.co.uk>
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 cmake_policy(SET CMP0015 NEW)
 cmake_policy(SET CMP0022 NEW)

--- a/debian/rules
+++ b/debian/rules
@@ -36,11 +36,6 @@ ifeq ($(DEB_HOST_ARCH),s390x)
 	COMMON_CONFIGURE_OPTIONS += -DMIR_LINK_TIME_OPTIMIZATION=OFF
 endif
 
-# Don't use "gold" linker 16.04 , due to failing to build on ppc64le
-ifneq ($(filter xenial,$(DEB_DISTRIBUTION)),)
-	COMMON_CONFIGURE_OPTIONS += -DMIR_USE_LD=ld
-endif
-
 $(info COMMON_CONFIGURE_OPTIONS: ${COMMON_CONFIGURE_OPTIONS})
 
 ifneq ($(filter amd64 i386,$(DEB_HOST_ARCH)),)

--- a/include/core/mir_toolkit/deprecations.h
+++ b/include/core/mir_toolkit/deprecations.h
@@ -18,12 +18,7 @@
 #define MIR_DEPRECATIONS_H_
 
 #ifndef MIR_ENABLE_DEPRECATIONS
-    // use __GNUC__ < 6 as a proxy for building on Ubunutu 16.04LTS ("Xenial")
-    #if defined(__clang__) || !defined(__GNUC__) || (__GNUC__ >= 6)
-        #define MIR_ENABLE_DEPRECATIONS 1
-    #else
-        #define MIR_ENABLE_DEPRECATIONS 0
-    #endif
+#define MIR_ENABLE_DEPRECATIONS 1
 #endif
 
 #if MIR_ENABLE_DEPRECATIONS > 0

--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -64,11 +64,6 @@ execute: |
         > /etc/apt/sources.list.d/cross-${DEB_HOST_ARCH}.list
 
         apt-get update
-
-        if [ "$(lsb_release -cs)" == "xenial" ]; then
-          # workaround for 16.04 passing invalid compiler names (LP#1728673)
-          apt-get --yes install debhelper/xenial-backports
-        fi
     fi
 
     cd $SPREAD_PATH

--- a/src/server/console/CMakeLists.txt
+++ b/src/server/console/CMakeLists.txt
@@ -1,9 +1,5 @@
 include_directories(${DRM_INCLUDE_DIRS})
 
-if(MIR_LIBDRM_HAS_IS_MASTER)
-  add_definitions(-DMIR_LIBDRM_HAS_IS_MASTER)
-endif()
-
 add_library(
   mirconsole OBJECT
 

--- a/src/server/console/minimal_console_services.cpp
+++ b/src/server/console/minimal_console_services.cpp
@@ -34,31 +34,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-// Older versions of libdrm do not provide drmIsMaster()
-#ifndef MIR_LIBDRM_HAS_IS_MASTER
-#include <drm.h>
-
-bool drmIsMaster(int fd)
-{
-    struct drm_mode_mode_cmd cmd;
-
-    ::memset(&cmd, 0, sizeof cmd);
-    /* Set an invalid connector_id to ensure that ATTACHMODE errors with
-     * EINVAL in the unlikely event someone feels like calling this on a
-     * kernel prior to 3.9. */
-    cmd.connector_id = -1;
-
-    if (drmIoctl(fd, DRM_IOCTL_MODE_ATTACHMODE, &cmd) != -1)
-    {
-        /* On 3.9 ATTACHMODE was changed to drm_noop, and so will succeed
-         * iff we've got a master fd */
-        return true;
-    }
-
-    return errno == EINVAL;
-}
-#endif
-
 mir::MinimalConsoleDevice::MinimalConsoleDevice(std::unique_ptr<mir::Device::Observer> observer)
     : observer{std::move(observer)}
 {

--- a/tests/mir_test_doubles/CMakeLists.txt
+++ b/tests/mir_test_doubles/CMakeLists.txt
@@ -38,10 +38,6 @@ set(
 )
 
 set(MIR_TEST_DOUBLES_UDEV_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/mock_udev.cpp)
-if(MIR_LIBDRM_HAS_IS_MASTER)
-  set_source_files_properties(mock_drm.cpp PROPERTIES COMPILE_DEFINITIONS MIR_LIBDRM_HAS_IS_MASTER)
-endif()
-
 
 set(
   MIR_TEST_DOUBLES_PLATFORM_SRCS

--- a/tests/mir_test_doubles/mock_drm.cpp
+++ b/tests/mir_test_doubles/mock_drm.cpp
@@ -689,12 +689,10 @@ int drmPrimeFDToHandle(int fd, int prime_fd, uint32_t *handle)
     return global_mock->drmPrimeFDToHandle(fd, prime_fd, handle);
 }
 
-#ifdef MIR_LIBDRM_HAS_IS_MASTER
 int drmIsMaster(int fd)
 {
     return global_mock->drmIsMaster(fd);
 }
-#endif
 
 int drmSetMaster(int fd)
 {

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -125,11 +125,6 @@ if (NOT HAVE_PTHREAD_GETNAME_NP)
   message(WARNING "pthread_getname_np() not supported: Disabling test_basic_thread_pool.cpp tests that rely on it")
 endif()
 
-if(MIR_LIBDRM_HAS_IS_MASTER)
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/console/test_minimal_console_services.cpp
-    PROPERTIES COMPILE_DEFINITIONS MIR_LIBDRM_HAS_IS_MASTER)
-endif()
-
 link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
 mir_add_wrapped_executable(mir_unit_tests NOINSTALL

--- a/tests/unit-tests/console/test_minimal_console_services.cpp
+++ b/tests/unit-tests/console/test_minimal_console_services.cpp
@@ -136,15 +136,8 @@ TEST_F(MinimalConsoleServicesTest, calls_drm_set_master_if_not_already_master)
 {
     int drm_fd = set_expectations_for_uevent_probe_of_drm(5, "/dev/dri/card5");
 
-#ifdef MIR_LIBDRM_HAS_IS_MASTER
     ON_CALL(drm, drmIsMaster(drm_fd))
         .WillByDefault(Return(0));
-#else
-    // Older versions of libdrm do not provide drmIsMaster()
-    // drmIsMaster checks the ATTACHMODE ioctl, detecting EPERM as not master.
-    ON_CALL(drm, drmIoctl(drm_fd, DRM_IOCTL_MODE_ATTACHMODE, _))
-        .WillByDefault(SetErrnoAndReturn(EPERM, -1));
-#endif
 
     EXPECT_CALL(drm, drmSetMaster(drm_fd));
 
@@ -168,15 +161,8 @@ TEST_F(MinimalConsoleServicesTest, failure_to_set_master_is_fatal)
 {
     int drm_fd = set_expectations_for_uevent_probe_of_drm(5, "/dev/dri/card5");
 
-#ifdef MIR_LIBDRM_HAS_IS_MASTER
     ON_CALL(drm, drmIsMaster(drm_fd))
         .WillByDefault(Return(0));
-#else
-    // Older versions of libdrm do not provide drmIsMaster()
-    // drmIsMaster checks the ATTACHMODE ioctl, detecting EPERM as not master.
-    ON_CALL(drm, drmIoctl(drm_fd, DRM_IOCTL_MODE_ATTACHMODE, _))
-        .WillByDefault(SetErrnoAndReturn(EPERM, -1));
-#endif
 
     ON_CALL(drm, drmSetMaster(drm_fd)).WillByDefault(Return(-EPERM));
 
@@ -201,15 +187,8 @@ TEST_F(MinimalConsoleServicesTest, does_not_call_set_master_if_already_master)
 {
     int drm_fd = set_expectations_for_uevent_probe_of_drm(5, "/dev/dri/card5");
 
-#ifdef MIR_LIBDRM_HAS_IS_MASTER
     ON_CALL(drm, drmIsMaster(drm_fd))
         .WillByDefault(Return(1));
-#else
-    // Older versions of libdrm do not provide drmIsMaster()
-    // drmIsMaster checks the ATTACHMODE ioctl, detecting EPERM as not master.
-    ON_CALL(drm, drmIoctl(drm_fd, DRM_IOCTL_MODE_ATTACHMODE, _))
-        .WillByDefault(SetErrnoAndReturn(EINVAL, -1));
-#endif
 
     ON_CALL(drm, drmSetMaster(drm_fd)).WillByDefault(Return(-EPERM));
 


### PR DESCRIPTION
We're no longer trying to build for Xenial, so drop a bunch of workarounds.