### PR TITLE
log: Annotate log functions with [[gnu::format]] attributes

### DIFF
--- a/include/common/mir/log.h
+++ b/include/common/mir/log.h
@@ -27,9 +27,10 @@
 
 namespace mir
 {
-
+[[gnu::format (printf, 3, 0)]]
 void logv(logging::Severity sev, const char *component,
           char const* fmt, va_list va);
+[[gnu::format (printf, 3, 4)]]
 void log(logging::Severity sev, const char *component,
          char const* fmt, ...);
 void log(logging::Severity sev, const char *component,
@@ -57,25 +58,34 @@ inline void log_info(std::string const& message)
                MIR_LOG_COMPONENT, message);
 }
 
-template<typename... Args>
-void log_info(char const* fmt, Args&&... args)
+[[gnu::format (printf, 1, 2)]]
+inline void log_info(char const* fmt, ...)
 {
-    ::mir::log(::mir::logging::Severity::informational,
-               MIR_LOG_COMPONENT, fmt, std::forward<Args>(args)...);
+    va_list va;
+    va_start(va, fmt);
+    ::mir::logv(::mir::logging::Severity::informational,
+                MIR_LOG_COMPONENT, fmt, va);
+    va_end(va);
 }
 
-template<typename... Args>
-void log_error(char const* fmt, Args&&... args)
+[[gnu::format (printf, 1, 2)]]
+inline void log_error(char const* fmt, ...)
 {
-    ::mir::log(::mir::logging::Severity::error,
-               MIR_LOG_COMPONENT, fmt, std::forward<Args>(args)...);
+    va_list va;
+    va_start(va, fmt);
+    ::mir::logv(::mir::logging::Severity::error,
+                MIR_LOG_COMPONENT, fmt, va);
+    va_end(va);
 }
 
-template<typename... Args>
-inline void log_debug(char const* fmt, Args&&... args)
+[[gnu::format (printf, 1, 2)]]
+inline void log_debug(char const* fmt, ...)
 {
-    ::mir::log(::mir::logging::Severity::debug,
-               MIR_LOG_COMPONENT, fmt, std::forward<Args>(args)...);
+    va_list va;
+    va_start(va, fmt);
+    ::mir::logv(::mir::logging::Severity::debug,
+               MIR_LOG_COMPONENT, fmt, va);
+    va_end(va);
 }
 
 inline void log_critical(std::string const& message)
@@ -84,11 +94,14 @@ inline void log_critical(std::string const& message)
                MIR_LOG_COMPONENT, message);
 }
 
-template<typename... Args>
-void log_critical(char const* fmt, Args&&... args)
+[[gnu::format(printf, 1, 2)]]
+inline void log_critical(char const* fmt, ...)
 {
-    ::mir::log(::mir::logging::Severity::critical,
-        MIR_LOG_COMPONENT, fmt, std::forward<Args>(args)...);
+    va_list va;
+    va_start(va, fmt);
+    ::mir::logv(::mir::logging::Severity::critical,
+               MIR_LOG_COMPONENT, fmt, va);
+    va_end(va);
 }
 
 inline void log_error(std::string const& message)
@@ -103,11 +116,14 @@ inline void log_warning(std::string const& message)
                MIR_LOG_COMPONENT, message);
 }
 
-template<typename... Args>
-void log_warning(char const* fmt, Args&&... args)
+[[gnu::format(printf, 1, 2)]]
+inline void log_warning(char const* fmt, ...)
 {
-    ::mir::log(::mir::logging::Severity::warning,
-               MIR_LOG_COMPONENT, fmt, std::forward<Args>(args)...);
+    va_list va;
+    va_start(va, fmt);
+    ::mir::logv(::mir::logging::Severity::warning,
+               MIR_LOG_COMPONENT, fmt, va);
+    va_end(va);
 }
 } // (nested anonymous) namespace
 #endif

--- a/src/client/handle_event_exception.h
+++ b/src/client/handle_event_exception.h
@@ -25,6 +25,6 @@
     }                                    \
     catch(std::exception const& e)       \
     {                                    \
-        mir::log_critical(e.what());     \
+        mir::log_critical("%s", e.what());     \
         abort();                         \
     }

--- a/src/miral/window_management_trace.cpp
+++ b/src/miral/window_management_trace.cpp
@@ -473,7 +473,7 @@ try {
     auto result = wrapped.active_output();
     std::stringstream out;
     out << result;
-    mir::log_info("%s -> ", __func__, out.str().c_str());
+    mir::log_info("%s -> %s", __func__, out.str().c_str());
     trace_count++;
     return result;
 }
@@ -485,7 +485,7 @@ try {
     auto result = wrapped.active_application_zone();
     std::stringstream out;
     out << result.extents();
-    mir::log_info("%s -> ", __func__, out.str().c_str());
+    mir::log_info("%s -> %s", __func__, out.str().c_str());
     trace_count++;
     return result;
 }
