### PR TITLE
[MirAL] Add ExternalClientLauncher::snapcraft_launch()

### DIFF
--- a/debian/libmiral4.symbols
+++ b/debian/libmiral4.symbols
@@ -60,6 +60,7 @@ libmiral.so.4 libmiral4 #MINVER#
  (c++)"miral::ExternalClientLauncher::launch(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) const@MIRAL_3.0" 3.0.0
  (c++)"miral::ExternalClientLauncher::launch_using_x11(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) const@MIRAL_3.0" 3.0.0
  (c++)"miral::ExternalClientLauncher::operator()(mir::Server&)@MIRAL_3.0" 3.0.0
+ (c++)"miral::ExternalClientLauncher::snapcraft_launch(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const@MIRAL_3.0" 3.0.0
  (c++)"miral::ExternalClientLauncher::~ExternalClientLauncher()@MIRAL_3.0" 3.0.0
  (c++)"miral::InternalClientLauncher::InternalClientLauncher()@MIRAL_3.0" 3.0.0
  (c++)"miral::InternalClientLauncher::launch(std::function<void (wl_display*)> const&, std::function<void (std::weak_ptr<mir::scene::Session>)> const&) const@MIRAL_3.0" 3.0.0

--- a/include/miral/miral/external_client.h
+++ b/include/miral/miral/external_client.h
@@ -49,6 +49,10 @@ public:
     /// \remark Return type changed from void in MirAL 3.0
     auto launch_using_x11(std::vector<std::string> const& command_line) const -> pid_t;
 
