### PR TITLE
Manage X11 windows that existed before window manager started

### DIFF
--- a/src/include/common/mir/c_memory.h
+++ b/src/include/common/mir/c_memory.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#ifndef MIR_C_MEMORY_H
+#define MIR_C_MEMORY_H
+
+#include <memory>
+#include <stdlib.h>
+
+namespace mir
+{
+struct DeleteCPtr { template<typename T> void operator()(T* p) { ::free(p); }};
+
+template<typename T> using UniqueCPtr = std::unique_ptr<T, DeleteCPtr>;
+template<typename T> auto make_unique_cptr(T* p) { return UniqueCPtr<T>{p}; }
+}
+
+#endif  // MIR_C_MEMORY_H

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -29,7 +29,6 @@
 #include "mir/fd.h"
 #include "mir/scene/null_observer.h"
 #include "mir/frontend/surface_stack.h"
-#include "mir/geometry/rectangle.h"
 
 #include <cstring>
 #include <poll.h>
@@ -163,9 +162,67 @@ mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, 
         connection->_NET_ACTIVE_WINDOW,
         static_cast<xcb_window_t>(XCB_WINDOW_NONE));
 
+    connection->flush();
+
     cursors->apply_default_to(connection->root_window());
 
     wm_shell->surface_stack->add_observer(scene_observer);
+
+    // Detect and manage any windows that already exist
+    auto const query_tree_cookie = xcb_query_tree(*connection, connection->root_window());
+    auto const query_tree_reply = xcb_query_tree_reply(*connection, query_tree_cookie, nullptr);
+    if (query_tree_reply)
+    {
+        std::vector<std::function<void()>> window_setup_funcs;
+        for (int i = 0; i < xcb_query_tree_children_length(query_tree_reply); ++i)
+        {
+            xcb_window_t const window = xcb_query_tree_children(query_tree_reply)[i];
+            if (!connection->is_ours(window))
+            {
+                if (verbose_xwayland_logging_enabled())
+                {
+                    log_debug("Window %s already exists", connection->window_debug_string(window).c_str());
+                }
+
+                auto const geometry_cookie = xcb_get_geometry(*connection, window);
+                auto const attrs_cookie = xcb_get_window_attributes(*connection, window);
+                window_setup_funcs.push_back([this, window, geometry_cookie, attrs_cookie]()
+                    {
+                        auto const geometry_reply = xcb_get_geometry_reply(*connection, geometry_cookie, nullptr);
+                        auto const attrs_reply = xcb_get_window_attributes_reply(*connection, attrs_cookie, nullptr);
+
+                        if (geometry_reply && attrs_reply)
+                        {
+                            manage_window(
+                                window,
+                                geom::Rectangle{
+                                    {geometry_reply->x, geometry_reply->y},
+                                    {geometry_reply->width, geometry_reply->height}},
+                                attrs_reply->override_redirect);
+                        }
+                        else
+                        {
+                            log_warning(
+                                "Faild to load geometry and attributes for %s",
+                                connection->window_debug_string(window).c_str());
+                        }
+
+                        free(geometry_reply);
+                        free(attrs_reply);
+                    });
+            }
+        }
+
+        for (auto const& f : window_setup_funcs)
+        {
+            f();
+        }
+    }
+    else
+    {
+        log_warning("Failed to query initial windows");
+    }
+    free(query_tree_reply);
 }
 
 mf::XWaylandWM::~XWaylandWM()
@@ -385,6 +442,73 @@ void mf::XWaylandWM::restack_surfaces()
     connection->flush();
 }
 
