### PR TITLE
Minor platform probing improvements

### DIFF
--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -164,6 +164,10 @@ enum PlatformPriority : uint32_t
     supported = 128,    /**< Capable of providing a functioning Platform on this device,
                          *    possibly with degraded performance or features.
                          */
+    hosted = 192,       /**< Capable of providing a fully-featured Platform on this device,
+                         *   running nested under some other display server rather than with
+                         *   exclusive hardware access.
+                         */
     best = 256          /**< Capable of providing a Platform with the best features and
                          *   performance this device is capable of.
                          */

--- a/src/platforms/eglstream-kms/server/platform_symbols.cpp
+++ b/src/platforms/eglstream-kms/server/platform_symbols.cpp
@@ -29,6 +29,7 @@
 #include "mir/graphics/egl_error.h"
 #include "one_shot_device_observer.h"
 #include "mir/raii.h"
+#include "kms-utils/drm_mode_resources.h"
 
 #include <boost/throw_exception.hpp>
 #include <boost/exception/diagnostic_information.hpp>
@@ -227,6 +228,17 @@ mg::PlatformPriority probe_graphics_platform(
                                 strerror(-err),
                                 -err);
                         }
+                        return false;
+                    }
+
+                    mg::kms::DRMModeResources kms_resources{drm_fd};
+                    if (
+                        kms_resources.num_connectors() == 0 ||
+                        kms_resources.num_encoders() == 0 ||
+                        kms_resources.num_crtcs() == 0)
+                    {
+                        mir::log_info("KMS support found, but device has no output hardware.");
+                        mir::log_info("This is probably a render-only hybrid graphics device");
                         return false;
                     }
 

--- a/src/platforms/eglstream-kms/server/platform_symbols.cpp
+++ b/src/platforms/eglstream-kms/server/platform_symbols.cpp
@@ -242,10 +242,7 @@ mg::PlatformPriority probe_graphics_platform(
                         return false;
                     }
 
-                    int const drm_node_attrib[] = {
-                        EGL_DRM_MASTER_FD_EXT, static_cast<int>(drm_fd), EGL_NONE
-                    };
-                    EGLDisplay display = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, device, drm_node_attrib);
+                    EGLDisplay display = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, device, nullptr);
 
                     if (display == EGL_NO_DISPLAY)
                     {

--- a/src/platforms/x11/graphics/graphics.cpp
+++ b/src/platforms/x11/graphics/graphics.cpp
@@ -76,7 +76,7 @@ mg::PlatformPriority probe_graphics_platform(
     if (dpy)
     {
         XCloseDisplay(dpy);
-        return mg::PlatformPriority::supported;
+        return mg::PlatformPriority::hosted;
     }
     return mg::PlatformPriority::unsupported;
 }


### PR DESCRIPTION
Add a `PlatformPriority::hosted` probe value, so we can select a hardware-accelerated X11 platform over a software-rasterised `mesa-kms` platform, and check whether or not there is any output hardware before calling the `eglstream-kms` platform appropriate.

Partially fixes: #1543. The only thing now left is that it can select `eglstream-kms`, which will work until trying to load the *input* platform, which will fail. Fixing that requires a more significant rework of platform probing, tying input & graphics platforms together.