### PR TITLE
Log SIGHUP and other signals

### DIFF
--- a/src/include/server/mir/glib_main_loop_sources.h
+++ b/src/include/server/mir/glib_main_loop_sources.h
@@ -114,10 +114,11 @@ private:
         std::vector<int> sigs;
         std::function<void(int)> handler;
     };
+    struct SignalPid { int sig; pid_t pid; };
 
     void dispatch_pending_signal();
     void ensure_signal_is_handled(int sig);
-    int read_pending_signal();
+    SignalPid read_pending_signal();
     void dispatch_signal(int sig);
 
     FdSources& fd_sources;

--- a/src/server/run_mir.cpp
+++ b/src/server/run_mir.cpp
@@ -20,6 +20,7 @@
 #include "mir/terminate_with_current_exception.h"
 #include "mir/display_server.h"
 #include "mir/fatal.h"
+#include "mir/log.h"
 #include "mir/main_loop.h"
 #include "mir/server_configuration.h"
 #include "mir/frontend/connector.h"
@@ -61,6 +62,29 @@ extern "C" void fatal_signal_cleanup(int sig)
     signal(sig, old_handler[sig]);
     raise(sig);
 }
+
+struct IgnoreSIGHUP
+{
+    IgnoreSIGHUP()
+    {
+        struct sigaction action;
+        sigemptyset(&action.sa_mask);
+        action.sa_flags = SA_SIGINFO;
+        action.sa_sigaction = [](int, siginfo_t* info, void*)
+            { mir::log_debug("Ignoring SUGHUP from pid=%d", info->si_pid); };
+        sigaction(SIGHUP, &action, &old_sighup_action);
+    }
+
+    ~IgnoreSIGHUP()
+    {
+        sigaction(SIGHUP, &old_sighup_action, nullptr);
+    }
+
+    struct sigaction old_sighup_action;
+
+    IgnoreSIGHUP(IgnoreSIGHUP const&) = delete;
+    IgnoreSIGHUP& operator=(IgnoreSIGHUP const&) = delete;
+};
 }
 
 void mir::run_mir(ServerConfiguration& config, std::function<void(DisplayServer&)> init)
@@ -75,6 +99,8 @@ void mir::run_mir(
 {
     DisplayServer* server_ptr{nullptr};
     clear_termination_exception();
+
+    IgnoreSIGHUP const ignore_sighup;
 
     auto const main_loop = config.the_main_loop();
 


### PR DESCRIPTION
Some deployments are sending Mir a SIGHUP that was causing us to exit untidily.

Explicitly handle SIGHUP and log all signal.