### PR TITLE
Support Layer Shell margin

### DIFF
--- a/include/core/mir/geometry/dimensions.h
+++ b/include/core/mir/geometry/dimensions.h
@@ -118,6 +118,8 @@ inline constexpr DeltaX operator+(DeltaX lhs, DeltaX rhs) { return DeltaX(lhs.as
 inline constexpr DeltaY operator+(DeltaY lhs, DeltaY rhs) { return DeltaY(lhs.as_int() + rhs.as_int()); }
 inline constexpr DeltaX operator-(DeltaX lhs, DeltaX rhs) { return DeltaX(lhs.as_int() - rhs.as_int()); }
 inline constexpr DeltaY operator-(DeltaY lhs, DeltaY rhs) { return DeltaY(lhs.as_int() - rhs.as_int()); }
+inline constexpr DeltaX operator-(DeltaX rhs) { return DeltaX(-rhs.as_int()); }
+inline constexpr DeltaY operator-(DeltaY rhs) { return DeltaY(-rhs.as_int()); }
 inline DeltaX& operator+=(DeltaX& lhs, DeltaX rhs) { return lhs = lhs + rhs; }
 inline DeltaY& operator+=(DeltaY& lhs, DeltaY rhs) { return lhs = lhs + rhs; }
 inline DeltaX& operator-=(DeltaX& lhs, DeltaX rhs) { return lhs = lhs - rhs; }

--- a/include/core/mir/geometry/displacement.h
+++ b/include/core/mir/geometry/displacement.h
@@ -71,6 +71,11 @@ inline constexpr Displacement operator-(Displacement const& lhs, Displacement co
     return Displacement{lhs.dx - rhs.dx, lhs.dy - rhs.dy};
 }
 
+inline constexpr Displacement operator-(Displacement const& rhs)
+{
+    return Displacement{-rhs.dx, -rhs.dy};
+}
+
 inline constexpr Point operator+(Point const& lhs, Displacement const& rhs)
 {
     return Point{lhs.x + rhs.dx, lhs.y + rhs.dy};

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -590,6 +590,25 @@ void mf::LayerSurfaceV1::handle_commit()
     margin.commit();
     opt_size.commit();
 
+    // wlr-layer-shell-unstable-v1.xml:
+    // "You must set your anchor to opposite edges in the dimensions you omit; not doing so is a protocol error."
+    bool const horiz_stretched = anchors.committed().left && anchors.committed().right;
+    bool const vert_stretched = anchors.committed().top && anchors.committed().bottom;
+    if (!horiz_stretched && !opt_size.committed().width)
+    {
+        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+            resource,
+            Error::invalid_size,
+            "Width may be unspecified only when surface is anchored to left and right edges"));
+    }
+    if (!vert_stretched && !opt_size.committed().height)
+    {
+        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+            resource,
+            Error::invalid_size,
+            "Height may be unspecified only when surface is anchored to top and bottom edges"));
+    }
+
     if (configure_on_next_commit)
     {
         configure();

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -28,7 +28,6 @@
 #include "mir/log.h"
 #include <boost/throw_exception.hpp>
 #include <deque>
-#include <mutex>
 
 namespace mf = mir::frontend;
 namespace ms = mir::scene;
@@ -99,10 +98,53 @@ public:
     static auto from(wl_resource* surface) -> std::experimental::optional<LayerSurfaceV1*>;
 
 private:
+    template<typename T>
+    class DoubleBuffered
+    {
+    public:
+        DoubleBuffered() = default;
+        DoubleBuffered(T const& initial) : _committed{initial} {}
+        DoubleBuffered(DoubleBuffered const&) = delete;
+        auto operator=(DoubleBuffered const&) const -> bool = delete;
+
+        auto pending() const -> T const& { return _pending ? _pending.value() : _committed; }
+        auto is_pending() const -> bool { return _pending; }
+        void set_pending(T const& value) { _pending = value; }
+        auto committed() const -> T const& { return _committed; }
+        void commit()
+        {
+            if (_pending)
+            {
+                _committed = _pending.value();
+            }
+            _pending = std::experimental::nullopt;
+        }
+
+    private:
+        std::experimental::optional<T> _pending;
+        T _committed;
+    };
+
     struct OptionalSize
     {
         std::experimental::optional<geom::Width> width;
         std::experimental::optional<geom::Height> height;
+    };
+
+    struct Margin
+    {
+        geom::DeltaX left{0};
+        geom::DeltaX right{0};
+        geom::DeltaY top{0};
+        geom::DeltaY bottom{0};
+    };
+
+    struct Anchors
+    {
+        bool left{false};
+        bool right{false};
+        bool top{false};
+        bool bottom{false};
     };
 
     /// Returns all anchored edges ored together
@@ -114,6 +156,18 @@ private:
 
     /// Returns the rectangele in surface coords that this surface is exclusive for (if any)
     auto get_exclusive_rect() const -> std::experimental::optional<geom::Rectangle>;
+
+    static auto horiz_padding(Anchors const& anchors, Margin const& margin) -> geom::DeltaX;
+    static auto vert_padding(Anchors const& anchors, Margin const& margin) -> geom::DeltaY;
+
+    /// Returns the size requested from the window manager minus the margin (which the raw requested size includes)
+    auto unpadded_requested_size() const -> geom::Size;
+
+    /// Returns the pending window size
+    auto unpadded_pending_size() const -> geom::Size;
+
+    /// Sets pending state on the WindowWlSurfaceRole
+    auto inform_window_role_of_pending_placement();
 
     /// Sends a configure event if needed
     void configure();
@@ -138,20 +192,12 @@ private:
         geometry::Size const& /*new_size*/) override;
     void handle_close_request() override;
 
