### PR TITLE
Keep the touchpad FD during suspend/resume

### DIFF
--- a/src/platforms/evdev/fd_store.cpp
+++ b/src/platforms/evdev/fd_store.cpp
@@ -41,6 +41,11 @@ mir::Fd mie::FdStore::take_fd(char const* path)
     }
     catch (std::out_of_range const&)
     {
+        if (removed.first == path)
+        {
+            mir::log_warning("Requested fd for path %s was removed", path);
+            return fds.insert(std::move(removed)).first->second;
+        }
         mir::log_warning("Failed to find requested fd for path %s", path);
     }
     return mir::Fd{};
@@ -62,6 +67,8 @@ void mie::FdStore::remove_fd(int fd)
     }
     else
     {
+        // We keep the last removed element in case libinput asks for it
+        removed = *element;
         fds.erase(element);
     }
 }

--- a/src/platforms/evdev/fd_store.h
+++ b/src/platforms/evdev/fd_store.h
@@ -44,6 +44,13 @@ private:
     FdStore& operator=(FdStore const&) = delete;
 
     std::unordered_map<std::string, mir::Fd> fds;
+
+    // LibInputPtr calls remove_fd() for touchpads on suspend but
+    // continues to use take_fd() to access the fd after resume!
+    // As a workaround, we remember the last removed fd and reinstate
+    // it if asked for.
+    //                  https://github.com/MirServer/mir/issues/1612
+    std::pair<std::string, mir::Fd> removed;
 };
 
 }


### PR DESCRIPTION
Keep the touchpad FD during suspend/resume. (Fixes: #1612)

Less a fix than a workaround. (I haven't tracked down the root cause of weirdness.)