### PR TITLE
wayland::LifetimeTracker

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -473,7 +473,7 @@ Description: Developer files for the Mir ABI-stable abstraction layer
  Contains header files required for development using the MirAL abstraction
  layer.
 
-Package: libmirwayland0
+Package: libmirwayland1
 Section: libs
 Architecture: linux-any
 Multi-Arch: same
@@ -491,7 +491,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirwayland0 (= ${binary:Version}),
+Depends: libmirwayland1 (= ${binary:Version}),
          libmircore-dev (= ${binary:Version}),
          ${misc:Depends},
          libmirwayland-bin (= ${binary:Version})

--- a/debian/libmirwayland0.install
+++ b/debian/libmirwayland0.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmirwayland.so.0

--- a/debian/libmirwayland1.install
+++ b/debian/libmirwayland1.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmirwayland.so.1

--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -32,8 +32,25 @@ namespace mir
 {
 namespace wayland
 {
+/// The base class of any object that wants to provide a destroyed flag
+/// The destroyed flag is only created when needed and automatically set to true on destruction
+/// This pattern is only safe in a single-threaded context
+class Destroyable
+{
+public:
+    Destroyable() = default;
+    Destroyable(Destroyable const&) = delete;
+    Destroyable& operator=(Destroyable const&) = delete;
+
+    virtual ~Destroyable();
+    auto destroyed_flag() const -> std::shared_ptr<bool>;
+
+private:
+    std::shared_ptr<bool> mutable destroyed{nullptr};
+};
 
 class Resource
+    : public Destroyable
 {
 public:
     template<int V>
@@ -42,18 +59,9 @@ public:
     };
 
     Resource();
-    virtual ~Resource();
-
-    Resource(Resource const&) = delete;
-    Resource& operator=(Resource const&) = delete;
-
-    auto destroyed_flag() const -> std::shared_ptr<bool>;
-
-private:
-    std::shared_ptr<bool> mutable destroyed;
 };
 
-/// A weak handle to a Wayland resource
+/// A weak handle to a Wayland resource (or any Destroyable)
 /// May only be safely used from the Wayland thread
 template<typename T>
 class Weak

--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -35,14 +35,14 @@ namespace wayland
 /// The base class of any object that wants to provide a destroyed flag
 /// The destroyed flag is only created when needed and automatically set to true on destruction
 /// This pattern is only safe in a single-threaded context
-class Destroyable
+class DestroyTracker
 {
 public:
-    Destroyable() = default;
-    Destroyable(Destroyable const&) = delete;
-    Destroyable& operator=(Destroyable const&) = delete;
+    DestroyTracker() = default;
+    DestroyTracker(DestroyTracker const&) = delete;
+    DestroyTracker& operator=(DestroyTracker const&) = delete;
 
-    virtual ~Destroyable();
+    virtual ~DestroyTracker();
     auto destroyed_flag() const -> std::shared_ptr<bool>;
 
 private:
@@ -50,7 +50,7 @@ private:
 };
 
 class Resource
-    : public Destroyable
+    : public DestroyTracker
 {
 public:
     template<int V>

--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -35,14 +35,14 @@ namespace wayland
 /// The base class of any object that wants to provide a destroyed flag
 /// The destroyed flag is only created when needed and automatically set to true on destruction
 /// This pattern is only safe in a single-threaded context
-class DestroyTracker
+class LifetimeTracker
 {
 public:
-    DestroyTracker() = default;
-    DestroyTracker(DestroyTracker const&) = delete;
-    DestroyTracker& operator=(DestroyTracker const&) = delete;
+    LifetimeTracker() = default;
+    LifetimeTracker(LifetimeTracker const&) = delete;
+    LifetimeTracker& operator=(LifetimeTracker const&) = delete;
 
-    virtual ~DestroyTracker();
+    virtual ~LifetimeTracker();
     auto destroyed_flag() const -> std::shared_ptr<bool>;
 
 private:
@@ -50,7 +50,7 @@ private:
 };
 
 class Resource
-    : public DestroyTracker
+    : public LifetimeTracker
 {
 public:
     template<int V>

--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -50,7 +50,7 @@ private:
 };
 
 class Resource
-    : public LifetimeTracker
+    : public virtual LifetimeTracker
 {
 public:
     template<int V>

--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MIRWAYLAND_ABI 0)
+set(MIRWAYLAND_ABI 1)
 set(symbol_map ${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)
 add_definitions(-DMIR_LOG_COMPONENT_FALLBACK="mirwayland")
 

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -1,4 +1,4 @@
-MIRWAYLAND_1.2 {
+MIRWAYLAND_1.3 {
 global:
   extern "C++" {
     mir::wayland::Buffer::*;
@@ -282,6 +282,10 @@ global:
     mir::wayland::zxdg_toplevel_v6_interface_data;
     mir::wayland::zxdg_output_v1_interface_data;
     mir::wayland::zxdg_output_manager_v1_interface_data;
+
+    mir::wayland::Destroyable::*;
+    typeinfo?for?mir::wayland::Destroyable;
+    vtable?for?mir::wayland::Destroyable;
 
     mir::wayland::Resource::*;
     typeinfo?for?mir::wayland::Resource;

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -283,9 +283,9 @@ global:
     mir::wayland::zxdg_output_v1_interface_data;
     mir::wayland::zxdg_output_manager_v1_interface_data;
 
-    mir::wayland::Destroyable::*;
-    typeinfo?for?mir::wayland::Destroyable;
-    vtable?for?mir::wayland::Destroyable;
+    mir::wayland::DestroyTracker::*;
+    typeinfo?for?mir::wayland::DestroyTracker;
+    vtable?for?mir::wayland::DestroyTracker;
 
     mir::wayland::Resource::*;
     typeinfo?for?mir::wayland::Resource;

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -1,4 +1,4 @@
-MIRWAYLAND_1.3 {
+MIRWAYLAND_2.0 {
 global:
   extern "C++" {
     mir::wayland::Buffer::*;

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -283,9 +283,9 @@ global:
     mir::wayland::zxdg_output_v1_interface_data;
     mir::wayland::zxdg_output_manager_v1_interface_data;
 
-    mir::wayland::DestroyTracker::*;
-    typeinfo?for?mir::wayland::DestroyTracker;
-    vtable?for?mir::wayland::DestroyTracker;
+    mir::wayland::LifetimeTracker::*;
+    typeinfo?for?mir::wayland::LifetimeTracker;
+    vtable?for?mir::wayland::LifetimeTracker;
 
     mir::wayland::Resource::*;
     typeinfo?for?mir::wayland::Resource;

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -296,6 +296,38 @@ global:
     vtable?for?mir::wayland::Global;
 
     mir::wayland::internal_error_processing_request*;
+
+    # Thunks needed in clang builds
+    virtual?thunk?to?mir::wayland::Callback::?Callback*;
+    virtual?thunk?to?mir::wayland::Compositor::?Compositor*;
+    virtual?thunk?to?mir::wayland::DataDevice::?DataDevice*;
+    virtual?thunk?to?mir::wayland::DataDeviceManager::?DataDeviceManager*;
+    virtual?thunk?to?mir::wayland::DataOffer::?DataOffer*;
+    virtual?thunk?to?mir::wayland::DataSource::?DataSource*;
+    virtual?thunk?to?mir::wayland::Keyboard::?Keyboard*;
+    virtual?thunk?to?mir::wayland::LayerShellV1::?LayerShellV1*;
+    virtual?thunk?to?mir::wayland::LayerSurfaceV1::?LayerSurfaceV1*;
+    virtual?thunk?to?mir::wayland::Pointer::?Pointer*;
+    virtual?thunk?to?mir::wayland::Region::?Region*;
+    virtual?thunk?to?mir::wayland::Seat::?Seat*;
+    virtual?thunk?to?mir::wayland::Shell::?Shell*;
+    virtual?thunk?to?mir::wayland::ShellSurface::?ShellSurface*;
+    virtual?thunk?to?mir::wayland::Subcompositor::?Subcompositor*;
+    virtual?thunk?to?mir::wayland::Subsurface::?Subsurface*;
+    virtual?thunk?to?mir::wayland::Surface::?Surface*;
+    virtual?thunk?to?mir::wayland::Touch::?Touch*;
+    virtual?thunk?to?mir::wayland::XdgOutputManagerV1::?XdgOutputManagerV1*;
+    virtual?thunk?to?mir::wayland::XdgOutputV1::?XdgOutputV1*;
+    virtual?thunk?to?mir::wayland::XdgPopupV6::?XdgPopupV6*;
+    virtual?thunk?to?mir::wayland::XdgPopup::?XdgPopup*;
+    virtual?thunk?to?mir::wayland::XdgPositionerV6::?XdgPositionerV6*;
+    virtual?thunk?to?mir::wayland::XdgPositioner::?XdgPositioner*;
+    virtual?thunk?to?mir::wayland::XdgShellV6::?XdgShellV6*;
+    virtual?thunk?to?mir::wayland::XdgSurfaceV6::?XdgSurfaceV6*;
+    virtual?thunk?to?mir::wayland::XdgSurface::?XdgSurface*;
+    virtual?thunk?to?mir::wayland::XdgToplevelV6::?XdgToplevelV6*;
+    virtual?thunk?to?mir::wayland::XdgToplevel::?XdgToplevel*;
+    virtual?thunk?to?mir::wayland::XdgWmBase::?XdgWmBase*;
   };
   local: *;
 };

--- a/src/wayland/wayland_base.cpp
+++ b/src/wayland/wayland_base.cpp
@@ -24,7 +24,7 @@
 
 namespace mw = mir::wayland;
 
-mw::Destroyable::~Destroyable()
+mw::DestroyTracker::~DestroyTracker()
 {
     if (destroyed)
     {
@@ -32,7 +32,7 @@ mw::Destroyable::~Destroyable()
     }
 }
 
-auto mw::Destroyable::destroyed_flag() const -> std::shared_ptr<bool>
+auto mw::DestroyTracker::destroyed_flag() const -> std::shared_ptr<bool>
 {
     if (!destroyed)
     {
@@ -42,7 +42,7 @@ auto mw::Destroyable::destroyed_flag() const -> std::shared_ptr<bool>
 }
 
 mw::Resource::Resource()
-    : Destroyable{}
+    : DestroyTracker{}
 {
 }
 

--- a/src/wayland/wayland_base.cpp
+++ b/src/wayland/wayland_base.cpp
@@ -24,12 +24,7 @@
 
 namespace mw = mir::wayland;
 
-mw::Resource::Resource()
-    : destroyed{nullptr}
-{
-}
-
-mw::Resource::~Resource()
+mw::Destroyable::~Destroyable()
 {
     if (destroyed)
     {
@@ -37,13 +32,18 @@ mw::Resource::~Resource()
     }
 }
 
-auto mw::Resource::destroyed_flag() const -> std::shared_ptr<bool>
+auto mw::Destroyable::destroyed_flag() const -> std::shared_ptr<bool>
 {
     if (!destroyed)
     {
         destroyed = std::make_shared<bool>(false);
     }
     return destroyed;
+}
+
+mw::Resource::Resource()
+    : Destroyable{}
+{
 }
 
 mw::Global::Global(wl_global* global)

--- a/src/wayland/wayland_base.cpp
+++ b/src/wayland/wayland_base.cpp
@@ -24,7 +24,7 @@
 
 namespace mw = mir::wayland;
 
-mw::DestroyTracker::~DestroyTracker()
+mw::LifetimeTracker::~LifetimeTracker()
 {
     if (destroyed)
     {
@@ -32,7 +32,7 @@ mw::DestroyTracker::~DestroyTracker()
     }
 }
 
-auto mw::DestroyTracker::destroyed_flag() const -> std::shared_ptr<bool>
+auto mw::LifetimeTracker::destroyed_flag() const -> std::shared_ptr<bool>
 {
     if (!destroyed)
     {
@@ -42,7 +42,6 @@ auto mw::DestroyTracker::destroyed_flag() const -> std::shared_ptr<bool>
 }
 
 mw::Resource::Resource()
-    : DestroyTracker{}
 {
 }
 


### PR DESCRIPTION
Break out management of the destoryed flag into a new `LifetimeTracker` class so non-resource objects can inherit from it as well. Future PR will make `WindowWlSurfaceRole` use it.