### PR TITLE
Add XWaylandServer::is_running()

### DIFF
--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -224,6 +224,12 @@ mf::XWaylandServer::~XWaylandServer()
             kill(xwayland_process.pid, SIGKILL);     // ...then kill it!
         }
     }
+
+    // Calling is_running() one more time will ensure the process is reaped
+    if (is_running())
+    {
+        log_warning("Failed to kill Xwayland process with PID %d", xwayland_process.pid);
+    }
 }
 
 auto mf::XWaylandServer::is_running() const -> bool

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -242,10 +242,6 @@ auto mf::XWaylandServer::is_running() const -> bool
         if (waitpid(xwayland_process.pid, &status, WNOHANG) != 0)
         {
             running = false;
-            if (WIFEXITED(status))
-            {
-                exit_code = WEXITSTATUS(status);
-            }
         }
     }
 

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -217,10 +217,15 @@ mf::XWaylandServer::~XWaylandServer()
     if (kill(xwayland_process.pid, SIGTERM) == 0)
     {
         std::this_thread::sleep_for(100ms);// After 100ms...
-        if (kill(xwayland_process.pid, 0) == 0)    // ...if Xwayland is still running...
+        if (is_running())
         {
             mir::log_info("Xwayland didn't close, killing it");
             kill(xwayland_process.pid, SIGKILL);     // ...then kill it!
         }
     }
+}
+
+auto mf::XWaylandServer::is_running() const -> bool
+{
+    return kill(xwayland_process.pid, 0) == 0;
 }

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -23,6 +23,8 @@
 
 #include <memory>
 #include <string>
+#include <mutex>
+#include <experimental/optional>
 
 struct wl_client;
 
@@ -51,7 +53,6 @@ public:
         pid_t pid;
         Fd wayland_server_fd;
         Fd x11_wm_client_fd;
-
     };
 
 private:
@@ -60,6 +61,10 @@ private:
 
     XWaylandProcess const xwayland_process;
     wl_client* const wayland_client{nullptr};
+
+    mutable std::mutex mutex;
+    mutable bool running;
+    mutable std::experimental::optional<int> exit_code;
 };
 }
 }

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -44,12 +44,14 @@ public:
 
     auto client() const -> wl_client* { return wayland_client; }
     auto wm_fd() const -> Fd const& { return xwayland_process.x11_wm_client_fd; }
+    auto is_running() const -> bool;
 
     struct XWaylandProcess
     {
         pid_t pid;
         Fd wayland_server_fd;
         Fd x11_wm_client_fd;
+
     };
 
 private:

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -64,7 +64,6 @@ private:
 
     mutable std::mutex mutex;
     mutable bool running;
-    mutable std::experimental::optional<int> exit_code;
 };
 }
 }


### PR DESCRIPTION
I've found this to be a more reliable way to check if the process is running than `kill(pid, 0) == 0`. It also results in the process being reaped, so we don't end up with a bunch of zombies. It's not safe to call `waitpid()` after it has returned that the process exited (the PID may be reused) so we only call it if the process is still marked as `running`.