### PR TITLE
Move XWayland spawner into connector

### DIFF
--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -22,6 +22,7 @@
 
 #include "wayland_connector.h"
 #include "xwayland_server.h"
+#include "xwayland_spawner.h"
 
 namespace mf = mir::frontend;
 
@@ -39,6 +40,7 @@ void mf::XWaylandConnector::start()
     {
         std::lock_guard<std::mutex> lock{mutex};
 
+        spawner = std::make_unique<XWaylandSpawner>([this]() { spawn(); });
         server = std::make_unique<XWaylandServer>(wayland_connector, xwayland_path);
         mir::log_info("XWayland started");
     }
@@ -50,10 +52,12 @@ void mf::XWaylandConnector::stop()
 
     bool const was_running{server};
 
+    auto local_spawner{std::move(spawner)};
     auto local_server{std::move(server)};
 
     lock.unlock();
 
+    local_spawner.reset();
     local_server.reset();
 
     if (was_running)
@@ -77,9 +81,9 @@ auto mf::XWaylandConnector::socket_name() const -> optional_value<std::string>
 {
     std::lock_guard<std::mutex> lock{mutex};
 
-    if (server)
+    if (spawner)
     {
-        return server->x11_display();
+        return spawner->x11_display();
     }
     else
     {
@@ -88,3 +92,28 @@ auto mf::XWaylandConnector::socket_name() const -> optional_value<std::string>
 }
 
 mf::XWaylandConnector::~XWaylandConnector() = default;
+
+void mf::XWaylandConnector::spawn()
+{
+    std::lock_guard<std::mutex> lock{mutex};
+
+    if (!spawner || !server)
+    {
+        // We have been stopped and have destroyed our spawner, nothing to do
+        return;
+    }
+
+    try
+    {
+        server->new_spawn_thread(*spawner);
+        mir::log_info("XWayland is running");
+    }
+    catch (...)
+    {
+        log(
+            logging::Severity::error,
+            MIR_LOG_COMPONENT,
+            std::current_exception(),
+            "Spawning XWayland failed");
+    }
+}

--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -37,16 +37,16 @@ void mf::XWaylandConnector::start()
 {
     if (wayland_connector->get_extension("x11-support"))
     {
-        xwayland_server = std::make_unique<XWaylandServer>(wayland_connector, xwayland_path);
+        server = std::make_unique<XWaylandServer>(wayland_connector, xwayland_path);
         mir::log_info("XWayland started");
     }
 }
 
 void mf::XWaylandConnector::stop()
 {
-    if (xwayland_server)
+    if (server)
     {
-        xwayland_server.reset();
+        server.reset();
         mir::log_info("XWayland stopped");
     }
 }
@@ -64,9 +64,9 @@ int mf::XWaylandConnector::client_socket_fd(
 
 auto mf::XWaylandConnector::socket_name() const -> optional_value<std::string>
 {
-    if (xwayland_server)
+    if (server)
     {
-        return xwayland_server->x11_display();
+        return server->x11_display();
     }
     else
     {

--- a/src/server/frontend_xwayland/xwayland_connector.h
+++ b/src/server/frontend_xwayland/xwayland_connector.h
@@ -21,6 +21,9 @@
 
 #include "mir/frontend/connector.h"
 
+#include <memory>
+#include <mutex>
+
 namespace mir
 {
 namespace frontend
@@ -48,6 +51,7 @@ private:
     std::shared_ptr<WaylandConnector> const wayland_connector;
     std::string const xwayland_path;
 
+    std::mutex mutable mutex;
     std::unique_ptr<XWaylandServer> server;
 };
 } /* frontend */

--- a/src/server/frontend_xwayland/xwayland_connector.h
+++ b/src/server/frontend_xwayland/xwayland_connector.h
@@ -30,6 +30,7 @@ namespace frontend
 {
 class WaylandConnector;
 class XWaylandServer;
+class XWaylandSpawner;
 class XWaylandConnector : public Connector
 {
 public:
@@ -51,7 +52,10 @@ private:
     std::shared_ptr<WaylandConnector> const wayland_connector;
     std::string const xwayland_path;
 
+    void spawn();
+
     std::mutex mutable mutex;
+    std::unique_ptr<XWaylandSpawner> spawner;
     std::unique_ptr<XWaylandServer> server;
 };
 } /* frontend */

--- a/src/server/frontend_xwayland/xwayland_connector.h
+++ b/src/server/frontend_xwayland/xwayland_connector.h
@@ -48,7 +48,7 @@ private:
     std::shared_ptr<WaylandConnector> const wayland_connector;
     std::string const xwayland_path;
 
-    std::unique_ptr<XWaylandServer> xwayland_server;
+    std::unique_ptr<XWaylandServer> server;
 };
 } /* frontend */
 } /* mir */

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -46,22 +46,21 @@ public:
     XWaylandServer(std::shared_ptr<WaylandConnector> wayland_connector, std::string const& xwayland_path);
     ~XWaylandServer();
 
-    auto x11_display() const -> std::string;
+    void new_spawn_thread(XWaylandSpawner const& spawner);
 
 private:
     XWaylandServer(XWaylandServer const&) = delete;
     XWaylandServer& operator=(XWaylandServer const&) = delete;
 
     /// Forks off the XWayland process
-    void spawn();
+    void spawn(XWaylandSpawner const& spawner);
     /// Called after fork() if we should turn into XWayland
-    void execl_xwayland(int wl_client_client_fd, int wm_client_fd);
+    void execl_xwayland(XWaylandSpawner const& spawner, int wl_client_client_fd, int wm_client_fd);
     /// Called after fork() if we should continue on as Mir
     void connect_wm_to_xwayland(
         Fd const& wl_client_server_fd,
         Fd const& wm_server_fd,
         std::unique_lock<std::mutex>& spawn_thread_lock);
-    void new_spawn_thread();
 
     enum Status {
         STARTING = 1,
@@ -72,7 +71,6 @@ private:
 
     std::shared_ptr<WaylandConnector> const wayland_connector;
     std::string const xwayland_path;
-    std::unique_ptr<XWaylandSpawner> const spawner;
 
     std::mutex mutable spawn_thread_mutex;
     std::thread spawn_thread;


### PR DESCRIPTION
Moves ownership of the `XWaylandSpawner` out of the `XWaylandServer` and into the `XWaylandConnector` which owns it. Some logic is added to make this all thread safe (I don't believe it was entirely thread safe before). Where this is going is the `XWaylandServer` will fork the server process on construction, kill it on destruction and have no other responsibilities.