-    uint32_t exclusive_zone{0};
-    struct anchor
-    {
-        bool left{false};
-        bool right{false};
-        bool top{false};
-        bool bottom{false};
-    } anchored;
-    std::experimental::optional<OptionalSize> pending_opt_size;
-    OptionalSize committed_opt_size;
+    DoubleBuffered<uint32_t> exclusive_zone{0};
+    DoubleBuffered<Anchors> anchors;
+    DoubleBuffered<Margin> margin;
+    DoubleBuffered<OptionalSize> opt_size;
     bool configure_on_next_commit{true}; ///< If to send a .configure event at the end of the next or current commit
-    std::mutex commit_mutex; ///< NOT used for thready saftey. Used to check if we are currently committing
     std::deque<std::pair<uint32_t, OptionalSize>> inflight_configures;
-    bool surface_data_dirty{false};
 };
 
 }
@@ -203,7 +249,7 @@ void mf::LayerShellV1::Instance::get_layer_surface(
     uint32_t layer,
     std::string const& namespace_)
 {
-    (void)namespace_; // TODO
+    (void)namespace_; // Can be ignored if no special behavior is required
 
     auto const output_id = output ?
         shell->output_manager->output_id_for(client, output.value()) :
@@ -263,16 +309,16 @@ auto mf::LayerSurfaceV1::get_placement_gravity() const -> MirPlacementGravity
 {
     MirPlacementGravity edges = mir_placement_gravity_center;
 
-    if (anchored.left)
+    if (anchors.pending().left)
         edges = MirPlacementGravity(edges | mir_placement_gravity_west);
 
-    if (anchored.right)
+    if (anchors.pending().right)
         edges = MirPlacementGravity(edges | mir_placement_gravity_east);
 
-    if (anchored.top)
+    if (anchors.pending().top)
         edges = MirPlacementGravity(edges | mir_placement_gravity_north);
 
-    if (anchored.bottom)
+    if (anchors.pending().bottom)
         edges = MirPlacementGravity(edges | mir_placement_gravity_south);
 
     return edges;
@@ -283,17 +329,17 @@ auto mf::LayerSurfaceV1::get_anchored_edge() const -> MirPlacementGravity
     MirPlacementGravity h_edge = mir_placement_gravity_center;
     MirPlacementGravity v_edge = mir_placement_gravity_center;
 
-    if (anchored.left != anchored.right)
+    if (anchors.pending().left != anchors.pending().right)
     {
-        if (anchored.left)
+        if (anchors.pending().left)
             h_edge = mir_placement_gravity_west;
         else
             h_edge = mir_placement_gravity_east;
     }
 
-    if (anchored.top != anchored.bottom)
+    if (anchors.pending().top != anchors.pending().bottom)
     {
-        if (anchored.top)
+        if (anchors.pending().top)
             v_edge = mir_placement_gravity_north;
         else
             v_edge = mir_placement_gravity_south;
@@ -309,37 +355,108 @@ auto mf::LayerSurfaceV1::get_anchored_edge() const -> MirPlacementGravity
 
 auto mf::LayerSurfaceV1::get_exclusive_rect() const -> std::experimental::optional<geom::Rectangle>
 {
-    if (exclusive_zone <= 0)
+    auto zone = exclusive_zone.pending();
+    if (zone <= 0)
         return std::experimental::nullopt;
 
     auto edge = get_anchored_edge();
-    auto size = pending_size();
+    auto size = pending_size(); // includes margin padding
 
     switch (edge)
     {
     case mir_placement_gravity_west:
         return geom::Rectangle{
             {0, 0},
-            {exclusive_zone, size.height}};
+            {geom::Width{zone} + margin.pending().left, size.height}};
 
     case mir_placement_gravity_east:
         return geom::Rectangle{
-            {geom::as_x(size.width) - geom::DeltaX{exclusive_zone}, 0},
-            {exclusive_zone, size.height}};
+            {geom::as_x(size.width) - geom::DeltaX{zone} - margin.pending().right, 0},
+            {geom::Width{zone} + margin.pending().right, size.height}};
 
     case mir_placement_gravity_north:
         return geom::Rectangle{
             {0, 0},
-            {size.width, exclusive_zone}};
+            {size.width, geom::Height{zone} + margin.pending().top}};
 
     case mir_placement_gravity_south:
         return geom::Rectangle{
-            {0, geom::as_y(size.height) - geom::DeltaY{exclusive_zone}},
-            {size.width, exclusive_zone}};
+            {0, geom::as_y(size.height) - geom::DeltaY{zone} - margin.pending().bottom},
+            {size.width, geom::Height{zone} + margin.pending().bottom}};
 
     default:
         return std::experimental::nullopt;
     }
