### PR TITLE
Minimize locking in KeyRepeatDispatcher

### DIFF
--- a/src/server/input/key_repeat_dispatcher.cpp
+++ b/src/server/input/key_repeat_dispatcher.cpp
@@ -125,10 +125,19 @@ void mi::KeyRepeatDispatcher::remove_device(MirInputDeviceId id)
         touch_button_device.consume();
 }
 
-mi::KeyRepeatDispatcher::KeyboardState& mi::KeyRepeatDispatcher::ensure_state_for_device_locked(std::lock_guard<std::mutex> const&, MirInputDeviceId id)
+void mi::KeyRepeatDispatcher::set_alarm_for_device(
+    MirInputDeviceId id,
+    std::shared_ptr<mir::time::Alarm> repeat_alarm)
 {
-    repeat_state_by_device.insert(std::make_pair(id, KeyboardState()));
-    return repeat_state_by_device[id];
+    {
+        std::lock_guard<std::mutex> lg(repeat_state_mutex);
+        // Get the current KeyboardState or insert a new one
+        auto const& iter = repeat_state_by_device.insert(std::make_pair(id, KeyboardState()));
+        // Set the new alarm
+        std::swap(repeat_alarm, iter.first->second.repeat_alarm);
+    }
+    // Reset the old alarm outside of the mutex lock
+    repeat_alarm.reset();
 }
 
 bool mi::KeyRepeatDispatcher::dispatch(std::shared_ptr<MirEvent const> const& event)
@@ -164,13 +173,7 @@ bool mi::KeyRepeatDispatcher::handle_key_input(MirInputDeviceId id, MirKeyboardE
     {
     case mir_keyboard_action_up:
     {
-        std::shared_ptr<time::Alarm> alarm;
-        {
-            std::lock_guard<std::mutex> lg(repeat_state_mutex);
-            auto& device_state = ensure_state_for_device_locked(lg, id);
-            alarm = std::move(device_state.repeat_alarm);
-        }
-        alarm.reset();
+        set_alarm_for_device(id, nullptr);
         break;
     }
     case mir_keyboard_action_down:
@@ -182,13 +185,7 @@ bool mi::KeyRepeatDispatcher::handle_key_input(MirInputDeviceId id, MirKeyboardE
         {
             // Further, we don't want to repeat with the old modifier state.
             // So just cancel any existing repeats and carry on.
-            std::shared_ptr<time::Alarm> alarm;
-            {
-                std::lock_guard<std::mutex> lg(repeat_state_mutex);
-                auto& device_state = ensure_state_for_device_locked(lg, id);
-                alarm = std::move(device_state.repeat_alarm);
-            }
-            alarm.reset();
+            set_alarm_for_device(id, nullptr);
             return false;
         }
 
@@ -227,12 +224,7 @@ bool mi::KeyRepeatDispatcher::handle_key_input(MirInputDeviceId id, MirKeyboardE
         // Fulfill the placeholder before scheduling the alarm.
         *shared_weak_alarm = alarm;
         alarm->reschedule_in(repeat_timeout);
-
-        {
-            std::lock_guard<std::mutex> lg(repeat_state_mutex);
-            auto& device_state = ensure_state_for_device_locked(lg, id);
-            device_state.repeat_alarm = alarm;
-        }
+        set_alarm_for_device(id, alarm);
     }
     case mir_keyboard_action_repeat:
         // Should we consume existing repeats?

--- a/src/server/input/key_repeat_dispatcher.h
+++ b/src/server/input/key_repeat_dispatcher.h
@@ -79,7 +79,8 @@ private:
         std::shared_ptr<mir::time::Alarm> repeat_alarm;
     };
     std::unordered_map<MirInputDeviceId, KeyboardState> repeat_state_by_device;
-    KeyboardState& ensure_state_for_device_locked(std::lock_guard<std::mutex> const&, MirInputDeviceId id);
+    /// repeat_state_mutex must NOT be locked when calling
+    void set_alarm_for_device(MirInputDeviceId id, std::shared_ptr<mir::time::Alarm> repeat_alarm);
 
     bool handle_key_input(MirInputDeviceId id, MirKeyboardEvent const* ev);
 };


### PR DESCRIPTION
Prevents future issues like #1617

A bit unrelated but also adds a test for key repeats not getting fired for meta keys.