### PR TITLE
performance tests: Record detailed results

### DIFF
--- a/tests/performance-tests/test_compositor.cpp
+++ b/tests/performance-tests/test_compositor.cpp
@@ -61,6 +61,7 @@ TEST_F(CompositorPerformance, regression_test_1563287)
     run_server_for(10s);
 
     read_compositor_report();
+    RecordProperty("framerate", std::to_string(compositor_fps));
     EXPECT_GE(compositor_fps, 58.0f);
     EXPECT_LT(compositor_render_time, 17.0f);
 }

--- a/tests/performance-tests/test_glmark2-es2.cpp
+++ b/tests/performance-tests/test_glmark2-es2.cpp
@@ -89,6 +89,9 @@ struct AbstractGLMark2Test : testing::Test, mtf::AsyncServerRunner {
             glmark2_output << json;
         }
 
+        // Use GTest's structured annotation support to expose the score
+        // to the test runner.
+        RecordProperty("score", score);
         return score;
     }
 


### PR DESCRIPTION
Use GTest's annotation support to record the GLMark2
score and compositor performance test's FPS.

Test runners can use the `--gtest_output` flag to get
a JSON or XML file with the results in a location of
their choice.