+}
+
+auto mf::LayerSurfaceV1::horiz_padding(Anchors const& anchors, Margin const& margin) -> geom::DeltaX
+{
+    return (anchors.left ? margin.left : geom::DeltaX{}) +
+        (anchors.right ? margin.right : geom::DeltaX{});
+}
+
+auto mf::LayerSurfaceV1::vert_padding(Anchors const& anchors, Margin const& margin) -> geom::DeltaY
+{
+    return (anchors.top ? margin.top : geom::DeltaY{}) +
+        (anchors.bottom ? margin.bottom : geom::DeltaY{});
+}
+
+auto mf::LayerSurfaceV1::unpadded_requested_size() const -> geom::Size
+{
+    auto size = requested_window_size().value_or(current_size());
+    size.width -= horiz_padding(anchors.committed(), margin.committed());
+    size.height -= vert_padding(anchors.committed(), margin.committed());
+    return size;
+}
+
+auto mf::LayerSurfaceV1::unpadded_pending_size() const -> geom::Size
+{
+    auto size = pending_size();
+    size.width -= horiz_padding(anchors.pending(), margin.pending());
+    size.height -= vert_padding(anchors.pending(), margin.pending());
+    return size;
+}
+
+auto mf::LayerSurfaceV1::inform_window_role_of_pending_placement()
+{
+    if (opt_size.pending().width)
+    {
+        auto width = opt_size.pending().width.value();
+        width += horiz_padding(anchors.pending(), margin.pending());
+        set_pending_width(width);
+    }
+
+    if (opt_size.pending().height)
+    {
+        auto height = opt_size.pending().height.value();
+        height += vert_padding(anchors.pending(), margin.pending());
+        set_pending_height(height);
+    }
+
+    geom::Displacement offset;
+
+    if (anchors.pending().left)
+    {
+        offset.dx += margin.pending().left;
+    }
+
+    if (anchors.pending().top)
+    {
+        offset.dy += margin.pending().top;
+    }
+
+    set_pending_offset(offset);
+
+    shell::SurfaceSpecification spec;
+
+    spec.attached_edges = get_placement_gravity();
+
+    auto const exclusive_rect = get_exclusive_rect();
+    spec.exclusive_rect = exclusive_rect ?
+        mir::optional_value<geom::Rectangle>(exclusive_rect.value()) :
+        mir::optional_value<geom::Rectangle>();
+
+    apply_spec(spec);
 }
 
 void mf::LayerSurfaceV1::configure()
@@ -347,17 +464,27 @@ void mf::LayerSurfaceV1::configure()
     // TODO: Error if told to configure on an axis the window is not streatched along
 
     OptionalSize configure_size{std::experimental::nullopt, std::experimental::nullopt};
-    auto requested = requested_window_size().value_or(current_size());
+    auto requested = unpadded_requested_size();
 
