### PR TITLE
[mir_performance_tests] Kill clients started in regression_test_1563287

### DIFF
--- a/tests/performance-tests/system_performance_test.h
+++ b/tests/performance-tests/system_performance_test.h
@@ -39,6 +39,7 @@ protected:
 private:
     std::string const bin_dir;
     pid_t server_pid = 0;
+    std::vector<pid_t> client_pids;
 };
 
 } } // namespace mir::test


### PR DESCRIPTION
[mir_performance_tests] Kill clients started in regression_test_1563287. (Fixes: #1637)