### PR TITLE
Add WindowManagerTools::active_application_zone()

### DIFF
--- a/debian/libmiral4.symbols
+++ b/debian/libmiral4.symbols
@@ -227,6 +227,7 @@ libmiral.so.4 libmiral4 #MINVER#
  (c++)"miral::WindowManagerTools::WindowManagerTools(miral::WindowManagerToolsImplementation*)@MIRAL_3.0" 3.0.0
  (c++)"miral::WindowManagerTools::active_output()@MIRAL_3.0" 3.0.0
  (c++)"miral::WindowManagerTools::active_window() const@MIRAL_3.0" 3.0.0
+ (c++)"miral::WindowManagerTools::active_zone()@MIRAL_3.0" 3.0.0
  (c++)"miral::WindowManagerTools::add_tree_to_workspace(miral::Window const&, std::shared_ptr<miral::Workspace> const&)@MIRAL_3.0" 3.0.0
  (c++)"miral::WindowManagerTools::ask_client_to_close(miral::Window const&)@MIRAL_3.0" 3.0.0
  (c++)"miral::WindowManagerTools::count_applications() const@MIRAL_3.0" 3.0.0

--- a/debian/libmiral4.symbols
+++ b/debian/libmiral4.symbols
@@ -225,9 +225,9 @@ libmiral.so.4 libmiral4 #MINVER#
  (c++)"miral::WindowManagerOptions::operator()(mir::Server&) const@MIRAL_3.0" 3.0.0
  (c++)"miral::WindowManagerTools::WindowManagerTools(miral::WindowManagerTools const&)@MIRAL_3.0" 3.0.0
  (c++)"miral::WindowManagerTools::WindowManagerTools(miral::WindowManagerToolsImplementation*)@MIRAL_3.0" 3.0.0
+ (c++)"miral::WindowManagerTools::active_application_zone()@MIRAL_3.0" 3.0.0
  (c++)"miral::WindowManagerTools::active_output()@MIRAL_3.0" 3.0.0
  (c++)"miral::WindowManagerTools::active_window() const@MIRAL_3.0" 3.0.0
- (c++)"miral::WindowManagerTools::active_zone()@MIRAL_3.0" 3.0.0
  (c++)"miral::WindowManagerTools::add_tree_to_workspace(miral::Window const&, std::shared_ptr<miral::Workspace> const&)@MIRAL_3.0" 3.0.0
  (c++)"miral::WindowManagerTools::ask_client_to_close(miral::Window const&)@MIRAL_3.0" 3.0.0
  (c++)"miral::WindowManagerTools::count_applications() const@MIRAL_3.0" 3.0.0

--- a/examples/example-server-lib/floating_window_manager.cpp
+++ b/examples/example-server-lib/floating_window_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2019 Canonical Ltd.
+ * Copyright © 2016-2020 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -24,6 +24,7 @@
 #include <miral/toolkit_event.h>
 #include <miral/window_info.h>
 #include <miral/window_manager_tools.h>
+#include <miral/zone.h>
 
 #include <linux/input.h>
 #include <csignal>
