### PR TITLE
[Wayland] Fix focus issues with popups

### DIFF
--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -294,6 +294,18 @@ void mf::WindowWlSurfaceRole::set_server_side_decorated(bool server_side_decorat
     }
 }
 
+void mir::frontend::WindowWlSurfaceRole::set_type(MirWindowType type)
+{
+    if (weak_scene_surface.lock())
+    {
+        spec().type = type;
+    }
+    else
+    {
+        params->type = type;
+    }
+}
+
 void mf::WindowWlSurfaceRole::set_state_now(MirWindowState state)
 {
     if (auto const scene_surface = weak_scene_surface.lock())
@@ -463,4 +475,3 @@ void mf::WindowWlSurfaceRole::create_scene_surface()
             }
         });
 }
-

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -87,6 +87,7 @@ public:
     void set_min_size(int32_t width, int32_t height);
     void set_fullscreen(std::experimental::optional<wl_resource*> const& output);
     void set_server_side_decorated(bool server_side_decorated);
+    void set_type(MirWindowType type);
 
     void set_state_now(MirWindowState state);
     void create_scene_surface();

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -298,7 +298,7 @@ mf::XdgPopupStable::XdgPopupStable(
                                     static_cast<mw::XdgPositioner*>(
                                         wl_resource_get_user_data(positioner))));
 
-    specification->type = mir_window_type_freestyle;
+    specification->type = mir_window_type_gloss;
     specification->placement_hints = mir_placement_hints_slide_any;
     if (parent_role)
     {
@@ -314,7 +314,7 @@ mf::XdgPopupStable::XdgPopupStable(
 void mf::XdgPopupStable::grab(struct wl_resource* seat, uint32_t serial)
 {
     (void)seat, (void)serial;
-    // TODO
+    set_type(mir_window_type_menu);
 }
 
 void mf::XdgPopupStable::destroy()

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -305,7 +305,7 @@ mf::XdgPopupV6::XdgPopupV6(
     auto const& parent_role = parent_surface->window_role();
     auto parent_scene_surface = parent_role ? parent_role.value().scene_surface() : std::experimental::nullopt;
 
-    specification->type = mir_window_type_freestyle;
+    specification->type = mir_window_type_gloss;
     specification->placement_hints = mir_placement_hints_slide_any;
     if (parent_scene_surface)
         specification->parent = parent_scene_surface.value();
@@ -318,7 +318,7 @@ mf::XdgPopupV6::XdgPopupV6(
 void mf::XdgPopupV6::grab(struct wl_resource* seat, uint32_t serial)
 {
     (void)seat, (void)serial;
-    // TODO
+    set_type(mir_window_type_menu);
 }
 
 void mf::XdgPopupV6::destroy()


### PR DESCRIPTION
[Wayland] Fix focus issues with popups. (Fixes: #1625)

A popup ought to be handled as either a `mir_window_type_gloss` or a `mir_window_type_menu` depending upon whether it is configured with a `grab`.

This avoids unexpectedly shifting the focus to an ungrabbed popup.