### PR TITLE
[mir_performance_tests] Do not recommend glmark2-es2-mir

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -222,7 +222,6 @@ Recommends: mir-demos,
             xmir,
             xwayland,
             glmark2-es2,
-            glmark2-es2-mir,
             glmark2-es2-wayland,
             mesa-utils-extra,
 Description: Display Server for Ubuntu - stress tests and other test tools


### PR DESCRIPTION
[mir_performance_tests] Do not recommend glmark2-es2-mir.

We don't use it, drop it from depends.