### PR TITLE
wayland::LifetimeTracker (as member)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -473,7 +473,7 @@ Description: Developer files for the Mir ABI-stable abstraction layer
  Contains header files required for development using the MirAL abstraction
  layer.
 
-Package: libmirwayland0
+Package: libmirwayland1
 Section: libs
 Architecture: linux-any
 Multi-Arch: same
@@ -491,7 +491,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirwayland0 (= ${binary:Version}),
+Depends: libmirwayland1 (= ${binary:Version}),
          libmircore-dev (= ${binary:Version}),
          ${misc:Depends},
          libmirwayland-bin (= ${binary:Version})

--- a/debian/libmirwayland0.install
+++ b/debian/libmirwayland0.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmirwayland.so.0

--- a/debian/libmirwayland1.install
+++ b/debian/libmirwayland1.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmirwayland.so.1

--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -32,7 +32,8 @@ namespace mir
 {
 namespace wayland
 {
-/// The base class of any object that wants to provide a destroyed flag
+/// Provides a destroyed flag for use by Weak
+/// For use by Weak, LifetimeTracker should be a public const class member variable named lifetime_tracker
 /// The destroyed flag is only created when needed and automatically set to true on destruction
 /// This pattern is only safe in a single-threaded context
 class LifetimeTracker
@@ -62,7 +63,7 @@ public:
     LifetimeTracker const lifetime_tracker;
 };
 
-/// A weak handle to a Wayland resource (or any Destroyable)
+/// A weak handle to a Wayland resource (or any object that has a LifetimeTracker member named lifetime_tracker)
 /// May only be safely used from the Wayland thread
 template<typename T>
 class Weak

--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -41,7 +41,7 @@ mf::WaylandInputDispatcher::WaylandInputDispatcher(
     : seat{seat},
       client{wl_surface->client},
       wl_surface{wl_surface},
-      wl_surface_destroyed{wl_surface->destroyed_flag()}
+      wl_surface_destroyed{wl_surface->lifetime_tracker.destroyed_flag()}
 {
 }
 

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -138,7 +138,7 @@ void mf::WlKeyboard::focussed(WlSurface* surface, bool should_be_focused)
         wl_array_release(&key_state);
 
         focused_surface = surface;
-        focused_surface_destroyed = surface->destroyed_flag();
+        focused_surface_destroyed = surface->lifetime_tracker.destroyed_flag();
     }
     else
     {

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -324,7 +324,7 @@ void mf::WlPointer::release()
 
 WlSurfaceCursor::WlSurfaceCursor(mf::WlSurface* surface, geom::Displacement hotspot)
     : surface{surface},
-      surface_destroyed{surface->destroyed_flag()},
+      surface_destroyed{surface->lifetime_tracker.destroyed_flag()},
       stream{surface->stream},
       surface_role{surface},
       hotspot{hotspot}

--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MIRWAYLAND_ABI 0)
+set(MIRWAYLAND_ABI 1)
 set(symbol_map ${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)
 add_definitions(-DMIR_LOG_COMPONENT_FALLBACK="mirwayland")
 

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -1,4 +1,4 @@
-MIRWAYLAND_1.2 {
+MIRWAYLAND_1.3 {
 global:
   extern "C++" {
     mir::wayland::Buffer::*;
@@ -282,6 +282,10 @@ global:
     mir::wayland::zxdg_toplevel_v6_interface_data;
     mir::wayland::zxdg_output_v1_interface_data;
     mir::wayland::zxdg_output_manager_v1_interface_data;
+
+    mir::wayland::LifetimeTracker::*;
+    typeinfo?for?mir::wayland::LifetimeTracker;
+    vtable?for?mir::wayland::LifetimeTracker;
 
     mir::wayland::Resource::*;
     typeinfo?for?mir::wayland::Resource;

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -1,4 +1,4 @@
-MIRWAYLAND_1.3 {
+MIRWAYLAND_2.0 {
 global:
   extern "C++" {
     mir::wayland::Buffer::*;

--- a/src/wayland/wayland_base.cpp
+++ b/src/wayland/wayland_base.cpp
@@ -24,12 +24,7 @@
 
 namespace mw = mir::wayland;
 
-mw::Resource::Resource()
-    : destroyed{nullptr}
-{
-}
-
-mw::Resource::~Resource()
+mw::LifetimeTracker::~LifetimeTracker()
 {
     if (destroyed)
     {
@@ -37,13 +32,17 @@ mw::Resource::~Resource()
     }
 }
 
-auto mw::Resource::destroyed_flag() const -> std::shared_ptr<bool>
+auto mw::LifetimeTracker::destroyed_flag() const -> std::shared_ptr<bool>
 {
     if (!destroyed)
     {
         destroyed = std::make_shared<bool>(false);
     }
     return destroyed;
+}
+
+mw::Resource::Resource()
+{
 }
 
 mw::Global::Global(wl_global* global)


### PR DESCRIPTION
Break the `destroyed_flag()` functionality out of `wayland::Resource` so it can be used by other classes. Alternative to #1573 (this variant makes `LifetimeTracker` a member of the classes that use it, and that one uses inheritance). I prefer #1573 because it doesn't require changing everything that uses `->destroyed_flag()` and, in my opinion, inheritance makes it easier to understand what's going on. Regardless, this is perfectly acceptable as well.