### PR TITLE
Enable EGL_KHR_debug extension on --debug

### DIFF
--- a/include/platform/mir/graphics/egl_extensions.h
+++ b/include/platform/mir/graphics/egl_extensions.h
@@ -14,7 +14,32 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  *   Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ *
+ * This file also contains a subset of EGL definitions taken from eglext.h.
+ * These are:
+ *
+ * Copyright (c) 2013-2017 The Khronos Group Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and/or associated documentation files (the
+ * "Materials"), to deal in the Materials without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Materials, and to
+ * permit persons to whom the Materials are furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
  */
+
 
 #ifndef MIR_GRAPHICS_EGL_EXTENSIONS_H_
 #define MIR_GRAPHICS_EGL_EXTENSIONS_H_
@@ -56,6 +81,28 @@ EGLAPI EGLSurface EGLAPIENTRY eglCreatePlatformWindowSurfaceEXT (EGLDisplay dpy,
 EGLAPI EGLSurface EGLAPIENTRY eglCreatePlatformPixmapSurfaceEXT (EGLDisplay dpy, EGLConfig config, void *native_pixmap, const EGLint *attrib_list);
 #endif
 #endif /* EGL_EXT_platform_base */
+
+#ifndef EGL_KHR_debug
+#define EGL_KHR_debug 1
+typedef void *EGLLabelKHR;
+typedef void *EGLObjectKHR;
+typedef void (EGLAPIENTRY  *EGLDEBUGPROCKHR)(EGLenum error,const char *command,EGLint messageType,EGLLabelKHR threadLabel,EGLLabelKHR objectLabel,const char* message);
+#define EGL_OBJECT_THREAD_KHR             0x33B0
+#define EGL_OBJECT_DISPLAY_KHR            0x33B1
+#define EGL_OBJECT_CONTEXT_KHR            0x33B2
+#define EGL_OBJECT_SURFACE_KHR            0x33B3
+#define EGL_OBJECT_IMAGE_KHR              0x33B4
+#define EGL_OBJECT_SYNC_KHR               0x33B5
+#define EGL_OBJECT_STREAM_KHR             0x33B6
+#define EGL_DEBUG_MSG_CRITICAL_KHR        0x33B9
+#define EGL_DEBUG_MSG_ERROR_KHR           0x33BA
+#define EGL_DEBUG_MSG_WARN_KHR            0x33BB
+#define EGL_DEBUG_MSG_INFO_KHR            0x33BC
+#define EGL_DEBUG_CALLBACK_KHR            0x33B8
+typedef EGLint (EGLAPIENTRYP PFNEGLDEBUGMESSAGECONTROLKHRPROC) (EGLDEBUGPROCKHR callback, const EGLAttrib *attrib_list);
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYDEBUGKHRPROC) (EGLint attribute, EGLAttrib *value);
+typedef EGLint (EGLAPIENTRYP PFNEGLLABELOBJECTKHRPROC) (EGLDisplay display, EGLenum objectType, EGLObjectKHR object, EGLLabelKHR label);
+#endif
 
 /*
  * FIXME: Remove both EGL_EXT_stream_acquire_mode and

--- a/include/platform/mir/graphics/egl_extensions.h
+++ b/include/platform/mir/graphics/egl_extensions.h
@@ -122,6 +122,26 @@ struct EGLExtensions
         PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC const eglCreatePlatformWindowSurface;
     };
     std::experimental::optional<PlatformBaseEXT> const platform_base;
+
+    class DebugKHR
+    {
+    public:
+        DebugKHR();
+
+        static DebugKHR extension_or_null_object();
+        static std::experimental::optional<DebugKHR> maybe_debug_khr();
+
+        PFNEGLDEBUGMESSAGECONTROLKHRPROC const eglDebugMessageControlKHR;
+        PFNEGLLABELOBJECTKHRPROC const eglLabelObjectKHR;
+        PFNEGLQUERYDEBUGKHRPROC const eglQueryDebugKHR;
+
+    private:
+        // Private helper for null object constructor.
+        DebugKHR(
+            PFNEGLDEBUGMESSAGECONTROLKHRPROC control,
+            PFNEGLLABELOBJECTKHRPROC label,
+            PFNEGLQUERYDEBUGKHRPROC query);
+    };
 };
 
 }

--- a/include/platform/mir/graphics/egl_logger.h
+++ b/include/platform/mir/graphics/egl_logger.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by:
+ *   Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef MIR_PLATFORM_GRAPHICS_EGL_LOGGER_H_
+#define MIR_PLATFORM_GRAPHICS_EGL_LOGGER_H_
+
+#include <memory>
+
+namespace mir
+{
+namespace logging
+{
+class Logger;
+}
+namespace graphics
+{
+/**
+ * Install a EGL_KHR_debug callback that prints messages using \p logger
+ *
+ * This will override any previous EGL_KHR_debug callback set; it does not attempt to stack callbacks.
+ *
+ * \param logger [in]   The logger to print to.
+ */
+void initialise_egl_logger(std::shared_ptr<mir::logging::Logger> logger);
+}
+}
+
+#endif //MIR_PLATFORM_GRAPHICS_EGL_LOGGER_H_

