### PR TITLE
eglstream-kms: Actually clean up context in probe

### DIFF
--- a/src/platforms/eglstream-kms/server/platform_symbols.cpp
+++ b/src/platforms/eglstream-kms/server/platform_symbols.cpp
@@ -298,7 +298,7 @@ mg::PlatformPriority probe_graphics_platform(
                             };
                             ctx = eglCreateContext(display, config, EGL_NO_CONTEXT, context_attr);
                         },
-                        [ctx, display]()
+                        [&ctx, display]()
                         {
                             if (ctx != EGL_NO_CONTEXT)
                             {


### PR DESCRIPTION
We need to capture the `EGLContext` by reference if we want it to be valid when we come to tear it down!