### PR TITLE
Drop --name option

### DIFF
--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -53,7 +53,6 @@ extern char const* const x11_display_opt;
 extern char const* const wayland_extensions_opt;
 extern char const* const enable_mirclient_opt;
 
-extern char const* const name_opt;
 extern char const* const offscreen_opt;
 
 extern char const* const enable_key_repeat_opt;

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -42,7 +42,6 @@ char const* const mo::input_report_opt            = "input-report";
 char const* const mo::seat_report_opt            = "seat-report";
 char const* const mo::shared_library_prober_report_opt = "shared-library-prober-report";
 char const* const mo::shell_report_opt            = "shell-report";
-char const* const mo::name_opt                    = "name";
 char const* const mo::offscreen_opt               = "offscreen";
 char const* const mo::touchspots_opt              = "enable-touchspots";
 char const* const mo::cursor_opt                  = "cursor";
@@ -183,8 +182,6 @@ mo::DefaultConfiguration::DefaultConfiguration(
             "frames from clients before compositing). Higher values result in "
             "lower latency but risk causing frame skipping. "
             "Default: A negative value means decide automatically.")
-        (name_opt, po::value<std::string>(),
-            "When nested, the name Mir uses when registering with the host.")
         (offscreen_opt,
             "Render to offscreen buffers instead of the real outputs.")
         (touchspots_opt,

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -117,7 +117,6 @@ MIRPLATFORM_2.0 {
     mir::options::logind_console;
     mir::options::lttng_opt_value*;
     mir::options::msg_processor_report_opt*;
-    mir::options::name_opt*;
     mir::options::nested_passthrough_opt*;
     mir::options::no_server_socket_opt*;
     mir::options::null_console;


### PR DESCRIPTION
Drop --name option that's been unused since we removed the "Nested Mir" quasi-platform