### PR TITLE
Add --show-splash command line option to control whether splash displays

### DIFF
--- a/examples/example-server-lib/sw_splash.cpp
+++ b/examples/example-server-lib/sw_splash.cpp
@@ -142,7 +142,7 @@ struct SwSplash::Self : SplashSession
 
     Globals globals;
 
-    bool splash;
+    bool show_splash=true;
 
     DrawContext ctx;
 
@@ -162,8 +162,8 @@ SwSplash::SwSplash() : self{std::make_shared<Self>()} {}
 
 SwSplash::~SwSplash() = default;
 
-void SwSplash::operator()(bool splash_opt){
-    self->splash = splash_opt;
+void SwSplash::enable (bool show_splash_opt){
+    self->show_splash = show_splash_opt;
 }
 
 void SwSplash::operator()(std::weak_ptr<mir::scene::Session> const& session)
@@ -179,7 +179,7 @@ SwSplash::operator std::shared_ptr<SplashSession>() const
 
 void SwSplash::Self::operator()(struct wl_display* display)
 {
-    if (!splash)
+    if (!show_splash)
         return;
     globals.init(display);
 

--- a/examples/example-server-lib/sw_splash.cpp
+++ b/examples/example-server-lib/sw_splash.cpp
@@ -18,7 +18,6 @@
 
 #include "sw_splash.h"
 #include "wayland_helpers.h"
-
 #include <wayland-client.h>
 
 #include <sys/types.h>
@@ -143,6 +142,8 @@ struct SwSplash::Self : SplashSession
 
     Globals globals;
 
+    bool splash;
+
     DrawContext ctx;
 
     std::mutex mutable mutex;
@@ -161,6 +162,10 @@ SwSplash::SwSplash() : self{std::make_shared<Self>()} {}
 
 SwSplash::~SwSplash() = default;
 
+void SwSplash::operator()(bool splash_opt){
+    self->splash = splash_opt;
+}
+
 void SwSplash::operator()(std::weak_ptr<mir::scene::Session> const& session)
 {
     std::lock_guard<decltype(self->mutex)> lock{self->mutex};
@@ -174,6 +179,8 @@ SwSplash::operator std::shared_ptr<SplashSession>() const
 
 void SwSplash::Self::operator()(struct wl_display* display)
 {
+    if (!splash)
+        return;
     globals.init(display);
 
     ctx.display = display;
@@ -222,6 +229,7 @@ void SwSplash::Self::operator()(struct wl_display* display)
 
     auto const time_limit = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
+    //this is the splash screen
     do
     {
         wl_display_dispatch(display);

--- a/examples/example-server-lib/sw_splash.h
+++ b/examples/example-server-lib/sw_splash.h
@@ -28,6 +28,7 @@ public:
     SwSplash();
     ~SwSplash();
 
+    void operator()(bool splash_opt);
     void operator()(struct wl_display* display);
     void operator()(std::weak_ptr<mir::scene::Session> const& session);
 

--- a/examples/example-server-lib/sw_splash.h
+++ b/examples/example-server-lib/sw_splash.h
@@ -28,10 +28,9 @@ public:
     SwSplash();
     ~SwSplash();
 
-    void operator()(bool splash_opt);
     void operator()(struct wl_display* display);
     void operator()(std::weak_ptr<mir::scene::Session> const& session);
-
+    void enable (bool show_splash_opt);
     operator std::shared_ptr<SplashSession>() const;
 
 private:

--- a/examples/miral-kiosk/kiosk_main.cpp
+++ b/examples/miral-kiosk/kiosk_main.cpp
@@ -79,7 +79,6 @@ struct KioskAuthorizer : miral::ApplicationAuthorizer
 };
 
 std::atomic<bool> KioskAuthorizer::startup_only{false};
-
 }
 
 int main(int argc, char const* argv[])
@@ -111,9 +110,9 @@ int main(int argc, char const* argv[])
     DisplayConfiguration display_config{runner};
  
     CommandLineOption show_splash{
-        [&](bool show_splash) {splash(show_splash); },
-        "splash",
-        "Control display splash on startup",
+        [&](bool show_splash) {splash.enable(show_splash); },
+        "show-splash",
+        "Set to false to suppress display of splash on startup",
         true};
 
     return runner.run_with(

--- a/examples/miral-kiosk/kiosk_main.cpp
+++ b/examples/miral-kiosk/kiosk_main.cpp
@@ -79,6 +79,7 @@ struct KioskAuthorizer : miral::ApplicationAuthorizer
 };
 
 std::atomic<bool> KioskAuthorizer::startup_only{false};
+
 }
 
 int main(int argc, char const* argv[])
@@ -108,6 +109,12 @@ int main(int argc, char const* argv[])
     MirRunner runner{argc, argv};
 
     DisplayConfiguration display_config{runner};
+ 
+    CommandLineOption show_splash{
+        [&](bool show_splash) {splash(show_splash); },
+        "splash",
+        "Control display splash on startup",
+        true};
 
     return runner.run_with(
         {
@@ -116,6 +123,7 @@ int main(int argc, char const* argv[])
             set_window_management_policy<KioskWindowManagerPolicy>(splash),
             SetApplicationAuthorizer<KioskAuthorizer>{splash},
             Keymap{},
+            show_splash,
             startup_only,
             CommandLineOption{run_startup_apps, "startup-apps", "Colon separated list of startup apps", ""},
             StartupInternalClient{splash}


### PR DESCRIPTION
Default is to display splash. --show-splash=false suppresses it. (Fixes ~ #830)