### PR TITLE
Don't use size_t in an ABI checked by a symbols file

### DIFF
--- a/debian/libmiral4.symbols
+++ b/debian/libmiral4.symbols
@@ -382,13 +382,13 @@ libmiral.so.4 libmiral4 #MINVER#
  (c++)"miral::toolkit::mir_pointer_event_buttons(MirPointerEvent const*)@MIRAL_3.0" 3.0.0
  (c++)"miral::toolkit::mir_pointer_event_input_event(MirPointerEvent const*)@MIRAL_3.0" 3.0.0
  (c++)"miral::toolkit::mir_pointer_event_modifiers(MirPointerEvent const*)@MIRAL_3.0" 3.0.0
- (c++)"miral::toolkit::mir_touch_event_action(MirTouchEvent const*, unsigned long)@MIRAL_3.0" 3.0.0
- (c++)"miral::toolkit::mir_touch_event_axis_value(MirTouchEvent const*, unsigned long, MirTouchAxis)@MIRAL_3.0" 3.0.0
- (c++)"miral::toolkit::mir_touch_event_id(MirTouchEvent const*, unsigned long)@MIRAL_3.0" 3.0.0
+ (c++)"miral::toolkit::mir_touch_event_action(MirTouchEvent const*, unsigned int)@MIRAL_3.0" 3.0.0
+ (c++)"miral::toolkit::mir_touch_event_axis_value(MirTouchEvent const*, unsigned int, MirTouchAxis)@MIRAL_3.0" 3.0.0
+ (c++)"miral::toolkit::mir_touch_event_id(MirTouchEvent const*, unsigned int)@MIRAL_3.0" 3.0.0
  (c++)"miral::toolkit::mir_touch_event_input_event(MirTouchEvent const*)@MIRAL_3.0" 3.0.0
  (c++)"miral::toolkit::mir_touch_event_modifiers(MirTouchEvent const*)@MIRAL_3.0" 3.0.0
  (c++)"miral::toolkit::mir_touch_event_point_count(MirTouchEvent const*)@MIRAL_3.0" 3.0.0
- (c++)"miral::toolkit::mir_touch_event_tooltype(MirTouchEvent const*, unsigned long)@MIRAL_3.0" 3.0.0
+ (c++)"miral::toolkit::mir_touch_event_tooltype(MirTouchEvent const*, unsigned int)@MIRAL_3.0" 3.0.0
  (c++)"miral::window_for(wl_resource*)@MIRAL_3.0" 3.0.0
  (c++)"typeinfo for miral::CanonicalWindowManagerPolicy@MIRAL_3.0" 3.0.0
  (c++)"typeinfo for miral::MinimalWindowManager@MIRAL_3.0" 3.0.0

--- a/include/miral/miral/toolkit_event.h
+++ b/include/miral/miral/toolkit_event.h
@@ -215,7 +215,7 @@ unsigned int mir_touch_event_point_count(MirTouchEvent const* event);
  *  \param [in] touch_index The touch index. Must be less than (touch_count - 1).
  *  \return                 ID of the touch at index
  */
-MirTouchId mir_touch_event_id(MirTouchEvent const* event, size_t touch_index);
+MirTouchId mir_touch_event_id(MirTouchEvent const* event, unsigned int touch_index);
 
 /**
  * Retrieve the action which occured for a touch at given index.
@@ -224,7 +224,7 @@ MirTouchId mir_touch_event_id(MirTouchEvent const* event, size_t touch_index);
  *  \param [in] touch_index The touch index. Must be less than (touch_count - 1).
  *  \return                 Action performed for the touch at index.
  */
-MirTouchAction mir_touch_event_action(MirTouchEvent const* event, size_t touch_index);
+MirTouchAction mir_touch_event_action(MirTouchEvent const* event, unsigned int touch_index);
 
 /**
  * Retrieve the tooltype for touch at given index.
@@ -233,8 +233,7 @@ MirTouchAction mir_touch_event_action(MirTouchEvent const* event, size_t touch_i
  *  \param [in] touch_index The touch index. Must be less than (touch_count - 1).
  *  \return                 Tooltype used for the touch at index
  */
-MirTouchTooltype mir_touch_event_tooltype(MirTouchEvent const* event,
-    size_t touch_index);
+MirTouchTooltype mir_touch_event_tooltype(MirTouchEvent const* event, unsigned int touch_index);
 
 
 /**
@@ -245,8 +244,7 @@ MirTouchTooltype mir_touch_event_tooltype(MirTouchEvent const* event,
  *  \param [in] axis        The axis to retreive a value from
  *  \return                 The value of the given axis
  */
-float mir_touch_event_axis_value(MirTouchEvent const* event,
-    size_t touch_index, MirTouchAxis axis);
+float mir_touch_event_axis_value(MirTouchEvent const* event, unsigned int touch_index, MirTouchAxis axis);
 
 /**
  * Retrieve the corresponding input event.

--- a/src/miral/toolkit_event.cpp
+++ b/src/miral/toolkit_event.cpp
@@ -109,24 +109,23 @@ unsigned int mir_touch_event_point_count(MirTouchEvent const* event)
     return ::mir_touch_event_point_count(event);
 }
 
-MirTouchId mir_touch_event_id(MirTouchEvent const* event, size_t touch_index)
+MirTouchId mir_touch_event_id(MirTouchEvent const* event, unsigned int touch_index)
 {
     return ::mir_touch_event_id(event, touch_index);
 }
 
-MirTouchAction mir_touch_event_action(MirTouchEvent const* event, size_t touch_index)
+MirTouchAction mir_touch_event_action(MirTouchEvent const* event, unsigned int touch_index)
 {
     return ::mir_touch_event_action(event, touch_index);
 }
 
-MirTouchTooltype mir_touch_event_tooltype(MirTouchEvent const* event, size_t touch_index)
+MirTouchTooltype mir_touch_event_tooltype(MirTouchEvent const* event, unsigned int touch_index)
 {
     return ::mir_touch_event_tooltype(event, touch_index);
 }
 
 float mir_touch_event_axis_value(
-    MirTouchEvent const* event,
-    size_t touch_index,
+    MirTouchEvent const* event, unsigned int touch_index,
     MirTouchAxis axis)
 {
     return ::mir_touch_event_axis_value(event, touch_index, axis);


### PR DESCRIPTION
Don't use size_t in an ABI checked by a symbols file. (Fixes: #1539)