@@ -599,7 +599,7 @@ MIRAL_TRACE_EXCEPTION
 void miral::WindowManagementTrace::end_drag_and_drop()
 try {
     log_input();
-    mir::log_info("%s window_info=%s", __func__);
+    mir::log_info("%s", __func__);
     trace_count++;
     wrapped.end_drag_and_drop();
 }
@@ -633,7 +633,7 @@ MIRAL_TRACE_EXCEPTION
 void miral::WindowManagementTrace::add_tree_to_workspace(
     miral::Window const& window, std::shared_ptr<miral::Workspace> const& workspace)
 try {
-    mir::log_info("%s window=%s, workspace =%p", __func__, dump_of(window).c_str(), workspace.get());
+    mir::log_info("%s window=%s, workspace =%p", __func__, dump_of(window).c_str(), static_cast<void*>(workspace.get()));
     wrapped.add_tree_to_workspace(window, workspace);
 }
 MIRAL_TRACE_EXCEPTION
@@ -641,7 +641,7 @@ MIRAL_TRACE_EXCEPTION
 void miral::WindowManagementTrace::remove_tree_from_workspace(
     miral::Window const& window, std::shared_ptr<miral::Workspace> const& workspace)
 try {
-    mir::log_info("%s window=%s, workspace =%p", __func__, dump_of(window).c_str(), workspace.get());
+    mir::log_info("%s window=%s, workspace =%p", __func__, dump_of(window).c_str(), static_cast<void*>(workspace.get()));
     wrapped.remove_tree_from_workspace(window, workspace);
 }
 MIRAL_TRACE_EXCEPTION
@@ -649,7 +649,7 @@ MIRAL_TRACE_EXCEPTION
 void miral::WindowManagementTrace::move_workspace_content_to_workspace(
     std::shared_ptr<Workspace> const& to_workspace, std::shared_ptr<Workspace> const& from_workspace)
 try {
-    mir::log_info("%s to_workspace=%p, from_workspace=%p", __func__, to_workspace.get(), from_workspace.get());
+    mir::log_info("%s to_workspace=%p, from_workspace=%p", __func__, static_cast<void*>(to_workspace.get()), static_cast<void*>(from_workspace.get()));
     wrapped.move_workspace_content_to_workspace(to_workspace, from_workspace);
 }
 MIRAL_TRACE_EXCEPTION
@@ -665,7 +665,7 @@ MIRAL_TRACE_EXCEPTION
 void miral::WindowManagementTrace::for_each_window_in_workspace(
     std::shared_ptr<miral::Workspace> const& workspace, std::function<void(miral::Window const&)> const& callback)
 try {
-    mir::log_info("%s workspace =%p", __func__, workspace.get());
+    mir::log_info("%s workspace =%p", __func__, static_cast<void*>(workspace.get()));
     wrapped.for_each_window_in_workspace(workspace, callback);
 }
 MIRAL_TRACE_EXCEPTION
@@ -862,7 +862,7 @@ MIRAL_TRACE_EXCEPTION
 void miral::WindowManagementTrace::advise_adding_to_workspace(
     std::shared_ptr<miral::Workspace> const& workspace, std::vector<miral::Window> const& windows)
 try {
-    mir::log_info("%s workspace=%p, windows=%s", __func__, workspace.get(), dump_of(windows).c_str());
+    mir::log_info("%s workspace=%p, windows=%s", __func__, static_cast<void*>(workspace.get()), dump_of(windows).c_str());
     policy->advise_adding_to_workspace(workspace, windows);
 }
 MIRAL_TRACE_EXCEPTION
@@ -870,7 +870,7 @@ MIRAL_TRACE_EXCEPTION
 void miral::WindowManagementTrace::advise_removing_from_workspace(
     std::shared_ptr<miral::Workspace> const& workspace, std::vector<miral::Window> const& windows)
 try {
-    mir::log_info("%s workspace=%p, windows=%s", __func__, workspace.get(), dump_of(windows).c_str());
+    mir::log_info("%s workspace=%p, windows=%s", __func__, static_cast<void*>(workspace.get()), dump_of(windows).c_str());
     policy->advise_removing_from_workspace(workspace, windows);
 }
 MIRAL_TRACE_EXCEPTION

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -137,12 +137,12 @@ mgx::X11Window::X11Window(::Display* x_dpy,
 
     mir::log_info("%d visual(s) found", num_visuals);
     mir::log_info("Using the first one :");
-    mir::log_info("ID\t\t:\t%d", visInfo->visualid);
+    mir::log_info("ID\t\t:\t%lu", visInfo->visualid);
     mir::log_info("screen\t:\t%d", visInfo->screen);
     mir::log_info("depth\t\t:\t%d", visInfo->depth);
-    mir::log_info("red_mask\t:\t0x%0X", visInfo->red_mask);
-    mir::log_info("green_mask\t:\t0x%0X", visInfo->green_mask);
-    mir::log_info("blue_mask\t:\t0x%0X", visInfo->blue_mask);
+    mir::log_info("red_mask\t:\t0x%0lX", visInfo->red_mask);
+    mir::log_info("green_mask\t:\t0x%0lX", visInfo->green_mask);
+    mir::log_info("blue_mask\t:\t0x%0lX", visInfo->blue_mask);
     mir::log_info("colormap_size\t:\t%d", visInfo->colormap_size);
     mir::log_info("bits_per_rgb\t:\t%d", visInfo->bits_per_rgb);
 

--- a/src/platforms/x11/input/input_platform.cpp
+++ b/src/platforms/x11/input/input_platform.cpp
@@ -61,7 +61,7 @@ geom::Point get_pos_on_output(Window x11_window, int x, int y)
     }
     else
     {
-        mir::log_warning("X11 window %d does not map to any known output, not applying input transformation", x11_window);
+        mir::log_warning("X11 window %lu does not map to any known output, not applying input transformation", x11_window);
         return geom::Point{x, y};
     }
 }

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -180,7 +180,7 @@ auto mf::LayerShellV1::get_window(wl_resource* surface) -> std::shared_ptr<ms::S
             }
         }
 
