### PR TITLE
More cleanup of XWaylandServer

### DIFF
--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -18,15 +18,8 @@
 
 #include "xwayland_server.h"
 #include "xwayland_spawner.h"
-
 #include "wayland_connector.h"
-
-#include "mir/dispatch/multiplexing_dispatchable.h"
-#include "mir/dispatch/readable_fd.h"
-#include "mir/fd.h"
 #include "mir/log.h"
-#include "mir/terminate_with_current_exception.h"
-#include <mir/thread_name.h>
 
 #include <boost/throw_exception.hpp>
 #include <csignal>
@@ -39,7 +32,6 @@
 #include <unistd.h>
 
 #include <chrono>
-#include <thread>
 #include <condition_variable>
 
 namespace mf = mir::frontend;

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -125,7 +125,7 @@ auto fork_xwayland_process(
         close(wayland_pipe[xwayland_side]);
         close(x11_pipe[mir_side]);
         close(x11_pipe[xwayland_side]);
-        BOOST_THROW_EXCEPTION(std::runtime_error("Failed to fork XWayland process"));
+        BOOST_THROW_EXCEPTION(std::system_error(errno, std::generic_category(), "Failed to fork XWayland process"));
 
     case 0:
         close(wayland_pipe[mir_side]);

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -118,7 +118,7 @@ auto fork_xwayland_process(
 
     case 0:
         exec_xwayland(spawner, xwayland_path, wayland_pipe.client, x11_wm_pipe.server);
-        fprintf(stderr, "Failed to start XWayland, should be unreachable");
+        perror("Failed to start XWayland, should be unreachable");
         abort();
 
     default:

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -52,7 +52,7 @@ auto make_socket_pair() -> SocketPair
     int pipe[2];
     if (socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, pipe) < 0)
     {
-        BOOST_THROW_EXCEPTION(std::system_error(errno, std::generic_category(), "Creating socket pair failed"));
+        BOOST_THROW_EXCEPTION(std::system_error(errno, std::system_category(), "Creating socket pair failed"));
     }
     return SocketPair{mir::Fd{pipe[0]}, mir::Fd{pipe[1]}};
 }
@@ -114,7 +114,7 @@ auto fork_xwayland_process(
     switch (xwayland_pid)
     {
     case -1:
-        BOOST_THROW_EXCEPTION(std::system_error(errno, std::generic_category(), "Failed to fork XWayland process"));
+        BOOST_THROW_EXCEPTION(std::system_error(errno, std::system_category(), "Failed to fork XWayland process"));
 
     case 0:
         exec_xwayland(spawner, xwayland_path, wayland_pipe.client, x11_wm_pipe.server);

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -131,7 +131,8 @@ auto fork_xwayland_process(
         close(wayland_pipe[mir_side]);
         close(x11_pipe[mir_side]);
         exec_xwayland(spawner, xwayland_path, wayland_pipe[xwayland_side], x11_pipe[xwayland_side]);
-        BOOST_THROW_EXCEPTION(std::logic_error("Should be unreachable"));
+        fprintf(stderr, "Failed to start XWayland, should be unreachable");
+        abort();
 
     default:
         close(wayland_pipe[xwayland_side]);

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -59,8 +59,6 @@ private:
     XWaylandServer(XWaylandServer const&) = delete;
     XWaylandServer& operator=(XWaylandServer const&) = delete;
 
-    /// Called after fork() if we should turn into XWayland
-    void execl_xwayland(XWaylandSpawner const& spawner, int wl_client_client_fd, int wm_client_fd);
     /// Called after fork() if we should continue on as Mir
     void connect_wm_to_xwayland();
 

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -53,22 +53,21 @@ public:
     ~XWaylandServer();
 
     auto client() const -> wl_client* { return wayland_client; }
-    auto wm_fd() const -> Fd const& { return x11_fd; }
+    auto wm_fd() const -> Fd const& { return xwayland_process.x11_fd; }
+
+    struct XWaylandProcess
+    {
+        pid_t pid;
+        Fd x11_fd;
+        Fd wayland_fd;
+    };
 
 private:
     XWaylandServer(XWaylandServer const&) = delete;
     XWaylandServer& operator=(XWaylandServer const&) = delete;
 
-    /// Called after fork() if we should continue on as Mir
-    void connect_wm_to_xwayland();
-
-    std::shared_ptr<WaylandConnector> const wayland_connector;
-    std::string const xwayland_path;
-
-    pid_t xwayland_pid;
-    wl_client* wayland_client{nullptr};
-    Fd x11_fd;
-    Fd wayland_fd;
+    XWaylandProcess const xwayland_process;
+    wl_client* const wayland_client{nullptr};
 };
 } /* frontend */
 } /* mir */

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -22,26 +22,16 @@
 #include "mir/fd.h"
 
 #include <memory>
-#include <mutex>
-#include <thread>
 #include <string>
-#include <vector>
 
 struct wl_client;
 
 namespace mir
 {
-namespace dispatch
-{
-class ReadableFd;
-class ThreadedDispatcher;
-class MultiplexingDispatchable;
-} /*dispatch */
 namespace frontend
 {
 class WaylandConnector;
 class XWaylandSpawner;
-class XWaylandWM;
 
 class XWaylandServer
 {
@@ -69,7 +59,7 @@ private:
     XWaylandProcess const xwayland_process;
     wl_client* const wayland_client{nullptr};
 };
-} /* frontend */
-} /* mir */
+}
+}
 
-#endif /* end of include guard: MIR_FRONTEND_XWAYLAND_SERVER_H */
+#endif // MIR_FRONTEND_XWAYLAND_SERVER_H

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -43,13 +43,13 @@ public:
     ~XWaylandServer();
 
     auto client() const -> wl_client* { return wayland_client; }
-    auto wm_fd() const -> Fd const& { return xwayland_process.x11_fd; }
+    auto wm_fd() const -> Fd const& { return xwayland_process.x11_wm_client_fd; }
 
     struct XWaylandProcess
     {
         pid_t pid;
-        Fd x11_fd;
-        Fd wayland_fd;
+        Fd wayland_server_fd;
+        Fd x11_wm_client_fd;
     };
 
 private:


### PR DESCRIPTION
Previously we made `XWaylandServer` fork on construction and removed the window manager logic from it. This cleans up the mess that was left over. It transitions from methods that set mutable class members to standalone initialization functions that are used to initialize const members. If the diff is confusing going through commit by commit might help.