### PR TITLE
Don't frig with the shutdown sequence in AsyncServerRunner

### DIFF
--- a/tests/mir_test_framework/async_server_runner.cpp
+++ b/tests/mir_test_framework/async_server_runner.cpp
@@ -94,12 +94,6 @@ void mtf::AsyncServerRunner::add_to_environment(char const* key, char const* val
     env.emplace_back(key, value);
 }
 
-namespace
-{
-// This avoids an intermittent shutdown crash deleting a stub-graphics buffer (LP: #1728931)
-std::shared_ptr<void> delay_unloading_graphics_platform;
-}
-
 void mtf::AsyncServerRunner::start_server()
 {
     set_window_management_policy(server);
@@ -121,8 +115,6 @@ void mtf::AsyncServerRunner::start_server()
         });
 
     server.apply_settings();
-
-    delay_unloading_graphics_platform = server.the_graphics_platform();
 
     mt::AutoJoinThread t([&]
         {
@@ -170,7 +162,6 @@ void mtf::AsyncServerRunner::wait_for_server_exit()
 
 mtf::AsyncServerRunner::~AsyncServerRunner() noexcept
 {
-    delay_unloading_graphics_platform.reset();
 }
 
 auto mtf::AsyncServerRunner::new_connection() -> std::string


### PR DESCRIPTION
Don't frig with the shutdown sequence in AsyncServerRunner. (Fixes: #1642)

Moves a workaround for a problem with stubbed graphics that can cause issues with real graphics.