+    /// Use the proposed `desktop-entry` snap interface to launch another snap
+    /// \remark Since MirAL 3.0
+    void snapcraft_launch(std::string const& desktop_file) const;
+
 private:
     struct Self;
     std::shared_ptr<Self> self;

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -9,6 +9,7 @@ set(symbol_map ${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)
 set(miral_include ${PROJECT_SOURCE_DIR}/include/miral)
 
 pkg_check_modules(YAML REQUIRED yaml-cpp)
+pkg_check_modules(GIO REQUIRED gio-2.0 gio-unix-2.0)
 
 add_library(mirclientcpp INTERFACE)
 
@@ -22,6 +23,7 @@ add_library(miral-internal STATIC
     display_configuration_listeners.cpp display_configuration_listeners.h
     launch_app.cpp                      launch_app.h
     mru_window_list.cpp                 mru_window_list.h
+    open_desktop_entry.cpp              open_desktop_entry.h
     static_display_config.cpp           static_display_config.h
     window_info_internal.cpp            window_info_internal.h
     window_management_trace.cpp         window_management_trace.h
@@ -91,7 +93,7 @@ target_include_directories(mirclientcpp
 
 target_include_directories(miral-internal
     PRIVATE "${miral_include}" ${MIRCLIENT_INCLUDE_DIRS}
-    PRIVATE ${MIRSERVER_INCLUDE_DIRS}
+    PRIVATE ${MIRSERVER_INCLUDE_DIRS} ${GIO_INCLUDE_DIRS}
 )
 
 target_link_libraries(miral-internal
@@ -99,6 +101,7 @@ target_link_libraries(miral-internal
         mirserver
         ${WAYLAND_CLIENT_LDFLAGS} ${WAYLAND_CLIENT_LIBRARIES}
         ${YAML_LIBRARIES}
+        ${GIO_LIBRARIES}
 )
 
 target_include_directories(miral

--- a/src/miral/external_client.cpp
+++ b/src/miral/external_client.cpp
@@ -101,7 +101,9 @@ void miral::ExternalClientLauncher::operator()(mir::Server& server)
 auto miral::ExternalClientLauncher::launch(std::vector<std::string> const& command_line) const -> pid_t
 {
     if (!self->server)
-        throw std::logic_error("Cannot launch apps when server has not started");
+    {
+        BOOST_THROW_EXCEPTION(std::logic_error("Cannot launch apps when server has not started"));
+    }
 
     auto const wayland_display = self->server->wayland_display();
     auto const x11_display = self->server->x11_display();
@@ -114,8 +116,9 @@ miral::ExternalClientLauncher::ExternalClientLauncher() : self{std::make_shared<
 auto  miral::ExternalClientLauncher::launch_using_x11(std::vector<std::string> const& command_line) const -> pid_t
 {
     if (!self->server)
-        throw std::logic_error("Cannot launch apps when server has not started");
-
+    {
+        BOOST_THROW_EXCEPTION(std::logic_error("Cannot launch apps when server has not started"));
+    }
 
     if (auto const x11_display = self->server->x11_display())
     {
@@ -129,7 +132,9 @@ auto  miral::ExternalClientLauncher::launch_using_x11(std::vector<std::string> c
 void miral::ExternalClientLauncher::snapcraft_launch(const std::string& desktop_file) const
 {
     if (!self->server)
-        throw std::logic_error("Cannot launch apps when server has not started");
+    {
+        BOOST_THROW_EXCEPTION(std::logic_error("Cannot launch apps when server has not started"));
+    }
 
     std::vector<std::string> env{
         "XDG_SESSION_DESKTOP=mir",

--- a/src/miral/external_client.cpp
+++ b/src/miral/external_client.cpp
@@ -19,6 +19,7 @@
 #include "miral/external_client.h"
 
 #include "launch_app.h"
+#include "open_desktop_entry.h"
 
 #include <mir/options/option.h>
 #include <mir/server.h>
@@ -123,6 +124,28 @@ auto  miral::ExternalClientLauncher::launch_using_x11(std::vector<std::string> c
     }
 
     return -1;
+}
+
+void miral::ExternalClientLauncher::snapcraft_launch(const std::string& desktop_file) const
+{
+    if (!self->server)
+        throw std::logic_error("Cannot launch apps when server has not started");
+
+    std::vector<std::string> env{
+        "XDG_SESSION_DESKTOP=mir",
+        "XDG_SESSION_TYPE=wayland"};
+
+    if (auto const& wayland_display = self->server->wayland_display())
+    {
+        env.push_back("WAYLAND_DISPLAY=" + wayland_display.value());
+    }
+
+    if (auto const& x11_display = self->server->x11_display())
+    {
+        env.push_back("DISPLAY=" + x11_display.value());
+    }
+
+    open_desktop_entry(desktop_file, env);
 }
 
 miral::ExternalClientLauncher::~ExternalClientLauncher() = default;

--- a/src/miral/open_desktop_entry.cpp
+++ b/src/miral/open_desktop_entry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Canonical Ltd.
+ * Copyright © 2019-2020 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3,
@@ -74,7 +74,7 @@ auto extract_id(std::string const& filename) -> std::string
 }
 }
 
-void egmde::open_desktop_entry(std::string const& desktop_file, std::vector<std::string> const& env)
+void miral::open_desktop_entry(std::string const& desktop_file, std::vector<std::string> const& env)
 {
     Connection const connection{g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, nullptr)};
 

--- a/src/miral/open_desktop_entry.cpp
+++ b/src/miral/open_desktop_entry.cpp
@@ -18,6 +18,8 @@
 
 #include "open_desktop_entry.h"
 
+#include <mir/log.h>
+
 #include <gio/gio.h>
 #include <memory>
 
@@ -90,25 +92,26 @@ void miral::open_desktop_entry(std::string const& desktop_file, std::vector<std:
     for (auto const& e : env)
         g_variant_builder_add (builder, "s", e.c_str());
 
-    if (auto const result = g_dbus_connection_call_sync(connection,
-                                                        dest,
-                                                        object_path,
-                                                        interface_name,
-                                                        method_name,
-                                                        g_variant_new("(sas)", id.c_str(), builder),
-                                                        nullptr,
-                                                        G_DBUS_CALL_FLAGS_NONE,
-                                                        G_MAXINT,
-                                                        nullptr,
-                                                        &error))
+    if (auto const result = g_dbus_connection_call_sync(
+            connection,
+            dest,
+            object_path,
+            interface_name,
+            method_name,
+            g_variant_new("(sas)", id.c_str(), builder),
+            nullptr,
+            G_DBUS_CALL_FLAGS_NONE,
+            G_MAXINT,
+            nullptr,
+            &error))
     {
         g_variant_unref(result);
     }
 
     if (error)
     {
-        puts(error->message);
-        printf("dest=%s, object_path=%s, interface_name=%s, method_name=%s, id=%s\n", dest, object_path, interface_name, method_name, id.c_str());
+        mir::log_info("Dbus error=%s, dest=%s, object_path=%s, interface_name=%s, method_name=%s, id=%s",
+                      error->message, dest, object_path, interface_name, method_name, id.c_str());
         g_error_free(error);
     }
 

--- a/src/miral/open_desktop_entry.cpp
+++ b/src/miral/open_desktop_entry.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "open_desktop_entry.h"
+
+#include <gio/gio.h>
+#include <memory>
+
+namespace
+{
+class Connection : std::shared_ptr<GDBusConnection>
+{
+public:
+    explicit Connection(GDBusConnection* connection) : std::shared_ptr<GDBusConnection>{connection, &g_object_unref} {}
+
+    operator GDBusConnection*() const { return get(); }
+
+private:
+    friend void g_object_unref(GDBusConnection*) = delete;
+};
+
+// Desktop File ID (https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id)
+//
+// Each desktop entry representing an application is identified by its desktop file ID, which is based
+// on its filename.
+//
+// To determine the ID of a desktop file, make its full path relative to the $XDG_DATA_DIRS component
+// in which the desktop file is installed, remove the "applications/" prefix, and turn '/' into '-'.
+//
+// For example /usr/share/applications/foo/bar.desktop has the desktop file ID foo-bar.desktop.
+//
+// If multiple files have the same desktop file ID, the first one in the $XDG_DATA_DIRS precedence
+// order is used.
+//
+// For example, if $XDG_DATA_DIRS contains the default paths /usr/local/share:/usr/share, then
+// /usr/local/share/applications/org.foo.bar.desktop and /usr/share/applications/org.foo.bar.desktop
+// both have the same desktop file ID org.foo.bar.desktop, but only the first one will be used.
+//
+// If both foo-bar.desktop and foo/bar.desktop exist, it is undefined which is selected.
+//
+// If the desktop file is not installed in an applications subdirectory of one of the $XDG_DATA_DIRS
+// components, it does not have an ID.
+auto extract_id(std::string const& filename) -> std::string
+{
+    static std::string const applications{"/applications/"};
+
+    auto const pos = filename.rfind(applications);
+    if (pos == std::string::npos)
+        return filename;
+
+    auto result = filename.substr(pos+applications.length());
+
+    for (auto& r : result)
+    {
+        if (r == '/') r = '-';
+    }
+
+    return result;
+}
+}
+
+void egmde::open_desktop_entry(std::string const& desktop_file, std::vector<std::string> const& env)
+{
+    Connection const connection{g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, nullptr)};
+
+    static char const* const dest = "io.snapcraft.Launcher";
+    static char const* const object_path = "/io/snapcraft/Launcher";
+    static char const* const interface_name = "io.snapcraft.Launcher";
+    static char const* const method_name = "OpenDesktopEntryEnv";
+    auto const id = extract_id(desktop_file);
+
+    GError* error = nullptr;
+
+    GVariantBuilder* const builder = g_variant_builder_new(G_VARIANT_TYPE ("as"));
+    for (auto const& e : env)
+        g_variant_builder_add (builder, "s", e.c_str());
+
+    if (auto const result = g_dbus_connection_call_sync(connection,
+                                                        dest,
+                                                        object_path,
+                                                        interface_name,
+                                                        method_name,
+                                                        g_variant_new("(sas)", id.c_str(), builder),
+                                                        nullptr,
+                                                        G_DBUS_CALL_FLAGS_NONE,
+                                                        G_MAXINT,
+                                                        nullptr,
+                                                        &error))
+    {
+        g_variant_unref(result);
+    }
+
+    if (error)
+    {
+        puts(error->message);
+        printf("dest=%s, object_path=%s, interface_name=%s, method_name=%s, id=%s\n", dest, object_path, interface_name, method_name, id.c_str());
+        g_error_free(error);
+    }
+
+    g_variant_builder_unref(builder);
+}

--- a/src/miral/open_desktop_entry.h
+++ b/src/miral/open_desktop_entry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Canonical Ltd.
+ * Copyright © 2019-2020 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3,
@@ -16,15 +16,15 @@
  * Authored by: Alan Griffiths <alan@octopull.co.uk>
  */
 
-#ifndef EGMDE_OPEN_DESKTOP_ENTRY_H
-#define EGMDE_OPEN_DESKTOP_ENTRY_H
+#ifndef MIRAL_OPEN_DESKTOP_ENTRY_H
+#define MIRAL_OPEN_DESKTOP_ENTRY_H
 
 #include <string>
 #include <vector>
 
-namespace egmde
+namespace miral
 {
 void open_desktop_entry(std::string const& desktop_file, std::vector<std::string> const& env);
 }
 
-#endif //EGMDE_OPEN_DESKTOP_ENTRY_H
+#endif //MIRAL_OPEN_DESKTOP_ENTRY_H

--- a/src/miral/open_desktop_entry.h
+++ b/src/miral/open_desktop_entry.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#ifndef EGMDE_OPEN_DESKTOP_ENTRY_H
+#define EGMDE_OPEN_DESKTOP_ENTRY_H
+
+#include <string>
+#include <vector>
+
+namespace egmde
+{
+void open_desktop_entry(std::string const& desktop_file, std::vector<std::string> const& env);
+}
+
+#endif //EGMDE_OPEN_DESKTOP_ENTRY_H

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -50,6 +50,7 @@ global:
     miral::ExternalClientLauncher::launch*;
     miral::ExternalClientLauncher::launch_using_x11*;
     miral::ExternalClientLauncher::operator*;
+    miral::ExternalClientLauncher::snapcraft_launch*;
     miral::InternalClientLauncher::?InternalClientLauncher*;
     miral::InternalClientLauncher::InternalClientLauncher*;
     miral::InternalClientLauncher::launch*;


### PR DESCRIPTION
[MirAL] Add ExternalClientLauncher::snapcraft_launch().

This introduces support for launching other snaps via the proposed desktop-launch interface. While that interface has yet to land in snapd the client-side code needed is unlikely to change.