-        log_debug("No window currently associated with wayland::LayerSurfaceV1 %p", surface);
+        log_debug("No window currently associated with wayland::LayerSurfaceV1 %p", static_cast<void*>(surface));
     }
 
     return {};

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -895,7 +895,7 @@ auto mf::get_wl_shell_window(wl_resource* surface) -> std::shared_ptr<ms::Surfac
             return scene_surface.value();
         }
 
-        log_debug("No window currently associated with wayland::Surface %p", surface);
+        log_debug("No window currently associated with wayland::Surface %p", static_cast<void*>(surface));
     }
 
     return {};

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -165,7 +165,7 @@ void mf::WlSurface::add_subsurface(WlSubsurface* child)
 {
     if (std::find(children.begin(), children.end(), child) != children.end())
     {
-        log_warning("Subsurface %p added to surface %p multiple times", child, this);
+        log_warning("Subsurface %p added to surface %p multiple times", static_cast<void*>(child), static_cast<void*>(this));
         return;
     }
 

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -704,7 +704,7 @@ auto mf::XdgShellStable::get_window(wl_resource* surface) -> std::shared_ptr<sce
             }
         }
 
-        log_debug("No window currently associated with wayland::XdgSurface %p", surface);
+        log_debug("No window currently associated with wayland::XdgSurface %p", static_cast<void*>(surface));
     }
 
     return {};

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -648,7 +648,7 @@ auto mf::XdgShellV6::get_window(wl_resource* surface) -> std::shared_ptr<scene::
             }
         }
 
-        log_debug("No window currently associated with wayland::XdgSurfaceV6 %p", surface);
+        log_debug("No window currently associated with wayland::XdgSurfaceV6 %p", static_cast<void*>(surface));
     }
 
     return {};

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -178,7 +178,7 @@ mf::XWaylandWM::~XWaylandWM()
     }
 
     if (verbose_xwayland_logging_enabled())
-        log_debug("Closing %lu XWayland surface(s)...", local_surfaces.size());
+        log_debug("Closing %zu XWayland surface(s)...", local_surfaces.size());
 
     for (auto const& surface : local_surfaces)
     {

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -178,7 +178,7 @@ mf::XWaylandWM::~XWaylandWM()
     }
 
     if (verbose_xwayland_logging_enabled())
-        log_debug("Closing %d XWayland surface(s)...", local_surfaces.size());
+        log_debug("Closing %lu XWayland surface(s)...", local_surfaces.size());
 
     for (auto const& surface : local_surfaces)
     {

--- a/src/server/shell/decoration/renderer.cpp
+++ b/src/server/shell/decoration/renderer.cpp
@@ -234,7 +234,7 @@ auto msd::Renderer::Text::instance() -> std::shared_ptr<Text>
         }
         catch (std::runtime_error const& error)
         {
-            log_warning(error.what());
+            log_warning("%s", error.what());
             shared = std::make_shared<Null>();
         }
         singleton = shared;
@@ -296,7 +296,7 @@ void msd::Renderer::Text::Impl::render(
     }
     catch (std::runtime_error const& error)
     {
-        log_warning(error.what());
+        log_warning("%s", error.what());
         return;
     }
 
@@ -321,7 +321,7 @@ void msd::Renderer::Text::Impl::render(
         }
         catch (std::runtime_error const& error)
         {
-            log_warning(error.what());
+            log_warning("%s", error.what());
         }
     }
 }
@@ -589,7 +589,7 @@ auto msd::Renderer::render_titlebar() -> std::experimental::optional<std::shared
             }
             else
             {
-                log_warning("Could not render decoration button with unknown function %d\n", button.function);
+                log_warning("Could not render decoration button with unknown function %d\n", static_cast<int>(button.function));
             }
         }
     }


### PR DESCRIPTION
And then fix all the places where we were accidentally invoking nasal daemons.