### PR TITLE
Safer wayland::Foo::from(wl_resource*)

### DIFF
--- a/src/wayland/generated/wayland_wrapper.cpp
+++ b/src/wayland/generated/wayland_wrapper.cpp
@@ -56,11 +56,6 @@ struct wl_interface const* all_null_types [] {
 
 // Callback
 
-mw::Callback* mw::Callback::from(struct wl_resource* resource)
-{
-    return static_cast<Callback*>(wl_resource_get_user_data(resource));
-}
-
 struct mw::Callback::Thunks
 {
     static int const supported_version;
@@ -97,12 +92,13 @@ void mw::Callback::destroy_wayland_object() const
 struct wl_message const mw::Callback::Thunks::event_messages[] {
     {"done", "u", all_null_types}};
 
-// Compositor
-
-mw::Compositor* mw::Compositor::from(struct wl_resource* resource)
+mw::Callback* mw::Callback::from(struct wl_resource* resource)
 {
-    return static_cast<Compositor*>(wl_resource_get_user_data(resource));
+    // WARNING: This is potentially unsafe; there is no guarantee that resource is a Callback
+    return static_cast<Callback*>(wl_resource_get_user_data(resource));
 }
+
+// Compositor
 
 struct mw::Compositor::Thunks
 {
@@ -248,12 +244,16 @@ void const* mw::Compositor::Thunks::request_vtable[] {
     (void*)Thunks::create_surface_thunk,
     (void*)Thunks::create_region_thunk};
 
-// ShmPool
-
-mw::ShmPool* mw::ShmPool::from(struct wl_resource* resource)
+mw::Compositor* mw::Compositor::from(struct wl_resource* resource)
 {
-    return static_cast<ShmPool*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_compositor_interface_data, Compositor::Thunks::request_vtable))
+    {
+        return static_cast<Compositor*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// ShmPool
 
 struct mw::ShmPool::Thunks
 {
@@ -373,12 +373,16 @@ void const* mw::ShmPool::Thunks::request_vtable[] {
     (void*)Thunks::destroy_thunk,
     (void*)Thunks::resize_thunk};
 
-// Shm
-
-mw::Shm* mw::Shm::from(struct wl_resource* resource)
+mw::ShmPool* mw::ShmPool::from(struct wl_resource* resource)
 {
-    return static_cast<Shm*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_shm_pool_interface_data, ShmPool::Thunks::request_vtable))
+    {
+        return static_cast<ShmPool*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// Shm
 
 struct mw::Shm::Thunks
 {
@@ -506,12 +510,16 @@ struct wl_message const mw::Shm::Thunks::event_messages[] {
 void const* mw::Shm::Thunks::request_vtable[] {
     (void*)Thunks::create_pool_thunk};
 
-// Buffer
-
-mw::Buffer* mw::Buffer::from(struct wl_resource* resource)
+mw::Shm* mw::Shm::from(struct wl_resource* resource)
 {
-    return static_cast<Buffer*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_shm_interface_data, Shm::Thunks::request_vtable))
+    {
+        return static_cast<Shm*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// Buffer
 
 struct mw::Buffer::Thunks
 {
@@ -586,12 +594,16 @@ struct wl_message const mw::Buffer::Thunks::event_messages[] {
 void const* mw::Buffer::Thunks::request_vtable[] {
     (void*)Thunks::destroy_thunk};
 
-// DataOffer
-
-mw::DataOffer* mw::DataOffer::from(struct wl_resource* resource)
+mw::Buffer* mw::Buffer::from(struct wl_resource* resource)
 {
-    return static_cast<DataOffer*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_buffer_interface_data, Buffer::Thunks::request_vtable))
+    {
+        return static_cast<Buffer*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// DataOffer
 
 struct mw::DataOffer::Thunks
 {
@@ -771,12 +783,16 @@ void const* mw::DataOffer::Thunks::request_vtable[] {
     (void*)Thunks::finish_thunk,
     (void*)Thunks::set_actions_thunk};
 
-// DataSource
-
-mw::DataSource* mw::DataSource::from(struct wl_resource* resource)
+mw::DataOffer* mw::DataOffer::from(struct wl_resource* resource)
 {
-    return static_cast<DataSource*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_data_offer_interface_data, DataOffer::Thunks::request_vtable))
+    {
+        return static_cast<DataOffer*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// DataSource
 
 struct mw::DataSource::Thunks
 {
@@ -941,12 +957,16 @@ void const* mw::DataSource::Thunks::request_vtable[] {
     (void*)Thunks::destroy_thunk,
     (void*)Thunks::set_actions_thunk};
 
-// DataDevice
-
-mw::DataDevice* mw::DataDevice::from(struct wl_resource* resource)
+mw::DataSource* mw::DataSource::from(struct wl_resource* resource)
 {
-    return static_cast<DataDevice*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_data_source_interface_data, DataSource::Thunks::request_vtable))
+    {
+        return static_cast<DataSource*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// DataDevice
 
 struct mw::DataDevice::Thunks
 {
@@ -1146,12 +1166,16 @@ void const* mw::DataDevice::Thunks::request_vtable[] {
     (void*)Thunks::set_selection_thunk,
     (void*)Thunks::release_thunk};
 
-// DataDeviceManager
-
-mw::DataDeviceManager* mw::DataDeviceManager::from(struct wl_resource* resource)
+mw::DataDevice* mw::DataDevice::from(struct wl_resource* resource)
 {
-    return static_cast<DataDeviceManager*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_data_device_interface_data, DataDevice::Thunks::request_vtable))
+    {
+        return static_cast<DataDevice*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// DataDeviceManager
 
 struct mw::DataDeviceManager::Thunks
 {
@@ -1298,12 +1322,16 @@ void const* mw::DataDeviceManager::Thunks::request_vtable[] {
     (void*)Thunks::create_data_source_thunk,
     (void*)Thunks::get_data_device_thunk};
 
-// Shell
-
-mw::Shell* mw::Shell::from(struct wl_resource* resource)
+mw::DataDeviceManager* mw::DataDeviceManager::from(struct wl_resource* resource)
 {
-    return static_cast<Shell*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_data_device_manager_interface_data, DataDeviceManager::Thunks::request_vtable))
+    {
+        return static_cast<DataDeviceManager*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// Shell
 
 struct mw::Shell::Thunks
 {
@@ -1420,12 +1448,16 @@ struct wl_message const mw::Shell::Thunks::request_messages[] {
 void const* mw::Shell::Thunks::request_vtable[] {
     (void*)Thunks::get_shell_surface_thunk};
 
-// ShellSurface
-
-mw::ShellSurface* mw::ShellSurface::from(struct wl_resource* resource)
+mw::Shell* mw::Shell::from(struct wl_resource* resource)
 {
-    return static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_shell_interface_data, Shell::Thunks::request_vtable))
+    {
+        return static_cast<Shell*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// ShellSurface
 
 struct mw::ShellSurface::Thunks
 {
@@ -1730,12 +1762,16 @@ void const* mw::ShellSurface::Thunks::request_vtable[] {
     (void*)Thunks::set_title_thunk,
     (void*)Thunks::set_class_thunk};
 
-// Surface
-
-mw::Surface* mw::Surface::from(struct wl_resource* resource)
+mw::ShellSurface* mw::ShellSurface::from(struct wl_resource* resource)
 {
-    return static_cast<Surface*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_shell_surface_interface_data, ShellSurface::Thunks::request_vtable))
+    {
+        return static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// Surface
 
 struct mw::Surface::Thunks
 {
@@ -2035,12 +2071,16 @@ void const* mw::Surface::Thunks::request_vtable[] {
     (void*)Thunks::set_buffer_scale_thunk,
     (void*)Thunks::damage_buffer_thunk};
 
-// Seat
-
-mw::Seat* mw::Seat::from(struct wl_resource* resource)
+mw::Surface* mw::Surface::from(struct wl_resource* resource)
 {
-    return static_cast<Seat*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_surface_interface_data, Surface::Thunks::request_vtable))
+    {
+        return static_cast<Surface*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// Seat
 
 struct mw::Seat::Thunks
 {
@@ -2256,12 +2296,16 @@ void const* mw::Seat::Thunks::request_vtable[] {
     (void*)Thunks::get_touch_thunk,
     (void*)Thunks::release_thunk};
 
-// Pointer
-
-mw::Pointer* mw::Pointer::from(struct wl_resource* resource)
+mw::Seat* mw::Seat::from(struct wl_resource* resource)
 {
-    return static_cast<Pointer*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_seat_interface_data, Seat::Thunks::request_vtable))
+    {
+        return static_cast<Seat*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// Pointer
 
 struct mw::Pointer::Thunks
 {
@@ -2452,12 +2496,16 @@ void const* mw::Pointer::Thunks::request_vtable[] {
     (void*)Thunks::set_cursor_thunk,
     (void*)Thunks::release_thunk};
 
-// Keyboard
-
-mw::Keyboard* mw::Keyboard::from(struct wl_resource* resource)
+mw::Pointer* mw::Pointer::from(struct wl_resource* resource)
 {
-    return static_cast<Keyboard*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_pointer_interface_data, Pointer::Thunks::request_vtable))
+    {
+        return static_cast<Pointer*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// Keyboard
 
 struct mw::Keyboard::Thunks
 {
@@ -2579,12 +2627,16 @@ struct wl_message const mw::Keyboard::Thunks::event_messages[] {
 void const* mw::Keyboard::Thunks::request_vtable[] {
     (void*)Thunks::release_thunk};
 
-// Touch
-
-mw::Touch* mw::Touch::from(struct wl_resource* resource)
+mw::Keyboard* mw::Keyboard::from(struct wl_resource* resource)
 {
-    return static_cast<Touch*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_keyboard_interface_data, Keyboard::Thunks::request_vtable))
+    {
+        return static_cast<Keyboard*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// Touch
 
 struct mw::Touch::Thunks
 {
@@ -2721,12 +2773,16 @@ struct wl_message const mw::Touch::Thunks::event_messages[] {
 void const* mw::Touch::Thunks::request_vtable[] {
     (void*)Thunks::release_thunk};
 
-// Output
-
-mw::Output* mw::Output::from(struct wl_resource* resource)
+mw::Touch* mw::Touch::from(struct wl_resource* resource)
 {
-    return static_cast<Output*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_touch_interface_data, Touch::Thunks::request_vtable))
+    {
+        return static_cast<Touch*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// Output
 
 struct mw::Output::Thunks
 {
@@ -2881,12 +2937,16 @@ struct wl_message const mw::Output::Thunks::event_messages[] {
 void const* mw::Output::Thunks::request_vtable[] {
     (void*)Thunks::release_thunk};
 
-// Region
-
-mw::Region* mw::Region::from(struct wl_resource* resource)
+mw::Output* mw::Output::from(struct wl_resource* resource)
 {
-    return static_cast<Region*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_output_interface_data, Output::Thunks::request_vtable))
+    {
+        return static_cast<Output*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// Region
 
 struct mw::Region::Thunks
 {
@@ -2990,12 +3050,16 @@ void const* mw::Region::Thunks::request_vtable[] {
     (void*)Thunks::add_thunk,
     (void*)Thunks::subtract_thunk};
 
-// Subcompositor
-
-mw::Subcompositor* mw::Subcompositor::from(struct wl_resource* resource)
+mw::Region* mw::Region::from(struct wl_resource* resource)
 {
-    return static_cast<Subcompositor*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_region_interface_data, Region::Thunks::request_vtable))
+    {
+        return static_cast<Region*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// Subcompositor
 
 struct mw::Subcompositor::Thunks
 {
@@ -3132,12 +3196,16 @@ void const* mw::Subcompositor::Thunks::request_vtable[] {
     (void*)Thunks::destroy_thunk,
     (void*)Thunks::get_subsurface_thunk};
 
-// Subsurface
-
-mw::Subsurface* mw::Subsurface::from(struct wl_resource* resource)
+mw::Subcompositor* mw::Subcompositor::from(struct wl_resource* resource)
 {
-    return static_cast<Subsurface*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &wl_subcompositor_interface_data, Subcompositor::Thunks::request_vtable))
+    {
+        return static_cast<Subcompositor*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// Subsurface
 
 struct mw::Subsurface::Thunks
 {
@@ -3305,6 +3373,15 @@ void const* mw::Subsurface::Thunks::request_vtable[] {
     (void*)Thunks::place_below_thunk,
     (void*)Thunks::set_sync_thunk,
     (void*)Thunks::set_desync_thunk};
+
+mw::Subsurface* mw::Subsurface::from(struct wl_resource* resource)
+{
+    if (wl_resource_instance_of(resource, &wl_subsurface_interface_data, Subsurface::Thunks::request_vtable))
+    {
+        return static_cast<Subsurface*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
+}
 
 namespace mir
 {

--- a/src/wayland/generated/wlr-foreign-toplevel-management-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-foreign-toplevel-management-unstable-v1_wrapper.cpp
@@ -41,11 +41,6 @@ struct wl_interface const* all_null_types [] {
 
 // ForeignToplevelManagerV1
 
-mw::ForeignToplevelManagerV1* mw::ForeignToplevelManagerV1::from(struct wl_resource* resource)
-{
-    return static_cast<ForeignToplevelManagerV1*>(wl_resource_get_user_data(resource));
-}
-
 struct mw::ForeignToplevelManagerV1::Thunks
 {
     static int const supported_version;
@@ -168,12 +163,16 @@ struct wl_message const mw::ForeignToplevelManagerV1::Thunks::event_messages[] {
 void const* mw::ForeignToplevelManagerV1::Thunks::request_vtable[] {
     (void*)Thunks::stop_thunk};
 
-// ForeignToplevelHandleV1
-
-mw::ForeignToplevelHandleV1* mw::ForeignToplevelHandleV1::from(struct wl_resource* resource)
+mw::ForeignToplevelManagerV1* mw::ForeignToplevelManagerV1::from(struct wl_resource* resource)
 {
-    return static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &zwlr_foreign_toplevel_manager_v1_interface_data, ForeignToplevelManagerV1::Thunks::request_vtable))
+    {
+        return static_cast<ForeignToplevelManagerV1*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// ForeignToplevelHandleV1
 
 struct mw::ForeignToplevelHandleV1::Thunks
 {
@@ -485,6 +484,15 @@ void const* mw::ForeignToplevelHandleV1::Thunks::request_vtable[] {
     (void*)Thunks::destroy_thunk,
     (void*)Thunks::set_fullscreen_thunk,
     (void*)Thunks::unset_fullscreen_thunk};
+
+mw::ForeignToplevelHandleV1* mw::ForeignToplevelHandleV1::from(struct wl_resource* resource)
+{
+    if (wl_resource_instance_of(resource, &zwlr_foreign_toplevel_handle_v1_interface_data, ForeignToplevelHandleV1::Thunks::request_vtable))
+    {
+        return static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
+}
 
 namespace mir
 {

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
@@ -41,11 +41,6 @@ struct wl_interface const* all_null_types [] {
 
 // LayerShellV1
 
-mw::LayerShellV1* mw::LayerShellV1::from(struct wl_resource* resource)
-{
-    return static_cast<LayerShellV1*>(wl_resource_get_user_data(resource));
-}
-
 struct mw::LayerShellV1::Thunks
 {
     static int const supported_version;
@@ -188,12 +183,16 @@ void const* mw::LayerShellV1::Thunks::request_vtable[] {
     (void*)Thunks::get_layer_surface_thunk,
     (void*)Thunks::destroy_thunk};
 
-// LayerSurfaceV1
-
-mw::LayerSurfaceV1* mw::LayerSurfaceV1::from(struct wl_resource* resource)
+mw::LayerShellV1* mw::LayerShellV1::from(struct wl_resource* resource)
 {
-    return static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &zwlr_layer_shell_v1_interface_data, LayerShellV1::Thunks::request_vtable))
+    {
+        return static_cast<LayerShellV1*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// LayerSurfaceV1
 
 struct mw::LayerSurfaceV1::Thunks
 {
@@ -429,6 +428,15 @@ void const* mw::LayerSurfaceV1::Thunks::request_vtable[] {
     (void*)Thunks::ack_configure_thunk,
     (void*)Thunks::destroy_thunk,
     (void*)Thunks::set_layer_thunk};
+
+mw::LayerSurfaceV1* mw::LayerSurfaceV1::from(struct wl_resource* resource)
+{
+    if (wl_resource_instance_of(resource, &zwlr_layer_surface_v1_interface_data, LayerSurfaceV1::Thunks::request_vtable))
+    {
+        return static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
+}
 
 namespace mir
 {

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
@@ -39,11 +39,6 @@ struct wl_interface const* all_null_types [] {
 
 // XdgOutputManagerV1
 
-mw::XdgOutputManagerV1* mw::XdgOutputManagerV1::from(struct wl_resource* resource)
-{
-    return static_cast<XdgOutputManagerV1*>(wl_resource_get_user_data(resource));
-}
-
 struct mw::XdgOutputManagerV1::Thunks
 {
     static int const supported_version;
@@ -178,12 +173,16 @@ void const* mw::XdgOutputManagerV1::Thunks::request_vtable[] {
     (void*)Thunks::destroy_thunk,
     (void*)Thunks::get_xdg_output_thunk};
 
-// XdgOutputV1
-
-mw::XdgOutputV1* mw::XdgOutputV1::from(struct wl_resource* resource)
+mw::XdgOutputManagerV1* mw::XdgOutputManagerV1::from(struct wl_resource* resource)
 {
-    return static_cast<XdgOutputV1*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &zxdg_output_manager_v1_interface_data, XdgOutputManagerV1::Thunks::request_vtable))
+    {
+        return static_cast<XdgOutputManagerV1*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// XdgOutputV1
 
 struct mw::XdgOutputV1::Thunks
 {
@@ -293,6 +292,15 @@ struct wl_message const mw::XdgOutputV1::Thunks::event_messages[] {
 
 void const* mw::XdgOutputV1::Thunks::request_vtable[] {
     (void*)Thunks::destroy_thunk};
+
+mw::XdgOutputV1* mw::XdgOutputV1::from(struct wl_resource* resource)
+{
+    if (wl_resource_instance_of(resource, &zxdg_output_v1_interface_data, XdgOutputV1::Thunks::request_vtable))
+    {
+        return static_cast<XdgOutputV1*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
+}
 
 namespace mir
 {

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
@@ -44,11 +44,6 @@ struct wl_interface const* all_null_types [] {
 
 // XdgShellV6
 
-mw::XdgShellV6* mw::XdgShellV6::from(struct wl_resource* resource)
-{
-    return static_cast<XdgShellV6*>(wl_resource_get_user_data(resource));
-}
-
 struct mw::XdgShellV6::Thunks
 {
     static int const supported_version;
@@ -241,12 +236,16 @@ void const* mw::XdgShellV6::Thunks::request_vtable[] {
     (void*)Thunks::get_xdg_surface_thunk,
     (void*)Thunks::pong_thunk};
 
-// XdgPositionerV6
-
-mw::XdgPositionerV6* mw::XdgPositionerV6::from(struct wl_resource* resource)
+mw::XdgShellV6* mw::XdgShellV6::from(struct wl_resource* resource)
 {
-    return static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &zxdg_shell_v6_interface_data, XdgShellV6::Thunks::request_vtable))
+    {
+        return static_cast<XdgShellV6*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// XdgPositionerV6
 
 struct mw::XdgPositionerV6::Thunks
 {
@@ -426,12 +425,16 @@ void const* mw::XdgPositionerV6::Thunks::request_vtable[] {
     (void*)Thunks::set_constraint_adjustment_thunk,
     (void*)Thunks::set_offset_thunk};
 
-// XdgSurfaceV6
-
-mw::XdgSurfaceV6* mw::XdgSurfaceV6::from(struct wl_resource* resource)
+mw::XdgPositionerV6* mw::XdgPositionerV6::from(struct wl_resource* resource)
 {
-    return static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &zxdg_positioner_v6_interface_data, XdgPositionerV6::Thunks::request_vtable))
+    {
+        return static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// XdgSurfaceV6
 
 struct mw::XdgSurfaceV6::Thunks
 {
@@ -606,12 +609,16 @@ void const* mw::XdgSurfaceV6::Thunks::request_vtable[] {
     (void*)Thunks::set_window_geometry_thunk,
     (void*)Thunks::ack_configure_thunk};
 
-// XdgToplevelV6
-
-mw::XdgToplevelV6* mw::XdgToplevelV6::from(struct wl_resource* resource)
+mw::XdgSurfaceV6* mw::XdgSurfaceV6::from(struct wl_resource* resource)
 {
-    return static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &zxdg_surface_v6_interface_data, XdgSurfaceV6::Thunks::request_vtable))
+    {
+        return static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// XdgToplevelV6
 
 struct mw::XdgToplevelV6::Thunks
 {
@@ -975,12 +982,16 @@ void const* mw::XdgToplevelV6::Thunks::request_vtable[] {
     (void*)Thunks::unset_fullscreen_thunk,
     (void*)Thunks::set_minimized_thunk};
 
-// XdgPopupV6
-
-mw::XdgPopupV6* mw::XdgPopupV6::from(struct wl_resource* resource)
+mw::XdgToplevelV6* mw::XdgToplevelV6::from(struct wl_resource* resource)
 {
-    return static_cast<XdgPopupV6*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &zxdg_toplevel_v6_interface_data, XdgToplevelV6::Thunks::request_vtable))
+    {
+        return static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// XdgPopupV6
 
 struct mw::XdgPopupV6::Thunks
 {
@@ -1084,6 +1095,15 @@ struct wl_message const mw::XdgPopupV6::Thunks::event_messages[] {
 void const* mw::XdgPopupV6::Thunks::request_vtable[] {
     (void*)Thunks::destroy_thunk,
     (void*)Thunks::grab_thunk};
+
+mw::XdgPopupV6* mw::XdgPopupV6::from(struct wl_resource* resource)
+{
+    if (wl_resource_instance_of(resource, &zxdg_popup_v6_interface_data, XdgPopupV6::Thunks::request_vtable))
+    {
+        return static_cast<XdgPopupV6*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
+}
 
 namespace mir
 {

--- a/src/wayland/generated/xdg-shell_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell_wrapper.cpp
@@ -44,11 +44,6 @@ struct wl_interface const* all_null_types [] {
 
 // XdgWmBase
 
-mw::XdgWmBase* mw::XdgWmBase::from(struct wl_resource* resource)
-{
-    return static_cast<XdgWmBase*>(wl_resource_get_user_data(resource));
-}
-
 struct mw::XdgWmBase::Thunks
 {
     static int const supported_version;
@@ -241,12 +236,16 @@ void const* mw::XdgWmBase::Thunks::request_vtable[] {
     (void*)Thunks::get_xdg_surface_thunk,
     (void*)Thunks::pong_thunk};
 
-// XdgPositioner
-
-mw::XdgPositioner* mw::XdgPositioner::from(struct wl_resource* resource)
+mw::XdgWmBase* mw::XdgWmBase::from(struct wl_resource* resource)
 {
-    return static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &xdg_wm_base_interface_data, XdgWmBase::Thunks::request_vtable))
+    {
+        return static_cast<XdgWmBase*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// XdgPositioner
 
 struct mw::XdgPositioner::Thunks
 {
@@ -426,12 +425,16 @@ void const* mw::XdgPositioner::Thunks::request_vtable[] {
     (void*)Thunks::set_constraint_adjustment_thunk,
     (void*)Thunks::set_offset_thunk};
 
-// XdgSurface
-
-mw::XdgSurface* mw::XdgSurface::from(struct wl_resource* resource)
+mw::XdgPositioner* mw::XdgPositioner::from(struct wl_resource* resource)
 {
-    return static_cast<XdgSurface*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &xdg_positioner_interface_data, XdgPositioner::Thunks::request_vtable))
+    {
+        return static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// XdgSurface
 
 struct mw::XdgSurface::Thunks
 {
@@ -611,12 +614,16 @@ void const* mw::XdgSurface::Thunks::request_vtable[] {
     (void*)Thunks::set_window_geometry_thunk,
     (void*)Thunks::ack_configure_thunk};
 
-// XdgToplevel
-
-mw::XdgToplevel* mw::XdgToplevel::from(struct wl_resource* resource)
+mw::XdgSurface* mw::XdgSurface::from(struct wl_resource* resource)
 {
-    return static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &xdg_surface_interface_data, XdgSurface::Thunks::request_vtable))
+    {
+        return static_cast<XdgSurface*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// XdgToplevel
 
 struct mw::XdgToplevel::Thunks
 {
@@ -980,12 +987,16 @@ void const* mw::XdgToplevel::Thunks::request_vtable[] {
     (void*)Thunks::unset_fullscreen_thunk,
     (void*)Thunks::set_minimized_thunk};
 
-// XdgPopup
-
-mw::XdgPopup* mw::XdgPopup::from(struct wl_resource* resource)
+mw::XdgToplevel* mw::XdgToplevel::from(struct wl_resource* resource)
 {
-    return static_cast<XdgPopup*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &xdg_toplevel_interface_data, XdgToplevel::Thunks::request_vtable))
+    {
+        return static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// XdgPopup
 
 struct mw::XdgPopup::Thunks
 {
@@ -1089,6 +1100,15 @@ struct wl_message const mw::XdgPopup::Thunks::event_messages[] {
 void const* mw::XdgPopup::Thunks::request_vtable[] {
     (void*)Thunks::destroy_thunk,
     (void*)Thunks::grab_thunk};
+
+mw::XdgPopup* mw::XdgPopup::from(struct wl_resource* resource)
+{
+    if (wl_resource_instance_of(resource, &xdg_popup_interface_data, XdgPopup::Thunks::request_vtable))
+    {
+        return static_cast<XdgPopup*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
+}
 
 namespace mir
 {

--- a/src/wayland/generator/interface.cpp
+++ b/src/wayland/generator/interface.cpp
@@ -124,12 +124,6 @@ Emitter Interface::implementation() const
         {"// ", generated_name},
         empty_line,
         EmptyLineList{
-            Lines{
-                {"mw::", generated_name, "* ", nmspace, "from(struct wl_resource* resource)"},
-                Block{
-                    {"return static_cast<", generated_name, "*>(wl_resource_get_user_data(resource));"}
-                }
-            },
             thunks_impl(),
             constructor_impl(),
             destructor_impl(),
@@ -143,7 +137,23 @@ Emitter Interface::implementation() const
             },
             (global ? global.value().implementation() : nullptr),
             types_init(),
-        }
+            Lines{
+                {"mw::", generated_name, "* ", nmspace, "from(struct wl_resource* resource)"},
+                Block{
+                    (has_vtable ?
+                        Lines{
+                            {"if (wl_resource_instance_of(resource, &", wl_name, "_interface_data, ", generated_name, "::Thunks::request_vtable))"},
+                            Block{
+                                {"return static_cast<", generated_name, "*>(wl_resource_get_user_data(resource));"}
+                            },
+                            {"return nullptr;"}}
+                        : Lines{
+                            {"// WARNING: This is potentially unsafe; there is no guarantee that resource is a ", generated_name},
+                            {"return static_cast<", generated_name, "*>(wl_resource_get_user_data(resource));"}
+                        }),
+                    }
+                }
+            },
     };
 }
 


### PR DESCRIPTION
A `static_cast` from `void*` obviously has no safety rails. But we can do better!
`wl_resource_instance_of` will tell us whether `resource` has the same implementation
as our wrapper class - basically a discount `dynamic_cast`.

We can only use it where the `wl_resource` *has* an implementation (so objects without
requests can't use this safety rail), but that covers most objects.

This is needed for the linux-dmabuf branch, as that deals with `wl_resource* buffer` which
*may* be instances of `mw::Buffer`, or may not, and the `static_cast` results in a subsequent
invalid memory access.