### PR TITLE
[MirAL] Drop deprecated functions from WaylandExtensions

### DIFF
--- a/debian/libmiral4.symbols
+++ b/debian/libmiral4.symbols
@@ -137,6 +137,7 @@ libmiral.so.4 libmiral4 #MINVER#
  (c++)"miral::WaylandExtensions::WaylandExtensions(miral::WaylandExtensions const&)@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::add_extension(miral::WaylandExtensions::Builder const&)@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::add_extension_disabled_by_default(miral::WaylandExtensions::Builder const&)@MIRAL_3.0" 3.0.0
+ (c++)"miral::WaylandExtensions::all_supported[abi:cxx11]() const@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::disable(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::enable(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::operator()(mir::Server&) const@MIRAL_3.0" 3.0.0

--- a/debian/libmiral4.symbols
+++ b/debian/libmiral4.symbols
@@ -135,7 +135,6 @@ libmiral.so.4 libmiral4 #MINVER#
  (c++)"miral::StartupInternalClient::~StartupInternalClient()@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::WaylandExtensions()@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::WaylandExtensions(miral::WaylandExtensions const&)@MIRAL_3.0" 3.0.0
- (c++)"miral::WaylandExtensions::WaylandExtensions(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::add_extension(miral::WaylandExtensions::Builder const&)@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::add_extension_disabled_by_default(miral::WaylandExtensions::Builder const&)@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::disable(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)@MIRAL_3.0" 3.0.0
@@ -143,10 +142,8 @@ libmiral.so.4 libmiral4 #MINVER#
  (c++)"miral::WaylandExtensions::operator()(mir::Server&) const@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::operator=(miral::WaylandExtensions const&)@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::recommended[abi:cxx11]()@MIRAL_3.0" 3.0.0
- (c++)"miral::WaylandExtensions::recommended_extensions[abi:cxx11]()@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::set_filter(std::function<bool (std::shared_ptr<mir::scene::Session> const&, char const*)> const&)@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::supported[abi:cxx11]()@MIRAL_3.0" 3.0.0
- (c++)"miral::WaylandExtensions::supported_extensions[abi:cxx11]() const@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::zwlr_layer_shell_v1@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::zxdg_output_manager_v1@MIRAL_3.0" 3.0.0
  (c++)"miral::WaylandExtensions::~WaylandExtensions()@MIRAL_3.0" 3.0.0

--- a/include/miral/miral/wayland_extensions.h
+++ b/include/miral/miral/wayland_extensions.h
@@ -51,28 +51,7 @@ public:
     /// Default to enabling the extensions recommended by Mir
     WaylandExtensions();
 
-    /// Initialize "enabled by default" to a custom set of extensions (colon
-    /// separated list).
-    /// \note This can only be a subset of supported_extensions()
-    /// \deprecated A better option is to use the default constructor, enable()
-    /// and disable(). You can call disable() on all recommended() extensions
-    /// if you want complete control over which are enabled
-    explicit WaylandExtensions(std::string const& default_value);
-
     void operator()(mir::Server& server) const;
-
-    /// All Wayland extensions currently supported (colon separated list).
-    /// This includes both the recommended_extensions() and any extensions that
-    /// have been added using add_extension().
-    /// \deprecated This is of no real use to the server, just for documenting
-    /// the configuration option.
-    auto supported_extensions() const -> std::string;
-
-    /// Default for extensions to enabled recommended by Mir (colon separated list)
-    /// \remark Since MirAL 2.5
-    /// \deprecated Instead of overridding the whole extension list in the constructor and using this to get the
-    /// recommended ones, you can now just enable() the extensions you want.
-    static auto recommended_extensions() -> std::string;
 
     ~WaylandExtensions();
     WaylandExtensions(WaylandExtensions const&);

--- a/include/miral/miral/wayland_extensions.h
+++ b/include/miral/miral/wayland_extensions.h
@@ -57,6 +57,12 @@ public:
     WaylandExtensions(WaylandExtensions const&);
     auto operator=(WaylandExtensions const&) -> WaylandExtensions&;
 
+    /// All Wayland extensions supported.
+    /// This includes both the supported() provided by Mir and any extensions
+    /// that have been added using add_extension().
+    /// \remark Since MirAL 3.0
+    auto all_supported() const -> std::set<std::string>;
+
     /// Context information useful for implementing Wayland extensions
     /// \remark Since MirAL 2.5
     class Context

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -128,10 +128,8 @@ global:
     miral::WaylandExtensions::enable*;
     miral::WaylandExtensions::operator*;
     miral::WaylandExtensions::recommended*;
-    miral::WaylandExtensions::recommended_extensions*;
     miral::WaylandExtensions::set_filter*;
     miral::WaylandExtensions::supported*;
-    miral::WaylandExtensions::supported_extensions*;
     miral::WaylandExtensions::zwlr_layer_shell_v1*;
     miral::WaylandExtensions::zxdg_output_manager_v1*;
     miral::Window::?Window*;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -124,6 +124,7 @@ global:
     miral::WaylandExtensions::WaylandExtensions*;
     miral::WaylandExtensions::add_extension*;
     miral::WaylandExtensions::add_extension_disabled_by_default*;
+    miral::WaylandExtensions::all_supported*;
     miral::WaylandExtensions::disable*;
     miral::WaylandExtensions::enable*;
     miral::WaylandExtensions::operator*;

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -192,32 +192,15 @@ miral::WaylandExtensions::WaylandExtensions()
 {
 }
 
