### PR TITLE
[Wayland] Report rotated output sizes

### DIFF
--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -133,7 +133,7 @@ void mgw::DisplayClient::Output::geometry(
     int32_t subpixel,
     const char */*make*/,
     const char */*model*/,
-    int32_t /*transform*/)
+    int32_t transform)
 {
     auto output = static_cast<Output*>(data);
 
@@ -171,8 +171,26 @@ void mgw::DisplayClient::Output::geometry(
         dcout.subpixel_arrangement = MirSubpixelArrangement::mir_subpixel_arrangement_unknown;
         break;
     }
-}
 
+    switch (transform)
+    {
+    case WL_OUTPUT_TRANSFORM_NORMAL:
+        dcout.orientation = mir_orientation_normal;
+        break;
+
+    case WL_OUTPUT_TRANSFORM_90:
+        dcout.orientation = mir_orientation_left;
+        break;
+
+    case WL_OUTPUT_TRANSFORM_180:
+        dcout.orientation = mir_orientation_inverted;
+        break;
+
+    case WL_OUTPUT_TRANSFORM_270:
+        dcout.orientation = mir_orientation_right;
+        break;
+    }
+}
 
 void mgw::DisplayClient::Output::mode(
     void *data,


### PR DESCRIPTION
Report rotated output sizes (a workaround until we correctly support transforms for outputs and surfaces)

Some clients (such as i3/Xwayland) legitimately think they have control of an output and get confused when we report inconsistent size and orientation.

We should support transforms, but until then, make the size consistent with the reported orientation.

Fixes: #1629, https://forum.snapcraft.io/t/mir-kiosk-problem-with-rotation/18239