### PR TITLE
platform: Drop the NativeDisplay interface

### DIFF
--- a/include/platform/mir/graphics/display.h
+++ b/include/platform/mir/graphics/display.h
@@ -20,6 +20,7 @@
 #define MIR_GRAPHICS_DISPLAY_H_
 
 #include "mir/graphics/frame.h"
+#include "mir/renderer/gl/context_source.h"
 #include <memory>
 #include <functional>
 #include <chrono>
@@ -96,7 +97,7 @@ protected:
 /**
  * Interface to the display subsystem.
  */
-class Display
+class Display : public renderer::gl::ContextSource
 {
 public:
     /**

--- a/include/platform/mir/graphics/display.h
+++ b/include/platform/mir/graphics/display.h
@@ -41,15 +41,6 @@ typedef std::function<bool()> DisplayPauseHandler;
 typedef std::function<bool()> DisplayResumeHandler;
 typedef std::function<void()> DisplayConfigurationChangeHandler;
 
-class NativeDisplay
-{
-protected:
-    NativeDisplay() = default;
-    virtual ~NativeDisplay() = default;
-    NativeDisplay(NativeDisplay const&) = delete;
-    NativeDisplay operator=(NativeDisplay const&) = delete;
-};
-
 /**
  * DisplaySyncGroup represents a group of displays that need to be output
  * in unison as a single post() call.
@@ -180,14 +171,6 @@ public:
      *  \returns null if the implementation does not support virtual outputs
      */
     virtual std::unique_ptr<VirtualOutput> create_virtual_output(int width, int height) = 0;
-
-    /** Returns a pointer to the native display object backing this
-     *  display.
-     *
-     *  The pointer to the native display remains valid as long as the
-     *  display object is valid.
-     */
-    virtual NativeDisplay* native_display() = 0;
 
     /**
      * Returns timing information for the last frame displayed on a given

--- a/include/test/mir/test/doubles/null_display.h
+++ b/include/test/mir/test/doubles/null_display.h
@@ -34,8 +34,7 @@ namespace doubles
 {
 
 class NullDisplay : public graphics::Display,
-                    public graphics::NativeDisplay,
-                    public renderer::gl::ContextSource
+                    public graphics::NativeDisplay
 {
  public:
     void for_each_display_sync_group(std::function<void(graphics::DisplaySyncGroup&)> const& f) override

--- a/include/test/mir/test/doubles/null_display.h
+++ b/include/test/mir/test/doubles/null_display.h
@@ -33,8 +33,7 @@ namespace test
 namespace doubles
 {
 
-class NullDisplay : public graphics::Display,
-                    public graphics::NativeDisplay
+class NullDisplay : public graphics::Display
 {
  public:
     void for_each_display_sync_group(std::function<void(graphics::DisplaySyncGroup&)> const& f) override
@@ -72,10 +71,6 @@ class NullDisplay : public graphics::Display,
     std::unique_ptr<graphics::VirtualOutput> create_virtual_output(int /*width*/, int /*height*/) override
     {
         return nullptr;
-    }
-    graphics::NativeDisplay* native_display() override
-    {
-        return this;
     }
     std::unique_ptr<renderer::gl::Context> create_gl_context() const override
     {

--- a/include/test/mir_test_framework/headless_test.h
+++ b/include/test/mir_test_framework/headless_test.h
@@ -43,7 +43,7 @@ public:
     ~HeadlessTest() noexcept;
 
 
-    void preset_display(std::shared_ptr<mir::graphics::Display> const& display);
+    void preset_display(std::unique_ptr<mir::graphics::Display> display);
 
     /// Override initial display layout
     void initial_display_layout(std::vector<mir::geometry::Rectangle> const& display_rects);

--- a/include/test/mir_test_framework/stub_server_platform_factory.h
+++ b/include/test/mir_test_framework/stub_server_platform_factory.h
@@ -43,7 +43,7 @@ std::shared_ptr<mir::graphics::Platform> make_stubbed_server_graphics_platform(s
 
 void set_next_display_rects(std::unique_ptr<std::vector<mir::geometry::Rectangle>>&& display_rects);
 
-void set_next_preset_display(std::shared_ptr<mir::graphics::Display> const& display);
+void set_next_preset_display(std::unique_ptr<mir::graphics::Display> display);
 
 mir::UniqueModulePtr<FakeInputDevice> add_fake_input_device(mir::input::InputDeviceInfo const& info);
 

--- a/src/platforms/eglstream-kms/server/display.cpp
+++ b/src/platforms/eglstream-kms/server/display.cpp
@@ -446,11 +446,6 @@ std::unique_ptr<mg::VirtualOutput> mge::Display::create_virtual_output(int /*wid
     return nullptr;
 }
 
-mg::NativeDisplay* mge::Display::native_display()
-{
-    return this;
-}
-
 std::unique_ptr<mir::renderer::gl::Context> mge::Display::create_gl_context() const
 {
     class GLContext : public renderer::gl::Context

--- a/src/platforms/eglstream-kms/server/display.h
+++ b/src/platforms/eglstream-kms/server/display.h
@@ -38,8 +38,7 @@ namespace eglstream
 {
 class DRMEventHandler;
 
-class Display : public mir::graphics::Display,
-                public mir::graphics::NativeDisplay
+class Display : public mir::graphics::Display
 {
 public:
     Display(
@@ -70,8 +69,6 @@ public:
     std::shared_ptr<Cursor> create_hardware_cursor() override;
 
     std::unique_ptr<VirtualOutput> create_virtual_output(int width, int height) override;
-
-    NativeDisplay* native_display() override;
 
     std::unique_ptr<renderer::gl::Context> create_gl_context() const override;
     Frame last_frame_on(unsigned output_id) const override;

--- a/src/platforms/eglstream-kms/server/display.h
+++ b/src/platforms/eglstream-kms/server/display.h
@@ -39,8 +39,7 @@ namespace eglstream
 class DRMEventHandler;
 
 class Display : public mir::graphics::Display,
-                public mir::graphics::NativeDisplay,
-                public mir::renderer::gl::ContextSource
+                public mir::graphics::NativeDisplay
 {
 public:
     Display(

--- a/src/platforms/gbm-kms/server/kms/display.cpp
+++ b/src/platforms/gbm-kms/server/kms/display.cpp
@@ -387,11 +387,6 @@ std::unique_ptr<mg::VirtualOutput> mgg::Display::create_virtual_output(int /*wid
     return nullptr;
 }
 
-mg::NativeDisplay* mgg::Display::native_display()
-{
-    return this;
-}
-
 std::unique_ptr<mir::renderer::gl::Context> mgg::Display::create_gl_context() const
 {
     return std::make_unique<GBMGLContext>(*gbm, *gl_config, shared_egl.context());

--- a/src/platforms/gbm-kms/server/kms/display.h
+++ b/src/platforms/gbm-kms/server/kms/display.h
@@ -61,8 +61,7 @@ class KMSOutput;
 class Cursor;
 
 class Display : public graphics::Display,
-                public graphics::NativeDisplay,
-                public renderer::gl::ContextSource
+                public graphics::NativeDisplay
 {
 public:
     Display(std::vector<std::shared_ptr<helpers::DRMHelper>> const& drm,

--- a/src/platforms/gbm-kms/server/kms/display.h
+++ b/src/platforms/gbm-kms/server/kms/display.h
@@ -60,8 +60,7 @@ class DisplayBuffer;
 class KMSOutput;
 class Cursor;
 
-class Display : public graphics::Display,
-                public graphics::NativeDisplay
+class Display : public graphics::Display
 {
 public:
     Display(std::vector<std::shared_ptr<helpers::DRMHelper>> const& drm,
@@ -95,7 +94,6 @@ public:
 
     std::shared_ptr<graphics::Cursor> create_hardware_cursor() override;
     std::unique_ptr<VirtualOutput> create_virtual_output(int width, int height) override;
-    NativeDisplay* native_display() override;
 
     std::unique_ptr<renderer::gl::Context> create_gl_context() const override;
 

--- a/src/platforms/rpi-dispmanx/display.cpp
+++ b/src/platforms/rpi-dispmanx/display.cpp
@@ -283,11 +283,6 @@ auto mg::rpi::Display::create_virtual_output(int /*width*/, int /*height*/) -> s
     return {nullptr};
 }
 
-auto mg::rpi::Display::native_display() -> NativeDisplay*
-{
-    return this;
-}
-
 auto mg::rpi::Display::last_frame_on(unsigned /*output_id*/) const -> Frame
 {
     return {};

--- a/src/platforms/rpi-dispmanx/display.h
+++ b/src/platforms/rpi-dispmanx/display.h
@@ -38,7 +38,6 @@ class DisplayBuffer;
 
 class Display
     : public graphics::Display,
-      public graphics::NativeDisplay,
       public renderer::gl::ContextSource
 {
 public:
@@ -59,7 +58,6 @@ public:
     void resume() override;
     std::shared_ptr<Cursor> create_hardware_cursor() override;
     std::unique_ptr<VirtualOutput> create_virtual_output(int width, int height) override;
-    NativeDisplay* native_display() override;
     Frame last_frame_on(unsigned output_id) const override;
 
     auto create_gl_context() const -> std::unique_ptr<renderer::gl::Context> override;

--- a/src/platforms/rpi-dispmanx/display.h
+++ b/src/platforms/rpi-dispmanx/display.h
@@ -37,8 +37,7 @@ namespace rpi
 class DisplayBuffer;
 
 class Display
-    : public graphics::Display,
-      public renderer::gl::ContextSource
+    : public graphics::Display
 {
 public:
     Display(EGLDisplay dpy, GLConfig const& gl_config, uint32_t device);

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -141,11 +141,6 @@ auto mgw::Display::create_virtual_output(int /*width*/, int /*height*/) -> std::
     return {};
 }
 
-auto mgw::Display::native_display() -> NativeDisplay*
-{
-    return this;
-}
-
 bool mgw::Display::apply_if_configuration_preserves_display_buffers(DisplayConfiguration const& /*conf*/)
 {
     return false;

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -52,8 +52,9 @@ namespace graphics
 {
 namespace wayland
 {
-class Display : public mir::graphics::Display, public mir::graphics::NativeDisplay,
-                public mir::renderer::gl::ContextSource, DisplayClient
+class Display : public mir::graphics::Display,
+                public mir::graphics::NativeDisplay,
+                DisplayClient
 {
 public:
     Display(

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -53,7 +53,6 @@ namespace graphics
 namespace wayland
 {
 class Display : public mir::graphics::Display,
-                public mir::graphics::NativeDisplay,
                 DisplayClient
 {
 public:
@@ -91,8 +90,6 @@ public:
     auto create_hardware_cursor() -> std::shared_ptr<Cursor>override;
 
     auto create_virtual_output(int width, int height) -> std::unique_ptr<VirtualOutput> override;
-
-    NativeDisplay* native_display() override;
 
     auto last_frame_on(unsigned output_id) const -> Frame override;
 

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -372,11 +372,6 @@ std::unique_ptr<mg::VirtualOutput> mgx::Display::create_virtual_output(int /*wid
     return nullptr;
 }
 
-mg::NativeDisplay* mgx::Display::native_display()
-{
-    return this;
-}
-
 std::unique_ptr<mir::renderer::gl::Context> mgx::Display::create_gl_context() const
 {
     return std::make_unique<XGLContext>(x_dpy, gl_config, shared_egl.context());

--- a/src/platforms/x11/graphics/display.h
+++ b/src/platforms/x11/graphics/display.h
@@ -67,8 +67,7 @@ private:
 };
 
 class Display : public graphics::Display,
-                public graphics::NativeDisplay,
-                public renderer::gl::ContextSource
+                public graphics::NativeDisplay
 {
 public:
     explicit Display(::Display* x_dpy,

--- a/src/platforms/x11/graphics/display.h
+++ b/src/platforms/x11/graphics/display.h
@@ -66,8 +66,7 @@ private:
     unsigned long r_mask;
 };
 
-class Display : public graphics::Display,
-                public graphics::NativeDisplay
+class Display : public graphics::Display
 {
 public:
     explicit Display(::Display* x_dpy,
@@ -99,8 +98,6 @@ public:
 
     std::shared_ptr<Cursor> create_hardware_cursor() override;
     std::unique_ptr<VirtualOutput> create_virtual_output(int width, int height) override;
-
-    NativeDisplay* native_display() override;
 
     std::unique_ptr<renderer::gl::Context> create_gl_context() const override;
 

--- a/src/server/graphics/offscreen/display.cpp
+++ b/src/server/graphics/offscreen/display.cpp
@@ -202,11 +202,6 @@ std::unique_ptr<mir::renderer::gl::Context> mgo::Display::create_gl_context() co
     return std::make_unique<SurfacelessEGLContext>(egl_display, egl_context_shared);
 }
 
-mg::NativeDisplay* mgo::Display::native_display()
-{
-    return this;
-}
-
 mg::Frame mgo::Display::last_frame_on(unsigned) const
 {
     return {};

--- a/src/server/graphics/offscreen/display.h
+++ b/src/server/graphics/offscreen/display.h
@@ -72,8 +72,7 @@ private:
 
 }
 
-class Display : public graphics::Display,
-                public graphics::NativeDisplay
+class Display : public graphics::Display
 {
 public:
     Display(EGLNativeDisplayType egl_native_display,
@@ -101,7 +100,6 @@ public:
     std::shared_ptr<Cursor> create_hardware_cursor() override;
     std::unique_ptr<VirtualOutput> create_virtual_output(int width, int height) override;
 
-    NativeDisplay* native_display() override;
     Frame last_frame_on(unsigned output_id) const override;
 
     std::unique_ptr<renderer::gl::Context> create_gl_context() const override;

--- a/src/server/graphics/offscreen/display.h
+++ b/src/server/graphics/offscreen/display.h
@@ -73,8 +73,7 @@ private:
 }
 
 class Display : public graphics::Display,
-                public graphics::NativeDisplay,
-                public renderer::gl::ContextSource
+                public graphics::NativeDisplay
 {
 public:
     Display(EGLNativeDisplayType egl_native_display,

--- a/src/server/scene/default_configuration.cpp
+++ b/src/server/scene/default_configuration.cpp
@@ -194,8 +194,7 @@ mir::DefaultServerConfiguration::the_pixel_buffer()
         {
             auto as_context_source = [](mg::Display* display)
             {
-                auto const ctx = dynamic_cast<renderer::gl::ContextSource*>(
-                        display->native_display());
+                auto const ctx = dynamic_cast<renderer::gl::ContextSource*>(display);
                 if (!ctx)
                     BOOST_THROW_EXCEPTION(std::logic_error("Display does not support GL rendering"));
                 return ctx;

--- a/tests/include/mir/test/doubles/mock_display.h
+++ b/tests/include/mir/test/doubles/mock_display.h
@@ -21,6 +21,7 @@
 
 #include "mir/graphics/display.h"
 #include "mir/graphics/virtual_output.h"
+#include "mir/renderer/gl/context.h"
 #include "mir/main_loop.h"
 #include "mir/test/gmock_fixes.h"
 #include <gmock/gmock.h>
@@ -51,6 +52,8 @@ public:
     MOCK_METHOD2(create_virtual_output, std::unique_ptr<graphics::VirtualOutput>(int, int));
     MOCK_METHOD0(native_display, graphics::NativeDisplay*());
     MOCK_CONST_METHOD1(last_frame_on, graphics::Frame(unsigned));
+
+    MOCK_CONST_METHOD0(create_gl_context, std::unique_ptr<mir::renderer::gl::Context>());
 };
 
 }

--- a/tests/include/mir/test/doubles/mock_display.h
+++ b/tests/include/mir/test/doubles/mock_display.h
@@ -50,7 +50,6 @@ public:
     MOCK_METHOD0(resume, void());
     MOCK_METHOD0(create_hardware_cursor, std::shared_ptr<graphics::Cursor>());
     MOCK_METHOD2(create_virtual_output, std::unique_ptr<graphics::VirtualOutput>(int, int));
-    MOCK_METHOD0(native_display, graphics::NativeDisplay*());
     MOCK_CONST_METHOD1(last_frame_on, graphics::Frame(unsigned));
 
     MOCK_CONST_METHOD0(create_gl_context, std::unique_ptr<mir::renderer::gl::Context>());

--- a/tests/mir_test_framework/headless_in_process_server.cpp
+++ b/tests/mir_test_framework/headless_in_process_server.cpp
@@ -16,6 +16,7 @@
  * Authored By: Alan Griffiths <alan@octopull.co.uk>
  */
 
+#include "mir/graphics/display.h"
 #include "mir_test_framework/headless_in_process_server.h"
 #include "mir_test_framework/stub_server_platform_factory.h"
 #include <mir/shell/canonical_window_manager.h>

--- a/tests/mir_test_framework/headless_test.cpp
+++ b/tests/mir_test_framework/headless_test.cpp
@@ -22,6 +22,7 @@
 
 #include "mir/shared_library.h"
 #include "mir/geometry/rectangle.h"
+#include "mir/graphics/display.h"
 #include "mir_test_framework/executable_path.h"
 
 #include <boost/throw_exception.hpp>
@@ -43,9 +44,9 @@ mtf::HeadlessTest::HeadlessTest()
 
 mtf::HeadlessTest::~HeadlessTest() noexcept = default;
 
-void mtf::HeadlessTest::preset_display(std::shared_ptr<mir::graphics::Display> const& display)
+void mtf::HeadlessTest::preset_display(std::unique_ptr<mir::graphics::Display> display)
 {
-    mtf::set_next_preset_display(display);
+    mtf::set_next_preset_display(std::move(display));
 }
 
 void mtf::HeadlessTest::initial_display_layout(std::vector<geom::Rectangle> const& display_rects)

--- a/tests/mir_test_framework/stub_server_platform_factory.cpp
+++ b/tests/mir_test_framework/stub_server_platform_factory.cpp
@@ -20,6 +20,7 @@
 #include "mir/shared_library.h"
 
 #include "mir/geometry/rectangle.h"
+#include "mir/graphics/display.h"
 
 #include "mir_test_framework/executable_path.h"
 #include "mir_test_framework/stub_server_platform_factory.h"
@@ -68,13 +69,13 @@ void mtf::set_next_display_rects(std::unique_ptr<std::vector<geom::Rectangle>>&&
     rect_setter(std::move(display_rects));
 }
 
-void mtf::set_next_preset_display(std::shared_ptr<mir::graphics::Display> const& display)
+void mtf::set_next_preset_display(std::unique_ptr<mir::graphics::Display> display)
 {
     ensure_platform_library();
 
-    auto display_setter = platform_graphics_lib->load_function<void(*)(std::shared_ptr<mir::graphics::Display> const&)>("set_next_preset_display");
+    auto display_setter = platform_graphics_lib->load_function<void(*)(std::unique_ptr<mir::graphics::Display>)>("set_next_preset_display");
 
-    display_setter(display);
+    display_setter(std::move(display));
 }
 
 void mtf::disable_flavors()

--- a/tests/mir_test_framework/stubbed_graphics_platform.cpp
+++ b/tests/mir_test_framework/stubbed_graphics_platform.cpp
@@ -108,6 +108,10 @@ struct WrappingDisplay : mg::Display
     {
         return display->last_frame_on(output_id);
     }
+    auto create_gl_context() const -> std::unique_ptr<mir::renderer::gl::Context> override
+    {
+        return display->create_gl_context();
+    }
     std::shared_ptr<Display> const display;
 };
 

--- a/tests/mir_test_framework/stubbed_graphics_platform.cpp
+++ b/tests/mir_test_framework/stubbed_graphics_platform.cpp
@@ -139,9 +139,11 @@ mir::UniqueModulePtr<mg::GraphicBufferAllocator> mtf::StubGraphicPlatform::creat
     return mir::make_module_ptr<StubGraphicBufferAllocator>();
 }
 
+extern "C" void set_next_display_rects(std::unique_ptr<std::vector<geom::Rectangle>>&& display_rects);
+
 namespace
 {
-std::shared_ptr<mg::Display> display_preset;
+std::unique_ptr<mg::Display> display_preset;
 }
 
 mir::UniqueModulePtr<mg::Display> mtf::StubGraphicPlatform::create_display(
@@ -295,9 +297,9 @@ extern "C" void set_next_display_rects(
     chosen_display_rects = std::move(display_rects);
 }
 
-extern "C" void set_next_preset_display(std::shared_ptr<mir::graphics::Display> const& display)
+extern "C" void set_next_preset_display(std::unique_ptr<mir::graphics::Display> display)
 {
-    display_preset = display;
+    display_preset = std::move(display);
 }
 
 extern "C" void disable_flavors()

--- a/tests/platform_test_harness/graphics_platform_test_harness.cpp
+++ b/tests/platform_test_harness/graphics_platform_test_harness.cpp
@@ -234,7 +234,7 @@ auto test_display_construction(mir::graphics::DisplayPlatform& platform, Minimal
 
 auto test_display_supports_gl(mg::Display& display) -> bool
 {
-    if (dynamic_cast<mir::renderer::gl::ContextSource*>(display.native_display()))
+    if (dynamic_cast<mir::renderer::gl::ContextSource*>(&display))
     {
         std::cout << "Display supports GL context creation" << std::endl;
         return true;

--- a/tests/unit-tests/platforms/test_display.h
+++ b/tests/unit-tests/platforms/test_display.h
@@ -28,7 +28,7 @@ namespace
 {
 auto as_context_source(mg::Display* display)
 {
-    auto const ctx = dynamic_cast<mir::renderer::gl::ContextSource*>(display->native_display());
+    auto const ctx = dynamic_cast<mir::renderer::gl::ContextSource*>(display);
     if (!ctx)
         BOOST_THROW_EXCEPTION(std::logic_error("Display does not support GL rendering"));
     return ctx;


### PR DESCRIPTION
This is only used to get a `gl::ContextSource` out of a `Display`, which we can just do a direct `dynamic_cast<>` for now.

In the near future this will be moved to the `RenderingPlatform` instead, as a part of allowing multiple display platforms to load, but for now leave it where it is.