### PR TITLE
Add an exception for Wayland protocol errors

### DIFF
--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -32,6 +32,28 @@ namespace mir
 {
 namespace wayland
 {
+/**
+ * An exception type representing a Wayland protocol error
+ *
+ * Throwing one of these from a request handler will result in the client
+ * being sent a \a code error on \a source, with the printf-style \a fmt string
+ * populated as the message.:
+ */
+class ProtocolError : public std::runtime_error
+{
+public:
+    [[gnu::format (printf, 4, 5)]]  // Format attribute counts the hidden this parameter
+    ProtocolError(wl_resource* source, uint32_t code, char const* fmt, ...);
+
+    auto message() const -> char const*;
+    auto resource() const -> wl_resource*;
+    auto code() const -> uint32_t;
+private:
+    std::string error_message;
+    wl_resource* const source;
+    uint32_t const error_code;
+};
+
 /// The base class of any object that wants to provide a destroyed flag
 /// The destroyed flag is only created when needed and automatically set to true on destruction
 /// This pattern is only safe in a single-threaded context

--- a/src/wayland/generated/wayland_wrapper.cpp
+++ b/src/wayland/generated/wayland_wrapper.cpp
@@ -122,6 +122,10 @@ struct mw::Compositor::Thunks
         {
             me->create_surface(id_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Compositor::create_surface()");
@@ -141,6 +145,10 @@ struct mw::Compositor::Thunks
         try
         {
             me->create_region(id_resolved);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -265,6 +273,10 @@ struct mw::ShmPool::Thunks
         {
             me->create_buffer(id_resolved, offset, width, height, stride, format);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ShmPool::create_buffer()");
@@ -278,6 +290,10 @@ struct mw::ShmPool::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ShmPool::destroy()");
@@ -290,6 +306,10 @@ struct mw::ShmPool::Thunks
         try
         {
             me->resize(size);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -378,6 +398,10 @@ struct mw::Shm::Thunks
         try
         {
             me->create_pool(id_resolved, fd_resolved, size);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -500,6 +524,10 @@ struct mw::Buffer::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Buffer::destroy()");
@@ -581,6 +609,10 @@ struct mw::DataOffer::Thunks
         {
             me->accept(serial, mime_type_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "DataOffer::accept()");
@@ -595,6 +627,10 @@ struct mw::DataOffer::Thunks
         {
             me->receive(mime_type, fd_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "DataOffer::receive()");
@@ -607,6 +643,10 @@ struct mw::DataOffer::Thunks
         try
         {
             me->destroy();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -621,6 +661,10 @@ struct mw::DataOffer::Thunks
         {
             me->finish();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "DataOffer::finish()");
@@ -633,6 +677,10 @@ struct mw::DataOffer::Thunks
         try
         {
             me->set_actions(dnd_actions, preferred_action);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -741,6 +789,10 @@ struct mw::DataSource::Thunks
         {
             me->offer(mime_type);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "DataSource::offer()");
@@ -754,6 +806,10 @@ struct mw::DataSource::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "DataSource::destroy()");
@@ -766,6 +822,10 @@ struct mw::DataSource::Thunks
         try
         {
             me->set_actions(dnd_actions);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -909,6 +969,10 @@ struct mw::DataDevice::Thunks
         {
             me->start_drag(source_resolved, origin, icon_resolved, serial);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "DataDevice::start_drag()");
@@ -927,6 +991,10 @@ struct mw::DataDevice::Thunks
         {
             me->set_selection(source_resolved, serial);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "DataDevice::set_selection()");
@@ -939,6 +1007,10 @@ struct mw::DataDevice::Thunks
         try
         {
             me->release();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -1099,6 +1171,10 @@ struct mw::DataDeviceManager::Thunks
         {
             me->create_data_source(id_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "DataDeviceManager::create_data_source()");
@@ -1118,6 +1194,10 @@ struct mw::DataDeviceManager::Thunks
         try
         {
             me->get_data_device(id_resolved, seat);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -1243,6 +1323,10 @@ struct mw::Shell::Thunks
         {
             me->get_shell_surface(id_resolved, surface);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Shell::get_shell_surface()");
@@ -1354,6 +1438,10 @@ struct mw::ShellSurface::Thunks
         {
             me->pong(serial);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ShellSurface::pong()");
@@ -1366,6 +1454,10 @@ struct mw::ShellSurface::Thunks
         try
         {
             me->move(seat, serial);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -1380,6 +1472,10 @@ struct mw::ShellSurface::Thunks
         {
             me->resize(seat, serial, edges);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ShellSurface::resize()");
@@ -1393,6 +1489,10 @@ struct mw::ShellSurface::Thunks
         {
             me->set_toplevel();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ShellSurface::set_toplevel()");
@@ -1405,6 +1505,10 @@ struct mw::ShellSurface::Thunks
         try
         {
             me->set_transient(parent, x, y, flags);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -1424,6 +1528,10 @@ struct mw::ShellSurface::Thunks
         {
             me->set_fullscreen(method, framerate, output_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ShellSurface::set_fullscreen()");
@@ -1436,6 +1544,10 @@ struct mw::ShellSurface::Thunks
         try
         {
             me->set_popup(seat, serial, parent, x, y, flags);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -1455,6 +1567,10 @@ struct mw::ShellSurface::Thunks
         {
             me->set_maximized(output_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ShellSurface::set_maximized()");
@@ -1468,6 +1584,10 @@ struct mw::ShellSurface::Thunks
         {
             me->set_title(title);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ShellSurface::set_title()");
@@ -1480,6 +1600,10 @@ struct mw::ShellSurface::Thunks
         try
         {
             me->set_class(class_);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -1624,6 +1748,10 @@ struct mw::Surface::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Surface::destroy()");
@@ -1642,6 +1770,10 @@ struct mw::Surface::Thunks
         {
             me->attach(buffer_resolved, x, y);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Surface::attach()");
@@ -1654,6 +1786,10 @@ struct mw::Surface::Thunks
         try
         {
             me->damage(x, y, width, height);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -1675,6 +1811,10 @@ struct mw::Surface::Thunks
         {
             me->frame(callback_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Surface::frame()");
@@ -1692,6 +1832,10 @@ struct mw::Surface::Thunks
         try
         {
             me->set_opaque_region(region_resolved);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -1711,6 +1855,10 @@ struct mw::Surface::Thunks
         {
             me->set_input_region(region_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Surface::set_input_region()");
@@ -1723,6 +1871,10 @@ struct mw::Surface::Thunks
         try
         {
             me->commit();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -1737,6 +1889,10 @@ struct mw::Surface::Thunks
         {
             me->set_buffer_transform(transform);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Surface::set_buffer_transform()");
@@ -1750,6 +1906,10 @@ struct mw::Surface::Thunks
         {
             me->set_buffer_scale(scale);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Surface::set_buffer_scale()");
@@ -1762,6 +1922,10 @@ struct mw::Surface::Thunks
         try
         {
             me->damage_buffer(x, y, width, height);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -1896,6 +2060,10 @@ struct mw::Seat::Thunks
         {
             me->get_pointer(id_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Seat::get_pointer()");
@@ -1915,6 +2083,10 @@ struct mw::Seat::Thunks
         try
         {
             me->get_keyboard(id_resolved);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -1936,6 +2108,10 @@ struct mw::Seat::Thunks
         {
             me->get_touch(id_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Seat::get_touch()");
@@ -1948,6 +2124,10 @@ struct mw::Seat::Thunks
         try
         {
             me->release();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -2099,6 +2279,10 @@ struct mw::Pointer::Thunks
         {
             me->set_cursor(serial, surface_resolved, hotspot_x, hotspot_y);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Pointer::set_cursor()");
@@ -2111,6 +2295,10 @@ struct mw::Pointer::Thunks
         try
         {
             me->release();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -2282,6 +2470,10 @@ struct mw::Keyboard::Thunks
         {
             me->release();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Keyboard::release()");
@@ -2404,6 +2596,10 @@ struct mw::Touch::Thunks
         try
         {
             me->release();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -2542,6 +2738,10 @@ struct mw::Output::Thunks
         try
         {
             me->release();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -2699,6 +2899,10 @@ struct mw::Region::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Region::destroy()");
@@ -2712,6 +2916,10 @@ struct mw::Region::Thunks
         {
             me->add(x, y, width, height);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Region::add()");
@@ -2724,6 +2932,10 @@ struct mw::Region::Thunks
         try
         {
             me->subtract(x, y, width, height);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -2796,6 +3008,10 @@ struct mw::Subcompositor::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Subcompositor::destroy()");
@@ -2815,6 +3031,10 @@ struct mw::Subcompositor::Thunks
         try
         {
             me->get_subsurface(id_resolved, surface, parent);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -2930,6 +3150,10 @@ struct mw::Subsurface::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Subsurface::destroy()");
@@ -2942,6 +3166,10 @@ struct mw::Subsurface::Thunks
         try
         {
             me->set_position(x, y);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -2956,6 +3184,10 @@ struct mw::Subsurface::Thunks
         {
             me->place_above(sibling);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Subsurface::place_above()");
@@ -2968,6 +3200,10 @@ struct mw::Subsurface::Thunks
         try
         {
             me->place_below(sibling);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -2982,6 +3218,10 @@ struct mw::Subsurface::Thunks
         {
             me->set_sync();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "Subsurface::set_sync()");
@@ -2994,6 +3234,10 @@ struct mw::Subsurface::Thunks
         try
         {
             me->set_desync();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {

--- a/src/wayland/generated/wlr-foreign-toplevel-management-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-foreign-toplevel-management-unstable-v1_wrapper.cpp
@@ -57,6 +57,10 @@ struct mw::ForeignToplevelManagerV1::Thunks
         {
             me->stop();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ForeignToplevelManagerV1::stop()");
@@ -182,6 +186,10 @@ struct mw::ForeignToplevelHandleV1::Thunks
         {
             me->set_maximized();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ForeignToplevelHandleV1::set_maximized()");
@@ -194,6 +202,10 @@ struct mw::ForeignToplevelHandleV1::Thunks
         try
         {
             me->unset_maximized();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -208,6 +220,10 @@ struct mw::ForeignToplevelHandleV1::Thunks
         {
             me->set_minimized();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ForeignToplevelHandleV1::set_minimized()");
@@ -220,6 +236,10 @@ struct mw::ForeignToplevelHandleV1::Thunks
         try
         {
             me->unset_minimized();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -234,6 +254,10 @@ struct mw::ForeignToplevelHandleV1::Thunks
         {
             me->activate(seat);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ForeignToplevelHandleV1::activate()");
@@ -246,6 +270,10 @@ struct mw::ForeignToplevelHandleV1::Thunks
         try
         {
             me->close();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -260,6 +288,10 @@ struct mw::ForeignToplevelHandleV1::Thunks
         {
             me->set_rectangle(surface, x, y, width, height);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ForeignToplevelHandleV1::set_rectangle()");
@@ -272,6 +304,10 @@ struct mw::ForeignToplevelHandleV1::Thunks
         try
         {
             me->destroy();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -291,6 +327,10 @@ struct mw::ForeignToplevelHandleV1::Thunks
         {
             me->set_fullscreen(output_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ForeignToplevelHandleV1::set_fullscreen()");
@@ -303,6 +343,10 @@ struct mw::ForeignToplevelHandleV1::Thunks
         try
         {
             me->unset_fullscreen();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
@@ -69,6 +69,10 @@ struct mw::LayerShellV1::Thunks
         {
             me->get_layer_surface(id_resolved, surface, output_resolved, layer, namespace_);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "LayerShellV1::get_layer_surface()");
@@ -81,6 +85,10 @@ struct mw::LayerShellV1::Thunks
         try
         {
             me->destroy();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -198,6 +206,10 @@ struct mw::LayerSurfaceV1::Thunks
         {
             me->set_size(width, height);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "LayerSurfaceV1::set_size()");
@@ -210,6 +222,10 @@ struct mw::LayerSurfaceV1::Thunks
         try
         {
             me->set_anchor(anchor);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -224,6 +240,10 @@ struct mw::LayerSurfaceV1::Thunks
         {
             me->set_exclusive_zone(zone);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "LayerSurfaceV1::set_exclusive_zone()");
@@ -236,6 +256,10 @@ struct mw::LayerSurfaceV1::Thunks
         try
         {
             me->set_margin(top, right, bottom, left);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -250,6 +274,10 @@ struct mw::LayerSurfaceV1::Thunks
         {
             me->set_keyboard_interactivity(keyboard_interactivity);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "LayerSurfaceV1::set_keyboard_interactivity()");
@@ -262,6 +290,10 @@ struct mw::LayerSurfaceV1::Thunks
         try
         {
             me->get_popup(popup);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -276,6 +308,10 @@ struct mw::LayerSurfaceV1::Thunks
         {
             me->ack_configure(serial);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "LayerSurfaceV1::ack_configure()");
@@ -289,6 +325,10 @@ struct mw::LayerSurfaceV1::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "LayerSurfaceV1::destroy()");
@@ -301,6 +341,10 @@ struct mw::LayerSurfaceV1::Thunks
         try
         {
             me->set_layer(layer);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
@@ -55,6 +55,10 @@ struct mw::XdgOutputManagerV1::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgOutputManagerV1::destroy()");
@@ -74,6 +78,10 @@ struct mw::XdgOutputManagerV1::Thunks
         try
         {
             me->get_xdg_output(id_resolved, output);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -187,6 +195,10 @@ struct mw::XdgOutputV1::Thunks
         try
         {
             me->destroy();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
@@ -60,6 +60,10 @@ struct mw::XdgShellV6::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgShellV6::destroy()");
@@ -79,6 +83,10 @@ struct mw::XdgShellV6::Thunks
         try
         {
             me->create_positioner(id_resolved);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -100,6 +108,10 @@ struct mw::XdgShellV6::Thunks
         {
             me->get_xdg_surface(id_resolved, surface);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgShellV6::get_xdg_surface()");
@@ -112,6 +124,10 @@ struct mw::XdgShellV6::Thunks
         try
         {
             me->pong(serial);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -243,6 +259,10 @@ struct mw::XdgPositionerV6::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgPositionerV6::destroy()");
@@ -255,6 +275,10 @@ struct mw::XdgPositionerV6::Thunks
         try
         {
             me->set_size(width, height);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -269,6 +293,10 @@ struct mw::XdgPositionerV6::Thunks
         {
             me->set_anchor_rect(x, y, width, height);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgPositionerV6::set_anchor_rect()");
@@ -281,6 +309,10 @@ struct mw::XdgPositionerV6::Thunks
         try
         {
             me->set_anchor(anchor);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -295,6 +327,10 @@ struct mw::XdgPositionerV6::Thunks
         {
             me->set_gravity(gravity);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgPositionerV6::set_gravity()");
@@ -308,6 +344,10 @@ struct mw::XdgPositionerV6::Thunks
         {
             me->set_constraint_adjustment(constraint_adjustment);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgPositionerV6::set_constraint_adjustment()");
@@ -320,6 +360,10 @@ struct mw::XdgPositionerV6::Thunks
         try
         {
             me->set_offset(x, y);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -400,6 +444,10 @@ struct mw::XdgSurfaceV6::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgSurfaceV6::destroy()");
@@ -419,6 +467,10 @@ struct mw::XdgSurfaceV6::Thunks
         try
         {
             me->get_toplevel(id_resolved);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -440,6 +492,10 @@ struct mw::XdgSurfaceV6::Thunks
         {
             me->get_popup(id_resolved, parent, positioner);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgSurfaceV6::get_popup()");
@@ -453,6 +509,10 @@ struct mw::XdgSurfaceV6::Thunks
         {
             me->set_window_geometry(x, y, width, height);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgSurfaceV6::set_window_geometry()");
@@ -465,6 +525,10 @@ struct mw::XdgSurfaceV6::Thunks
         try
         {
             me->ack_configure(serial);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -560,6 +624,10 @@ struct mw::XdgToplevelV6::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevelV6::destroy()");
@@ -578,6 +646,10 @@ struct mw::XdgToplevelV6::Thunks
         {
             me->set_parent(parent_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevelV6::set_parent()");
@@ -590,6 +662,10 @@ struct mw::XdgToplevelV6::Thunks
         try
         {
             me->set_title(title);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -604,6 +680,10 @@ struct mw::XdgToplevelV6::Thunks
         {
             me->set_app_id(app_id);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevelV6::set_app_id()");
@@ -616,6 +696,10 @@ struct mw::XdgToplevelV6::Thunks
         try
         {
             me->show_window_menu(seat, serial, x, y);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -630,6 +714,10 @@ struct mw::XdgToplevelV6::Thunks
         {
             me->move(seat, serial);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevelV6::move()");
@@ -642,6 +730,10 @@ struct mw::XdgToplevelV6::Thunks
         try
         {
             me->resize(seat, serial, edges);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -656,6 +748,10 @@ struct mw::XdgToplevelV6::Thunks
         {
             me->set_max_size(width, height);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevelV6::set_max_size()");
@@ -668,6 +764,10 @@ struct mw::XdgToplevelV6::Thunks
         try
         {
             me->set_min_size(width, height);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -682,6 +782,10 @@ struct mw::XdgToplevelV6::Thunks
         {
             me->set_maximized();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevelV6::set_maximized()");
@@ -694,6 +798,10 @@ struct mw::XdgToplevelV6::Thunks
         try
         {
             me->unset_maximized();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -713,6 +821,10 @@ struct mw::XdgToplevelV6::Thunks
         {
             me->set_fullscreen(output_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevelV6::set_fullscreen()");
@@ -726,6 +838,10 @@ struct mw::XdgToplevelV6::Thunks
         {
             me->unset_fullscreen();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevelV6::unset_fullscreen()");
@@ -738,6 +854,10 @@ struct mw::XdgToplevelV6::Thunks
         try
         {
             me->set_minimized();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -873,6 +993,10 @@ struct mw::XdgPopupV6::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgPopupV6::destroy()");
@@ -885,6 +1009,10 @@ struct mw::XdgPopupV6::Thunks
         try
         {
             me->grab(seat, serial);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {

--- a/src/wayland/generated/xdg-shell_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell_wrapper.cpp
@@ -60,6 +60,10 @@ struct mw::XdgWmBase::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgWmBase::destroy()");
@@ -79,6 +83,10 @@ struct mw::XdgWmBase::Thunks
         try
         {
             me->create_positioner(id_resolved);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -100,6 +108,10 @@ struct mw::XdgWmBase::Thunks
         {
             me->get_xdg_surface(id_resolved, surface);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgWmBase::get_xdg_surface()");
@@ -112,6 +124,10 @@ struct mw::XdgWmBase::Thunks
         try
         {
             me->pong(serial);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -243,6 +259,10 @@ struct mw::XdgPositioner::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgPositioner::destroy()");
@@ -255,6 +275,10 @@ struct mw::XdgPositioner::Thunks
         try
         {
             me->set_size(width, height);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -269,6 +293,10 @@ struct mw::XdgPositioner::Thunks
         {
             me->set_anchor_rect(x, y, width, height);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgPositioner::set_anchor_rect()");
@@ -281,6 +309,10 @@ struct mw::XdgPositioner::Thunks
         try
         {
             me->set_anchor(anchor);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -295,6 +327,10 @@ struct mw::XdgPositioner::Thunks
         {
             me->set_gravity(gravity);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgPositioner::set_gravity()");
@@ -308,6 +344,10 @@ struct mw::XdgPositioner::Thunks
         {
             me->set_constraint_adjustment(constraint_adjustment);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgPositioner::set_constraint_adjustment()");
@@ -320,6 +360,10 @@ struct mw::XdgPositioner::Thunks
         try
         {
             me->set_offset(x, y);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -400,6 +444,10 @@ struct mw::XdgSurface::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgSurface::destroy()");
@@ -419,6 +467,10 @@ struct mw::XdgSurface::Thunks
         try
         {
             me->get_toplevel(id_resolved);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -445,6 +497,10 @@ struct mw::XdgSurface::Thunks
         {
             me->get_popup(id_resolved, parent_resolved, positioner);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgSurface::get_popup()");
@@ -458,6 +514,10 @@ struct mw::XdgSurface::Thunks
         {
             me->set_window_geometry(x, y, width, height);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgSurface::set_window_geometry()");
@@ -470,6 +530,10 @@ struct mw::XdgSurface::Thunks
         try
         {
             me->ack_configure(serial);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -565,6 +629,10 @@ struct mw::XdgToplevel::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevel::destroy()");
@@ -583,6 +651,10 @@ struct mw::XdgToplevel::Thunks
         {
             me->set_parent(parent_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevel::set_parent()");
@@ -595,6 +667,10 @@ struct mw::XdgToplevel::Thunks
         try
         {
             me->set_title(title);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -609,6 +685,10 @@ struct mw::XdgToplevel::Thunks
         {
             me->set_app_id(app_id);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevel::set_app_id()");
@@ -621,6 +701,10 @@ struct mw::XdgToplevel::Thunks
         try
         {
             me->show_window_menu(seat, serial, x, y);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -635,6 +719,10 @@ struct mw::XdgToplevel::Thunks
         {
             me->move(seat, serial);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevel::move()");
@@ -647,6 +735,10 @@ struct mw::XdgToplevel::Thunks
         try
         {
             me->resize(seat, serial, edges);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -661,6 +753,10 @@ struct mw::XdgToplevel::Thunks
         {
             me->set_max_size(width, height);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevel::set_max_size()");
@@ -673,6 +769,10 @@ struct mw::XdgToplevel::Thunks
         try
         {
             me->set_min_size(width, height);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -687,6 +787,10 @@ struct mw::XdgToplevel::Thunks
         {
             me->set_maximized();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevel::set_maximized()");
@@ -699,6 +803,10 @@ struct mw::XdgToplevel::Thunks
         try
         {
             me->unset_maximized();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -718,6 +826,10 @@ struct mw::XdgToplevel::Thunks
         {
             me->set_fullscreen(output_resolved);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevel::set_fullscreen()");
@@ -731,6 +843,10 @@ struct mw::XdgToplevel::Thunks
         {
             me->unset_fullscreen();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgToplevel::unset_fullscreen()");
@@ -743,6 +859,10 @@ struct mw::XdgToplevel::Thunks
         try
         {
             me->set_minimized();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -878,6 +998,10 @@ struct mw::XdgPopup::Thunks
         {
             me->destroy();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "XdgPopup::destroy()");
@@ -890,6 +1014,10 @@ struct mw::XdgPopup::Thunks
         try
         {
             me->grab(seat, serial);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {

--- a/src/wayland/generator/request.cpp
+++ b/src/wayland/generator/request.cpp
@@ -40,6 +40,10 @@ Emitter Request::thunk_impl() const
             Block{
                 {"me->", name, "(", mir_call_args(), ");"}
             },
+            "catch(ProtocolError const& err)",
+            Block{
+                {"wl_resource_post_error(err.resource(), err.code(), \"%s\", err.message());"},
+            },
             "catch(...)",
             Block{
                 {"internal_error_processing_request(client, \"", class_name, "::", name, "()\");"},

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -350,5 +350,14 @@ global:
     typeinfo?for?mir::wayland::ForeignToplevelHandleV1;
     vtable?for?mir::wayland::ForeignToplevelHandleV1;
     mir::wayland::zwlr_foreign_toplevel_manager_v1_interface_data;
+
+    mir::wayland::ProtocolError::*;
+    non-virtual?thunk?to?mir::wayland::ProtocolError::*;
+    virtual?thunk?to?mir::wayland::ProtocolError::?ProtocolError*;
+    mir::wayland::ProtocolError::message*;
+    mir::wayland::ProtocolError::code*;
+    mir::wayland::ProtocolError::resource*;
+    typeinfo?for?mir::wayland::ProtocolError;
+    vtable?for?mir::wayland::ProtocolError;
   };
 } MIRWAYLAND_2.0;

--- a/src/wayland/wayland_base.cpp
+++ b/src/wayland/wayland_base.cpp
@@ -24,6 +24,40 @@
 
 namespace mw = mir::wayland;
 
+mw::ProtocolError::ProtocolError(
+    wl_resource* source,
+    uint32_t code,
+    char const* fmt, ...) :
+        std::runtime_error{"Client protocol error"},
+        source{source},
+        error_code{code}
+{
+    va_list va;
+    char message[1024];
+
+    va_start(va, fmt);
+    auto const max = sizeof(message) - 1;
+    auto const len = vsnprintf(message, max, fmt, va);
+    va_end(va);
+
+    error_message = std::string(std::begin(message), std::begin(message) + len);
+}
+
+auto mw::ProtocolError::message() const -> char const*
+{
+    return error_message.c_str();
+}
+
+auto mw::ProtocolError::resource() const -> wl_resource*
+{
+    return source;
+}
+
+auto mw::ProtocolError::code() const -> uint32_t
+{
+    return error_code;
+}
+
 mw::LifetimeTracker::~LifetimeTracker()
 {
     if (destroyed)

--- a/tests/miral/generated/server-decoration_wrapper.cpp
+++ b/tests/miral/generated/server-decoration_wrapper.cpp
@@ -62,6 +62,10 @@ struct mw::ServerDecorationManager::Thunks
         {
             me->create(id_resolved, surface);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ServerDecorationManager::create()");
@@ -182,6 +186,10 @@ struct mw::ServerDecoration::Thunks
         {
             me->release();
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "ServerDecoration::release()");
@@ -194,6 +202,10 @@ struct mw::ServerDecoration::Thunks
         try
         {
             me->request_mode(mode);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {


### PR DESCRIPTION
This adds `mir::wayland::ProtocolError`, an exception that request handlers can throw which will result in a Wayland protocol error being sent to the client.

This is more convenient than bubbling early-returns up the call stack.