### PR TITLE
Don't restore mapped window unless it was hidden

### DIFF
--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -380,7 +380,7 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
     {
         bool const is_mapped = scene_surface->visible();
         bool const should_be_mapped = static_cast<bool>(surface->buffer_size());
-        if (!is_mapped && should_be_mapped)
+        if (!is_mapped && should_be_mapped && scene_surface->state() == mir_window_state_hidden)
         {
             spec().state = mir_window_state_restored;
         }

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -99,7 +99,7 @@ void mf::XWaylandSurfaceRole::commit(WlSurfaceState const& state)
 
         bool const is_mapped = surface.value()->visible();
         bool const should_be_mapped = static_cast<bool>(wl_surface->buffer_size());
-        if (!is_mapped && should_be_mapped)
+        if (!is_mapped && should_be_mapped && surface.value()->state() == mir_window_state_hidden)
         {
             spec.state = mir_window_state_restored;
         }


### PR DESCRIPTION
There's all sorts of pre-existing questionableness around here. One of these days someone is going to straighten it all out, but not today.

It's unclear if restoring mapped windows when they were previously hidden is a good idea, but I'm pretty sure we should **not** restore windows in any other state. Specifically, this is required for Mir to pass the foreign toplevel tests.