### PR TITLE
platform: Drop the entirely-unused NativeDisplayPlatform interface

### DIFF
--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -80,15 +80,6 @@ public:
         Display const& output) = 0;
 };
 
-class NativeDisplayPlatform
-{
-protected:
-    NativeDisplayPlatform() = default;
-    virtual ~NativeDisplayPlatform() = default;
-    NativeDisplayPlatform(NativeDisplayPlatform const&) = delete;
-    NativeDisplayPlatform& operator=(NativeDisplayPlatform const&) = delete;
-};
-
 class DisplayPlatform
 {
 public:
@@ -104,11 +95,6 @@ public:
     virtual UniqueModulePtr<Display> create_display(
         std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
         std::shared_ptr<GLConfig> const& gl_config) = 0;
-
-    /**
-     * Access the platform-specific resource[s] from the display.
-     */
-    virtual NativeDisplayPlatform* native_display_platform() = 0;
 };
 
 class Platform : public DisplayPlatform,

--- a/include/test/mir/test/doubles/null_platform.h
+++ b/include/test/mir/test/doubles/null_platform.h
@@ -44,11 +44,6 @@ class NullPlatform : public graphics::Platform
     {
         return mir::make_module_ptr<NullDisplay>();
     }
-
-    graphics::NativeDisplayPlatform* native_display_platform() override
-    {
-        return nullptr;
-    }
 };
 }
 }

--- a/src/platforms/eglstream-kms/server/platform.cpp
+++ b/src/platforms/eglstream-kms/server/platform.cpp
@@ -100,11 +100,6 @@ mir::UniqueModulePtr<mg::Display> mge::DisplayPlatform::create_display(
     return retval;
 }
 
-mg::NativeDisplayPlatform* mge::DisplayPlatform::native_display_platform()
-{
-    return nullptr;
-}
-
 mir::UniqueModulePtr<mg::GraphicBufferAllocator> mge::RenderingPlatform::create_buffer_allocator(
     mg::Display const& output)
 {
@@ -143,7 +138,3 @@ mir::UniqueModulePtr<mg::Display> mge::Platform::create_display(
     return display->create_display(policy, config);
 }
 
-mg::NativeDisplayPlatform* mge::Platform::native_display_platform()
-{
-    return display->native_display_platform();
-}

--- a/src/platforms/eglstream-kms/server/platform.h
+++ b/src/platforms/eglstream-kms/server/platform.h
@@ -61,7 +61,6 @@ public:
     UniqueModulePtr<Display> create_display(
         std::shared_ptr<DisplayConfigurationPolicy> const& /*initial_conf_policy*/,
         std::shared_ptr<GLConfig> const& /*gl_config*/) override;
-    NativeDisplayPlatform* native_display_platform() override;
 
 private:
     std::shared_ptr<DisplayReport> const display_report;
@@ -84,7 +83,6 @@ public:
     UniqueModulePtr<Display> create_display(
         std::shared_ptr<DisplayConfigurationPolicy> const& /*initial_conf_policy*/,
         std::shared_ptr<GLConfig> const& /*gl_config*/) override;
-    NativeDisplayPlatform* native_display_platform() override;
 
 private:
     std::shared_ptr<RenderingPlatform> const rendering;

--- a/src/platforms/gbm-kms/server/drm_native_platform.h
+++ b/src/platforms/gbm-kms/server/drm_native_platform.h
@@ -33,8 +33,7 @@ namespace helpers
 class DRMHelper;
 }
 
-class DRMNativePlatformAuthFactory : public graphics::NativeDisplayPlatform,
-                                     public graphics::PlatformAuthenticationFactory
+class DRMNativePlatformAuthFactory : public graphics::PlatformAuthenticationFactory
 {
 public:
     DRMNativePlatformAuthFactory(helpers::DRMHelper&);

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -84,11 +84,6 @@ mir::UniqueModulePtr<mg::Display> mgg::Platform::create_display(
         listener);
 }
 
-mg::NativeDisplayPlatform* mgg::Platform::native_display_platform()
-{
-    return auth_factory.get();
-}
-
 MirServerEGLNativeDisplayType mgg::Platform::egl_native_display() const
 {
     return gbm->device;

--- a/src/platforms/gbm-kms/server/kms/platform.h
+++ b/src/platforms/gbm-kms/server/kms/platform.h
@@ -51,7 +51,6 @@ public:
     UniqueModulePtr<graphics::Display> create_display(
         std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
         std::shared_ptr<GLConfig> const& gl_config) override;
-    NativeDisplayPlatform* native_display_platform() override;
 
     MirServerEGLNativeDisplayType egl_native_display() const override;
 

--- a/src/platforms/rpi-dispmanx/display_platform.cpp
+++ b/src/platforms/rpi-dispmanx/display_platform.cpp
@@ -55,7 +55,3 @@ auto mir::graphics::rpi::DisplayPlatform::create_display(
     return mir::make_module_ptr<rpi::Display>(dpy, *gl_config, 0);
 }
 
-mir::graphics::NativeDisplayPlatform* mir::graphics::rpi::DisplayPlatform::native_display_platform()
-{
-    return nullptr;
-}

--- a/src/platforms/rpi-dispmanx/display_platform.h
+++ b/src/platforms/rpi-dispmanx/display_platform.h
@@ -38,7 +38,6 @@ public:
         std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
         std::shared_ptr<GLConfig> const& gl_config)
         ->UniqueModulePtr<graphics::Display> override;