--- a/src/platform/graphics/CMakeLists.txt
+++ b/src/platform/graphics/CMakeLists.txt
@@ -23,6 +23,8 @@ set(
   egl_wayland_allocator.cpp
   ${PROJECT_SOURCE_DIR}/include/platform/mir/renderer/sw/pixel_source.h
   cpu_buffers.cpp
+  egl_logger.cpp
+  ${PROJECT_SOURCE_DIR}/include/platform/mir/graphics/egl_logger.h
 )
 
 add_library(mirplatformgraphicscommon OBJECT

--- a/src/platform/graphics/egl_logger.cpp
+++ b/src/platform/graphics/egl_logger.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by:
+ *   Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+#include "mir/graphics/egl_logger.h"
+
+#include "mir/log.h"
+#include "mir/graphics/egl_extensions.h"
+#include "mir/graphics/egl_error.h"
+
+namespace mg = mir::graphics;
+
+namespace
+{
+std::shared_ptr<mir::logging::Logger> egl_logger;
+
+void egl_debug_logger(
+    EGLenum error,
+    char const* command,
+    EGLint message_type,
+    EGLLabelKHR thread_label,
+    EGLLabelKHR object_label,
+    char const* message)
+{
+    char const* const thread_id = thread_label ? static_cast<char const*>(thread_label) : "Unlabelled thread";
+    char const* const object_id = object_label ? static_cast<char const*>(object_label) : "Unlabelled object";
+
+    auto const severity =
+        [](EGLint egl_severity)
+        {
+            switch (egl_severity)
+            {
+                case EGL_DEBUG_MSG_INFO_KHR:
+                return mir::logging::Severity::debug;
+                case EGL_DEBUG_MSG_WARN_KHR:
+                return mir::logging::Severity::warning;
+                case EGL_DEBUG_MSG_ERROR_KHR:
+                return mir::logging::Severity::error;
+                case EGL_DEBUG_MSG_CRITICAL_KHR:
+                return mir::logging::Severity::critical;
+                default:
+                egl_logger->log(
+                    "EGL",
+                    mir::logging::Severity::error,
+                    "Unexpected EGL log level encountered: %i. This is a Mir programming error.",
+                    egl_severity);
+                // Shrug. Let's pick error?
+                return mir::logging::Severity::error;
+            }
+        }(message_type);
+
+    egl_logger->log(
+        "EGL",
+        severity,
+        "[%s] on [%s]: %s (%s): %s",
+        thread_id,
+        object_id,
+        command,
+        mg::egl_category().message(error).c_str(),
+        message);
+}
+
+}
+
+void mg::initialise_egl_logger(std::shared_ptr<mir::logging::Logger> logger)
+{
+    egl_logger = std::move(logger);
+    if (auto debug_khr = mg::EGLExtensions::DebugKHR::maybe_debug_khr())
+    {
+        EGLAttrib enable_all_logging[] = {
+            EGL_DEBUG_MSG_CRITICAL_KHR, EGL_TRUE,
+            EGL_DEBUG_MSG_ERROR_KHR, EGL_TRUE,
+            EGL_DEBUG_MSG_WARN_KHR, EGL_TRUE,
+            EGL_DEBUG_MSG_INFO_KHR, EGL_TRUE,
+            EGL_NONE
+        };
+        debug_khr->eglDebugMessageControlKHR(&egl_debug_logger, enable_all_logging);
+        egl_logger->log(
+            "EGL",
+            mir::logging::Severity::informational,
+            "EGL_KHR_debug logging enabled at maximum verbosity");
+    }
+    else
+    {
+        egl_logger->log(
+            "EGL",
+            mir::logging::Severity::informational,
+            "No EGL_KHR_debug support detected");
+    }
+}

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -193,3 +193,12 @@ MIRPLATFORM_2.1 {
     mir::renderer::software::alloc_buffer_with_content*;
  };
 } MIRPLATFORM_2.0;