@@ -353,7 +354,7 @@ bool FloatingWindowManagerPolicy::handle_keyboard_event(MirKeyboardEvent const* 
     {
         if (auto active_window = tools.active_window())
         {
-            auto active_zone = tools.active_zone();
+            auto active_zone = tools.active_application_zone().extents();
             auto& window_info = tools.info_for(active_window);
             WindowSpecification modifications;
 

--- a/examples/example-server-lib/floating_window_manager.cpp
+++ b/examples/example-server-lib/floating_window_manager.cpp
@@ -353,7 +353,7 @@ bool FloatingWindowManagerPolicy::handle_keyboard_event(MirKeyboardEvent const* 
     {
         if (auto active_window = tools.active_window())
         {
-            auto active_output = tools.active_output();
+            auto active_zone = tools.active_zone();
             auto& window_info = tools.info_for(active_window);
             WindowSpecification modifications;
 
@@ -363,8 +363,8 @@ bool FloatingWindowManagerPolicy::handle_keyboard_event(MirKeyboardEvent const* 
                 modifications.state() = mir_window_state_vertmaximized;
                 tools.place_and_size_for_state(modifications, window_info);
                 modifications.top_left() = window_info.needs_titlebar(window_info.type()) ?
-                                           active_output.top_left + title_bar_height :
-                                           active_output.top_left;
+                                               active_zone.top_left + title_bar_height :
+                                               active_zone.top_left;
                 break;
 
             case KEY_RIGHT:
@@ -376,8 +376,8 @@ bool FloatingWindowManagerPolicy::handle_keyboard_event(MirKeyboardEvent const* 
                     (modifications.size().is_set() ? modifications.size().value() : active_window.size()).width;
 
                 modifications.top_left() = window_info.needs_titlebar(window_info.type()) ?
-                                           active_output.top_right() - Displacement{as_delta(new_width), 0} + title_bar_height :
-                                           active_output.top_right() - Displacement{as_delta(new_width), 0};
+                        active_zone.top_right() - Displacement{as_delta(new_width), 0} + title_bar_height :
+                        active_zone.top_right() - Displacement{as_delta(new_width), 0};
                 break;
             }
 
@@ -385,14 +385,15 @@ bool FloatingWindowManagerPolicy::handle_keyboard_event(MirKeyboardEvent const* 
                 modifications.state() = mir_window_state_horizmaximized;
                 tools.place_and_size_for_state(modifications, window_info);
                 modifications.top_left() = window_info.needs_titlebar(window_info.type()) ?
-                                           active_output.top_left + title_bar_height :
-                                           active_output.top_left;
+                                               active_zone.top_left + title_bar_height :
+                                               active_zone.top_left;
                 break;
 
             case KEY_DOWN:
                 modifications.state() = mir_window_state_horizmaximized;
                 tools.place_and_size_for_state(modifications, window_info);
-                modifications.top_left() = active_output.bottom_right() - as_displacement(
+                modifications.top_left() =
+                    active_zone.bottom_right() - as_displacement(
                     modifications.size().is_set() ? modifications.size().value() : active_window.size());
                 break;
 

--- a/include/miral/miral/window_manager_tools.h
+++ b/include/miral/miral/window_manager_tools.h
@@ -38,6 +38,7 @@ class Window;
 struct WindowInfo;
 struct ApplicationInfo;
 class WindowSpecification;
+class Zone;
 
 /**
  * Workspace is intentionally opaque in the miral API. Its only purpose is to
@@ -165,7 +166,7 @@ public:
 
     /// Find the active zone area
     /// \remark Since MirAL 3.0
-    auto active_zone() -> mir::geometry::Rectangle const;
+    auto active_application_zone() const -> Zone;
 
     /// Raise window and all its children
     void raise_tree(Window const& root);

--- a/include/miral/miral/window_manager_tools.h
+++ b/include/miral/miral/window_manager_tools.h
@@ -163,6 +163,10 @@ public:
     /// Find the active output area
     auto active_output() -> mir::geometry::Rectangle const;
 
+    /// Find the active zone area
+    /// \remark Since MirAL 3.0
+    auto active_zone() -> mir::geometry::Rectangle const;
+
     /// Raise window and all its children
     void raise_tree(Window const& root);
 

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -880,6 +880,11 @@ auto miral::BasicWindowManager::active_output() -> geometry::Rectangle const
     return active_display_area()->area;
 }
 
+auto miral::BasicWindowManager::active_zone() -> mir::geometry::Rectangle
+{
+    return active_display_area()->application_zone.extents();
+}
+
 void miral::BasicWindowManager::raise_tree(Window const& root)
 {
     auto const& info = info_for(root);

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -880,9 +880,9 @@ auto miral::BasicWindowManager::active_output() -> geometry::Rectangle const
     return active_display_area()->area;
 }
 
-auto miral::BasicWindowManager::active_zone() -> mir::geometry::Rectangle
+auto miral::BasicWindowManager::active_application_zone() -> Zone
 {
-    return active_display_area()->application_zone.extents();
+    return active_display_area()->application_zone;
 }
 
 void miral::BasicWindowManager::raise_tree(Window const& root)

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -179,7 +179,7 @@ public:
     auto window_at(mir::geometry::Point cursor) const -> Window override;
 
     auto active_output() -> mir::geometry::Rectangle const override;
-    auto active_zone() -> mir::geometry::Rectangle override;
+    auto active_application_zone() -> Zone override;
 
     void raise_tree(Window const& root) override;
     void start_drag_and_drop(WindowInfo& window_info, std::vector<uint8_t> const& handle) override;

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -179,6 +179,7 @@ public:
     auto window_at(mir::geometry::Point cursor) const -> Window override;
 
     auto active_output() -> mir::geometry::Rectangle const override;
+    auto active_zone() -> mir::geometry::Rectangle override;
 
     void raise_tree(Window const& root) override;
     void start_drag_and_drop(WindowInfo& window_info, std::vector<uint8_t> const& handle) override;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -206,9 +206,9 @@ global:
     miral::WindowManagerOptions::operator*;
     miral::WindowManagerTools::?WindowManagerTools*;
     miral::WindowManagerTools::WindowManagerTools*;
+    miral::WindowManagerTools::active_application_zone*;
     miral::WindowManagerTools::active_output*;
     miral::WindowManagerTools::active_window*;
-    miral::WindowManagerTools::active_zone*;
     miral::WindowManagerTools::add_tree_to_workspace*;
     miral::WindowManagerTools::ask_client_to_close*;
     miral::WindowManagerTools::count_applications*;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -180,13 +180,6 @@ global:
     miral::WindowInfo::width_inc*;
     miral::WindowInfo::window*;
     miral::WindowManagementPolicy::?WindowManagementPolicy*;
-    miral::WindowManagementPolicy::ApplicationZoneAddendum::?ApplicationZoneAddendum*;
-    miral::WindowManagementPolicy::ApplicationZoneAddendum::ApplicationZoneAddendum*;
-    miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_create*;
-    miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_delete*;
-    miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_update*;
-    miral::WindowManagementPolicy::ApplicationZoneAddendum::from*;
-    miral::WindowManagementPolicy::ApplicationZoneAddendum::operator*;
     miral::WindowManagementPolicy::WindowManagementPolicy*;
     miral::WindowManagementPolicy::advise_adding_to_workspace*;
     miral::WindowManagementPolicy::advise_application_zone_create*;
@@ -215,6 +208,7 @@ global:
     miral::WindowManagerTools::WindowManagerTools*;
     miral::WindowManagerTools::active_output*;
     miral::WindowManagerTools::active_window*;
+    miral::WindowManagerTools::active_zone*;
     miral::WindowManagerTools::add_tree_to_workspace*;
     miral::WindowManagerTools::ask_client_to_close*;
     miral::WindowManagerTools::count_applications*;
@@ -348,10 +342,6 @@ global:
     non-virtual?thunk?to?miral::MinimalWindowManager::place_new_window*;
     non-virtual?thunk?to?miral::WaylandExtensions::Context::?Context*;
     non-virtual?thunk?to?miral::WindowManagementPolicy::?WindowManagementPolicy*;
-    non-virtual?thunk?to?miral::WindowManagementPolicy::ApplicationZoneAddendum::?ApplicationZoneAddendum*;
-    non-virtual?thunk?to?miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_create*;
-    non-virtual?thunk?to?miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_delete*;
-    non-virtual?thunk?to?miral::WindowManagementPolicy::ApplicationZoneAddendum::advise_application_zone_update*;
     non-virtual?thunk?to?miral::WindowManagementPolicy::advise_adding_to_workspace*;
     non-virtual?thunk?to?miral::WindowManagementPolicy::advise_application_zone_create*;
     non-virtual?thunk?to?miral::WindowManagementPolicy::advise_application_zone_delete*;
@@ -399,7 +389,6 @@ global:
     typeinfo?for?miral::Window;
     typeinfo?for?miral::WindowInfo;
     typeinfo?for?miral::WindowManagementPolicy;
-    typeinfo?for?miral::WindowManagementPolicy::ApplicationZoneAddendum;
     typeinfo?for?miral::WindowManagerOption;
     typeinfo?for?miral::WindowManagerOptions;
     typeinfo?for?miral::WindowManagerTools;
@@ -434,7 +423,6 @@ global:
     vtable?for?miral::Window;
     vtable?for?miral::WindowInfo;
     vtable?for?miral::WindowManagementPolicy;
-    vtable?for?miral::WindowManagementPolicy::ApplicationZoneAddendum;
     vtable?for?miral::WindowManagerOption;
     vtable?for?miral::WindowManagerOptions;
     vtable?for?miral::WindowManagerTools;

--- a/src/miral/window_management_trace.cpp
+++ b/src/miral/window_management_trace.cpp
@@ -479,12 +479,12 @@ try {
 }
 MIRAL_TRACE_EXCEPTION
 
-mir::geometry::Rectangle miral::WindowManagementTrace::active_zone()
+auto miral::WindowManagementTrace::active_application_zone() -> Zone
 try {
     log_input();
-    auto result = wrapped.active_zone();
+    auto result = wrapped.active_application_zone();
     std::stringstream out;
-    out << result;
+    out << result.extents();
     mir::log_info("%s -> ", __func__, out.str().c_str());
     trace_count++;
     return result;

--- a/src/miral/window_management_trace.cpp
+++ b/src/miral/window_management_trace.cpp
@@ -479,6 +479,18 @@ try {
 }
 MIRAL_TRACE_EXCEPTION
 
+mir::geometry::Rectangle miral::WindowManagementTrace::active_zone()
+try {
+    log_input();
+    auto result = wrapped.active_zone();
+    std::stringstream out;
+    out << result;
+    mir::log_info("%s -> ", __func__, out.str().c_str());
+    trace_count++;
+    return result;
+}
+MIRAL_TRACE_EXCEPTION
+
 auto miral::WindowManagementTrace::info_for_window_id(std::string const& id) const -> WindowInfo&
 try {
     log_input();

--- a/src/miral/window_management_trace.h
+++ b/src/miral/window_management_trace.h
@@ -56,7 +56,7 @@ private:
     virtual auto select_active_window(Window const& hint) -> Window override;
     virtual auto window_at(mir::geometry::Point cursor) const -> Window override;
     virtual auto active_output() -> mir::geometry::Rectangle const override;
-    virtual auto active_zone() -> mir::geometry::Rectangle override;
+    virtual auto active_application_zone() -> Zone override;
     virtual auto info_for_window_id(std::string const& id) const -> WindowInfo& override;
     virtual auto id_for_window(Window const& window) const -> std::string override;
     virtual void place_and_size_for_state(WindowSpecification& modifications, WindowInfo const& window_info) const override;

--- a/src/miral/window_management_trace.h
+++ b/src/miral/window_management_trace.h
@@ -56,6 +56,7 @@ private:
     virtual auto select_active_window(Window const& hint) -> Window override;
     virtual auto window_at(mir::geometry::Point cursor) const -> Window override;
     virtual auto active_output() -> mir::geometry::Rectangle const override;
+    virtual auto active_zone() -> mir::geometry::Rectangle override;
     virtual auto info_for_window_id(std::string const& id) const -> WindowInfo& override;
     virtual auto id_for_window(Window const& window) const -> std::string override;
     virtual void place_and_size_for_state(WindowSpecification& modifications, WindowInfo const& window_info) const override;

--- a/src/miral/window_manager_tools.cpp
+++ b/src/miral/window_manager_tools.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "miral/window_manager_tools.h"
+#include "miral/zone.h"
 #include "window_manager_tools_implementation.h"
 
 miral::WindowManagerTools::WindowManagerTools(WindowManagerToolsImplementation* tools) :
@@ -80,8 +81,8 @@ auto miral::WindowManagerTools::window_at(mir::geometry::Point cursor) const -> 
 auto miral::WindowManagerTools::active_output() -> mir::geometry::Rectangle const
 { return tools->active_output(); }
 
-auto miral::WindowManagerTools::active_zone() -> mir::geometry::Rectangle const
-{ return tools->active_zone(); }
+auto miral::WindowManagerTools::active_application_zone() const -> Zone
+{ return tools->active_application_zone(); }
 
 void miral::WindowManagerTools::raise_tree(Window const& root)
 { tools->raise_tree(root); }

--- a/src/miral/window_manager_tools.cpp
+++ b/src/miral/window_manager_tools.cpp
@@ -80,6 +80,9 @@ auto miral::WindowManagerTools::window_at(mir::geometry::Point cursor) const -> 
 auto miral::WindowManagerTools::active_output() -> mir::geometry::Rectangle const
 { return tools->active_output(); }
 
+auto miral::WindowManagerTools::active_zone() -> mir::geometry::Rectangle const
+{ return tools->active_zone(); }
+
 void miral::WindowManagerTools::raise_tree(Window const& root)
 { tools->raise_tree(root); }
 

--- a/src/miral/window_manager_tools_implementation.h
+++ b/src/miral/window_manager_tools_implementation.h
@@ -66,6 +66,7 @@ public:
     virtual void focus_prev_within_application() = 0;
     virtual auto window_at(mir::geometry::Point cursor) const -> Window = 0;
     virtual auto active_output() -> mir::geometry::Rectangle const = 0;
+    virtual auto active_zone() -> mir::geometry::Rectangle = 0;
     virtual void raise_tree(Window const& root) = 0;
     virtual void start_drag_and_drop(WindowInfo& window_info, std::vector<uint8_t> const& handle) = 0;
     virtual void end_drag_and_drop() = 0;

--- a/src/miral/window_manager_tools_implementation.h
+++ b/src/miral/window_manager_tools_implementation.h
@@ -37,6 +37,7 @@ struct WindowInfo;
 struct ApplicationInfo;
 class WindowSpecification;
 class Workspace;
+class Zone;
 
 // The interface through which the policy instructs the controller.
 class WindowManagerToolsImplementation
@@ -66,7 +67,7 @@ public:
     virtual void focus_prev_within_application() = 0;
     virtual auto window_at(mir::geometry::Point cursor) const -> Window = 0;
     virtual auto active_output() -> mir::geometry::Rectangle const = 0;
-    virtual auto active_zone() -> mir::geometry::Rectangle = 0;
+    virtual auto active_application_zone() -> Zone = 0;
     virtual void raise_tree(Window const& root) = 0;
     virtual void start_drag_and_drop(WindowInfo& window_info, std::vector<uint8_t> const& handle) = 0;
     virtual void end_drag_and_drop() = 0;


### PR DESCRIPTION
Add WindowManagerTools::active_application_zone(). (Fixes: #1530)

Also uses it in the miral-shell "floating" window manager.