### PR TITLE
XWaylandConnector: error if destroyed without being stopped

### DIFF
--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -35,6 +35,20 @@ mf::XWaylandConnector::XWaylandConnector(
 {
 }
 
+mf::XWaylandConnector::~XWaylandConnector()
+{
+    if (spawner || server || wm || wm_event_thread)
+    {
+        fatal_error(
+            "XWaylandConnector was not stopped before being destroyed "
+            "(spawner: %s, server: %s, wm: %s, wm_event_thread: %s)",
+            spawner ? "exists" : "null",
+            wm ? "exists" : "null",
+            spawner ? "exists" : "null",
+            wm_event_thread ? "exists" : "null");
+    }
+}
+
 void mf::XWaylandConnector::start()
 {
     if (wayland_connector->get_extension("x11-support"))
@@ -92,8 +106,6 @@ auto mf::XWaylandConnector::socket_name() const -> optional_value<std::string>
         return optional_value<std::string>();
     }
 }
-
-mf::XWaylandConnector::~XWaylandConnector() = default;
 
 void mf::XWaylandConnector::spawn()
 {

--- a/src/server/frontend_xwayland/xwayland_connector.h
+++ b/src/server/frontend_xwayland/xwayland_connector.h
@@ -38,7 +38,7 @@ public:
     XWaylandConnector(
         std::shared_ptr<WaylandConnector> const& wayland_connector,
         std::string const& xwayland_path);
-    ~XWaylandConnector() override;
+    ~XWaylandConnector();
 
     void start() override;
     void stop() override;


### PR DESCRIPTION
There's thread safety issues if this ever happens. Lets make sure it doesn't.