### PR TITLE
wayland::Weak: add .nullable_ptr() method

### DIFF
--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -93,6 +93,18 @@ public:
         return *resource;
     }
 
+    auto as_nullable_ptr() const -> T*
+    {
+        if (*this)
+        {
+            return resource;
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+
 private:
     T* resource;
     /// Is null if and only if resource is null


### PR DESCRIPTION
This is useful to easily compare the contained resource with another, or in if assignments:
```c++
if (auto const surface = wl_surface.or_null())
{
    use(surface);
}
```
EDIT: changed example slightly to reflect how things are actually commonly named in the code