### PR TITLE
Do not force XWayland EGL to use DRM

### DIFF
--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -66,7 +66,6 @@ void exec_xwayland(
     mf::XWaylandSpawner::set_cloexec(wayland_client_fd, false);
     mf::XWaylandSpawner::set_cloexec(x11_wm_server_fd, false);
 
-    setenv("EGL_PLATFORM", "DRM", 1);
     setenv("WAYLAND_SOCKET", std::to_string(wayland_client_fd).c_str(), 1);
 
     auto const x11_wm_server = std::to_string(x11_wm_server_fd);


### PR DESCRIPTION
I have no idea why this environment variable is set. @RAOF noted previously that it was a bit odd. Unless there are any objections, I say we take it out, and put it back in with a comment if that causes any problems.