### PR TITLE
[MirAL] Drop --startup-apps

### DIFF
--- a/examples/miral-kiosk/kiosk_main.cpp
+++ b/examples/miral-kiosk/kiosk_main.cpp
@@ -21,6 +21,7 @@
 #include <miral/runner.h>
 #include <miral/application_authorizer.h>
 #include <miral/display_configuration.h>
+#include <miral/external_client.h>
 #include <miral/command_line_option.h>
 #include <miral/keymap.h>
 #include <miral/set_window_management_policy.h>
@@ -92,6 +93,18 @@ int main(int argc, char const* argv[])
         "Only allow applications to connect during startup",
         KioskAuthorizer::startup_only};
 
+    ExternalClientLauncher launcher;
+
+    auto run_startup_apps = [&](std::string const& apps)
+    {
+      for (auto i = begin(apps); i != end(apps); )
+      {
+          auto const j = find(i, end(apps), ':');
+          launcher.launch(std::vector<std::string>{std::string{i, j}});
+          if ((i = j) != end(apps)) ++i;
+      }
+    };
+
     MirRunner runner{argc, argv};
 
     DisplayConfiguration display_config{runner};
@@ -104,6 +117,7 @@ int main(int argc, char const* argv[])
             SetApplicationAuthorizer<KioskAuthorizer>{splash},
             Keymap{},
             startup_only,
+            CommandLineOption{run_startup_apps, "startup-apps", "Colon separated list of startup apps", ""},
             StartupInternalClient{splash}
         });
 }

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -102,6 +102,17 @@ int main(int argc, char const* argv[])
     Keymap config_keymap;
     DebugExtension debug_extensions;
 
+    auto run_startup_apps = [&](std::string const& apps)
+    {
+      for (auto i = begin(apps); i != end(apps); )
+      {
+          auto const j = find(i, end(apps), ':');
+          external_client_launcher.launch(std::vector<std::string>{std::string{i, j}});
+          if ((i = j) != end(apps)) ++i;
+      }
+    };
+
+
     return runner.run_with(
         {
             CursorTheme{"default:DMZ-White"},
@@ -115,6 +126,7 @@ int main(int argc, char const* argv[])
             debug_extensions,
             AppendEventFilter{quit_on_ctrl_alt_bksp},
             StartupInternalClient{spinner},
+            CommandLineOption{run_startup_apps, "startup-apps", "Colon separated list of startup apps", ""},
             pre_init(CommandLineOption{[&](std::string const& typeface) { ::wallpaper::font_file(typeface); },
                                        "shell-wallpaper-font", "font file to use for wallpaper", ::wallpaper::font_file()}),
             CommandLineOption{[&](std::string const& cmd) { terminal_cmd = cmd; },

--- a/src/miral/external_client.cpp
+++ b/src/miral/external_client.cpp
@@ -104,9 +104,8 @@ void miral::ExternalClientLauncher::launch(std::vector<std::string> const& comma
 
     auto const wayland_display = self->server->wayland_display();
     auto const x11_display = self->server->x11_display();
-    auto const mir_socket = self->server->mir_socket_name();
 
-    self->pid = launch_app_env(command_line, wayland_display, mir_socket, x11_display, self->env);
+    self->pid = launch_app_env(command_line, wayland_display, x11_display, self->env);
 }
 
 miral::ExternalClientLauncher::ExternalClientLauncher() : self{std::make_shared<Self>()} {}
@@ -125,8 +124,7 @@ void miral::ExternalClientLauncher::launch_using_x11(std::vector<std::string> co
     if (auto const x11_display = self->server->x11_display())
     {
         auto const wayland_display = self->server->wayland_display();
-        auto const mir_socket = self->server->mir_socket_name();
-        self->pid = launch_app_env(command_line, wayland_display, mir_socket, x11_display, self->x11_env);
+        self->pid = launch_app_env(command_line, wayland_display, x11_display, self->x11_env);
     }
 }
 

--- a/src/miral/launch_app.h
+++ b/src/miral/launch_app.h
@@ -31,16 +31,10 @@
 
 namespace miral
 {
-auto launch_app(std::vector<std::string> const& app,
-                mir::optional_value<std::string> const& wayland_display,
-                mir::optional_value<std::string> const& mir_socket,
-                mir::optional_value<std::string> const& x11_display) -> pid_t;
-
 using AppEnvironment = std::map<std::string, std::experimental::optional<std::string>>;
 
 auto launch_app_env(std::vector<std::string> const& app,
     mir::optional_value<std::string> const& wayland_display,
-    mir::optional_value<std::string> const& mir_socket,
     mir::optional_value<std::string> const& x11_display,
     AppEnvironment const& app_env) -> pid_t;
 }


### PR DESCRIPTION
[MirAL] Drop the --startup-apps configuration option from MirRunner. (Fixes: #1531)

This isn't needed as a feature of MirRunner, as it can be done better using other MirAL features.

In case anyone is using it in miral-kiosk or miral-shell, and to demonstrate, it is re-implemented for these.