-    if (anchored.left && anchored.right)
+    if (anchors.committed().left && anchors.committed().right)
+    {
         configure_size.width = requested.width;
-    if (anchored.bottom && anchored.top)
-        configure_size.height = requested.height;
+    }
 
-    if (committed_opt_size.width)
-        configure_size.width = committed_opt_size.width.value();
-    if (committed_opt_size.height)
-        configure_size.height = committed_opt_size.height.value();
+    if (anchors.committed().bottom && anchors.committed().top)
+    {
+        configure_size.height = requested.height;
+    }
+
+    if (opt_size.committed().width)
+    {
+        configure_size.width = opt_size.committed().width.value();
+    }
+
+    if (opt_size.committed().height)
+    {
+        configure_size.height = opt_size.committed().height.value();
+    }
 
     auto const serial = wl_display_next_serial(wl_client_get_display(wayland::LayerSurfaceV1::client));
     if (!inflight_configures.empty() && serial <= inflight_configures.back().first)
@@ -372,35 +499,37 @@ void mf::LayerSurfaceV1::configure()
 
 void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
 {
-    pending_opt_size = OptionalSize{std::experimental::nullopt, std::experimental::nullopt};
-    if (width > 0)
-        pending_opt_size.value().width = geom::Width{width};
-    if (height > 0)
-        pending_opt_size.value().height = geom::Height{height};
+    opt_size.set_pending(OptionalSize{
+        width  > 0 ? std::experimental::make_optional(geom::Width {width }) : std::experimental::nullopt,
+        height > 0 ? std::experimental::make_optional(geom::Height{height}) : std::experimental::nullopt});
+    inform_window_role_of_pending_placement();
     configure_on_next_commit = true;
 }
 
 void mf::LayerSurfaceV1::set_anchor(uint32_t anchor)
 {
-    anchored.left = anchor & Anchor::left;
-    anchored.right = anchor & Anchor::right;
-    anchored.top = anchor & Anchor::top;
-    anchored.bottom = anchor & Anchor::bottom;
-    surface_data_dirty = true;
+    anchors.set_pending(Anchors{
+        static_cast<bool>(anchor & Anchor::left),
+        static_cast<bool>(anchor & Anchor::right),
+        static_cast<bool>(anchor & Anchor::top),
+        static_cast<bool>(anchor & Anchor::bottom)});
+    inform_window_role_of_pending_placement();
 }
 
 void mf::LayerSurfaceV1::set_exclusive_zone(int32_t zone)
 {
-    exclusive_zone = zone;
-    surface_data_dirty = true;
+    exclusive_zone.set_pending(zone);
+    inform_window_role_of_pending_placement();
 }
 
 void mf::LayerSurfaceV1::set_margin(int32_t top, int32_t right, int32_t bottom, int32_t left)
 {
-    (void)top;
-    (void)right;
-    (void)bottom;
-    (void)left;
+    margin.set_pending(Margin{
+        geom::DeltaX{left},
+        geom::DeltaX{right},
+        geom::DeltaY{top},
+        geom::DeltaY{bottom}});
+    inform_window_role_of_pending_placement();
 }
 
 void mf::LayerSurfaceV1::set_keyboard_interactivity(uint32_t keyboard_interactivity)
@@ -434,8 +563,11 @@ void mf::LayerSurfaceV1::ack_configure(uint32_t serial)
             "Could not find acked configure with serial " + std::to_string(serial)));
     }
 
-    pending_opt_size = inflight_configures.front().second;
+    opt_size.set_pending(inflight_configures.front().second);
     inflight_configures.pop_front();
+
+    // Do NOT set configure_on_next_commit (as we do in the other case when opt_size is set)
+    // We don't want to make the client acking one configure result in us sending another
 }
 
 void mf::LayerSurfaceV1::destroy()
@@ -448,36 +580,15 @@ void mf::LayerSurfaceV1::set_layer(uint32_t layer)
     shell::SurfaceSpecification spec;
     spec.depth_layer = layer_shell_layer_to_mir_depth_layer(layer);
     apply_spec(spec);
