### PR TITLE
Disable LTO which is failing for armhf and ppc64el in PPA builds

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -32,7 +32,7 @@ else
 endif
 
 # Disable LTO on s390x, armhf & ppc64el due to failing to build
-ifneq ($(filter amd64 i386 arm64,$(DEB_HOST_ARCH)),)
+ifeq ($(filter amd64 i386 arm64,$(DEB_HOST_ARCH)),)
 	COMMON_CONFIGURE_OPTIONS += -DMIR_LINK_TIME_OPTIMIZATION=OFF
 endif
 


### PR DESCRIPTION
Disable LTO which is failing for armhf and ppc64el in PPA builds. (Fixes: #1525)

Hopefully a short-term fix