+
+MIR_PLATFORM_2.2 {
+ global:
+  extern "C++" {
+    mir::graphics::EGLExtensions::DebugKHR::DebugKHR*;
+    mir::graphics::EGLExtensions::DebugKHR::extension_or_null_object*;
+    mir::graphics::EGLExtensions::DebugKHR::maybe_debug_khr*;
+  };
+} MIRPLATFORM_2.1;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -200,5 +200,6 @@ MIR_PLATFORM_2.2 {
     mir::graphics::EGLExtensions::DebugKHR::DebugKHR*;
     mir::graphics::EGLExtensions::DebugKHR::extension_or_null_object*;
     mir::graphics::EGLExtensions::DebugKHR::maybe_debug_khr*;
+    mir::graphics::initialise_egl_logger*;
   };
 } MIRPLATFORM_2.1;

--- a/src/platforms/eglstream-kms/server/platform_symbols.cpp
+++ b/src/platforms/eglstream-kms/server/platform_symbols.cpp
@@ -22,6 +22,7 @@
 #include "utils.h"
 #include "mir/graphics/platform.h"
 #include "mir/options/option.h"
+#include "mir/options/configuration.h"
 #include "mir/module_deleter.h"
 #include "mir/assert_module_entry_point.h"
 #include "mir/libname.h"
@@ -30,6 +31,7 @@
 #include "one_shot_device_observer.h"
 #include "mir/raii.h"
 #include "kms-utils/drm_mode_resources.h"
+#include "mir/graphics/egl_logger.h"
 
 #include <boost/throw_exception.hpp>
 #include <boost/exception/diagnostic_information.hpp>
