### PR TITLE
Implement zwlr_layer_shell_v1 version 3

### DIFF
--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
@@ -75,6 +75,19 @@ struct mw::LayerShellV1::Thunks
         }
     }
 
+    static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
+    {
+        auto me = static_cast<LayerShellV1*>(wl_resource_get_user_data(resource));
+        try
+        {
+            me->destroy();
+        }
+        catch(...)
+        {
+            internal_error_processing_request(client, "LayerShellV1::destroy()");
+        }
+    }
+
     static void resource_destroyed_thunk(wl_resource* resource)
     {
         delete static_cast<LayerShellV1*>(wl_resource_get_user_data(resource));
@@ -108,9 +121,9 @@ struct mw::LayerShellV1::Thunks
     static void const* request_vtable[];
 };
 
-int const mw::LayerShellV1::Thunks::supported_version = 1;
+int const mw::LayerShellV1::Thunks::supported_version = 3;
 
-mw::LayerShellV1::LayerShellV1(struct wl_resource* resource, Version<1>)
+mw::LayerShellV1::LayerShellV1(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -136,7 +149,7 @@ void mw::LayerShellV1::destroy_wayland_object() const
     wl_resource_destroy(resource);
 }
 
-mw::LayerShellV1::Global::Global(wl_display* display, Version<1>)
+mw::LayerShellV1::Global::Global(wl_display* display, Version<3>)
     : wayland::Global{
           wl_global_create(
               display,
@@ -160,10 +173,12 @@ struct wl_interface const* mw::LayerShellV1::Thunks::get_layer_surface_types[] {
     nullptr};
 
 struct wl_message const mw::LayerShellV1::Thunks::request_messages[] {
-    {"get_layer_surface", "no?ous", get_layer_surface_types}};
+    {"get_layer_surface", "no?ous", get_layer_surface_types},
+    {"destroy", "3", all_null_types}};
 
 void const* mw::LayerShellV1::Thunks::request_vtable[] {
-    (void*)Thunks::get_layer_surface_thunk};
+    (void*)Thunks::get_layer_surface_thunk,
+    (void*)Thunks::destroy_thunk};
 
 // LayerSurfaceV1
 
@@ -280,6 +295,19 @@ struct mw::LayerSurfaceV1::Thunks
         }
     }
 
+    static void set_layer_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t layer)
+    {
+        auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
+        try
+        {
+            me->set_layer(layer);
+        }
+        catch(...)
+        {
+            internal_error_processing_request(client, "LayerSurfaceV1::set_layer()");
+        }
+    }
+
     static void resource_destroyed_thunk(wl_resource* resource)
     {
         delete static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
@@ -291,9 +319,9 @@ struct mw::LayerSurfaceV1::Thunks
     static void const* request_vtable[];
 };
 
-int const mw::LayerSurfaceV1::Thunks::supported_version = 1;
+int const mw::LayerSurfaceV1::Thunks::supported_version = 3;
 
-mw::LayerSurfaceV1::LayerSurfaceV1(struct wl_resource* resource, Version<1>)
+mw::LayerSurfaceV1::LayerSurfaceV1(struct wl_resource* resource, Version<3>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -340,7 +368,8 @@ struct wl_message const mw::LayerSurfaceV1::Thunks::request_messages[] {
     {"set_keyboard_interactivity", "u", all_null_types},
     {"get_popup", "o", get_popup_types},
     {"ack_configure", "u", all_null_types},
-    {"destroy", "", all_null_types}};
+    {"destroy", "", all_null_types},
+    {"set_layer", "2u", all_null_types}};
 
 struct wl_message const mw::LayerSurfaceV1::Thunks::event_messages[] {
     {"configure", "uuu", all_null_types},
@@ -354,7 +383,8 @@ void const* mw::LayerSurfaceV1::Thunks::request_vtable[] {
     (void*)Thunks::set_keyboard_interactivity_thunk,
     (void*)Thunks::get_popup_thunk,
     (void*)Thunks::ack_configure_thunk,
-    (void*)Thunks::destroy_thunk};
+    (void*)Thunks::destroy_thunk,
+    (void*)Thunks::set_layer_thunk};
 
 namespace mir
 {
@@ -364,13 +394,13 @@ namespace wayland
 struct wl_interface const zwlr_layer_shell_v1_interface_data {
     mw::LayerShellV1::interface_name,
     mw::LayerShellV1::Thunks::supported_version,
-    1, mw::LayerShellV1::Thunks::request_messages,
+    2, mw::LayerShellV1::Thunks::request_messages,
     0, nullptr};
 
 struct wl_interface const zwlr_layer_surface_v1_interface_data {
     mw::LayerSurfaceV1::interface_name,
     mw::LayerSurfaceV1::Thunks::supported_version,
-    8, mw::LayerSurfaceV1::Thunks::request_messages,
+    9, mw::LayerSurfaceV1::Thunks::request_messages,
     2, mw::LayerSurfaceV1::Thunks::event_messages};
 
 }

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
@@ -30,7 +30,7 @@ public:
 
     static LayerShellV1* from(struct wl_resource*);
 
-    LayerShellV1(struct wl_resource* resource, Version<1>);
+    LayerShellV1(struct wl_resource* resource, Version<3>);
     virtual ~LayerShellV1();
 
     void destroy_wayland_object() const;
