### PR TITLE
Provide a way for platforms to tweak the Xwayland options and use it for eglstream-kms

### DIFF
--- a/src/platforms/eglstream-kms/server/platform.cpp
+++ b/src/platforms/eglstream-kms/server/platform.cpp
@@ -119,12 +119,23 @@ mir::UniqueModulePtr<mg::GraphicBufferAllocator> mge::RenderingPlatform::create_
     return mir::make_module_ptr<mge::BufferAllocator>(output);
 }
 
+namespace
+{
+const auto mir_xwayland_option = "MIR_XWAYLAND_OPTION";
+}
+
 mge::Platform::Platform(
     std::shared_ptr<RenderingPlatform> const& rendering,
     std::shared_ptr<DisplayPlatform> const& display) :
     rendering(rendering),
     display(display)
 {
+    setenv(mir_xwayland_option, "-eglstream", 1);
+}
+
+mir::graphics::eglstream::Platform::~Platform()
+{
+    unsetenv(mir_xwayland_option);
 }
 
 mir::UniqueModulePtr<mg::GraphicBufferAllocator>

--- a/src/platforms/eglstream-kms/server/platform.h
+++ b/src/platforms/eglstream-kms/server/platform.h
@@ -77,7 +77,7 @@ public:
     Platform(
         std::shared_ptr<RenderingPlatform> const&,
         std::shared_ptr<DisplayPlatform> const&);
-    ~Platform() = default;
+    ~Platform();
 
     UniqueModulePtr<GraphicBufferAllocator>
         create_buffer_allocator(Display const& output) override;

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -95,6 +95,9 @@ void exec_xwayland(
         args.push_back(strdup(std::to_string(fd).c_str()));
     }
 
+    if (auto const xwayland_option = getenv("MIR_XWAYLAND_OPTION"))
+        args.push_back(xwayland_option);
+
     args.push_back(nullptr);
 
     execvp(xwayland_path.c_str(), const_cast<char* const*>(args.data()));


### PR DESCRIPTION
Provide a way for platforms to tweak the Xwayland options and use it for eglstream-kms. (Fixes: #1634)

We don't have a good way for platforms to pass config options to the front end, using an environment variable is a bad way but it works.