### PR TITLE
Use LifetimeTracker for WindowWlSurfaceRole

### DIFF
--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -44,6 +44,7 @@ public:
 
     virtual ~LifetimeTracker();
     auto destroyed_flag() const -> std::shared_ptr<bool>;
+    void mark_destroyed() const;
 
 private:
     std::shared_ptr<bool> mutable destroyed{nullptr};

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -68,8 +68,7 @@ mf::WindowWlSurfaceRole::WindowWlSurfaceRole(
     WlSurface* surface,
     std::shared_ptr<msh::Shell> const& shell,
     OutputManager* output_manager)
-    : destroyed{std::make_shared<bool>(false)},
-      surface{surface},
+    : surface{surface},
       client{client},
       shell{shell},
       session{get_session(client)},
@@ -85,9 +84,9 @@ mf::WindowWlSurfaceRole::WindowWlSurfaceRole(
 
 mf::WindowWlSurfaceRole::~WindowWlSurfaceRole()
 {
+    mark_destroyed();
     surface->clear_role();
     observer->disconnect();
-    *destroyed = true;
     if (auto const scene_surface = weak_scene_surface.lock())
     {
         shell->destroy_surface(session, scene_surface);

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -21,7 +21,7 @@
 
 #include "wl_surface_role.h"
 
-#include "mir/frontend/surface_id.h"
+#include "mir/wayland/wayland_base.h"
 #include "mir/geometry/displacement.h"
 #include "mir/geometry/size.h"
 #include "mir/geometry/rectangle.h"
@@ -54,7 +54,9 @@ class OutputManager;
 class WlSurface;
 class WlSeat;
 
-class WindowWlSurfaceRole : public WlSurfaceRole
+class WindowWlSurfaceRole
+    : public WlSurfaceRole,
+      public virtual wayland::LifetimeTracker
 {
 public:
 
@@ -67,7 +69,6 @@ public:
 
     ~WindowWlSurfaceRole() override;
 
-    std::shared_ptr<bool> destroyed_flag() const { return destroyed; }
     auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
 
     void populate_spec_with_surface_data(shell::SurfaceSpecification& spec);
@@ -101,8 +102,6 @@ public:
     virtual void handle_close_request() = 0;
 
 protected:
-    std::shared_ptr<bool> const destroyed;
-
     /// The size the window will be after the next commit
     auto pending_size() const -> geometry::Size;
 

--- a/src/wayland/wayland_base.cpp
+++ b/src/wayland/wayland_base.cpp
@@ -41,6 +41,14 @@ auto mw::LifetimeTracker::destroyed_flag() const -> std::shared_ptr<bool>
     return destroyed;
 }
 
+void mw::LifetimeTracker::mark_destroyed() const
+{
+    if (destroyed)
+    {
+        *destroyed = true;
+    }
+}
+
 mw::Resource::Resource()
 {
 }


### PR DESCRIPTION
Classes that inherit from `WindowWlSurfaceRole` often also get a `LifetimeTracker` from inheriting from a Wayland resource, but virtual inheritance is used to make sure there's only ever one. `LifetimeTracker::mark_destroyed()` is added to allow classes to mark themselves as destroyed at the beginning of their destructors. Without it the calls to `shell->destroy_surface(session, scene_surface);` result in crashes.