### PR TITLE
Create event dispatcher before running server

### DIFF
--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -133,15 +133,19 @@ void mf::XWaylandConnector::spawn()
 
     try
     {
+        auto const wayland_socket_pair = XWaylandServer::make_socket_pair();
+        auto const x11_socket_pair = XWaylandServer::make_socket_pair();
         server = std::make_unique<XWaylandServer>(
             wayland_connector,
             *spawner,
-            xwayland_path);
+            xwayland_path,
+            wayland_socket_pair,
+            x11_socket_pair.second);
         wm = std::make_unique<XWaylandWM>(
             wayland_connector,
             server->client(),
-            server->wm_fd());
-        auto const wm_dispatcher = std::make_shared<md::ReadableFd>(server->wm_fd(), [this]()
+            x11_socket_pair.first);
+        auto const wm_dispatcher = std::make_shared<md::ReadableFd>(x11_socket_pair.first, [this]()
             {
                 std::lock_guard<std::mutex> lock{mutex};
                 if (wm)

--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -135,16 +135,6 @@ void mf::XWaylandConnector::spawn()
     {
         auto const wayland_socket_pair = XWaylandServer::make_socket_pair();
         auto const x11_socket_pair = XWaylandServer::make_socket_pair();
-        server = std::make_unique<XWaylandServer>(
-            wayland_connector,
-            *spawner,
-            xwayland_path,
-            wayland_socket_pair,
-            x11_socket_pair.second);
-        wm = std::make_unique<XWaylandWM>(
-            wayland_connector,
-            server->client(),
-            x11_socket_pair.first);
         auto const wm_dispatcher = std::make_shared<md::ReadableFd>(x11_socket_pair.first, [this]()
             {
                 std::lock_guard<std::mutex> lock{mutex};
@@ -181,6 +171,16 @@ void mf::XWaylandConnector::spawn()
                 // We can't destroy a ThreadedDispatcher from inside a call it made, so do it from another thread
                 std::thread{[&](){ local_wm_event_thread.reset(); }}.join();
             });
+        server = std::make_unique<XWaylandServer>(
+            wayland_connector,
+            *spawner,
+            xwayland_path,
+            wayland_socket_pair,
+            x11_socket_pair.second);
+        wm = std::make_unique<XWaylandWM>(
+            wayland_connector,
+            server->client(),
+            x11_socket_pair.first);
         mir::log_info("XWayland is running");
     }
     catch (...)

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -41,25 +41,23 @@ public:
     XWaylandServer(
         std::shared_ptr<WaylandConnector> const& wayland_connector,
         XWaylandSpawner const& spawner,
-        std::string const& xwayland_path);
+        std::string const& xwayland_path,
+        std::pair<mir::Fd, mir::Fd> const& wayland_socket_pair,
+        mir::Fd const& x11_server_fd);
     ~XWaylandServer();
 
     auto client() const -> wl_client* { return wayland_client; }
-    auto wm_fd() const -> Fd const& { return xwayland_process.x11_wm_client_fd; }
     auto is_running() const -> bool;
 
-    struct XWaylandProcess
-    {
-        pid_t pid;
-        Fd wayland_server_fd;
-        Fd x11_wm_client_fd;
-    };
+    // Returns a symmetrical pair of connected sockets
+    static auto make_socket_pair() -> std::pair<mir::Fd, mir::Fd>;
 
 private:
     XWaylandServer(XWaylandServer const&) = delete;
     XWaylandServer& operator=(XWaylandServer const&) = delete;
 
-    XWaylandProcess const xwayland_process;
+    pid_t const xwayland_pid;
+    mir::Fd const wayland_server_fd;
     wl_client* const wayland_client{nullptr};
 
     mutable std::mutex mutex;


### PR DESCRIPTION
Related to #1722 and #1723. In combination with #1725, I think this fixes the race condition (though I haven't tested in a confined snap yet). This moves socket pair creation out of the `XWaylandServer` constructor, and creates the event dispatcher before creating the window manager or spawning the server. Because `XWaylandConnector`'s mutex is locked, any events will be blocked on the window manager being created and wont be dropped.