-    NativeDisplayPlatform* native_display_platform() override;
 
 private:
     EGLDisplay dpy;

--- a/src/platforms/rpi-dispmanx/platform.cpp
+++ b/src/platforms/rpi-dispmanx/platform.cpp
@@ -41,8 +41,3 @@ auto mg::rpi::Platform::create_display(
 {
     return display_platform->create_display(initial_conf_policy, gl_config);
 }
-
-auto mg::rpi::Platform::native_display_platform() -> NativeDisplayPlatform *
-{
-    return display_platform->native_display_platform();
-}

--- a/src/platforms/rpi-dispmanx/platform.h
+++ b/src/platforms/rpi-dispmanx/platform.h
@@ -39,7 +39,6 @@ public:
     auto create_display(
         std::shared_ptr<DisplayConfigurationPolicy> const &initial_conf_policy,
         std::shared_ptr<GLConfig> const &gl_config) -> UniqueModulePtr<Display> override;
-    auto native_display_platform() -> NativeDisplayPlatform *override;
 
 private:
     std::unique_ptr<DisplayPlatform> const display_platform;

--- a/src/platforms/wayland/platform.cpp
+++ b/src/platforms/wayland/platform.cpp
@@ -48,11 +48,6 @@ mir::UniqueModulePtr<mg::Display> mgw::Platform::create_display(
   return mir::make_module_ptr<mgw::Display>(wl_display, gl_config, report);
 }
 
-mg::NativeDisplayPlatform* mgw::Platform::native_display_platform()
-{
-    return nullptr;
-}
-
 EGLNativeDisplayType mgw::Platform::egl_native_display() const
 {
     return eglGetDisplay(wl_display);

--- a/src/platforms/wayland/platform.h
+++ b/src/platforms/wayland/platform.h
@@ -49,7 +49,6 @@ public:
     UniqueModulePtr<Display> create_display(
         std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
         std::shared_ptr<GLConfig> const& gl_config) override;
-    NativeDisplayPlatform* native_display_platform() override;
 
     EGLNativeDisplayType egl_native_display() const override;
 

--- a/src/platforms/x11/graphics/platform.cpp
+++ b/src/platforms/x11/graphics/platform.cpp
@@ -123,11 +123,6 @@ mir::UniqueModulePtr<mg::Display> mgx::Platform::create_display(
     return make_module_ptr<mgx::Display>(x11_connection.get(), output_sizes, initial_conf_policy, gl_config, report);
 }
 
-mg::NativeDisplayPlatform* mgx::Platform::native_display_platform()
-{
-    return nullptr;
-}
-
 EGLNativeDisplayType mgx::Platform::egl_native_display() const
 {
     return eglGetDisplay(x11_connection.get());

--- a/src/platforms/x11/graphics/platform.h
+++ b/src/platforms/x11/graphics/platform.h
@@ -72,7 +72,6 @@ public:
     UniqueModulePtr<graphics::Display> create_display(
         std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
         std::shared_ptr<GLConfig> const& gl_config) override;
-    NativeDisplayPlatform* native_display_platform() override;
 
     EGLNativeDisplayType egl_native_display() const override;
 private:

--- a/tests/mir_test_framework/platform_graphics_throw.cpp
+++ b/tests/mir_test_framework/platform_graphics_throw.cpp
@@ -77,14 +77,6 @@ public:
         return stub_platform->create_display(ptr, shared_ptr);
     }
 
-    mg::NativeDisplayPlatform* native_display_platform() override
-    {
-        if (should_throw.at(ExceptionLocation::at_native_display_platform))
-            BOOST_THROW_EXCEPTION(std::runtime_error("Exception during egl_native_display"));
-
-        return stub_platform->native_display_platform();
-    }
-
 private:
     enum ExceptionLocation : uint32_t
     {
@@ -93,7 +85,6 @@ private:
         at_create_display,
         at_make_ipc_operations,
         at_native_rendering_platform,
-        at_native_display_platform,
     };
 
     static std::unordered_map<ExceptionLocation, bool, std::hash<uint32_t>> parse_exception_request(char const* request)
@@ -109,8 +100,6 @@ private:
             static_cast<bool>(strstr(request, "make_ipc_operations"));
         requested_exceptions[ExceptionLocation::at_native_rendering_platform] =
             static_cast<bool>(strstr(request, "native_rendering_platform"));
-        requested_exceptions[ExceptionLocation::at_native_display_platform] =
-            static_cast<bool>(strstr(request, "native_display_platform"));
 
         return requested_exceptions;
     };

--- a/tests/mir_test_framework/stubbed_graphics_platform.cpp
+++ b/tests/mir_test_framework/stubbed_graphics_platform.cpp
@@ -123,11 +123,6 @@ struct GuestPlatformAdapter : mg::Platform
         return adaptee->create_display(initial_conf_policy, gl_config);
     }
 
-    mg::NativeDisplayPlatform* native_display_platform() override
-    {
-        return adaptee->native_display_platform();
-    }
-
     std::shared_ptr<mg::PlatformAuthentication> const context;
     std::shared_ptr<mg::Platform> const adaptee;
 };


### PR DESCRIPTION
There are apparently still bits of the platform interface that can be hewn away!