### PR TITLE
New mir-wlcs-integration package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -232,8 +232,8 @@ Description: Display Server for Ubuntu - test tools
 Package: mir-wlcs-integration
 Architecture: linux-any
 Pre-Depends: ${misc:Pre-Depends}
-Breaks: mir-test-tools (<< 2.1)
-Replaces: mir-test-tools (<< 2.1)
+Breaks: mir-test-tools (<< 2.0.0.0+dev148~)
+Replaces: mir-test-tools (<< 2.0.0.0+dev148~)
 Depends: ${misc:Depends},
          ${shlibs:Depends},
 Description: Display Server for Ubuntu - wlcs integration

--- a/debian/control
+++ b/debian/control
@@ -232,6 +232,8 @@ Description: Display Server for Ubuntu - test tools
 Package: mir-wlcs-integration
 Architecture: linux-any
 Pre-Depends: ${misc:Pre-Depends}
+Breaks: mir-test-tools (<< 2.1)
+Replaces: mir-test-tools (<< 2.1)
 Depends: ${misc:Depends},
          ${shlibs:Depends},
 Description: Display Server for Ubuntu - wlcs integration

--- a/debian/control
+++ b/debian/control
@@ -223,11 +223,22 @@ Depends: ${misc:Depends},
          glmark2-es2-wayland,
          mesa-utils-extra,
          dmz-cursor-theme,
-Description: Display Server for Ubuntu - stress tests and other test tools
+Description: Display Server for Ubuntu - test tools
  Mir is a display server running on linux systems, with a focus on efficiency,
  robust operation and a well-defined driver model.
  .
- Contains a tool for stress testing the Mir display server
+ Contains tools for smoke and performance testing the Mir display server
+
+Package: mir-wlcs-integration
+Architecture: linux-any
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${misc:Depends},
+         ${shlibs:Depends},
+Description: Display Server for Ubuntu - wlcs integration
+ Mir is a display server running on linux systems, with a focus on efficiency,
+ robust operation and a well-defined driver model.
+ .
+ Contains libraries for integration with the wlcs test suite
 
 Package: libmircore1
 Section: libs

--- a/debian/mir-test-tools.install
+++ b/debian/mir-test-tools.install
@@ -5,7 +5,3 @@ usr/lib/*/mir/tools/libmirclientlttng.so
 usr/lib/*/mir/tools/libmirserverlttng.so
 usr/bin/mir_demo_client_*
 usr/bin/mir_demo_server
-usr/lib/*/mir/server-platform/graphics-dummy.so
-usr/lib/*/mir/server-platform/input-stub.so
-usr/lib/*/mir/client-platform/dummy.so
-usr/lib/*/mir/miral_wlcs_integration.so

--- a/debian/mir-wlcs-integration.install
+++ b/debian/mir-wlcs-integration.install
@@ -1,0 +1,3 @@
+usr/lib/*/mir/miral_wlcs_integration.so
+usr/lib/*/mir/server-platform/graphics-dummy.so
+usr/lib/*/mir/server-platform/input-stub.so

--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -185,7 +185,6 @@ set_target_properties(
 
 install(TARGETS mirplatformgraphicsstub LIBRARY DESTINATION ${MIR_SERVER_PLATFORM_PATH})
 install(TARGETS mirplatforminputstub LIBRARY DESTINATION ${MIR_SERVER_PLATFORM_PATH})
-install(TARGETS mirclientplatformstub LIBRARY DESTINATION ${MIR_CLIENT_PLATFORM_PATH})
 
 add_library(
   mirplatformgraphicsthrow MODULE


### PR DESCRIPTION
Split the wlcs related libraries out of mir-test-tools and into a new mir-wlcs-integration package