### PR TITLE
[Explicit destruction version] Give each XWayland app it's own session

### DIFF
--- a/src/server/frontend_xwayland/CMakeLists.txt
+++ b/src/server/frontend_xwayland/CMakeLists.txt
@@ -9,6 +9,7 @@ set(
   xwayland_wm.cpp         xwayland_wm.h
   xwayland_cursors.cpp    xwayland_cursors.h
   xwayland_surface.cpp    xwayland_surface.h
+  xwayland_client_manager.cpp xwayland_client_manager.h
   xwayland_surface_role.cpp xwayland_surface_role.h
                           xwayland_surface_role_surface.h
   xwayland_surface_observer.cpp xwayland_surface_observer.h

--- a/src/server/frontend_xwayland/xwayland_client_manager.cpp
+++ b/src/server/frontend_xwayland/xwayland_client_manager.cpp
@@ -41,7 +41,7 @@ mf::XWaylandClientManager::~XWaylandClientManager()
     {
         log_warning(
             "XWaylandClientManager destroyed without all sessions being released "
-            "(sessions_by_pid: %lu, sessions_by_owner: %lu)",
+            "(sessions_by_pid: %zu, sessions_by_owner: %zu)",
             sessions_by_pid.size(),
             sessions_by_owner.size());
 

--- a/src/server/frontend_xwayland/xwayland_client_manager.cpp
+++ b/src/server/frontend_xwayland/xwayland_client_manager.cpp
@@ -60,7 +60,7 @@ mf::XWaylandClientManager::~XWaylandClientManager()
     }
 }
 
