### PR TITLE
[miral-shell] Use key codes, not scan codes to identify keys

### DIFF
--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -35,7 +35,7 @@
 #include <miral/wayland_extensions.h>
 
 
-#include <linux/input.h>
+#include <xkbcommon/xkbcommon-keysyms.h>
 #include <unistd.h>
 #include <boost/filesystem.hpp>
 
@@ -79,17 +79,19 @@ int main(int argc, char const* argv[])
             if (!(mods & mir_input_event_modifier_alt) || !(mods & mir_input_event_modifier_ctrl))
                 return false;
 
-            switch (mir_keyboard_event_scan_code(kev))
+            switch (mir_keyboard_event_key_code(kev))
             {
-            case KEY_BACKSPACE:
+            case XKB_KEY_BackSpace:
                 runner.stop();
                 return true;
 
-            case KEY_T:
+            case XKB_KEY_t:
+            case XKB_KEY_T:
                 external_client_launcher.launch({terminal_cmd});
                 return false;
 
-            case KEY_X:
+            case XKB_KEY_x:
+            case XKB_KEY_X:
                 external_client_launcher.launch_using_x11({"xterm"});
                 return false;
 

--- a/include/miral/miral/toolkit_event.h
+++ b/include/miral/miral/toolkit_event.h
@@ -147,7 +147,7 @@ MirKeyboardAction mir_keyboard_event_action(MirKeyboardEvent const* event);
 
 /**
  * Retrieve the xkb mapped keycode associated with the key acted on.. May
- * be interpreted as per <xkbcommon/xkb-keysyms.h>
+ * be interpreted as per <xkbcommon/xkbcommon-keysyms.h>
  *
  *   \param [in] event The key event
  *   \return           The xkb_keysym


### PR DESCRIPTION
[miral-shell] Use key codes, not scan codes to identify keys. (Fixes: #1627)