### PR TITLE
XWaylandServer: fork on construction

### DIFF
--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -78,19 +78,12 @@ mf::XWaylandServer::~XWaylandServer()
             }
         }
     }
-
-    if (spawn_thread.joinable())
-        spawn_thread.join();
 }
 
 void mf::XWaylandServer::spawn(XWaylandSpawner const& spawner)
 {
-    set_thread_name("XWaylandServer::spawn");
-
     enum { server, client, size };
     int wl_client_fd[size], wm_fd[size];
-
-    std::lock_guard<std::mutex> lock{spawn_thread_mutex};
 
     spawn_thread_xserver_status = STARTING;
 
@@ -268,9 +261,5 @@ void mf::XWaylandServer::new_spawn_thread(XWaylandSpawner const& spawner)
     spawn_thread_wm.reset();
     spawn_thread_xserver_status = STARTING;
 
-    if (spawn_thread.joinable()) spawn_thread.join();
-    spawn_thread = std::thread{[this, &spawner]()
-        {
-            spawn(spawner);
-        }};
+    spawn(spawner);
 }

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -41,6 +41,7 @@ namespace frontend
 {
 class WaylandConnector;
 class XWaylandSpawner;
+class XWaylandWM;
 
 class XWaylandServer
 {
@@ -79,6 +80,7 @@ private:
     Fd spawn_thread_wl_client_fd;
     Status spawn_thread_xserver_status{Status::STOPPED};
     bool spawn_thread_terminate{false};
+    std::shared_ptr<XWaylandWM> spawn_thread_wm;
 };
 } /* frontend */
 } /* mir */

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -46,39 +46,28 @@ class XWaylandWM;
 class XWaylandServer
 {
 public:
-    XWaylandServer(std::shared_ptr<WaylandConnector> wayland_connector, std::string const& xwayland_path);
+    XWaylandServer(
+        std::shared_ptr<WaylandConnector> const& wayland_connector,
+        XWaylandSpawner const& spawner,
+        std::string const& xwayland_path);
     ~XWaylandServer();
-
-    void new_spawn_thread(XWaylandSpawner const& spawner);
 
 private:
     XWaylandServer(XWaylandServer const&) = delete;
     XWaylandServer& operator=(XWaylandServer const&) = delete;
 
-    /// Forks off the XWayland process
-    void spawn(XWaylandSpawner const& spawner);
     /// Called after fork() if we should turn into XWayland
     void execl_xwayland(XWaylandSpawner const& spawner, int wl_client_client_fd, int wm_client_fd);
     /// Called after fork() if we should continue on as Mir
     void connect_wm_to_xwayland();
 
-    enum Status {
-        STARTING = 1,
-        RUNNING = 2,
-        STOPPED = -1,
-        FAILED = -2
-    };
-
     std::shared_ptr<WaylandConnector> const wayland_connector;
     std::string const xwayland_path;
 
-    std::mutex mutable spawn_thread_mutex;
     pid_t spawn_thread_pid;
     wl_client* spawn_thread_client{nullptr};
     Fd spawn_thread_wm_server_fd;
     Fd spawn_thread_wl_client_fd;
-    Status spawn_thread_xserver_status{Status::STOPPED};
-    bool spawn_thread_terminate{false};
     std::shared_ptr<XWaylandWM> spawn_thread_wm;
 };
 } /* frontend */

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -60,7 +60,7 @@ private:
     /// Called after fork() if we should turn into XWayland
     void execl_xwayland(XWaylandSpawner const& spawner, int wl_client_client_fd, int wm_client_fd);
     /// Called after fork() if we should continue on as Mir
-    void connect_wm_to_xwayland(std::unique_lock<std::mutex>& spawn_thread_lock);
+    void connect_wm_to_xwayland();
 
     enum Status {
         STARTING = 1,

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -73,7 +73,6 @@ private:
     std::string const xwayland_path;
 
     std::mutex mutable spawn_thread_mutex;
-    std::thread spawn_thread;
     pid_t spawn_thread_pid;
     wl_client* spawn_thread_client{nullptr};
     Fd spawn_thread_wm_server_fd;

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -64,11 +64,11 @@ private:
     std::shared_ptr<WaylandConnector> const wayland_connector;
     std::string const xwayland_path;
 
-    pid_t spawn_thread_pid;
-    wl_client* spawn_thread_client{nullptr};
-    Fd spawn_thread_wm_server_fd;
-    Fd spawn_thread_wl_client_fd;
-    std::shared_ptr<XWaylandWM> spawn_thread_wm;
+    pid_t xwayland_pid;
+    wl_client* wayland_client{nullptr};
+    Fd x11_fd;
+    Fd wayland_fd;
+    std::shared_ptr<XWaylandWM> wm;
 };
 } /* frontend */
 } /* mir */

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -27,6 +27,8 @@
 #include <string>
 #include <vector>
 
+struct wl_client;
+
 namespace mir
 {
 namespace dispatch
@@ -57,10 +59,7 @@ private:
     /// Called after fork() if we should turn into XWayland
     void execl_xwayland(XWaylandSpawner const& spawner, int wl_client_client_fd, int wm_client_fd);
     /// Called after fork() if we should continue on as Mir
-    void connect_wm_to_xwayland(
-        Fd const& wl_client_server_fd,
-        Fd const& wm_server_fd,
-        std::unique_lock<std::mutex>& spawn_thread_lock);
+    void connect_wm_to_xwayland(std::unique_lock<std::mutex>& spawn_thread_lock);
 
     enum Status {
         STARTING = 1,
@@ -75,6 +74,9 @@ private:
     std::mutex mutable spawn_thread_mutex;
     std::thread spawn_thread;
     pid_t spawn_thread_pid;
+    wl_client* spawn_thread_client{nullptr};
+    Fd spawn_thread_wm_server_fd;
+    Fd spawn_thread_wl_client_fd;
     Status spawn_thread_xserver_status{Status::STOPPED};
     bool spawn_thread_terminate{false};
 };


### PR DESCRIPTION
The `XWaylandServer` should fork off the XWayland process on construction and kill it on destruction, rather than the 2-step initialization we were doing. In the process, the spawn thread and logic that waits for the XWayland server to quit is removed.