-auto mf::XWaylandClientManager::get_session_for_client(
+auto mf::XWaylandClientManager::register_owner_for_client(
     void* owner_key, pid_t client_pid) -> std::shared_ptr<ms::Session>
 {
     std::lock_guard<std::mutex> lock{mutex};

--- a/src/server/frontend_xwayland/xwayland_client_manager.cpp
+++ b/src/server/frontend_xwayland/xwayland_client_manager.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "xwayland_client_manager.h"
+#include "null_event_sink.h"
+#include "mir/shell/shell.h"
+#include "mir/scene/session.h"
+#include "mir/log.h"
+
+#include "boost/throw_exception.hpp"
+
+namespace mf = mir::frontend;
+namespace msh = mir::shell;
+namespace ms = mir::scene;
+
+mf::XWaylandClientManager::XWaylandClientManager(std::shared_ptr<shell::Shell> const& shell)
+    : shell{shell}
+{
+}
+
+mf::XWaylandClientManager::~XWaylandClientManager()
+{
+    // release() should have been called for every owner before destroying
+    if (!sessions_by_pid.empty() || !sessions_by_owner.empty())
+    {
+        log_warning(
+            "XWaylandClientManager destroyed without all sessions being released "
+            "(sessions_by_pid: %lu, sessions_by_owner: %lu)",
+            sessions_by_pid.size(),
+            sessions_by_owner.size());
+
+        // Clean up to prevent memory leaks
+
+        std::vector<void*> forgetful_owners;
+        for (auto const& iter : sessions_by_owner)
+        {
+            forgetful_owners.push_back(iter.first);
+        }
+
+        for (auto const& owner : forgetful_owners)
+        {
+            release(owner);
+        }
+    }
+}
+
+auto mf::XWaylandClientManager::get_session_for_client(
+    void* owner_key, pid_t client_pid) -> std::shared_ptr<ms::Session>
+{
+    std::lock_guard<std::mutex> lock{mutex};
+
+    if (sessions_by_owner.find(owner_key) != sessions_by_owner.end())
+    {
+        // This would happen if an owner tries to get a new session without release()ing the previous one
+        BOOST_THROW_EXCEPTION(std::logic_error(
+            "XWaylandClientManager::get_session_for_client() called with already existing owner_key"));
+    }
+
+    SessionInfo* info;
+    auto const iter = sessions_by_pid.find(client_pid);
+    if (iter == sessions_by_pid.end())
+    {
+        // We don't currently have an active session for the given PID, create a new one
+        // Ideally we wouldn't run open_session() under lock, but that complicates the logic and isn't required
+        auto const session = shell->open_session(client_pid, "", std::make_shared<NullEventSink>());
+        // Start the owner count at 0, it will get incremented below
+        // The info struct will be deleted in release() when the owner count hits 0 again
+        info = new SessionInfo{session, client_pid, 0};
+        sessions_by_pid.insert(std::make_pair(client_pid, info));
+    }
+    else
+    {
+        // We already have an active session for the given PID, use it
+        info = iter->second;
+    }
+
+    info->owner_count++; // Changes the owner count from 0 to 1 the first time
+    sessions_by_owner.insert(std::make_pair(owner_key, info));
+    return info->session;
+}
+
+void mf::XWaylandClientManager::release(void* owner_key)
+{
+    std::unique_lock<std::mutex> lock{mutex};
+
+    auto const iter = sessions_by_owner.find(owner_key);
+    if (iter == sessions_by_owner.end())
+    {
+        // You must already be a session owner in order to call release()
+        BOOST_THROW_EXCEPTION(std::logic_error(
+            "XWaylandClientManager::release() called with unknown owner_key"));
+    }
+
+    auto const info = iter->second;
+    sessions_by_owner.erase(iter);
+
+    std::shared_ptr<scene::Session> session_to_close;
+    info->owner_count--; // The session now has one less owner
+    if (info->owner_count <= 0)
+    {
+        // When a session has no owners, close it and delete the info struct
+        session_to_close = std::move(info->session);
+        sessions_by_pid.erase(info->pid);
+        delete info;
+    }
+
+    // Don't run close_session() under lock because there's no reason to
+    lock.unlock();
+    if (session_to_close)
+    {
+        shell->close_session(session_to_close);
+    }
+}

--- a/src/server/frontend_xwayland/xwayland_client_manager.h
+++ b/src/server/frontend_xwayland/xwayland_client_manager.h
@@ -44,7 +44,7 @@ public:
 
     /// Returns the session associated with the given client_pid, or creates a new one if needed
     /// Stores a strong reference to the session associated with the given owner_key
-    auto get_session_for_client(void* owner_key, pid_t client_pid) -> std::shared_ptr<scene::Session>;
+    auto register_owner_for_client(void* owner_key, pid_t client_pid) -> std::shared_ptr<scene::Session>;
 
     /// Unassociates the session from owner_key
     /// Closes the session if it is not associated with any other owners

--- a/src/server/frontend_xwayland/xwayland_client_manager.h
+++ b/src/server/frontend_xwayland/xwayland_client_manager.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_FRONTEND_XWAYLAND_CLIENT_MANAGER_H
+#define MIR_FRONTEND_XWAYLAND_CLIENT_MANAGER_H
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+namespace mir
+{
+namespace shell
+{
+class Shell;
+}
+namespace scene
+{
+class Session;
+}
+namespace frontend
+{
+
+class XWaylandClientManager
+{
+public:
+    XWaylandClientManager(std::shared_ptr<shell::Shell> const& shell);
+    ~XWaylandClientManager();
+
+    /// Returns the session associated with the given client_pid, or creates a new one if needed
+    /// Stores a strong reference to the session associated with the given owner_key
+    auto get_session_for_client(void* owner_key, pid_t client_pid) -> std::shared_ptr<scene::Session>;
+
+    /// Unassociates the session from owner_key
+    /// Closes the session if it is not associated with any other owners
+    void release(void* owner_key);
+
+private:
+    struct SessionInfo
+    {
+        std::shared_ptr<scene::Session> session;
+        /// We could use session->process_id() instead, but storing our own copy is cheap and prevents internal memory
+        /// safety from depending on external implementations
+        pid_t pid;
+        int owner_count;
+    };
+
+    std::shared_ptr<shell::Shell> const shell;
+    std::mutex mutex;
+    std::unordered_map<pid_t, SessionInfo*> sessions_by_pid;
+    std::unordered_map<void*, SessionInfo*> sessions_by_owner;
+};
+
+}
+}
+
+#endif // MIR_FRONTEND_XWAYLAND_CLIENT_MANAGER_H

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -562,7 +562,7 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
         window, connection->_NET_WM_PID,
         [&](uint32_t pid)
         {
-            session = client_manager->get_session_for_client(this, pid);
+            session = client_manager->register_owner_for_client(this, pid);
         },
         [&]()
         {

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -19,6 +19,7 @@
 #include "xwayland_surface.h"
 #include "xwayland_log.h"
 #include "xwayland_surface_observer.h"
+#include "xwayland_client_manager.h"
 
 #include "mir/frontend/wayland.h"
 #include "mir/scene/surface_creation_parameters.h"
@@ -136,11 +137,13 @@ mf::XWaylandSurface::XWaylandSurface(
     std::shared_ptr<XCBConnection> const& connection,
     WlSeat& seat,
     std::shared_ptr<shell::Shell> const& shell,
+    std::shared_ptr<XWaylandClientManager> const& client_manager,
     xcb_create_notify_event_t *event)
     : xwm(wm),
       connection{connection},
       seat(seat),
       shell{shell},
+      client_manager{client_manager},
       window(event->window),
       property_handlers{
           property_handler<std::string const&>(
@@ -299,6 +302,8 @@ void mf::XWaylandSurface::close()
         shell->destroy_surface(scene_surface->session().lock(), scene_surface);
         scene_surface.reset();
         // Someone may still be holding on to the surface somewhere, and that's fine
+
+        client_manager->release(this);
     }
 
     if (observer)
@@ -552,10 +557,28 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
         reply_functions.push_back(handler.second());
     }
 
+    std::shared_ptr<ms::Session> session;
+    reply_functions.push_back(connection->read_property(
+        window, connection->_NET_WM_PID,
+        [&](uint32_t pid)
+        {
+            session = client_manager->get_session_for_client(this, pid);
+        },
+        [&]()
+        {
+            log_warning("X11 app did not set _NET_WM_PID, grouping it under the default XWayland application");
+            session = get_session(wl_surface->resource);
+        }));
+
     // Wait for and process all the XCB replies
     for (auto const& reply_function : reply_functions)
     {
         reply_function();
+    }
+
+    if (!session)
+    {
+        fatal_error("Property handlers did not set a valid session");
     }
 
     // property_handlers will have updated the pending spec. Use it.
@@ -570,7 +593,6 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
         }
     }
 
-    auto const session = get_session(wl_surface->resource);
     auto const surface = shell->create_surface(session, params, observer);
     inform_client_of_window_state(state);
     connection->configure_window(

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -168,7 +168,6 @@ private:
 
     /// Set in set_wl_surface and cleared when a scene surface is created from it
     std::experimental::optional<std::shared_ptr<XWaylandSurfaceObserver>> surface_observer;
-    std::weak_ptr<scene::Session> weak_session;
     std::unique_ptr<shell::SurfaceSpecification> nullable_pending_spec;
     std::weak_ptr<scene::Surface> weak_scene_surface;
 };

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -42,6 +42,7 @@ namespace frontend
 class WlSeat;
 class XWaylandWM;
 class XWaylandSurfaceObserver;
+class XWaylandClientManager;
 
 class XWaylandSurface
     : public XWaylandSurfaceRoleSurface,
@@ -53,6 +54,7 @@ public:
         std::shared_ptr<XCBConnection> const& connection,
         WlSeat& seat,
         std::shared_ptr<shell::Shell> const& shell,
+        std::shared_ptr<XWaylandClientManager> const& client_manager,
         xcb_create_notify_event_t *event);
     ~XWaylandSurface();
 