@@ -83,13 +85,19 @@ EGLDeviceEXT find_device()
 }
 
 mir::UniqueModulePtr<mg::Platform> create_host_platform(
-    std::shared_ptr<mo::Option> const&,
+    std::shared_ptr<mo::Option> const& options,
     std::shared_ptr<mir::EmergencyCleanupRegistry> const&,
     std::shared_ptr<mir::ConsoleServices> const& console,
     std::shared_ptr<mg::DisplayReport> const& display_report,
-    std::shared_ptr<mir::logging::Logger> const&)
+    std::shared_ptr<mir::logging::Logger> const& logger)
 {
     mir::assert_entry_point_signature<mg::CreateHostPlatform>(&create_host_platform);
+
+    if (options->is_set(mo::debug_opt))
+    {
+        mg::initialise_egl_logger(logger);
+    }
+
     return mir::make_module_ptr<mge::Platform>(
         std::make_shared<mge::RenderingPlatform>(),
         std::make_shared<mge::DisplayPlatform>(*console, find_device(), display_report));

--- a/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
@@ -24,6 +24,7 @@
 #include "display_helpers.h"
 #include "mir/options/program_option.h"
 #include "mir/options/option.h"
+#include "mir/options/configuration.h"
 #include "mir/udev/wrapper.h"
 #include "mir/module_deleter.h"
 #include "mir/assert_module_entry_point.h"
@@ -50,6 +51,52 @@ namespace
 char const* bypass_option_name{"bypass"};
 char const* host_socket{"host-socket"};
 
+std::shared_ptr<mir::logging::Logger> egl_logger;
+void egl_debug_logger(
+    EGLenum error,
+    char const* command,
+    EGLint message_type,
+    EGLLabelKHR thread_label,
+    EGLLabelKHR object_label,
+    char const* message)
+{
+    char const* const thread_id = thread_label ? static_cast<char const*>(thread_label) : "Unlabelled thread";
+    char const* const object_id = object_label ? static_cast<char const*>(object_label) : "Unlabelled object";
+
+    auto const severity =
+        [](EGLint egl_severity)
+        {
+            switch (egl_severity)
+            {
+            case EGL_DEBUG_MSG_INFO_KHR:
+                return mir::logging::Severity::debug;
+            case EGL_DEBUG_MSG_WARN_KHR:
+                return mir::logging::Severity::warning;
+            case EGL_DEBUG_MSG_ERROR_KHR:
+                return mir::logging::Severity::error;
+            case EGL_DEBUG_MSG_CRITICAL_KHR:
+                return mir::logging::Severity::critical;
+            default:
+                egl_logger->log(
+                    "EGL",
+                    mir::logging::Severity::error,
+                    "Unexpected EGL log level encountered: %i. This is a Mir programming error.",
+                    egl_severity);
+                // Shrug. Let's pick error?
+                return mir::logging::Severity::error;
+            }
+        }(message_type);
+
+    egl_logger->log(
+        "EGL",
+        severity,
+        "[%s] on [%s]: %s (%s): %s",
+        thread_id,
+        object_id,
+        command,
+        mg::egl_category().message(error).c_str(),
+        message);
+}
 }
 
 mir::UniqueModulePtr<mg::Platform> create_host_platform(
@@ -57,10 +104,37 @@ mir::UniqueModulePtr<mg::Platform> create_host_platform(
     std::shared_ptr<mir::EmergencyCleanupRegistry> const& emergency_cleanup_registry,
     std::shared_ptr<mir::ConsoleServices> const& console,
     std::shared_ptr<mg::DisplayReport> const& report,
-    std::shared_ptr<mir::logging::Logger> const& /*logger*/)
+    std::shared_ptr<mir::logging::Logger> const& logger)
 {
     mir::assert_entry_point_signature<mg::CreateHostPlatform>(&create_host_platform);
     // ensure gbm-kms finds the gbm-kms mir-platform symbols
+
+    if (options->is_set(mir::options::debug_opt))
+    {
+        egl_logger = logger;
+        if (auto debug_khr = mg::EGLExtensions::DebugKHR::maybe_debug_khr())
+        {
+            EGLAttrib enable_all_logging[] = {
+                EGL_DEBUG_MSG_CRITICAL_KHR, EGL_TRUE,
+                EGL_DEBUG_MSG_ERROR_KHR, EGL_TRUE,
+                EGL_DEBUG_MSG_WARN_KHR, EGL_TRUE,
+                EGL_DEBUG_MSG_INFO_KHR, EGL_TRUE,
+                EGL_NONE
+            };
+            debug_khr->eglDebugMessageControlKHR(&egl_debug_logger, enable_all_logging);
+            logger->log(
+                "gbm-kms",
+                mir::logging::Severity::informational,
+                "EGL_KHR_debug logging enabled at maximum verbosity");
+        }
+        else
+        {
+            logger->log(
+                "gbm-kms",
+                mir::logging::Severity::informational,
+                "No EGL_KHR_debug support detected");
+        }
+    }
 
     auto bypass_option = mgg::BypassOption::allowed;
     if (!options->get<bool>(bypass_option_name))

--- a/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
@@ -34,6 +34,7 @@
 #include "mir/raii.h"
 #include "mir/graphics/egl_error.h"
 #include "mir/graphics/gl_config.h"
+#include "mir/graphics/egl_logger.h"
 
 #include <EGL/egl.h>
 #include <GLES2/gl2.h>
@@ -51,52 +52,6 @@ namespace
 char const* bypass_option_name{"bypass"};
 char const* host_socket{"host-socket"};
 
-std::shared_ptr<mir::logging::Logger> egl_logger;
-void egl_debug_logger(
-    EGLenum error,
-    char const* command,
-    EGLint message_type,
-    EGLLabelKHR thread_label,
-    EGLLabelKHR object_label,
-    char const* message)
-{
-    char const* const thread_id = thread_label ? static_cast<char const*>(thread_label) : "Unlabelled thread";
-    char const* const object_id = object_label ? static_cast<char const*>(object_label) : "Unlabelled object";
-
-    auto const severity =
-        [](EGLint egl_severity)
-        {
-            switch (egl_severity)
-            {
-            case EGL_DEBUG_MSG_INFO_KHR:
-                return mir::logging::Severity::debug;
-            case EGL_DEBUG_MSG_WARN_KHR:
-                return mir::logging::Severity::warning;
-            case EGL_DEBUG_MSG_ERROR_KHR:
-                return mir::logging::Severity::error;
-            case EGL_DEBUG_MSG_CRITICAL_KHR:
-                return mir::logging::Severity::critical;
-            default:
-                egl_logger->log(
-                    "EGL",
-                    mir::logging::Severity::error,
-                    "Unexpected EGL log level encountered: %i. This is a Mir programming error.",
-                    egl_severity);
-                // Shrug. Let's pick error?
-                return mir::logging::Severity::error;
-            }
-        }(message_type);
-
-    egl_logger->log(
-        "EGL",
-        severity,
-        "[%s] on [%s]: %s (%s): %s",
-        thread_id,
-        object_id,
-        command,
-        mg::egl_category().message(error).c_str(),
-        message);
-}
 }
 
 mir::UniqueModulePtr<mg::Platform> create_host_platform(
@@ -111,29 +66,7 @@ mir::UniqueModulePtr<mg::Platform> create_host_platform(
 
     if (options->is_set(mir::options::debug_opt))
     {
-        egl_logger = logger;
-        if (auto debug_khr = mg::EGLExtensions::DebugKHR::maybe_debug_khr())
-        {
-            EGLAttrib enable_all_logging[] = {
-                EGL_DEBUG_MSG_CRITICAL_KHR, EGL_TRUE,
-                EGL_DEBUG_MSG_ERROR_KHR, EGL_TRUE,
-                EGL_DEBUG_MSG_WARN_KHR, EGL_TRUE,
-                EGL_DEBUG_MSG_INFO_KHR, EGL_TRUE,
-                EGL_NONE
-            };
-            debug_khr->eglDebugMessageControlKHR(&egl_debug_logger, enable_all_logging);
-            logger->log(
-                "gbm-kms",
-                mir::logging::Severity::informational,
-                "EGL_KHR_debug logging enabled at maximum verbosity");
-        }
-        else
-        {
-            logger->log(
-                "gbm-kms",
-                mir::logging::Severity::informational,
-                "No EGL_KHR_debug support detected");
-        }
+        mg::initialise_egl_logger(logger);
     }
 
     auto bypass_option = mgg::BypassOption::allowed;

--- a/src/platforms/x11/graphics/graphics.cpp
+++ b/src/platforms/x11/graphics/graphics.cpp
@@ -27,9 +27,7 @@
 #include "mir/log.h"
 #include "mir/graphics/egl_error.h"
 #include "mir/graphics/egl_extensions.h"
-
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
+#include "mir/graphics/egl_logger.h"
 
 #include <boost/throw_exception.hpp>
 
@@ -42,53 +40,6 @@ namespace geom = mir::geometry;
 namespace
 {
 char const* x11_displays_option_name{"x11-output"};
-
-std::shared_ptr<mir::logging::Logger> egl_logger;
-void egl_debug_logger(
-    EGLenum error,
-    char const* command,
-    EGLint message_type,
-    EGLLabelKHR thread_label,
-    EGLLabelKHR object_label,
-    char const* message)
-{
-    char const* const thread_id = thread_label ? static_cast<char const*>(thread_label) : "Unlabelled thread";
-    char const* const object_id = object_label ? static_cast<char const*>(object_label) : "Unlabelled object";
-
-    auto const severity =
-        [](EGLint egl_severity)
-        {
-            switch (egl_severity)
-            {
-                case EGL_DEBUG_MSG_INFO_KHR:
-                    return mir::logging::Severity::debug;
-                case EGL_DEBUG_MSG_WARN_KHR:
-                    return mir::logging::Severity::warning;
-                case EGL_DEBUG_MSG_ERROR_KHR:
-                    return mir::logging::Severity::error;
-                case EGL_DEBUG_MSG_CRITICAL_KHR:
-                    return mir::logging::Severity::critical;
-                default:
-                    egl_logger->log(
-                        "EGL",
-                        mir::logging::Severity::error,
-                        "Unexpected EGL log level encountered: %i. This is a Mir programming error.",
-                        egl_severity);
-                    // Shrug. Let's pick error?
-                    return mir::logging::Severity::error;
-            }
-        }(message_type);
-
-    egl_logger->log(
-        "EGL",
-        severity,
-        "[%s] on [%s]: %s (%s): %s",
-        thread_id,
-        object_id,
-        command,
-        mg::egl_category().message(error).c_str(),
-        message);
-}
 }
 
 mir::UniqueModulePtr<mg::Platform> create_host_platform(
@@ -104,29 +55,7 @@ mir::UniqueModulePtr<mg::Platform> create_host_platform(
 
     if (options->is_set(mir::options::debug_opt))
     {
-        egl_logger = logger;
-        if (auto debug_khr = mg::EGLExtensions::DebugKHR::maybe_debug_khr())
-        {
-            EGLAttrib enable_all_logging[] = {
-                EGL_DEBUG_MSG_CRITICAL_KHR, EGL_TRUE,
-                EGL_DEBUG_MSG_ERROR_KHR, EGL_TRUE,
-                EGL_DEBUG_MSG_WARN_KHR, EGL_TRUE,
-                EGL_DEBUG_MSG_INFO_KHR, EGL_TRUE,
-                EGL_NONE
-            };
-            debug_khr->eglDebugMessageControlKHR(&egl_debug_logger, enable_all_logging);
-            logger->log(
-                "gbm-kms",
-                mir::logging::Severity::informational,
-                "EGL_KHR_debug logging enabled at maximum verbosity");
-        }
-        else
-        {
-            logger->log(
-                "gbm-kms",
-                mir::logging::Severity::informational,
-                "No EGL_KHR_debug support detected");
-        }
+        mg::initialise_egl_logger(logger);
     }
 
     auto output_sizes = mgx::Platform::parse_output_sizes(options->get<std::string>(x11_displays_option_name));


### PR DESCRIPTION
This is a fairly minimal implementation using `EGL_KHR_debug`. Followup work can improve the debug messages printed by tagging objects like “this is the rendering thread”, “this is the EGL context used for buffer allocation”, “this is the EGL context used for a `DisplayBuffer`” and so on.