@@ -60,7 +60,7 @@ public:
     class Global : public wayland::Global
     {
     public:
-        Global(wl_display* display, Version<1>);
+        Global(wl_display* display, Version<3>);
 
         auto interface_name() const -> char const* override;
 
@@ -71,6 +71,7 @@ public:
 
 private:
     virtual void get_layer_surface(struct wl_resource* id, struct wl_resource* surface, std::experimental::optional<struct wl_resource*> const& output, uint32_t layer, std::string const& namespace_) = 0;
+    virtual void destroy() = 0;
 };
 
 class LayerSurfaceV1 : public Resource
@@ -80,7 +81,7 @@ public:
 
     static LayerSurfaceV1* from(struct wl_resource*);
 
-    LayerSurfaceV1(struct wl_resource* resource, Version<1>);
+    LayerSurfaceV1(struct wl_resource* resource, Version<3>);
     virtual ~LayerSurfaceV1();
 
     void send_configure_event(uint32_t serial, uint32_t width, uint32_t height) const;
@@ -125,6 +126,7 @@ private:
     virtual void get_popup(struct wl_resource* popup) = 0;
     virtual void ack_configure(uint32_t serial) = 0;
     virtual void destroy() = 0;
+    virtual void set_layer(uint32_t layer) = 0;
 };
 
 }

--- a/src/wayland/protocol/wlr-layer-shell-unstable-v1.xml
+++ b/src/wayland/protocol/wlr-layer-shell-unstable-v1.xml
@@ -25,7 +25,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zwlr_layer_shell_v1" version="1">
+  <interface name="zwlr_layer_shell_v1" version="3">
     <description summary="create surfaces that are layers of the desktop">
       Clients can use this interface to assign the surface_layer role to
       wl_surfaces. Such surfaces are assigned to a "layer" of the output and
@@ -82,17 +82,27 @@
       <entry name="top" value="2"/>
       <entry name="overlay" value="3"/>
     </enum>
+
+    <!-- Version 3 additions -->
+
+    <request name="destroy" type="destructor" since="3">
+      <description summary="destroy the layer_shell object">
+        This request indicates that the client will not use the layer_shell
+        object any more. Objects that have been created through this instance
+        are not affected.
+      </description>
+    </request>
   </interface>
 
-  <interface name="zwlr_layer_surface_v1" version="1">
+  <interface name="zwlr_layer_surface_v1" version="3">
     <description summary="layer metadata interface">
       An interface that may be implemented by a wl_surface, for surfaces that
       are designed to be rendered as a layer of a stacked desktop-like
       environment.
 
-      Layer surface state (size, anchor, exclusive zone, margin, interactivity)
-      is double-buffered, and will be applied at the time wl_surface.commit of
-      the corresponding wl_surface is called.
+      Layer surface state (layer, size, anchor, exclusive zone,
+      margin, interactivity) is double-buffered, and will be applied at the
+      time wl_surface.commit of the corresponding wl_surface is called.
     </description>
 
     <request name="set_size">
@@ -115,7 +125,7 @@
     <request name="set_anchor">
       <description summary="configures the anchor point of the surface">
         Requests that the compositor anchor the surface to the specified edges
-        and corners. If two orthoginal edges are specified (e.g. 'top' and
+        and corners. If two orthogonal edges are specified (e.g. 'top' and
         'left'), then the anchor point will be the intersection of the edges
         (e.g. the top left corner of the output); otherwise the anchor point
         will be centered on that edge, or in the center if none is specified.
@@ -127,20 +137,25 @@
 
     <request name="set_exclusive_zone">
       <description summary="configures the exclusive geometry of this surface">
-        Requests that the compositor avoids occluding an area of the surface
-        with other surfaces. The compositor's use of this information is
+        Requests that the compositor avoids occluding an area with other
+        surfaces. The compositor's use of this information is
         implementation-dependent - do not assume that this region will not
         actually be occluded.
 
-        A positive value is only meaningful if the surface is anchored to an
-        edge, rather than a corner. The zone is the number of surface-local
-        coordinates from the edge that are considered exclusive.
+        A positive value is only meaningful if the surface is anchored to one
+        edge or an edge and both perpendicular edges. If the surface is not
+        anchored, anchored to only two perpendicular edges (a corner), anchored
+        to only two parallel edges or anchored to all edges, a positive value
+        will be treated the same as zero.
+
+        A positive zone is the distance from the edge in surface-local
+        coordinates to consider exclusive.
 
         Surfaces that do not wish to have an exclusive zone may instead specify
         how they should interact with surfaces that do. If set to zero, the
         surface indicates that it would like to be moved to avoid occluding
-        surfaces with a positive excluzive zone. If set to -1, the surface
-        indicates that it would not like to be moved to accomodate for other
+        surfaces with a positive exclusive zone. If set to -1, the surface
+        indicates that it would not like to be moved to accommodate for other
         surfaces, and the compositor should extend it all the way to the edges
         it is anchored to.
 
@@ -281,5 +296,16 @@
       <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
       <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
     </enum>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_layer" since="2">
+      <description summary="change the layer of the surface">
+        Change the layer that the surface is rendered on.
+
+        Layer is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="layer" type="uint" enum="zwlr_layer_shell_v1.layer" summary="layer to move this surface to"/>
+    </request>
   </interface>
 </protocol>


### PR DESCRIPTION
Note that the major unstable version of layer shell is still 1, so all the changes are backwards compatible. The important change is the addition of a `.set_layer()` request. Tested in https://github.com/MirServer/wlcs/pull/173. Fixes https://github.com/MirServer/mir/issues/1589.