### PR TITLE
Wait for XWayland process to exit

### DIFF
--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -23,6 +23,8 @@
 
 #include <memory>
 #include <string>
+#include <atomic>
+#include <thread>
 
 struct wl_client;
 
@@ -56,8 +58,13 @@ private:
     XWaylandServer(XWaylandServer const&) = delete;
     XWaylandServer& operator=(XWaylandServer const&) = delete;
 
+    void wait_for_process();
+
     XWaylandProcess const xwayland_process;
     wl_client* const wayland_client{nullptr};
+
+    std::thread process_waiter_thread;
+    std::atomic_bool process_exited{false};
 };
 }
 }


### PR DESCRIPTION
This keeps us from having zombie processes hanging around and might end up being useful later