### PR TITLE
Ensure that libmirclient-dev gets removed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -178,6 +178,7 @@ Package: libmirclient9
 Section: libs
 Architecture: linux-any
 Breaks: libmirclient-dev
+Replaces: libmirclient-dev
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends},

--- a/debian/control
+++ b/debian/control
@@ -177,6 +177,7 @@ Description: Display server for Ubuntu - development headers
 Package: libmirclient9
 Section: libs
 Architecture: linux-any
+Breaks: libmirclient-dev
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends},


### PR DESCRIPTION
Ensure that libmirclient-dev gets removed. (Fixes: #1518)
