### PR TITLE
Send wl_touch.up() and wl_keyboard.leave() events when surface destroyed

### DIFF
--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -67,6 +67,10 @@ mf::WlKeyboard::WlKeyboard(
 
 mf::WlKeyboard::~WlKeyboard()
 {
+    if (focused_surface)
+    {
+        focused_surface.value().remove_destroy_listener(this);
+    }
     on_destroy(this);
 }
 
@@ -111,6 +115,7 @@ void mf::WlKeyboard::focussed(WlSurface* surface, bool should_be_focused)
 
     if (focused_surface)
     {
+        focused_surface.value().remove_destroy_listener(this);
         auto const serial = wl_display_next_serial(wl_client_get_display(client));
         send_leave_event(serial, focused_surface.value().raw_resource());
     }
@@ -142,6 +147,13 @@ void mf::WlKeyboard::focussed(WlSurface* surface, bool should_be_focused)
                 keyboard_state.data(),
                 keyboard_state.size() * sizeof(decltype(keyboard_state)::value_type));
         }
+
+        surface->add_destroy_listener(
+            this,
+            [this, surface]()
+            {
+                focussed(surface, false);
+            });
 
         auto const serial = wl_display_next_serial(wl_client_get_display(client));
         send_enter_event(serial, surface->raw_resource(), &key_state);

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -25,6 +25,7 @@
 #include "mir/anonymous_shm_file.h"
 #include "mir/input/keymap.h"
 #include "mir/log.h"
+#include "mir/fatal.h"
 
 #include <xkbcommon/xkbcommon.h>
 #include <boost/throw_exception.hpp>
@@ -98,6 +99,11 @@ void mf::WlKeyboard::key(std::chrono::milliseconds const& ms, WlSurface* surface
 
 void mf::WlKeyboard::focussed(WlSurface* surface, bool should_be_focused)
 {
+    if (client != surface->client)
+    {
+        fatal_error("WlKeyboard::focussed() called with a surface of the wrong client");
+    }
+
     bool const is_currently_focused = (focused_surface && &focused_surface.value() == surface);
 
     if (should_be_focused == is_currently_focused)

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -59,10 +59,16 @@ public:
 
 private:
     std::function<void(WlTouch*)> on_destroy;
-    std::unordered_map<int32_t, wayland::Weak<WlSurface>> touches; ///< Maps touch IDs to the surfaces the touch is on
+    /// Maps touch IDs to the surfaces the touch is on
+    std::unordered_map<int32_t, wayland::Weak<WlSurface>> touch_id_to_surface;
     bool can_send_frame{false};
 
     void release() override;
+
+    /// Maps every touch_id for every WlTouch to a stable and globally unique pointer
+    /// Used for surface destory listener keys
+    /// The returned pointer should only be used as a key, it will not necessarily point to anything meaningful/valid
+    void const* unique_key_for(int32_t touch_id) const;
 };
 
 }

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -59,7 +59,7 @@ public:
 
 private:
     std::function<void(WlTouch*)> on_destroy;
-    std::unordered_map<int32_t, WlSurface*> focused_surface_for_ids;
+    std::unordered_map<int32_t, wayland::Weak<WlSurface>> touches; ///< Maps touch IDs to the surfaces the touch is on
     bool can_send_frame{false};
 
     void release() override;


### PR DESCRIPTION
We already send a `wl_pointer.leave()` event using this same method, but we were not sending `wl_touch.up()` and `wl_keyboard.leave()`. The former is tested by https://github.com/MirServer/wlcs/pull/177. The latter fixes #1236.