### PR TITLE
Minor XWayland cleanup

### DIFF
--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -65,6 +65,11 @@ void mf::XWaylandConnector::start()
     {
         std::lock_guard<std::mutex> lock{mutex};
 
+        if (spawner)
+        {
+            return;
+        }
+
         spawner = std::make_unique<XWaylandSpawner>([this]() { spawn(); });
         mir::log_info("XWayland started on X11 display %s", spawner->x11_display().c_str());
     }

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -138,13 +138,15 @@ mf::XWaylandSurface::XWaylandSurface(
     WlSeat& seat,
     std::shared_ptr<shell::Shell> const& shell,
     std::shared_ptr<XWaylandClientManager> const& client_manager,
-    xcb_create_notify_event_t *event)
+    xcb_window_t window,
+    geometry::Rectangle const& geometry,
+    bool override_redirect)
     : xwm(wm),
       connection{connection},
       seat(seat),
       shell{shell},
       client_manager{client_manager},
-      window(event->window),
+      window(window),
       property_handlers{
           property_handler<std::string const&>(
               connection,
@@ -206,9 +208,9 @@ mf::XWaylandSurface::XWaylandSurface(
                   this->cached.supported_wm_protocols.clear();
               })}
 {
-    cached.override_redirect = event->override_redirect;
-    cached.size = {event->width, event->height};
-    cached.top_left = {event->x, event->y};
+    cached.top_left = geometry.top_left;
+    cached.size = geometry.size;
+    cached.override_redirect = override_redirect;
 
     uint32_t const value = XCB_EVENT_MASK_PROPERTY_CHANGE | XCB_EVENT_MASK_FOCUS_CHANGE;
     xcb_change_window_attributes(*connection, window, XCB_CW_EVENT_MASK, &value);

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -55,7 +55,9 @@ public:
         WlSeat& seat,
         std::shared_ptr<shell::Shell> const& shell,
         std::shared_ptr<XWaylandClientManager> const& client_manager,
-        xcb_create_notify_event_t *event);
+        xcb_window_t window,
+        geometry::Rectangle const& geometry,
+        bool override_redirect);
     ~XWaylandSurface();
 
     void map();

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -29,6 +29,7 @@
 #include "mir/fd.h"
 #include "mir/scene/null_observer.h"
 #include "mir/frontend/surface_stack.h"
+#include "mir/geometry/rectangle.h"
 
 #include <cstring>
 #include <poll.h>
@@ -38,6 +39,7 @@
 
 namespace mf = mir::frontend;
 namespace ms = mir::scene;
+namespace geom = mir::geometry;
 
 namespace
 {
@@ -571,7 +573,9 @@ void mf::XWaylandWM::handle_create_notify(xcb_create_notify_event_t *event)
             wm_shell->seat,
             wm_shell->shell,
             client_manager,
-            event);
+            event->window,
+            geom::Rectangle{{event->x, event->y}, {event->width, event->height}},
+            event->override_redirect);
 
         {
             std::lock_guard<std::mutex> lock{mutex};

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -216,7 +216,7 @@ void mf::XWaylandWM::handle_events()
                 logging::Severity::warning,
                 MIR_LOG_COMPONENT,
                 std::current_exception(),
-                "Failed to handle xcb event.");
+                "Error processing XCB event");
         }
         free(event);
         got_events = true;


### PR DESCRIPTION
Including not creating a spawner if it already exists and constructing `XWaylandSurface` with actual properties instead of an event pointer. Nothing super important, but cleans the boring commits out of my xwayland-master branch.