+void mf::XWaylandWM::manage_window(xcb_window_t window, geom::Rectangle const& geometry, bool override_redirect)
+{
+    if (verbose_xwayland_logging_enabled())
+    {
+        auto const props_cookie = xcb_list_properties(*connection, window);
+        auto const props_reply = xcb_list_properties_reply(*connection, props_cookie, nullptr);
+        if (props_reply)
+        {
+            std::vector<std::function<void()>> functions;
+            int const prop_count = xcb_list_properties_atoms_length(props_reply);
+            for (int i = 0; i < prop_count; i++)
+            {
+                auto const atom = xcb_list_properties_atoms(props_reply)[i];
+
+                auto const log_prop = [this, atom](std::string const& value)
+                    {
+                        auto const prop_name = connection->query_name(atom);
+                        log_debug(
+                            "  | %s: %s",
+                            prop_name.c_str(),
+                            value.c_str());
+                    };
+
+                functions.push_back(connection->read_property(
+                    window,
+                    atom,
+                    [this, log_prop](xcb_get_property_reply_t* reply)
+                    {
+                        auto const reply_str = connection->reply_debug_string(reply);
+                        log_prop(reply_str);
+                    },
+                    [log_prop]()
+                    {
+                        log_prop("Error getting value");
+                    }));
+            }
+            free(props_reply);
+
+            log_debug("%s has %d initial propertie(s):", connection->window_debug_string(window).c_str(), prop_count);
+            for (auto const& f : functions)
+                f();
+        }
+        else
+        {
+            log_debug("%s's initial properties failed to load", connection->window_debug_string(window).c_str());
+        }
+    }
+
+    std::lock_guard<std::mutex> lock{mutex};
+
+    if (surfaces.find(window) != surfaces.end())
+    {
+        // If a window is created during startup, we may be double-notified of it
+        return;
+    }
+
+    surfaces[window] = std::make_shared<XWaylandSurface>(
+        this,
+        connection,
+        wm_shell->seat,
+        wm_shell->shell,
+        client_manager,
+        window,
+        geometry,
+        override_redirect);
+}
+
 void mf::XWaylandWM::handle_event(xcb_generic_event_t* event)
 {
     // see https://www.systutorials.com/docs/linux/man/3-xcb-requests/
@@ -520,72 +644,14 @@ void mf::XWaylandWM::handle_create_notify(xcb_create_notify_event_t *event)
 
         if (event->border_width)
             log_warning("border width unsupported (border width %d)", event->border_width);
-
-        auto const props_cookie = xcb_list_properties(*connection, event->window);
-        auto const props_reply = xcb_list_properties_reply(*connection, props_cookie, nullptr);
-        if (props_reply)
-        {
-            std::vector<std::function<void()>> functions;
-            int const prop_count = xcb_list_properties_atoms_length(props_reply);
-            for (int i = 0; i < prop_count; i++)
-            {
-                auto const atom = xcb_list_properties_atoms(props_reply)[i];
-
-                auto const log_prop = [this, atom](std::string const& value)
-                    {
-                        auto const prop_name = connection->query_name(atom);
-                        log_debug(
-                            "                  | %s: %s",
-                            prop_name.c_str(),
-                            value.c_str());
-                    };
-
-                functions.push_back(connection->read_property(
-                    event->window,
-                    atom,
-                    [this, log_prop](xcb_get_property_reply_t* reply)
-                    {
-                        auto const reply_str = connection->reply_debug_string(reply);
-                        log_prop(reply_str);
-                    },
-                    [log_prop]()
-                    {
-                        log_prop("Error getting value");
-                    }));
-            }
-            free(props_reply);
-
-            log_debug("                  initial properties: %d", prop_count);
-            for (auto const& f : functions)
-                f();
-        }
-        else
-        {
-            log_debug("                  initial properties: failed to load");
-        }
     }
 
     if (!connection->is_ours(event->window))
     {
-        auto const surface = std::make_shared<XWaylandSurface>(
-            this,
-            connection,
-            wm_shell->seat,
-            wm_shell->shell,
-            client_manager,
+        manage_window(
             event->window,
             geom::Rectangle{{event->x, event->y}, {event->width, event->height}},
             event->override_redirect);
-
-        {
-            std::lock_guard<std::mutex> lock{mutex};
-
-            if (surfaces.find(event->window) != surfaces.end())
-                BOOST_THROW_EXCEPTION(
-                    std::runtime_error("X11 window " + std::to_string(event->window) + " created, but already known"));
-
-            surfaces[event->window] = surface;
-        }
     }
 }
 

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -26,9 +26,10 @@
 #include "xwayland_cursors.h"
 #include "xwayland_client_manager.h"
 
+#include "mir/c_memory.h"
 #include "mir/fd.h"
-#include "mir/scene/null_observer.h"
 #include "mir/frontend/surface_stack.h"
+#include "mir/scene/null_observer.h"
 
 #include <cstring>
 #include <poll.h>
@@ -170,8 +171,7 @@ mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, 
 
     // Detect and manage any windows that already exist
     auto const query_tree_cookie = xcb_query_tree(*connection, connection->root_window());
-    std::unique_ptr<xcb_query_tree_reply_t> query_tree_reply{
-        xcb_query_tree_reply(*connection, query_tree_cookie, nullptr)};
+    auto const query_tree_reply = make_unique_cptr(xcb_query_tree_reply(*connection, query_tree_cookie, nullptr));
     if (query_tree_reply)
     {
         std::vector<std::function<void()>> window_setup_funcs;
@@ -189,10 +189,8 @@ mf::XWaylandWM::XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, 
                 auto const attrs_cookie = xcb_get_window_attributes(*connection, window);
                 window_setup_funcs.push_back([this, window, geometry_cookie, attrs_cookie]()
                     {
-                        std::unique_ptr<xcb_get_geometry_reply_t> geometry_reply{
-                            xcb_get_geometry_reply(*connection, geometry_cookie, nullptr)};
-                        std::unique_ptr<xcb_get_window_attributes_reply_t> attrs_reply{
-                            xcb_get_window_attributes_reply(*connection, attrs_cookie, nullptr)};
+                        auto const geometry_reply = make_unique_cptr(xcb_get_geometry_reply(*connection, geometry_cookie, nullptr));
+                        auto const attrs_reply = make_unique_cptr(xcb_get_window_attributes_reply(*connection, attrs_cookie, nullptr));
 
                         if (geometry_reply && attrs_reply)
                         {

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -20,6 +20,7 @@
 #define MIR_FRONTEND_XWAYLAND_WM_H
 
 #include "mir/dispatch/threaded_dispatcher.h"
+#include "mir/geometry/rectangle.h"
 #include "wayland_connector.h"
 #include "xcb_connection.h"
 
@@ -75,6 +76,10 @@ private:
     XWaylandWM& operator=(XWaylandWM const&) = delete;
 
     void restack_surfaces();
+
+    /// Called for all windows at startup and whenever a window is created
+    /// May occasionally be called multiple times for the same window
+    void manage_window(xcb_window_t window, geometry::Rectangle const& geometry, bool override_redirect);
 
     void handle_event(xcb_generic_event_t* event);
     void handle_create_notify(xcb_create_notify_event_t *event);


### PR DESCRIPTION
Related to #1722 and #1723. It's a lot of code because XCB is messy, but all it's doing is going through the list of windows, getting their properties and setting up a `XWaylandSurface` for them the same way we do on newly created windows. This alone is not enough to fix the race condition because we don't get the `WL_SURFACE_ID` client message. See next PR for fixing that.