@@ -145,6 +147,7 @@ private:
     std::shared_ptr<XCBConnection> const connection;
     WlSeat& seat;
     std::shared_ptr<shell::Shell> const shell;
+    std::shared_ptr<XWaylandClientManager> const client_manager;
     xcb_window_t const window;
     std::map<xcb_window_t, std::function<std::function<void()>()>> const property_handlers;
 

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -24,6 +24,7 @@
 #include "xwayland_wm_shell.h"
 #include "xwayland_surface_role.h"
 #include "xwayland_cursors.h"
+#include "xwayland_client_manager.h"
 
 #include "mir/fd.h"
 #include "mir/scene/null_observer.h"
@@ -133,7 +134,8 @@ mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, 
       wm_shell{std::static_pointer_cast<XWaylandWMShell>(wayland_connector->get_extension("x11-support"))},
       cursors{std::make_unique<XWaylandCursors>(connection)},
       wm_window{create_wm_window(*connection)},
-      scene_observer{std::make_shared<XWaylandSceneObserver>(this)}
+      scene_observer{std::make_shared<XWaylandSceneObserver>(this)},
+      client_manager{std::make_shared<XWaylandClientManager>(wm_shell->shell)}
 {
     check_xfixes(*connection);
 
@@ -568,6 +570,7 @@ void mf::XWaylandWM::handle_create_notify(xcb_create_notify_event_t *event)
             connection,
             wm_shell->seat,
             wm_shell->shell,
+            client_manager,
             event);
 
         {

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -44,6 +44,7 @@ namespace frontend
 class XWaylandSurface;
 class XWaylandWMShell;
 class XWaylandCursors;
+class XWaylandClientManager;
 
 class XWaylandSceneObserver;
 
@@ -96,6 +97,7 @@ private:
     std::unique_ptr<XWaylandCursors> const cursors;
     xcb_window_t const wm_window;
     std::shared_ptr<XWaylandSceneObserver> const scene_observer;
+    std::shared_ptr<XWaylandClientManager> const client_manager;
 
     std::mutex mutex;
     std::map<xcb_window_t, std::shared_ptr<XWaylandSurface>> surfaces;

--- a/src/server/scene/session_manager.cpp
+++ b/src/server/scene/session_manager.cpp
@@ -143,14 +143,14 @@ std::shared_ptr<ms::Session> ms::SessionManager::open_session(
 {
     std::shared_ptr<Session> new_session = std::make_shared<ApplicationSession>(
         surface_stack,
-            surface_factory,
-            buffer_stream_factory,
-            client_pid,
-            name,
-            snapshot_strategy,
-            observers,
-            sender,
-            allocator);
+        surface_factory,
+        buffer_stream_factory,
+        client_pid,
+        name,
+        snapshot_strategy,
+        observers,
+        sender,
+        allocator);
 
     app_container->insert_session(new_session);
 

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -95,6 +95,7 @@ CMAKE_DEPENDENT_OPTION(
 add_subdirectory(compositor/)
 add_subdirectory(console/)
 add_subdirectory(dispatch/)
+add_subdirectory(frontend_xwayland/)
 add_subdirectory(geometry/)
 add_subdirectory(gl/)
 add_subdirectory(graphics/)

--- a/tests/unit-tests/frontend_xwayland/CMakeLists.txt
+++ b/tests/unit-tests/frontend_xwayland/CMakeLists.txt
@@ -1,0 +1,6 @@
+list(
+  APPEND UNIT_TEST_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_xwayland_client_manager.cpp
+)
+
+set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/tests/unit-tests/frontend_xwayland/test_xwayland_client_manager.cpp
+++ b/tests/unit-tests/frontend_xwayland/test_xwayland_client_manager.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "src/server/frontend_xwayland/xwayland_client_manager.h"
+#include "mir/test/doubles/stub_shell.h"
+#include "mir/test/doubles/stub_session.h"
+#include "mir/test/fake_shared.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace mf = mir::frontend;
+namespace msh = mir::shell;
+namespace ms = mir::scene;
+namespace mt = mir::test;
+namespace mtd = mt::doubles;
+
+using namespace testing;
+
+namespace
+{
+struct MockShell : mtd::StubShell
+{
+    MOCK_METHOD3(open_session, std::shared_ptr<ms::Session>(
+        pid_t, std::string const&, std::shared_ptr<mf::EventSink> const&));
+    MOCK_METHOD1(close_session, void(std::shared_ptr<ms::Session> const&));
+};
+
+struct XWaylandClientManagerTest : Test
+{
+    NiceMock<MockShell> shell;
+    mtd::StubSession session_1;
+    mtd::StubSession session_2;
+    mtd::StubSession session_3;
+    int owner_a; ///< Only used for it's address, value/type not important
+    int owner_b; ///< Only used for it's address, value/type not important
+    int owner_c; ///< Only used for it's address, value/type not important
+
+    void SetUp() override
+    {
+        ON_CALL(shell, open_session(_, _, _))
+            .WillByDefault(Return(mt::fake_shared(session_1)));
+    }
+};
+
+}
+
+TEST_F(XWaylandClientManagerTest, can_be_created)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+}
+
+TEST_F(XWaylandClientManagerTest, get_session_initially_creates_session)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+
+    EXPECT_CALL(shell, open_session(1, _, _))
+        .Times(1)
+        .WillOnce(Return(mt::fake_shared(session_1)));
+
+    EXPECT_THAT(manager.get_session_for_client(&owner_a, 1).get(), Eq(&session_1));
+}
+
+TEST_F(XWaylandClientManagerTest, repeated_get_session_with_same_pid_returns_same_session)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+
+    EXPECT_CALL(shell, open_session(1, _, _))
+        .Times(1)
+        .WillOnce(Return(mt::fake_shared(session_1)));
+
+    EXPECT_THAT(manager.get_session_for_client(&owner_a, 1).get(), Eq(&session_1));
+    EXPECT_THAT(manager.get_session_for_client(&owner_b, 1).get(), Eq(&session_1));
+    EXPECT_THAT(manager.get_session_for_client(&owner_c, 1).get(), Eq(&session_1));
+}
+
+TEST_F(XWaylandClientManagerTest, repeated_get_session_with_different_pids_creates_new_sessions)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+
+    EXPECT_CALL(shell, open_session(_, _, _))
+        .Times(3)
+        .WillOnce(Return(mt::fake_shared(session_1)))
+        .WillOnce(Return(mt::fake_shared(session_2)))
+        .WillOnce(Return(mt::fake_shared(session_3)));
+
+    EXPECT_THAT(manager.get_session_for_client(&owner_a, 1).get(), Eq(&session_1));
+    EXPECT_THAT(manager.get_session_for_client(&owner_b, 2).get(), Eq(&session_2));
+    EXPECT_THAT(manager.get_session_for_client(&owner_c, 3).get(), Eq(&session_3));
+}
+
+TEST_F(XWaylandClientManagerTest, release_closes_session_if_only_one_owner)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+
+    EXPECT_CALL(shell, open_session(_, _, _))
+        .Times(1)
+        .WillOnce(Return(mt::fake_shared(session_1)));
+    EXPECT_CALL(shell, close_session(Eq(mt::fake_shared(session_1))))
+        .Times(1);
+
+    manager.get_session_for_client(&owner_a, 1);
+    manager.release(&owner_a);
+}
+
+TEST_F(XWaylandClientManagerTest, release_does_not_close_session_if_multiple_owners)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+
+    EXPECT_CALL(shell, open_session(_, _, _))
+        .Times(1)
+        .WillOnce(Return(mt::fake_shared(session_1)));
+    EXPECT_CALL(shell, close_session(Eq(mt::fake_shared(session_1))))
+        .Times(0);
+
+    manager.get_session_for_client(&owner_a, 1);
+    manager.get_session_for_client(&owner_b, 1);
+    manager.release(&owner_a);
+
+    Mock::VerifyAndClearExpectations(&shell);
+}
+
+TEST_F(XWaylandClientManagerTest, closes_all_active_sessions_on_destroy)
+{
+    EXPECT_CALL(shell, open_session(_, _, _))
+        .Times(2)
+        .WillOnce(Return(mt::fake_shared(session_1)))
+        .WillOnce(Return(mt::fake_shared(session_2)));
+    EXPECT_CALL(shell, close_session(Eq(mt::fake_shared(session_1))))
+        .Times(1);
+    EXPECT_CALL(shell, close_session(Eq(mt::fake_shared(session_2))))
+        .Times(1);
+
+    {
+        mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+        manager.get_session_for_client(&owner_a, 1);
+        manager.get_session_for_client(&owner_b, 1);
+        manager.get_session_for_client(&owner_c, 2);
+    }
+}
+
+TEST_F(XWaylandClientManagerTest, session_closed_when_all_owners_release)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+
+    EXPECT_CALL(shell, open_session(_, _, _))
+        .Times(1)
+        .WillOnce(Return(mt::fake_shared(session_1)));
+    EXPECT_CALL(shell, close_session(Eq(mt::fake_shared(session_1))))
+        .Times(1);
+
+    manager.get_session_for_client(&owner_a, 1);
+    manager.get_session_for_client(&owner_b, 1);
+    manager.get_session_for_client(&owner_c, 1);
+    manager.release(&owner_a);
+    manager.release(&owner_b);
+    manager.release(&owner_c);
+}
+
+TEST_F(XWaylandClientManagerTest, new_session_created_after_old_session_for_same_pid_closed)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+    manager.get_session_for_client(&owner_a, 1);
+    manager.release(&owner_a);
+
+    EXPECT_CALL(shell, open_session(_, _, _))
+        .Times(1)
+        .WillRepeatedly(Return(mt::fake_shared(session_2)));
+    EXPECT_THAT(manager.get_session_for_client(&owner_a, 1).get(), Eq(&session_2));
+}
+
+TEST_F(XWaylandClientManagerTest, get_session_with_active_owner_and_same_pid_throws)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+    manager.get_session_for_client(&owner_a, 1);
+    EXPECT_THROW(manager.get_session_for_client(&owner_a, 1), std::logic_error);
+}
+
+TEST_F(XWaylandClientManagerTest, get_session_with_active_owner_and_different_pid_throws)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+    manager.get_session_for_client(&owner_a, 1);
+    EXPECT_THROW(manager.get_session_for_client(&owner_a, 2), std::logic_error);
+}


### PR DESCRIPTION
Fixes #479. Allows for better switching between different windows on the same apps, and I believe may help Unity8 (ping @mariogrip). 