### PR TITLE
[shared_ptr version] Give each XWayland app it's own session

### DIFF
--- a/src/server/frontend_xwayland/CMakeLists.txt
+++ b/src/server/frontend_xwayland/CMakeLists.txt
@@ -9,6 +9,7 @@ set(
   xwayland_wm.cpp         xwayland_wm.h
   xwayland_cursors.cpp    xwayland_cursors.h
   xwayland_surface.cpp    xwayland_surface.h
+  xwayland_client_manager.cpp xwayland_client_manager.h
   xwayland_surface_role.cpp xwayland_surface_role.h
                           xwayland_surface_role_surface.h
   xwayland_surface_observer.cpp xwayland_surface_observer.h

--- a/src/server/frontend_xwayland/xwayland_client_manager.cpp
+++ b/src/server/frontend_xwayland/xwayland_client_manager.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "xwayland_client_manager.h"
+#include "xwayland_log.h"
+#include "null_event_sink.h"
+#include "mir/shell/shell.h"
+#include "mir/scene/session.h"
+#include "mir/log.h"
+
+namespace mf = mir::frontend;
+namespace msh = mir::shell;
+namespace ms = mir::scene;
+
+mf::XWaylandClientManager::Session::Session(XWaylandClientManager* manager, pid_t client_pid)
+    : manager{manager},
+      client_pid{client_pid},
+      _session{manager->shell->open_session(client_pid, "", std::make_shared<NullEventSink>())}
+{
+}
+
+mf::XWaylandClientManager::Session::~Session()
+{
+    manager->shell->close_session(_session);
+    manager->drop_expired(client_pid);
+}
+
+auto mf::XWaylandClientManager::Session::session() const -> std::shared_ptr<scene::Session>
+{
+    return _session;
+}
+
+mf::XWaylandClientManager::XWaylandClientManager(std::shared_ptr<shell::Shell> const& shell)
+    : shell{shell}
+{
+}
+
+mf::XWaylandClientManager::~XWaylandClientManager()
+{
+    // drop_expired() should have been called for every owner before destroying
+    if (!sessions_by_pid.empty())
+    {
+        log_warning(
+            "XWaylandClientManager destroyed with %zu sessions in the map; "
+            "if any XWaylandClientManager::Sessions are still alive, a crash is likely when they are destroyed",
+            sessions_by_pid.size());
+    }
+}
+
+auto mf::XWaylandClientManager::get_session_for_client(pid_t client_pid) -> std::shared_ptr<Session>
+{
+    std::lock_guard<std::mutex> lock{mutex};
+
+    std::shared_ptr<Session> session;
+    auto const iter = sessions_by_pid.find(client_pid);
+    if (iter != sessions_by_pid.end())
+    {
+        session = iter->second.lock();
+    }
+
+    if (session)
+    {
+        if (verbose_xwayland_logging_enabled())
+        {
+            log_info("Returning existing XWayland session for PID %d (use count %lu)", client_pid, session.use_count());
+        }
+    }
+    else
+    {
+        session = std::make_shared<Session>(this, client_pid);
+        sessions_by_pid[client_pid] = session;
+        if (verbose_xwayland_logging_enabled())
+        {
+            log_info("Created new XWayland session for PID %d", client_pid);
+        }
+    }
+
+    return session;
+}
+
+void mf::XWaylandClientManager::drop_expired(pid_t client_pid)
+{
+    std::unique_lock<std::mutex> lock{mutex};
+
+    auto const iter = sessions_by_pid.find(client_pid);
+
+    // Various rare special cases could cause this to fail (such as a new session being created after the weak_ptr to
+    // the old one expired but before destructor called this function). If the PID is not associated with an expired
+    // session it's safe to assume nothing needs to be done.
+    if (iter != sessions_by_pid.end() && !iter->second.lock())
+    {
+        sessions_by_pid.erase(iter);
+        if (verbose_xwayland_logging_enabled())
+        {
+            log_info("Closed XWayland session for PID %d", client_pid);
+        }
+    }
+    else if (verbose_xwayland_logging_enabled())
+    {
+        log_info("XWaylandClientManager::drop_expired() called with PID %d, which is not expired", client_pid);
+    }
+}

--- a/src/server/frontend_xwayland/xwayland_client_manager.cpp
+++ b/src/server/frontend_xwayland/xwayland_client_manager.cpp
@@ -62,7 +62,7 @@ mf::XWaylandClientManager::~XWaylandClientManager()
     }
 }
 
