### PR TITLE
LogindConsoleServices should release control on destruction

### DIFF
--- a/src/server/console/logind_console_services.cpp
+++ b/src/server/console/logind_console_services.cpp
@@ -883,3 +883,8 @@ std::unique_ptr<mir::VTSwitcher> mir::LogindConsoleServices::create_vt_switcher(
             &g_object_unref},
         ml);
 }
+
+mir::LogindConsoleServices::~LogindConsoleServices()
+{
+    restore();
+}

--- a/src/server/console/logind_console_services.h
+++ b/src/server/console/logind_console_services.h
@@ -34,6 +34,7 @@ class LogindConsoleServices : public ConsoleServices
 {
 public:
     LogindConsoleServices(std::shared_ptr<GLibMainLoop> const& ml);
+    ~LogindConsoleServices();
 
     void register_switch_handlers(
         graphics::EventHandlerRegister& handlers,


### PR DESCRIPTION
LogindConsoleServices should release control on destruction. (Fixes: #1635)

Also fixes at least part of #1631 and #1632.