-miral::WaylandExtensions::WaylandExtensions(std::string const& default_value)
-    : WaylandExtensions{}
-{
-    auto extensions = Self::parse_extensions_option(default_value);
-    self->validate(extensions);
-    self->default_extensions = extensions;
-}
-
-auto miral::WaylandExtensions::supported_extensions() const -> std::string
-{
-    std::vector<std::string> extensions{self->supported_extensions.begin(), self->supported_extensions.end()};
-    return Self::serialize_colon_list(extensions);
-}
-
-auto miral::WaylandExtensions::recommended_extensions() -> std::string
-{
-    return Self::serialize_colon_list(mir::frontend::get_standard_extensions());
-}
-
 void miral::WaylandExtensions::operator()(mir::Server& server) const
 {
     StaticExtensionTracker::add_server_extension(&server, self.get());
 
+    std::vector<std::string> extensions{self->supported_extensions.begin(), self->supported_extensions.end()};
+
     server.add_configuration_option(
         mo::wayland_extensions_opt,
-        ("Wayland extensions to enable. [" + supported_extensions() + "]"),
+        ("Wayland extensions to enable. [" + Self::serialize_colon_list(extensions) + "]"),
         mir::OptionType::string);
 
     server.add_pre_init_callback([self=self, &server]

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -154,6 +154,7 @@ struct miral::WaylandExtensions::Self
     {
         wayland_extension_hooks.push_back(builder);
         supported_extensions.insert(builder.name);
+        printf("%s = %s\n", __PRETTY_FUNCTION__, builder.name.c_str());
     }
 
     void enable_extension(std::string name)
@@ -294,6 +295,11 @@ auto miral::WaylandExtensions::disable(std::string name) -> WaylandExtensions&
 {
     self->disable_extension(name);
     return *this;
+}
+
+auto miral::WaylandExtensions::all_supported() const -> std::set<std::string>
+{
+    return self->supported_extensions;
 }
 
 auto miral::application_for(wl_client* client) -> Application

--- a/tests/miral/wayland_extensions.cpp
+++ b/tests/miral/wayland_extensions.cpp
@@ -275,14 +275,11 @@ TEST_F(WaylandExtensions, client_sees_default_extensions)
 
     run_as_client(enumerator_client);
 
-    auto const available_extensions = miral::WaylandExtensions::recommended_extensions() += ':';
+    auto const available_extensions = miral::WaylandExtensions::recommended();
 
-    for (char const* start = available_extensions.c_str(); char const* end = strchr(start, ':'); start = end+1)
+    for (auto const& extension : available_extensions)
     {
-        if (start != end)
-        {
-            EXPECT_THAT(*enumerator_client.interfaces, Contains(Eq(std::string{start, end})));
-        }
+        EXPECT_THAT(*enumerator_client.interfaces, Contains(Eq(extension)));
     }
 }
 
@@ -326,30 +323,11 @@ TEST_F(WaylandExtensions, add_extension_adds_protocol_to_supported_enabled_exten
 {
     miral::WaylandExtensions extensions;
 
-    EXPECT_THAT(extensions.supported_extensions(), Not(HasSubstr(mir::examples::server_decoration_extension().name)));
+    EXPECT_THAT(extensions.supported(), Not(Contains(Eq(mir::examples::server_decoration_extension().name))));
 
     extensions.add_extension(mir::examples::server_decoration_extension());
 
-    EXPECT_THAT(extensions.supported_extensions(), HasSubstr(mir::examples::server_decoration_extension().name));
-}
-
-TEST_F(WaylandExtensions, server_can_remove_default_extensions)
-{
-    std::string const extension_to_remove{":zxdg_shell_v6"};
-    auto reduced_default_extensions = miral::WaylandExtensions::recommended_extensions();
-    auto const find = reduced_default_extensions.find(extension_to_remove);
-    ASSERT_THAT(find, Gt(0));
-    reduced_default_extensions.replace(find, extension_to_remove.size(), "");
-
-    miral::WaylandExtensions extensions;
-    ClientGlobalEnumerator enumerator_client;
-
-    add_server_init(extensions);
-    start_server();
-
-    run_as_client(enumerator_client);
-
-    EXPECT_THAT(*enumerator_client.interfaces, Not(Contains(Eq(extension_to_remove))));
+    EXPECT_THAT(extensions.supported(), Contains(Eq(mir::examples::server_decoration_extension().name)));
 }
 
 TEST_F(WaylandExtensions, add_extension_disabled_by_default_adds_protocol_to_supported_extensions_only)

--- a/tests/miral/wayland_extensions.cpp
+++ b/tests/miral/wayland_extensions.cpp
@@ -323,11 +323,11 @@ TEST_F(WaylandExtensions, add_extension_adds_protocol_to_supported_enabled_exten
 {
     miral::WaylandExtensions extensions;
 
-    EXPECT_THAT(extensions.supported(), Not(Contains(Eq(mir::examples::server_decoration_extension().name))));
+    EXPECT_THAT(extensions.all_supported(), Not(Contains(Eq(mir::examples::server_decoration_extension().name))));
 
     extensions.add_extension(mir::examples::server_decoration_extension());
 
-    EXPECT_THAT(extensions.supported(), Contains(Eq(mir::examples::server_decoration_extension().name)));
+    EXPECT_THAT(extensions.all_supported(), Contains(Eq(mir::examples::server_decoration_extension().name)));
 }
 
 TEST_F(WaylandExtensions, add_extension_disabled_by_default_adds_protocol_to_supported_extensions_only)


### PR DESCRIPTION
[MirAL] Drop deprecated functions from WaylandExtensions. (Fixes: #1559)