-auto mf::XWaylandClientManager::get_session_for_client(pid_t client_pid) -> std::shared_ptr<Session>
+auto mf::XWaylandClientManager::session_for_client(pid_t client_pid) -> std::shared_ptr<Session>
 {
     std::lock_guard<std::mutex> lock{mutex};
 

--- a/src/server/frontend_xwayland/xwayland_client_manager.h
+++ b/src/server/frontend_xwayland/xwayland_client_manager.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_FRONTEND_XWAYLAND_CLIENT_MANAGER_H
+#define MIR_FRONTEND_XWAYLAND_CLIENT_MANAGER_H
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+namespace mir
+{
+namespace shell
+{
+class Shell;
+}
+namespace scene
+{
+class Session;
+}
+namespace frontend
+{
+/// Keeps track of which session is associated with which XWayland client PID
+class XWaylandClientManager
+{
+public:
+    /// Creates, owns and destroyes a scene::Session
+    /// Can NOT outlive the XWaylandClientManager that created it
+    class Session
+    {
+    public:
+        Session(XWaylandClientManager* manager, pid_t client_pid);
+        Session(Session const&) = delete;
+        ~Session();
+
+        auto session() const -> std::shared_ptr<scene::Session>;
+
+    private:
+        XWaylandClientManager* const manager;
+        pid_t const client_pid;
+        std::shared_ptr<scene::Session> const _session;
+    };
+
+    XWaylandClientManager(std::shared_ptr<shell::Shell> const& shell);
+    ~XWaylandClientManager();
+
+    auto get_session_for_client(pid_t client_pid) -> std::shared_ptr<Session>;
+
+private:
+    void drop_expired(pid_t client_pid);
+
+    std::shared_ptr<shell::Shell> const shell;
+    std::mutex mutex;
+    std::unordered_map<pid_t, std::weak_ptr<Session>> sessions_by_pid;
+};
+
+}
+}
+
+#endif // MIR_FRONTEND_XWAYLAND_CLIENT_MANAGER_H

--- a/src/server/frontend_xwayland/xwayland_client_manager.h
+++ b/src/server/frontend_xwayland/xwayland_client_manager.h
@@ -40,12 +40,11 @@ class XWaylandClientManager
 {
 public:
     /// Creates, owns and destroyes a scene::Session
-    /// Can NOT outlive the XWaylandClientManager that created it
+    /// Should not outlive the XWaylandClientManager that created it
     class Session
     {
     public:
         Session(XWaylandClientManager* manager, pid_t client_pid);
-        Session(Session const&) = delete;
         ~Session();
 
         auto session() const -> std::shared_ptr<scene::Session>;
@@ -59,7 +58,7 @@ public:
     XWaylandClientManager(std::shared_ptr<shell::Shell> const& shell);
     ~XWaylandClientManager();
 
-    auto get_session_for_client(pid_t client_pid) -> std::shared_ptr<Session>;
+    auto session_for_client(pid_t client_pid) -> std::shared_ptr<Session>;
 
 private:
     void drop_expired(pid_t client_pid);

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -566,7 +566,7 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
         window, connection->_NET_WM_PID,
         [&](uint32_t pid)
         {
-            local_client_session = client_manager->get_session_for_client(pid);
+            local_client_session = client_manager->session_for_client(pid);
             session = local_client_session->session();
         },
         [&]()

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -168,7 +168,6 @@ private:
 
     /// Set in set_wl_surface and cleared when a scene surface is created from it
     std::experimental::optional<std::shared_ptr<XWaylandSurfaceObserver>> surface_observer;
-    std::weak_ptr<scene::Session> weak_session;
     std::unique_ptr<shell::SurfaceSpecification> nullable_pending_spec;
     std::weak_ptr<scene::Surface> weak_scene_surface;
 };

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -21,6 +21,7 @@
 
 #include "wl_surface.h"
 #include "xwayland_wm.h"
+#include "xwayland_client_manager.h"
 #include "xwayland_surface_role_surface.h"
 #include "xwayland_surface_observer_surface.h"
 
@@ -53,6 +54,7 @@ public:
         std::shared_ptr<XCBConnection> const& connection,
         WlSeat& seat,
         std::shared_ptr<shell::Shell> const& shell,
+        std::shared_ptr<XWaylandClientManager> const& client_manager,
         xcb_create_notify_event_t *event);
     ~XWaylandSurface();
 
@@ -145,6 +147,7 @@ private:
     std::shared_ptr<XCBConnection> const connection;
     WlSeat& seat;
     std::shared_ptr<shell::Shell> const shell;
+    std::shared_ptr<XWaylandClientManager> const client_manager;
     xcb_window_t const window;
     std::map<xcb_window_t, std::function<std::function<void()>()>> const property_handlers;
 
@@ -169,6 +172,7 @@ private:
     /// Set in set_wl_surface and cleared when a scene surface is created from it
     std::experimental::optional<std::shared_ptr<XWaylandSurfaceObserver>> surface_observer;
     std::unique_ptr<shell::SurfaceSpecification> nullable_pending_spec;
+    std::shared_ptr<XWaylandClientManager::Session> client_session;
     std::weak_ptr<scene::Surface> weak_scene_surface;
 };
 } /* frontend */

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -24,6 +24,7 @@
 #include "xwayland_wm_shell.h"
 #include "xwayland_surface_role.h"
 #include "xwayland_cursors.h"
