### PR TITLE
No LTO on arm64

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -31,8 +31,8 @@ else
 	COMMON_CONFIGURE_OPTIONS += -DMIR_LINK_TIME_OPTIMIZATION=ON
 endif
 
-# Disable LTO on s390x, armhf & ppc64el due to failing to build
-ifeq ($(filter amd64 i386 arm64,$(DEB_HOST_ARCH)),)
+# Disable LTO on s390x, armhf, ppc64el & arm64 due to failing to build
+ifeq ($(filter amd64 i386,$(DEB_HOST_ARCH)),)
 	COMMON_CONFIGURE_OPTIONS += -DMIR_LINK_TIME_OPTIMIZATION=OFF
 endif
 


### PR DESCRIPTION
No LTO on arm64.

More wallpaper over cracks: The LTO build failures seen in Launchpad are now happening on arm64. This keeps the PPA building, but it would be good to figure out the root cause.