+    // Don't use inform_window_role_of_pending_placement() because the layer doesn't interfere with any other properties
 }
 
 void mf::LayerSurfaceV1::handle_commit()
 {
-    std::lock_guard<std::mutex> comitting{commit_mutex};
-
-    if (pending_opt_size)
-    {
-        if (pending_opt_size.value().width)
-            set_pending_width(pending_opt_size.value().width.value());
-        if (pending_opt_size.value().height)
-            set_pending_height(pending_opt_size.value().height.value());
-        committed_opt_size = pending_opt_size.value();
-        pending_opt_size = std::experimental::nullopt;
-        surface_data_dirty = true;
-    }
-
-    if (surface_data_dirty)
-    {
-        std::experimental::optional<geom::Rectangle> exclusive_rect_std = get_exclusive_rect();
-        mir::optional_value<geom::Rectangle> exclusive_rect_mir;
-        if (exclusive_rect_std)
-            exclusive_rect_mir = exclusive_rect_std.value();
-
-        shell::SurfaceSpecification spec;
-        spec.attached_edges = get_placement_gravity();
-        spec.exclusive_rect = exclusive_rect_mir;
-        apply_spec(spec);
-        surface_data_dirty = false;
-    }
+    exclusive_zone.commit();
+    anchors.commit();
+    margin.commit();
+    opt_size.commit();
 
     if (configure_on_next_commit)
     {

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -165,9 +165,6 @@ private:
     /// Returns the size requested from the window manager minus the margin (which the raw requested size includes)
     auto unpadded_requested_size() const -> geom::Size;
 
-    /// Returns the pending window size
-    auto unpadded_pending_size() const -> geom::Size;
-
     /// Sets pending state on the WindowWlSurfaceRole
     auto inform_window_role_of_pending_placement();
 
@@ -410,14 +407,6 @@ auto mf::LayerSurfaceV1::unpadded_requested_size() const -> geom::Size
     auto size = requested_window_size().value_or(current_size());
     size.width -= horiz_padding(anchors.committed(), margin.committed());
     size.height -= vert_padding(anchors.committed(), margin.committed());
-    return size;
-}
-
-auto mf::LayerSurfaceV1::unpadded_pending_size() const -> geom::Size
-{
-    auto size = pending_size();
-    size.width -= horiz_padding(anchors.pending(), margin.pending());
-    size.height -= vert_padding(anchors.pending(), margin.pending());
     return size;
 }
 

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -139,10 +139,13 @@ private:
     void handle_close_request() override;
 
     uint32_t exclusive_zone{0};
-    bool anchored_left{false};
-    bool anchored_right{false};
-    bool anchored_top{false};
-    bool anchored_bottom{false};
+    struct anchor
+    {
+        bool left{false};
+        bool right{false};
+        bool top{false};
+        bool bottom{false};
+    } anchored;
     std::experimental::optional<OptionalSize> pending_opt_size;
     OptionalSize committed_opt_size;
     bool configure_on_next_commit{true}; ///< If to send a .configure event at the end of the next or current commit
@@ -260,16 +263,16 @@ auto mf::LayerSurfaceV1::get_placement_gravity() const -> MirPlacementGravity
 {
     MirPlacementGravity edges = mir_placement_gravity_center;
 
-    if (anchored_left)
+    if (anchored.left)
         edges = MirPlacementGravity(edges | mir_placement_gravity_west);
 
-    if (anchored_right)
+    if (anchored.right)
         edges = MirPlacementGravity(edges | mir_placement_gravity_east);
 
-    if (anchored_top)
+    if (anchored.top)
         edges = MirPlacementGravity(edges | mir_placement_gravity_north);
 
-    if (anchored_bottom)
+    if (anchored.bottom)
         edges = MirPlacementGravity(edges | mir_placement_gravity_south);
 
     return edges;
@@ -280,17 +283,17 @@ auto mf::LayerSurfaceV1::get_anchored_edge() const -> MirPlacementGravity
     MirPlacementGravity h_edge = mir_placement_gravity_center;
     MirPlacementGravity v_edge = mir_placement_gravity_center;
 
-    if (anchored_left != anchored_right)
+    if (anchored.left != anchored.right)
     {
-        if (anchored_left)
+        if (anchored.left)
             h_edge = mir_placement_gravity_west;
         else
             h_edge = mir_placement_gravity_east;
     }
 
-    if (anchored_top != anchored_bottom)
+    if (anchored.top != anchored.bottom)
     {
-        if (anchored_top)
+        if (anchored.top)
             v_edge = mir_placement_gravity_north;
         else
             v_edge = mir_placement_gravity_south;
@@ -346,9 +349,9 @@ void mf::LayerSurfaceV1::configure()
     OptionalSize configure_size{std::experimental::nullopt, std::experimental::nullopt};
     auto requested = requested_window_size().value_or(current_size());
 
-    if (anchored_left && anchored_right)
+    if (anchored.left && anchored.right)
         configure_size.width = requested.width;
-    if (anchored_bottom && anchored_top)
+    if (anchored.bottom && anchored.top)
         configure_size.height = requested.height;
 
     if (committed_opt_size.width)
@@ -379,10 +382,10 @@ void mf::LayerSurfaceV1::set_size(uint32_t width, uint32_t height)
 
 void mf::LayerSurfaceV1::set_anchor(uint32_t anchor)
 {
-    anchored_left = anchor & Anchor::left;
-    anchored_right = anchor & Anchor::right;
-    anchored_top = anchor & Anchor::top;
-    anchored_bottom = anchor & Anchor::bottom;
+    anchored.left = anchor & Anchor::left;
+    anchored.right = anchor & Anchor::right;
+    anchored.top = anchor & Anchor::top;
+    anchored.bottom = anchor & Anchor::bottom;
     surface_data_dirty = true;
 }
 

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -344,17 +344,17 @@ auto mf::WindowWlSurfaceRole::current_size() const -> geom::Size
     return size;
 }
 
-std::experimental::optional<geom::Size> mf::WindowWlSurfaceRole::requested_window_size()
+auto mf::WindowWlSurfaceRole::requested_window_size() const -> std::experimental::optional<geom::Size>
 {
     return observer->requested_window_size();
 }
 
-auto mf::WindowWlSurfaceRole::window_state() -> MirWindowState
+auto mf::WindowWlSurfaceRole::window_state() const -> MirWindowState
 {
     return observer->state();
 }
 
-auto mf::WindowWlSurfaceRole::is_active() -> bool
+auto mf::WindowWlSurfaceRole::is_active() const -> bool
 {
     if (auto const scene_surface = weak_scene_surface.lock())
         return scene_surface->focus_state() == mir_window_focus_state_focused;
@@ -362,7 +362,7 @@ auto mf::WindowWlSurfaceRole::is_active() -> bool
         return false;
 }
 
-std::chrono::nanoseconds mf::WindowWlSurfaceRole::latest_timestamp()
+auto mf::WindowWlSurfaceRole::latest_timestamp() const -> std::chrono::nanoseconds
 {
     return observer->latest_timestamp();
 }

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -110,11 +110,11 @@ protected:
     auto current_size() const -> geometry::Size;
 
     /// Window size requested by Mir
-    std::experimental::optional<geometry::Size> requested_window_size();
+    auto requested_window_size() const -> std::experimental::optional<geometry::Size>;
 
-    auto window_state() -> MirWindowState;
-    auto is_active() -> bool;
-    auto latest_timestamp() -> std::chrono::nanoseconds;
+    auto window_state() const -> MirWindowState;
+    auto is_active() const -> bool;
+    auto latest_timestamp() const -> std::chrono::nanoseconds;
 
     void commit(WlSurfaceState const& state) override;
 

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -65,6 +65,10 @@ public:
         wl_resource* positioner,
         WlSurface* surface);
 
+    /// Used when the aux rect needs to be adjusted due to the parent logical Wayland surface not lining up with the
+    /// parent scene surface (as is the case for layer shell surfaces with a margin)
+    void set_aux_rect_offset_now(geometry::Displacement const& new_aux_rect_offset);
+
     void grab(struct wl_resource* seat, uint32_t serial) override;
     void destroy() override;
 
@@ -82,7 +86,10 @@ private:
     std::experimental::optional<geometry::Point> cached_top_left;
     std::experimental::optional<geometry::Size> cached_size;
 
+    std::shared_ptr<shell::Shell> const shell;
     XdgSurfaceStable* const xdg_surface;
+    geometry::Rectangle aux_rect;
+    geometry::Displacement aux_rect_offset;
 };
 
 }


### PR DESCRIPTION
The immediate reason to support margin is so MATE notifications look right. This implementation creates a large `scene::Surface` uses `WindowWlSurfaceRole::set_pending_offset()` to place the `WlSurface` in the correct position. Input dispatching just works (because that's already implemented for offset surfaces), but popups need further adjustment. It might be preferable to do this a different way (such as adding a margin surface property specifically for this use case?) or we might want to merge this and see what design makes sense after the surface/window abstraction split.

Extensive refactoring of the layer shell implementation was required. I also added some protocol errors that we weren't catching before (this will probably make it fail any version of WLCS before https://github.com/MirServer/wlcs/pull/181 lands).

FIxes #1719, tested by https://github.com/MirServer/wlcs/pull/181. I also manually tested with gtk-layer-demo.