### PR TITLE
Allow GDK to try x11 if wayland fails

### DIFF
--- a/examples/miral-shell/miral-app.sh
+++ b/examples/miral-shell/miral-app.sh
@@ -45,7 +45,7 @@ else
   done
   wayland_display=wayland-${port}
   qt_qpa=wayland
-  gdk_backend=wayland
+  gdk_backend=wayland,x11
   sdl_videodriver=wayland
 
   if [ "${miral_server}" == "miral-kiosk" ]

--- a/src/miral/external_client.cpp
+++ b/src/miral/external_client.cpp
@@ -71,7 +71,7 @@ void miral::ExternalClientLauncher::operator()(mir::Server& server)
     self->server = &server;
 
     static auto const app_env = "app-env";
-    static auto const default_env = "GDK_BACKEND=wayland:QT_QPA_PLATFORM=wayland:SDL_VIDEODRIVER=wayland:"
+    static auto const default_env = "GDK_BACKEND=wayland,x11:QT_QPA_PLATFORM=wayland:SDL_VIDEODRIVER=wayland:"
         "-QT_QPA_PLATFORMTHEME:NO_AT_BRIDGE=1:QT_ACCESSIBILITY:QT_LINUX_ACCESSIBILITY_ALWAYS_ON:"
         "_JAVA_AWT_WM_NONREPARENTING=1:-GTK_MODULES:-OOO_FORCE_DESKTOP:-GNOME_ACCESSIBILITY:";
     static auto const app_x11_env = "app-env-x11";

--- a/tests/miral/external_client.cpp
+++ b/tests/miral/external_client.cpp
@@ -90,7 +90,7 @@ TEST_F(ExternalClient, default_app_env_is_as_expected)
 
     start_server();
 
-    EXPECT_THAT(client_env_value("GDK_BACKEND"), StrEq("wayland"));
+    EXPECT_THAT(client_env_value("GDK_BACKEND"), StrEq("wayland,x11"));
     EXPECT_THAT(client_env_value("QT_QPA_PLATFORM"), StrEq("wayland"));
     EXPECT_THAT(client_env_value("SDL_VIDEODRIVER"), StrEq("wayland"));
     EXPECT_THAT(client_env_value("NO_AT_BRIDGE"), StrEq("1"));


### PR DESCRIPTION
Allow GDK to try x11 if wayland fails. (Fixes: #1621)

Some apps need GDK to fall back to X11. (Which is the default, but firefox doesn't follow the GDK default unless MOZ_ENABLE_WAYLAND is set and there might be others.