+#include "xwayland_client_manager.h"
 
 #include "mir/fd.h"
 #include "mir/scene/null_observer.h"
@@ -133,7 +134,8 @@ mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, 
       wm_shell{std::static_pointer_cast<XWaylandWMShell>(wayland_connector->get_extension("x11-support"))},
       cursors{std::make_unique<XWaylandCursors>(connection)},
       wm_window{create_wm_window(*connection)},
-      scene_observer{std::make_shared<XWaylandSceneObserver>(this)}
+      scene_observer{std::make_shared<XWaylandSceneObserver>(this)},
+      client_manager{std::make_shared<XWaylandClientManager>(wm_shell->shell)}
 {
     check_xfixes(*connection);
 
@@ -568,6 +570,7 @@ void mf::XWaylandWM::handle_create_notify(xcb_create_notify_event_t *event)
             connection,
             wm_shell->seat,
             wm_shell->shell,
+            client_manager,
             event);
 
         {

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -44,6 +44,7 @@ namespace frontend
 class XWaylandSurface;
 class XWaylandWMShell;
 class XWaylandCursors;
+class XWaylandClientManager;
 
 class XWaylandSceneObserver;
 
@@ -96,6 +97,7 @@ private:
     std::unique_ptr<XWaylandCursors> const cursors;
     xcb_window_t const wm_window;
     std::shared_ptr<XWaylandSceneObserver> const scene_observer;
+    std::shared_ptr<XWaylandClientManager> const client_manager;
 
     std::mutex mutex;
     std::map<xcb_window_t, std::shared_ptr<XWaylandSurface>> surfaces;

--- a/src/server/scene/session_manager.cpp
+++ b/src/server/scene/session_manager.cpp
@@ -143,14 +143,14 @@ std::shared_ptr<ms::Session> ms::SessionManager::open_session(
 {
     std::shared_ptr<Session> new_session = std::make_shared<ApplicationSession>(
         surface_stack,
-            surface_factory,
-            buffer_stream_factory,
-            client_pid,
-            name,
-            snapshot_strategy,
-            observers,
-            sender,
-            allocator);
+        surface_factory,
+        buffer_stream_factory,
+        client_pid,
+        name,
+        snapshot_strategy,
+        observers,
+        sender,
+        allocator);
 
     app_container->insert_session(new_session);
 

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -95,6 +95,7 @@ CMAKE_DEPENDENT_OPTION(
 add_subdirectory(compositor/)
 add_subdirectory(console/)
 add_subdirectory(dispatch/)
+add_subdirectory(frontend_xwayland/)
 add_subdirectory(geometry/)
 add_subdirectory(gl/)
 add_subdirectory(graphics/)

--- a/tests/unit-tests/frontend_xwayland/CMakeLists.txt
+++ b/tests/unit-tests/frontend_xwayland/CMakeLists.txt
@@ -1,0 +1,6 @@
+list(
+  APPEND UNIT_TEST_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_xwayland_client_manager.cpp
+)
+
+set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/tests/unit-tests/frontend_xwayland/test_xwayland_client_manager.cpp
+++ b/tests/unit-tests/frontend_xwayland/test_xwayland_client_manager.cpp
@@ -70,7 +70,7 @@ TEST_F(XWaylandClientManagerTest, get_session_initially_creates_session)
         .Times(1)
         .WillOnce(Return(mt::fake_shared(session_1)));
 
-    auto const client_session_1 = manager.get_session_for_client(1);
+    auto const client_session_1 = manager.session_for_client(1);
     EXPECT_THAT(client_session_1->session().get(), Eq(&session_1));
 }
 
@@ -82,9 +82,9 @@ TEST_F(XWaylandClientManagerTest, repeated_get_session_with_same_pid_returns_sam
         .Times(1)
         .WillOnce(Return(mt::fake_shared(session_1)));
 
-    auto const client_session_1 = manager.get_session_for_client(1);
-    auto const client_session_2 = manager.get_session_for_client(1);
-    auto const client_session_3 = manager.get_session_for_client(1);
+    auto const client_session_1 = manager.session_for_client(1);
+    auto const client_session_2 = manager.session_for_client(1);
+    auto const client_session_3 = manager.session_for_client(1);
     EXPECT_THAT(client_session_1.get(), Eq(client_session_2.get()));
     EXPECT_THAT(client_session_1.get(), Eq(client_session_3.get()));
 }
@@ -99,9 +99,9 @@ TEST_F(XWaylandClientManagerTest, repeated_get_session_with_different_pids_creat
         .WillOnce(Return(mt::fake_shared(session_2)))
         .WillOnce(Return(mt::fake_shared(session_3)));
 
-    auto const client_session_1 = manager.get_session_for_client(1);
-    auto const client_session_2 = manager.get_session_for_client(2);
-    auto const client_session_3 = manager.get_session_for_client(3);
+    auto const client_session_1 = manager.session_for_client(1);
+    auto const client_session_2 = manager.session_for_client(2);
+    auto const client_session_3 = manager.session_for_client(3);
 
     EXPECT_THAT(client_session_1->session().get(), Eq(&session_1));
     EXPECT_THAT(client_session_2->session().get(), Eq(&session_2));
@@ -117,7 +117,7 @@ TEST_F(XWaylandClientManagerTest, resetting_client_session_closes_session)
         .WillOnce(Return(mt::fake_shared(session_1)));
     EXPECT_CALL(shell, close_session(_))
         .Times(0);
-    auto client_session_1 = manager.get_session_for_client(1);
+    auto client_session_1 = manager.session_for_client(1);
     Mock::VerifyAndClearExpectations(&shell);
 
     EXPECT_CALL(shell, close_session(Eq(mt::fake_shared(session_1))))
@@ -136,8 +136,8 @@ TEST_F(XWaylandClientManagerTest, reset_does_not_close_session_if_multiple_owner
     EXPECT_CALL(shell, close_session(Eq(mt::fake_shared(session_1))))
         .Times(0);
 
-    auto client_session_1 = manager.get_session_for_client(1);
-    auto client_session_2 = manager.get_session_for_client(1);
+    auto client_session_1 = manager.session_for_client(1);
+    auto client_session_2 = manager.session_for_client(1);
     client_session_1.reset();
 
     Mock::VerifyAndClearExpectations(&shell);
@@ -153,9 +153,9 @@ TEST_F(XWaylandClientManagerTest, session_closed_when_all_client_sessions_reset)
     EXPECT_CALL(shell, close_session(Eq(mt::fake_shared(session_1))))
         .Times(1);
 
-    auto client_session_1 = manager.get_session_for_client(1);
-    auto client_session_2 = manager.get_session_for_client(1);
-    auto client_session_3 = manager.get_session_for_client(1);
+    auto client_session_1 = manager.session_for_client(1);
+    auto client_session_2 = manager.session_for_client(1);
+    auto client_session_3 = manager.session_for_client(1);
 
     client_session_1.reset();
     client_session_2.reset();
@@ -165,12 +165,12 @@ TEST_F(XWaylandClientManagerTest, session_closed_when_all_client_sessions_reset)
 TEST_F(XWaylandClientManagerTest, new_session_created_after_old_session_for_same_pid_closed)
 {
     mf::XWaylandClientManager manager{mt::fake_shared(shell)};
-    auto client_session_1 = manager.get_session_for_client(1);
+    auto client_session_1 = manager.session_for_client(1);
     client_session_1.reset();
 
     EXPECT_CALL(shell, open_session(_, _, _))
         .Times(1)
         .WillRepeatedly(Return(mt::fake_shared(session_2)));
-    auto const client_session_2 = manager.get_session_for_client(1);
+    auto const client_session_2 = manager.session_for_client(1);
     EXPECT_THAT(client_session_2->session().get(), Eq(&session_2));
 }

--- a/tests/unit-tests/frontend_xwayland/test_xwayland_client_manager.cpp
+++ b/tests/unit-tests/frontend_xwayland/test_xwayland_client_manager.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "src/server/frontend_xwayland/xwayland_client_manager.h"
+#include "mir/test/doubles/stub_shell.h"
+#include "mir/test/doubles/stub_session.h"
+#include "mir/test/fake_shared.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace mf = mir::frontend;
+namespace msh = mir::shell;
+namespace ms = mir::scene;
+namespace mt = mir::test;
+namespace mtd = mt::doubles;
+
+using namespace testing;
+
+namespace
+{
+struct MockShell : mtd::StubShell
+{
+    MOCK_METHOD3(open_session, std::shared_ptr<ms::Session>(
+        pid_t, std::string const&, std::shared_ptr<mf::EventSink> const&));
+    MOCK_METHOD1(close_session, void(std::shared_ptr<ms::Session> const&));
+};
+
+struct XWaylandClientManagerTest : Test
+{
+    NiceMock<MockShell> shell;
+    mtd::StubSession session_1;
+    mtd::StubSession session_2;
+    mtd::StubSession session_3;
+
+    void SetUp() override
+    {
+        ON_CALL(shell, open_session(_, _, _))
+            .WillByDefault(Return(mt::fake_shared(session_1)));
+    }
+};
+
+}
+
+TEST_F(XWaylandClientManagerTest, can_be_created)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+}
+
+TEST_F(XWaylandClientManagerTest, get_session_initially_creates_session)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+
+    EXPECT_CALL(shell, open_session(1, _, _))
+        .Times(1)
+        .WillOnce(Return(mt::fake_shared(session_1)));
+
+    auto const client_session_1 = manager.get_session_for_client(1);
+    EXPECT_THAT(client_session_1->session().get(), Eq(&session_1));
+}
+
+TEST_F(XWaylandClientManagerTest, repeated_get_session_with_same_pid_returns_same_session)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+
+    EXPECT_CALL(shell, open_session(1, _, _))
+        .Times(1)
+        .WillOnce(Return(mt::fake_shared(session_1)));
+
+    auto const client_session_1 = manager.get_session_for_client(1);
+    auto const client_session_2 = manager.get_session_for_client(1);
+    auto const client_session_3 = manager.get_session_for_client(1);
+    EXPECT_THAT(client_session_1.get(), Eq(client_session_2.get()));
+    EXPECT_THAT(client_session_1.get(), Eq(client_session_3.get()));
+}
+
+TEST_F(XWaylandClientManagerTest, repeated_get_session_with_different_pids_creates_new_sessions)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+
+    EXPECT_CALL(shell, open_session(_, _, _))
+        .Times(3)
+        .WillOnce(Return(mt::fake_shared(session_1)))
+        .WillOnce(Return(mt::fake_shared(session_2)))
+        .WillOnce(Return(mt::fake_shared(session_3)));
+
+    auto const client_session_1 = manager.get_session_for_client(1);
+    auto const client_session_2 = manager.get_session_for_client(2);
+    auto const client_session_3 = manager.get_session_for_client(3);
+
+    EXPECT_THAT(client_session_1->session().get(), Eq(&session_1));
+    EXPECT_THAT(client_session_2->session().get(), Eq(&session_2));
+    EXPECT_THAT(client_session_3->session().get(), Eq(&session_3));
+}
+
+TEST_F(XWaylandClientManagerTest, resetting_client_session_closes_session)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+
+    EXPECT_CALL(shell, open_session(_, _, _))
+        .Times(1)
+        .WillOnce(Return(mt::fake_shared(session_1)));
+    EXPECT_CALL(shell, close_session(_))
+        .Times(0);
+    auto client_session_1 = manager.get_session_for_client(1);
+    Mock::VerifyAndClearExpectations(&shell);
+
+    EXPECT_CALL(shell, close_session(Eq(mt::fake_shared(session_1))))
+        .Times(1);
+    client_session_1.reset();
+    Mock::VerifyAndClearExpectations(&shell);
+}
+
+TEST_F(XWaylandClientManagerTest, reset_does_not_close_session_if_multiple_owners)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+
+    EXPECT_CALL(shell, open_session(_, _, _))
+        .Times(1)
+        .WillOnce(Return(mt::fake_shared(session_1)));
+    EXPECT_CALL(shell, close_session(Eq(mt::fake_shared(session_1))))
+        .Times(0);
+
+    auto client_session_1 = manager.get_session_for_client(1);
+    auto client_session_2 = manager.get_session_for_client(1);
+    client_session_1.reset();
+
+    Mock::VerifyAndClearExpectations(&shell);
+}
+
+TEST_F(XWaylandClientManagerTest, session_closed_when_all_client_sessions_reset)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+
+    EXPECT_CALL(shell, open_session(_, _, _))
+        .Times(1)
+        .WillOnce(Return(mt::fake_shared(session_1)));
+    EXPECT_CALL(shell, close_session(Eq(mt::fake_shared(session_1))))
+        .Times(1);
+
+    auto client_session_1 = manager.get_session_for_client(1);
+    auto client_session_2 = manager.get_session_for_client(1);
+    auto client_session_3 = manager.get_session_for_client(1);
+
+    client_session_1.reset();
+    client_session_2.reset();
+    client_session_3.reset();
+}
+
+TEST_F(XWaylandClientManagerTest, new_session_created_after_old_session_for_same_pid_closed)
+{
+    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+    auto client_session_1 = manager.get_session_for_client(1);
+    client_session_1.reset();
+
+    EXPECT_CALL(shell, open_session(_, _, _))
+        .Times(1)
+        .WillRepeatedly(Return(mt::fake_shared(session_2)));
+    auto const client_session_2 = manager.get_session_for_client(1);
+    EXPECT_THAT(client_session_2->session().get(), Eq(&session_2));
+}


### PR DESCRIPTION
Alternative to #1698, fixes #479. Allows for better switching between different windows on the same apps, and I believe may help Unity8. This version adds a `XWaylandClientManager::Session` class and uses `shared_ptr`s to that to determine when to destroy a session.

Advantages:
- Less likely to leak sessions (although it should be noted the other approach has a check in place to leaks are not silent) 
- Slightly less code

Disadvantages:
- This is (IMO) a little more complicated and less obvious to fresh eyes
- Prone to a different type of bug. If a `XWaylandClientManager::Session` outlives the manager, it will call into the manager and crash. This could be mitigated a couple ways, but that would add additional complexity.

Either is fine with me.