### PR TITLE
Rename XCBConnection atoms to match X11 atom names

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -185,7 +185,7 @@ auto mf::XCBConnection::query_name(xcb_atom_t atom) const -> std::string
 
 auto mf::XCBConnection::reply_contains_string_data(xcb_get_property_reply_t const* reply) const -> bool
 {
-    return reply->type == XCB_ATOM_STRING || reply->type == utf8_string || reply->type == compound_text;
+    return reply->type == XCB_ATOM_STRING || reply->type == UTF8_STRING || reply->type == COMPOUND_TEXT;
 }
 
 auto mf::XCBConnection::string_from(xcb_get_property_reply_t const* reply) const -> std::string
@@ -544,9 +544,9 @@ auto mf::XCBConnection::xcb_type_atom(XCBType type) const -> xcb_atom_t
         case XCBType::WINDOW:       return XCB_ATOM_WINDOW;
         case XCBType::CARDINAL32:   return XCB_ATOM_CARDINAL;
         case XCBType::STRING:       return XCB_ATOM_STRING;
-        case XCBType::UTF8_STRING:  return utf8_string;
-        case XCBType::WM_STATE:     return wm_state;
-        case XCBType::WM_PROTOCOLS: return wm_protocols;
+        case XCBType::UTF8_STRING:  return UTF8_STRING;
+        case XCBType::WM_STATE:     return WM_STATE;
+        case XCBType::WM_PROTOCOLS: return WM_PROTOCOLS;
     }
 
     BOOST_THROW_EXCEPTION(std::runtime_error(

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -204,48 +204,52 @@ public:
     auto error_debug_string(xcb_generic_error_t* error) const -> std::string;
     /// @}
 
-    Atom const wm_protocols{"WM_PROTOCOLS", this};
-    Atom const wm_take_focus{"WM_TAKE_FOCUS", this};
-    Atom const wm_delete_window{"WM_DELETE_WINDOW", this};
-    Atom const wm_state{"WM_STATE", this};
-    Atom const wm_change_state{"WM_CHANGE_STATE", this};
-    Atom const wm_s0{"WM_S0", this};
-    Atom const net_wm_cm_s0{"_NET_WM_CM_S0", this};
-    Atom const net_wm_name{"_NET_WM_NAME", this};
-    Atom const net_wm_pid{"_NET_WM_PID", this};
-    Atom const net_wm_state{"_NET_WM_STATE", this};
-    Atom const net_wm_state_maximized_vert{"_NET_WM_STATE_MAXIMIZED_VERT", this};
-    Atom const net_wm_state_maximized_horz{"_NET_WM_STATE_MAXIMIZED_HORZ", this};
-    Atom const net_wm_state_hidden{"_NET_WM_STATE_HIDDEN", this};
-    Atom const net_wm_state_fullscreen{"_NET_WM_STATE_FULLSCREEN", this};
-    Atom const net_wm_user_time{"_NET_WM_USER_TIME", this};
-    Atom const net_wm_icon_name{"_NET_WM_ICON_NAME", this};
-    Atom const net_wm_desktop{"_NET_WM_DESKTOP", this};
-    Atom const net_wm_window_type{"_NET_WM_WINDOW_TYPE", this};
-    Atom const net_wm_window_type_desktop{"_NET_WM_WINDOW_TYPE_DESKTOP", this};
-    Atom const net_wm_window_type_dock{"_NET_WM_WINDOW_TYPE_DOCK", this};
-    Atom const net_wm_window_type_toolbar{"_NET_WM_WINDOW_TYPE_TOOLBAR", this};
-    Atom const net_wm_window_type_menu{"_NET_WM_WINDOW_TYPE_MENU", this};
-    Atom const net_wm_window_type_utility{"_NET_WM_WINDOW_TYPE_UTILITY", this};
-    Atom const net_wm_window_type_splash{"_NET_WM_WINDOW_TYPE_SPLASH", this};
-    Atom const net_wm_window_type_dialog{"_NET_WM_WINDOW_TYPE_DIALOG", this};
-    Atom const net_wm_window_type_dropdown{"_NET_WM_WINDOW_TYPE_DROPDOWN_MENU", this};
-    Atom const net_wm_window_type_popup{"_NET_WM_WINDOW_TYPE_POPUP_MENU", this};
-    Atom const net_wm_window_type_tooltip{"_NET_WM_WINDOW_TYPE_TOOLTIP", this};
-    Atom const net_wm_window_type_notification{"_NET_WM_WINDOW_TYPE_NOTIFICATION", this};
-    Atom const net_wm_window_type_combo{"_NET_WM_WINDOW_TYPE_COMBO", this};
-    Atom const net_wm_window_type_dnd{"_NET_WM_WINDOW_TYPE_DND", this};
-    Atom const net_wm_window_type_normal{"_NET_WM_WINDOW_TYPE_NORMAL", this};
-    Atom const net_wm_moveresize{"_NET_WM_MOVERESIZE", this};
-    Atom const net_supporting_wm_check{"_NET_SUPPORTING_WM_CHECK", this};
-    Atom const net_supported{"_NET_SUPPORTED", this};
-    Atom const net_active_window{"_NET_ACTIVE_WINDOW", this};
-    Atom const motif_wm_hints{"_MOTIF_WM_HINTS", this};
-    Atom const clipboard{"CLIPBOARD", this};
-    Atom const clipboard_manager{"CLIPBOARD_MANAGER", this};
-    Atom const utf8_string{"UTF8_STRING", this};
-    Atom const compound_text{"COMPOUND_TEXT", this};
-    Atom const wl_surface_id{"WL_SURFACE_ID", this};
+#define DECLARE_ATOM(name) Atom const name{#name, this}
+
+    DECLARE_ATOM(WM_PROTOCOLS);
+    DECLARE_ATOM(WM_TAKE_FOCUS);
+    DECLARE_ATOM(WM_DELETE_WINDOW);
+    DECLARE_ATOM(WM_STATE);
+    DECLARE_ATOM(WM_CHANGE_STATE);
+    DECLARE_ATOM(WM_S0);
+    DECLARE_ATOM(_NET_WM_CM_S0);
+    DECLARE_ATOM(_NET_WM_NAME);
+    DECLARE_ATOM(_NET_WM_PID);
+    DECLARE_ATOM(_NET_WM_STATE);
+    DECLARE_ATOM(_NET_WM_STATE_MAXIMIZED_VERT);
+    DECLARE_ATOM(_NET_WM_STATE_MAXIMIZED_HORZ);
+    DECLARE_ATOM(_NET_WM_STATE_HIDDEN);
+    DECLARE_ATOM(_NET_WM_STATE_FULLSCREEN);
+    DECLARE_ATOM(_NET_WM_USER_TIME);
+    DECLARE_ATOM(_NET_WM_ICON_NAME);
+    DECLARE_ATOM(_NET_WM_DESKTOP);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_DESKTOP);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_DOCK);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_TOOLBAR);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_MENU);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_UTILITY);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_SPLASH);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_DIALOG);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_DROPDOWN_MENU);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_POPUP_MENU);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_TOOLTIP);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_NOTIFICATION);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_COMBO);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_DND);
+    DECLARE_ATOM(_NET_WM_WINDOW_TYPE_NORMAL);
+    DECLARE_ATOM(_NET_WM_MOVERESIZE);
+    DECLARE_ATOM(_NET_SUPPORTING_WM_CHECK);
+    DECLARE_ATOM(_NET_SUPPORTED);
+    DECLARE_ATOM(_NET_ACTIVE_WINDOW);
+    DECLARE_ATOM(_MOTIF_WM_HINTS);
+    DECLARE_ATOM(CLIPBOARD);
+    DECLARE_ATOM(CLIPBOARD_MANAGER);
+    DECLARE_ATOM(UTF8_STRING);
+    DECLARE_ATOM(COMPOUND_TEXT);
+    DECLARE_ATOM(WL_SURFACE_ID);
+
+#undef DECLARE_ATOM
 
 private:
     XCBConnection(XCBConnection&) = delete;

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -164,7 +164,7 @@ mf::XWaylandSurface::XWaylandSurface(
           property_handler<std::string const&>(
               connection,
               window,
-              connection->net_wm_name,
+              connection->_NET_WM_NAME,
               [this](auto value)
               {
                   std::lock_guard<std::mutex> lock{mutex};
@@ -185,13 +185,13 @@ mf::XWaylandSurface::XWaylandSurface(
           property_handler<xcb_atom_t>(
               connection,
               window,
-              connection->net_wm_window_type,
+              connection->_NET_WM_WINDOW_TYPE,
               [this](xcb_atom_t wm_type) { window_type(wm_type); },
               []{}),
           property_handler<std::vector<xcb_atom_t> const&>(
               connection,
               window,
-              connection->wm_protocols,
+              connection->WM_PROTOCOLS,
               [this](std::vector<xcb_atom_t> const& value)
               {
                   std::lock_guard<std::mutex> lock{mutex};
@@ -229,7 +229,7 @@ void mf::XWaylandSurface::map()
     // The client should use a client message to change state later
     auto const cookie = connection->read_property(
         window,
-        connection->net_wm_state,
+        connection->_NET_WM_STATE,
         [&](std::vector<xcb_atom_t> net_wm_states)
         {
             for (auto const& net_wm_state : net_wm_states)
@@ -245,7 +245,7 @@ void mf::XWaylandSurface::map()
     uint32_t const workspace = 1;
     connection->set_property<XCBType::CARDINAL32>(
         window,
-        connection->net_wm_desktop,
+        connection->_NET_WM_DESKTOP,
         workspace);
 
     state.withdrawn = false;
@@ -283,7 +283,7 @@ void mf::XWaylandSurface::close()
         xwm->forget_scene_surface(scene_surface);
     }
 
-    connection->delete_property(window, connection->net_wm_desktop);
+    connection->delete_property(window, connection->_NET_WM_DESKTOP);
 
     state.withdrawn = true;
     inform_client_of_window_state(state);
@@ -327,14 +327,14 @@ void mf::XWaylandSurface::take_focus()
             return;
 
         supports_take_focus = (
-            cached.supported_wm_protocols.find(connection->wm_take_focus) !=
+            cached.supported_wm_protocols.find(connection->WM_TAKE_FOCUS) !=
             cached.supported_wm_protocols.end());
     }
 
     if (supports_take_focus)
     {
         uint32_t const client_message_data[]{
-            connection->wm_take_focus,
+            connection->WM_TAKE_FOCUS,
             XCB_TIME_CURRENT_TIME};
 
         connection->send_client_message<XCBType::WM_PROTOCOLS>(
@@ -636,11 +636,11 @@ void mf::XWaylandSurface::WindowState::apply_change(
 {
     bool nil{false}, *prop_ptr = &nil;
 
-    if (net_wm_state == connection->net_wm_state_hidden)
+    if (net_wm_state == connection->_NET_WM_STATE_HIDDEN)
         prop_ptr = &minimized;
-    else if (net_wm_state == connection->net_wm_state_maximized_horz) // assume vert is also set
+    else if (net_wm_state == connection->_NET_WM_STATE_MAXIMIZED_HORZ) // assume vert is also set
         prop_ptr = &maximized;
-    else if (net_wm_state == connection->net_wm_state_fullscreen)
+    else if (net_wm_state == connection->_NET_WM_STATE_FULLSCREEN)
         prop_ptr = &fullscreen;
 
     switch (action)
@@ -775,7 +775,7 @@ void mf::XWaylandSurface::scene_surface_close_requested()
     {
         std::lock_guard<std::mutex> lock{mutex};
         delete_window = (
-            cached.supported_wm_protocols.find(connection->wm_delete_window) !=
+            cached.supported_wm_protocols.find(connection->WM_DELETE_WINDOW) !=
             cached.supported_wm_protocols.end());
     }
 
@@ -788,7 +788,7 @@ void mf::XWaylandSurface::scene_surface_close_requested()
                 connection->window_debug_string(window).c_str());
         }
         uint32_t const client_message_data[]{
-            connection->wm_delete_window,
+            connection->WM_DELETE_WINDOW,
             XCB_TIME_CURRENT_TIME,
         };
         connection->send_client_message<XCBType::WM_PROTOCOLS>(window, XCB_EVENT_MASK_NO_EVENT, client_message_data);
@@ -901,14 +901,14 @@ void mf::XWaylandSurface::inform_client_of_window_state(WindowState const& new_w
         static_cast<uint32_t>(wm_state),
         XCB_WINDOW_NONE // Icon window
     };
-    connection->set_property<XCBType::WM_STATE>(window, connection->wm_state, wm_state_properties);
+    connection->set_property<XCBType::WM_STATE>(window, connection->WM_STATE, wm_state_properties);
 
     if (new_window_state.withdrawn)
     {
         xcb_delete_property(
             *connection,
             window,
-            connection->net_wm_state);
+            connection->_NET_WM_STATE);
     }
     else
     {
@@ -916,20 +916,20 @@ void mf::XWaylandSurface::inform_client_of_window_state(WindowState const& new_w
 
         if (new_window_state.minimized)
         {
-            net_wm_states.push_back(connection->net_wm_state_hidden);
+            net_wm_states.push_back(connection->_NET_WM_STATE_HIDDEN);
         }
         if (new_window_state.maximized)
         {
-            net_wm_states.push_back(connection->net_wm_state_maximized_horz);
-            net_wm_states.push_back(connection->net_wm_state_maximized_vert);
+            net_wm_states.push_back(connection->_NET_WM_STATE_MAXIMIZED_HORZ);
+            net_wm_states.push_back(connection->_NET_WM_STATE_MAXIMIZED_VERT);
         }
         if (new_window_state.fullscreen)
         {
-            net_wm_states.push_back(connection->net_wm_state_fullscreen);
+            net_wm_states.push_back(connection->_NET_WM_STATE_FULLSCREEN);
         }
         // TODO: Set _NET_WM_STATE_MODAL if appropriate
 
-        connection->set_property<XCBType::ATOM>(window, connection->net_wm_state, net_wm_states);
+        connection->set_property<XCBType::ATOM>(window, connection->_NET_WM_STATE, net_wm_states);
     }
 
     connection->flush();
@@ -1005,15 +1005,15 @@ void mf::XWaylandSurface::window_type(xcb_atom_t wm_type)
             pending_spec(lock).type = type;
         };
 
-    if (connection->net_wm_window_type_normal == wm_type)
+    if (connection->_NET_WM_WINDOW_TYPE_NORMAL == wm_type)
     {
         set_type(mir_window_type_freestyle);
     }
-    else if (connection->net_wm_window_type_popup == wm_type)
+    else if (connection->_NET_WM_WINDOW_TYPE_POPUP_MENU == wm_type)
     {
         set_type(mir_window_type_gloss);
     }
-    else if (connection->net_wm_window_type_menu == wm_type)
+    else if (connection->_NET_WM_WINDOW_TYPE_MENU == wm_type)
     {
         set_type(mir_window_type_menu);
     }

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -55,18 +55,18 @@ auto create_wm_window(mf::XCBConnection const& connection) -> xcb_window_t
         connection.screen()->root_visual,
         0, NULL);
 
-    connection.set_property<mf::XCBType::WINDOW>(wm_window, connection.net_supporting_wm_check, wm_window);
-    connection.set_property<mf::XCBType::UTF8_STRING>(wm_window, connection.net_wm_name, wm_name);
+    connection.set_property<mf::XCBType::WINDOW>(wm_window, connection._NET_SUPPORTING_WM_CHECK, wm_window);
+    connection.set_property<mf::XCBType::UTF8_STRING>(wm_window, connection._NET_WM_NAME, wm_name);
 
     connection.set_property<mf::XCBType::WINDOW>(
         connection.root_window(),
-        connection.net_supporting_wm_check,
+        connection._NET_SUPPORTING_WM_CHECK,
         wm_window);
 
     /* Claim the WM_S0 selection even though we don't support
      * the --replace functionality. */
-    xcb_set_selection_owner(connection, wm_window, connection.wm_s0, XCB_TIME_CURRENT_TIME);
-    xcb_set_selection_owner(connection, wm_window, connection.net_wm_cm_s0, XCB_TIME_CURRENT_TIME);
+    xcb_set_selection_owner(connection, wm_window, connection.WM_S0, XCB_TIME_CURRENT_TIME);
+    xcb_set_selection_owner(connection, wm_window, connection._NET_WM_CM_S0, XCB_TIME_CURRENT_TIME);
 
     return wm_window;
 }
@@ -145,18 +145,18 @@ mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, 
     xcb_composite_redirect_subwindows(*connection, connection->root_window(), XCB_COMPOSITE_REDIRECT_MANUAL);
 
     xcb_atom_t const supported[]{
-        connection->net_wm_moveresize,
-        connection->net_wm_state,
-        connection->net_wm_state_fullscreen,
-        connection->net_wm_state_maximized_vert,
-        connection->net_wm_state_maximized_horz,
-        connection->net_active_window};
+        connection->_NET_WM_MOVERESIZE,
+        connection->_NET_WM_STATE,
+        connection->_NET_WM_STATE_FULLSCREEN,
+        connection->_NET_WM_STATE_MAXIMIZED_VERT,
+        connection->_NET_WM_STATE_MAXIMIZED_HORZ,
+        connection->_NET_ACTIVE_WINDOW};
 
-    connection->set_property<XCBType::ATOM>(connection->root_window(), connection->net_supported, supported);
+    connection->set_property<XCBType::ATOM>(connection->root_window(), connection->_NET_SUPPORTED, supported);
 
     connection->set_property<XCBType::WINDOW>(
         connection->root_window(),
-        connection->net_active_window,
+        connection->_NET_ACTIVE_WINDOW,
         static_cast<xcb_window_t>(XCB_WINDOW_NONE));
 
     cursors->apply_default_to(connection->root_window());
@@ -272,7 +272,7 @@ void mf::XWaylandWM::set_focus(xcb_window_t xcb_window, bool should_be_focused)
     {
         connection->set_property<XCBType::WINDOW>(
             connection->root_window(),
-            connection->net_active_window,
+            connection->_NET_ACTIVE_WINDOW,
             xcb_window);
 
         if (auto const surface = get_wm_surface(xcb_window))
@@ -284,7 +284,7 @@ void mf::XWaylandWM::set_focus(xcb_window_t xcb_window, bool should_be_focused)
     {
         connection->set_property<XCBType::WINDOW>(
             connection->root_window(),
-            connection->net_active_window,
+            connection->_NET_ACTIVE_WINDOW,
             static_cast<xcb_window_t>(XCB_WINDOW_NONE));
 
         xcb_set_input_focus_checked(
@@ -674,13 +674,13 @@ void mf::XWaylandWM::handle_client_message(xcb_client_message_event_t *event)
     if (auto const surface = get_wm_surface(event->window))
     {
         // TODO: net_active_window?
-        if (event->type == connection->net_wm_moveresize)
+        if (event->type == connection->_NET_WM_MOVERESIZE)
             handle_move_resize(surface.value(), event);
-        else if (event->type == connection->net_wm_state)
+        else if (event->type == connection->_NET_WM_STATE)
             surface.value()->net_wm_state_client_message(event->data.data32);
-        else if (event->type == connection->wm_change_state)
+        else if (event->type == connection->WM_CHANGE_STATE)
             surface.value()->wm_change_state_client_message(event->data.data32);
-        else if (event->type == connection->wl_surface_id)
+        else if (event->type == connection->WL_SURFACE_ID)
             handle_surface_id(surface.value(), event);
     }
 }


### PR DESCRIPTION
Open for discussion.

Pros:
- No possibility of accidentally initializing an atom with the wrong name
- IMO all caps distinguish atoms in the code better and match the atom constants provided by XCB
- Obvious exactly which atoms are being used/you can copy paste from the code into google to look up an atom

Cons:
- Technically a style guide violation
- Not the most important thing for me to be doing right now (but it's already done)

(NOTE: I'm not currently working and won't respond to reviews until Friday, Posting now because I just noticed the per-rec PR merged)