### PR TITLE
When the focus moves to a new client ensure the keyboard state is (re)synchronized

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -736,7 +736,7 @@ void mf::WaylandConnector::start()
         },
         display.get()};
 
-    executor->spawn([this]{ seat_global->server_restart(); });
+    executor->spawn([this]{ seat_global->resync_keyboard_state(); });
 }
 
 void mf::WaylandConnector::stop()

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -211,6 +211,8 @@ void mf::WlSeat::notify_focus(wl_client *focus)
         focused_client = focus;
         for (auto const listener : focus_listeners)
             listener->focus_on(focus);
+
+        executor->spawn([this] { resync_keyboard_state(); });
     }
 }
 
@@ -312,7 +314,7 @@ void mf::WlSeat::remove_focus_listener(ListenerTracker* listener)
     focus_listeners.erase(remove(begin(focus_listeners), end(focus_listeners), listener), end(focus_listeners));
 }
 
-void mf::WlSeat::server_restart()
+void mf::WlSeat::resync_keyboard_state()
 {
     if (focus.client)
         for_each_listener(focus.client, [](WlKeyboard* keyboard) { keyboard->resync_keyboard(); });

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -81,7 +81,7 @@ public:
     void remove_focus_listener(ListenerTracker* listener);
     void notify_focus(wl_client* focus);
 
-    void server_restart();
+    void resync_keyboard_state();
 
 private:
     wl_client* focused_client{nullptr}; ///< Can be null


### PR DESCRIPTION
When the focus moves to a new client ensure the keyboard state is (re)synchronized.

Improves, maybe fixes #1515