### PR TITLE
Don't wait for Xwayland to init before starting WM

### DIFF
--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -71,13 +71,6 @@ void exec_xwayland(
     auto const x11_wm_server = std::to_string(x11_wm_server_fd);
     auto const dsp_str = spawner.x11_display();
 
-    // Propagate SIGUSR1 to parent process
-    struct sigaction action;
-    sigemptyset(&action.sa_mask);
-    action.sa_flags = 0;
-    action.sa_handler = SIG_IGN;
-    sigaction(SIGUSR1, &action, nullptr);
-
     std::vector<char const*> args =
         {
             xwayland_path.c_str(),
@@ -133,26 +126,6 @@ auto connect_xwayland_wl_client(
     std::shared_ptr<mf::WaylandConnector> const& wayland_connector,
     mir::Fd const& wayland_fd) -> wl_client*
 {
-    // We need to set up the signal handling before connecting wl_client_server_fd
-    static bool xserver_ready{ false };
-    static std::condition_variable cv;
-
-    // In practice, there ought to be no contention on xserver_ready, but let's be certain
-    static std::mutex xserver_ready_mutex;
-    std::unique_lock<decltype(xserver_ready_mutex)> lock{xserver_ready_mutex};
-    xserver_ready = false;
-
-    struct sigaction action;
-    struct sigaction old_action;
-    action.sa_handler = [](int) {
-        std::lock_guard<decltype(xserver_ready_mutex)> lock{xserver_ready_mutex};
-        xserver_ready = true;
-        cv.notify_all();
-    };
-    sigemptyset(&action.sa_mask);
-    action.sa_flags = 0;
-    sigaction(SIGUSR1, &action, &old_action);
-
     struct CreateClientContext
     {
         std::mutex mutex;
@@ -182,15 +155,6 @@ auto connect_xwayland_wl_client(
     if (!ctx->client)
     {
         BOOST_THROW_EXCEPTION(std::runtime_error("Failed to create XWayland wl_client"));
-    }
-
-    //The client can connect, now wait for it to signal ready (SIGUSR1)
-    auto const xwayland_startup_timed_out = !cv.wait_for(lock, 5s, [] { return xserver_ready; });
-    sigaction(SIGUSR1, &old_action, nullptr);
-
-    if (xwayland_startup_timed_out)
-    {
-        BOOST_THROW_EXCEPTION(std::runtime_error("XWayland server failed to start"));
     }
 
     return ctx->client;


### PR DESCRIPTION
Don't wait for Xwayland to init before starting WM. (Fixes: #1722)

There is a race between the X11 client connecting (which triggers launching Xwayland) and the WM connecting. Something about the confined environment makes it likely the client wins the race.

If the client wins the race, our WM never processes the client window and nothing gets displayed.

There's no need to wait on SIGUSR1 before starting the WM, it will block awaiting events anyway. And, empirically, not waiting for SIGUSR1 means the WM wins the race even in the confined environment.

(This PR doesn't actually resolve the race, just fixes the outcome.)
