### PR TITLE
Unbreak offscreen renderer.

### DIFF
--- a/src/server/graphics/offscreen/display.cpp
+++ b/src/server/graphics/offscreen/display.cpp
@@ -63,7 +63,13 @@ void mgo::detail::EGLDisplayHandle::initialize()
     if (eglInitialize(egl_display, &major, &minor) == EGL_FALSE)
         BOOST_THROW_EXCEPTION(mg::egl_error("Failed to initialize EGL"));
 
-    if ((major != 1) || (minor < 4))
+    if (major > 1)
+    {
+        BOOST_THROW_EXCEPTION((
+            std::runtime_error{"EGL version 1.x required, found: " +
+            std::to_string(major) + "." + std::to_string(minor)}));
+    }
+    if (minor < 4)
         BOOST_THROW_EXCEPTION(
             std::runtime_error(
                 std::string{"EGL version ≥ 1.4 needed, found "} +

--- a/src/server/graphics/offscreen/display.cpp
+++ b/src/server/graphics/offscreen/display.cpp
@@ -63,8 +63,11 @@ void mgo::detail::EGLDisplayHandle::initialize()
     if (eglInitialize(egl_display, &major, &minor) == EGL_FALSE)
         BOOST_THROW_EXCEPTION(mg::egl_error("Failed to initialize EGL"));
 
-    if ((major != 1) || (minor != 4))
-        BOOST_THROW_EXCEPTION(std::runtime_error("EGL version 1.4 needed"));
+    if ((major != 1) || (minor < 4))
+        BOOST_THROW_EXCEPTION(
+            std::runtime_error(
+                std::string{"EGL version ≥ 1.4 needed, found "} +
+                std::to_string(major) + "." + std::to_string(minor)));
 }
 
 mgo::detail::EGLDisplayHandle::~EGLDisplayHandle() noexcept


### PR DESCRIPTION
It turns out we check for EGL version strictly equal to 1.4,
but Mesa has returned 1.5 for a while (and NVIDIA has returned
1.5 for*ever*).

There's no reason we won't work with newer minor EGL versions,
so don't fail if we find them.

I'm not sure how valuable this is, given that it's been broken
for *some time* and no-one has noticed, but we might as well
do the easy fix.