### PR TITLE
More key repeat tweaking

### DIFF
--- a/src/server/frontend_xwayland/xwayland_surface_observer.h
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.h
@@ -21,6 +21,7 @@
 
 #include "mir/scene/null_surface_observer.h"
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <chrono>
@@ -84,6 +85,9 @@ private:
 
     XWaylandSurfaceObserverSurface* const wm_surface;
     std::shared_ptr<ThreadsafeInputDispatcher> const input_dispatcher;
+
+    std::atomic<bool> has_focus{false};
+    void focussed(bool has_focus);
 
     /// Runs work on the Wayland thread if the input dispatcher still exists
     /// Does nothing if the input dispatcher has already been destroyed

--- a/src/server/input/key_repeat_dispatcher.h
+++ b/src/server/input/key_repeat_dispatcher.h
@@ -76,7 +76,7 @@ private:
 
     struct KeyboardState
     {
-        std::unordered_map<int, std::shared_ptr<mir::time::Alarm>> repeat_alarms_by_scancode;
+        std::shared_ptr<mir::time::Alarm> repeat_alarm;
     };
     std::unordered_map<MirInputDeviceId, KeyboardState> repeat_state_by_device;
     KeyboardState& ensure_state_for_device_locked(std::lock_guard<std::mutex> const&, MirInputDeviceId id);


### PR DESCRIPTION
More key repeat tweaking.

Reduce the key repeat logic to the simplest thing: don't repeat meta keys, only repeat one key, and don't repeat after modifier state changes.