### PR TITLE
Move wm ownership from server to connector

### DIFF
--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -42,7 +42,7 @@ void mf::XWaylandConnector::start()
         std::lock_guard<std::mutex> lock{mutex};
 
         spawner = std::make_unique<XWaylandSpawner>([this]() { spawn(); });
-        mir::log_info("XWayland started");
+        mir::log_info("XWayland started on X11 display %s", spawner->x11_display().c_str());
     }
 }
 

--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -23,6 +23,7 @@
 #include "wayland_connector.h"
 #include "xwayland_server.h"
 #include "xwayland_spawner.h"
+#include "xwayland_wm.h"
 
 namespace mf = mir::frontend;
 
@@ -52,11 +53,13 @@ void mf::XWaylandConnector::stop()
     bool const was_running{server};
 
     auto local_spawner{std::move(spawner)};
+    auto local_wm{std::move(wm)};
     auto local_server{std::move(server)};
 
     lock.unlock();
 
     local_spawner.reset();
+    local_wm.reset();
     local_server.reset();
 
     if (was_running)
@@ -110,6 +113,10 @@ void mf::XWaylandConnector::spawn()
             wayland_connector,
             *spawner,
             xwayland_path);
+        wm = std::make_unique<XWaylandWM>(
+            wayland_connector,
+            server->client(),
+            server->wm_fd());
         mir::log_info("XWayland is running");
     }
     catch (...)

--- a/src/server/frontend_xwayland/xwayland_connector.h
+++ b/src/server/frontend_xwayland/xwayland_connector.h
@@ -31,6 +31,7 @@ namespace frontend
 class WaylandConnector;
 class XWaylandServer;
 class XWaylandSpawner;
+class XWaylandWM;
 class XWaylandConnector : public Connector
 {
 public:
@@ -57,6 +58,7 @@ private:
     std::mutex mutable mutex;
     std::unique_ptr<XWaylandSpawner> spawner;
     std::unique_ptr<XWaylandServer> server;
+    std::unique_ptr<XWaylandWM> wm;
 };
 } /* frontend */
 } /* mir */

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -52,6 +52,9 @@ public:
         std::string const& xwayland_path);
     ~XWaylandServer();
 
+    auto client() const -> wl_client* { return wayland_client; }
+    auto wm_fd() const -> Fd const& { return x11_fd; }
+
 private:
     XWaylandServer(XWaylandServer const&) = delete;
     XWaylandServer& operator=(XWaylandServer const&) = delete;
@@ -68,7 +71,6 @@ private:
     wl_client* wayland_client{nullptr};
     Fd x11_fd;
     Fd wayland_fd;
-    std::shared_ptr<XWaylandWM> wm;
 };
 } /* frontend */
 } /* mir */


### PR DESCRIPTION
We are going to want to be able to gracefully shut down the server on a window manager error. This will be easier to do when the server does not own the window manager.