### PR TITLE
gbm-kms: Support zwp_linux_dmabuf_unstable_v1

### DIFF
--- a/include/platform/mir/graphics/egl_extensions.h
+++ b/include/platform/mir/graphics/egl_extensions.h
@@ -60,6 +60,7 @@
  */
 #ifndef EGL_KHR_stream
 #define EGL_KHR_stream 1
+typedef khronos_uint64_t EGLuint64KHR;
 typedef void* EGLStreamKHR;
 #endif
 
@@ -133,6 +134,52 @@ typedef EGLBoolean (EGLAPIENTRYP PFNEGLSTREAMCONSUMERACQUIREATTRIBEXTPROC) (EGLD
 EGLAPI EGLBoolean EGLAPIENTRY eglStreamConsumerAcquireAttribEXT (EGLDisplay dpy, EGLStreamKHR stream, const EGLAttrib *attrib_list);
 #endif
 #endif /* EGL_EXT_stream_acquire_mode */
+
+/*
+ * More polyfill for the RPi's EGL headers...
+ */
+#ifndef EGL_EXT_image_dma_buf_import
+#define EGL_EXT_image_dma_buf_import 1
+#define EGL_LINUX_DMA_BUF_EXT             0x3270
+#define EGL_LINUX_DRM_FOURCC_EXT          0x3271
+#define EGL_DMA_BUF_PLANE0_FD_EXT         0x3272
+#define EGL_DMA_BUF_PLANE0_OFFSET_EXT     0x3273
+#define EGL_DMA_BUF_PLANE0_PITCH_EXT      0x3274
+#define EGL_DMA_BUF_PLANE1_FD_EXT         0x3275
+#define EGL_DMA_BUF_PLANE1_OFFSET_EXT     0x3276
+#define EGL_DMA_BUF_PLANE1_PITCH_EXT      0x3277
+#define EGL_DMA_BUF_PLANE2_FD_EXT         0x3278
+#define EGL_DMA_BUF_PLANE2_OFFSET_EXT     0x3279
+#define EGL_DMA_BUF_PLANE2_PITCH_EXT      0x327A
+#define EGL_YUV_COLOR_SPACE_HINT_EXT      0x327B
+#define EGL_SAMPLE_RANGE_HINT_EXT         0x327C
+#define EGL_YUV_CHROMA_HORIZONTAL_SITING_HINT_EXT 0x327D
+#define EGL_YUV_CHROMA_VERTICAL_SITING_HINT_EXT 0x327E
+#define EGL_ITU_REC601_EXT                0x327F
+#define EGL_ITU_REC709_EXT                0x3280
+#define EGL_ITU_REC2020_EXT               0x3281
+#define EGL_YUV_FULL_RANGE_EXT            0x3282
+#define EGL_YUV_NARROW_RANGE_EXT          0x3283
+#define EGL_YUV_CHROMA_SITING_0_EXT       0x3284
+#define EGL_YUV_CHROMA_SITING_0_5_EXT     0x3285
+#endif /* EGL_EXT_image_dma_buf_import */
+
+#ifndef EGL_EXT_image_dma_buf_import_modifiers
+#define EGL_EXT_image_dma_buf_import_modifiers 1
+#define EGL_DMA_BUF_PLANE3_FD_EXT         0x3440
+#define EGL_DMA_BUF_PLANE3_OFFSET_EXT     0x3441
+#define EGL_DMA_BUF_PLANE3_PITCH_EXT      0x3442
+#define EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT 0x3443
+#define EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT 0x3444
+#define EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT 0x3445
+#define EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT 0x3446
+#define EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT 0x3447
+#define EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT 0x3448
+#define EGL_DMA_BUF_PLANE3_MODIFIER_LO_EXT 0x3449
+#define EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT 0x344A
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYDMABUFFORMATSEXTPROC) (EGLDisplay dpy, EGLint max_formats, EGLint *formats, EGLint *num_formats);
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYDMABUFMODIFIERSEXTPROC) (EGLDisplay dpy, EGLint format, EGLint max_modifiers, EGLuint64KHR *modifiers, EGLBoolean *external_only, EGLint *num_modifiers);
+#endif /* EGL_EXT_image_dma_buf_import_modifiers */
 
 namespace mir
 {

--- a/include/platform/mir/graphics/egl_extensions.h
+++ b/include/platform/mir/graphics/egl_extensions.h
@@ -189,6 +189,14 @@ struct EGLExtensions
             PFNEGLLABELOBJECTKHRPROC label,
             PFNEGLQUERYDEBUGKHRPROC query);
     };
+
+    struct EXTImageDmaBufImportModifiers
+    {
+        EXTImageDmaBufImportModifiers(EGLDisplay dpy);
+
+        PFNEGLQUERYDMABUFFORMATSEXTPROC const eglQueryDmaBufFormatsExt;
+        PFNEGLQUERYDMABUFMODIFIERSEXTPROC const eglQueryDmaBufModifiersExt;
+    };
 };
 
 }

--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -64,6 +64,7 @@ execute: |
         > /etc/apt/sources.list.d/cross-${DEB_HOST_ARCH}.list
 
         apt-get update
+        apt-get --yes install qemu-user-static binfmt-support
     fi
 
     cd $SPREAD_PATH

--- a/src/platform/graphics/egl_extensions.cpp
+++ b/src/platform/graphics/egl_extensions.cpp
@@ -179,3 +179,20 @@ auto mg::EGLExtensions::DebugKHR::maybe_debug_khr() -> std::experimental::option
         return {};
     }
 }
+
+mg::EGLExtensions::EXTImageDmaBufImportModifiers::EXTImageDmaBufImportModifiers(EGLDisplay dpy)
+    : eglQueryDmaBufFormatsExt{
+        reinterpret_cast<PFNEGLQUERYDMABUFFORMATSEXTPROC>(
+            eglGetProcAddress("eglQueryDmaBufFormatsEXT"))},
+      eglQueryDmaBufModifiersExt{
+        reinterpret_cast<PFNEGLQUERYDMABUFMODIFIERSEXTPROC>(
+            eglGetProcAddress("eglQueryDmaBufModifiersEXT"))}
+{
+    auto const egl_extensions = eglQueryString(dpy, EGL_EXTENSIONS);
+    if (!egl_extensions ||
+        !strstr(egl_extensions, "EGL_EXT_image_dma_buf_import_modifiers"))
+    {
+        BOOST_THROW_EXCEPTION((
+            std::runtime_error{"EGL_EXT_image_dma_buf_import_modifiers not supported"}));
+    }
+}

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -26,6 +26,7 @@ MIRPLATFORM_2.1 {
     mir::graphics::EGLExtensions::NVStreamAttribExtensions::NVStreamAttribExtensions*;
     mir::graphics::EGLExtensions::PlatformBaseEXT*;
     mir::graphics::EGLExtensions::WaylandExtensions::WaylandExtensions*;
+    mir::graphics::EGLExtensions::EXTImageDmaBufImportModifiers::EXTImageDmaBufImportModifiers*;
     mir::graphics::EGLSurfaceStore::?EGLSurfaceStore*;
     mir::graphics::EGLSurfaceStore::EGLSurfaceStore*;
     mir::graphics::EGLSurfaceStore::EGLSurfaceStore*;

--- a/src/platforms/gbm-kms/server/CMakeLists.txt
+++ b/src/platforms/gbm-kms/server/CMakeLists.txt
@@ -1,10 +1,7 @@
 add_subdirectory(kms/)
 
-include_directories(
-    ${server_common_include_dirs}
-    ${DRM_INCLUDE_DIRS}
-    ${WAYLAND_SERVER_INCLUDE_DIRS}
-)
+set(DMABUF_PROTO_HEADER ${CMAKE_CURRENT_BINARY_DIR}/linux-dmabuf-unstable-v1_wrapper.h)
+set(DMABUF_PROTO_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/linux-dmabuf-unstable-v1_wrapper.cpp)
 
 add_library(
   mirsharedgbmservercommon-static STATIC
@@ -15,6 +12,46 @@ add_library(
   gbm_platform.cpp
   nested_authentication.cpp
   drm_native_platform.cpp
+  ${DMABUF_PROTO_HEADER}
+  ${DMABUF_PROTO_SOURCE}
+  linux_dmabuf.h
+  linux_dmabuf.cpp
+)
+
+target_include_directories(
+  mirsharedgbmservercommon-static
+  PUBLIC
+    ${server_common_include_dirs}
+    ${DRM_INCLUDE_DIRS}
+    ${WAYLAND_SERVER_INCLUDE_DIRS}
+    ${PROJECT_SOURCE_DIR}/include/wayland
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+set(LINUX_DMABUF_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/protocol/linux-dmabuf-unstable-v1.xml")
+set(WAYLAND_GENERATOR "${CMAKE_BINARY_DIR}/bin/mir_wayland_generator")
+
+add_custom_command(
+  OUTPUT
+    linux-dmabuf-unstable-v1_wrapper.h
+  VERBATIM
+  COMMAND
+    "sh" "-c"
+    "${WAYLAND_GENERATOR} zwp_ ${LINUX_DMABUF_PROTO} header > ${DMABUF_PROTO_HEADER}"
+  DEPENDS
+    ${LINUX_DMABUF_PROTO}
+    mir_wayland_generator
+)
+add_custom_command(
+  OUTPUT
+    linux-dmabuf-unstable-v1_wrapper.cpp
+  VERBATIM
+  COMMAND
+    "sh" "-c"
+    "${WAYLAND_GENERATOR} zwp_ ${LINUX_DMABUF_PROTO} source > ${DMABUF_PROTO_SOURCE}"
+  DEPENDS
+    ${LINUX_DMABUF_PROTO}
+    mir_wayland_generator
 )
 
 target_link_libraries(
@@ -23,5 +60,6 @@ target_link_libraries(
 
   server_platform_common
   kms_utils
+  mirwayland
   ${WAYLAND_SERVER_LDFLAGS} ${WAYLAND_SERVER_LIBRARIES}
 )

--- a/src/platforms/gbm-kms/server/buffer_allocator.h
+++ b/src/platforms/gbm-kms/server/buffer_allocator.h
@@ -23,6 +23,7 @@
 #include "mir/graphics/graphic_buffer_allocator.h"
 #include "mir/graphics/buffer_id.h"
 #include "mir_toolkit/mir_native_buffer.h"
+#include "linux_dmabuf.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic warning "-Wall"
@@ -91,6 +92,7 @@ private:
     std::shared_ptr<renderer::gl::Context> const ctx;
     std::shared_ptr<common::EGLContextExecutor> const egl_delegate;
     std::shared_ptr<Executor> wayland_executor;
+    std::unique_ptr<LinuxDmaBufUnstable> dmabuf_extension;
     gbm_device* const device;
     std::shared_ptr<EGLExtensions> const egl_extensions;
 

--- a/src/platforms/gbm-kms/server/kms/CMakeLists.txt
+++ b/src/platforms/gbm-kms/server/kms/CMakeLists.txt
@@ -45,6 +45,12 @@ add_library(
   mutex.h
 )
 
+target_link_libraries(
+  mirplatformgraphicsgbmkmsobjects
+  PUBLIC
+    mirsharedgbmservercommon-static
+)
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/symbols.map.in
     ${CMAKE_CURRENT_BINARY_DIR}/symbols.map
     )

--- a/src/platforms/gbm-kms/server/kms/CMakeLists.txt
+++ b/src/platforms/gbm-kms/server/kms/CMakeLists.txt
@@ -12,6 +12,8 @@ include_directories(
     ${WAYLAND_SERVER_INCLUDE_DIRS}
     ${UDEV_INCLUDE_DIRS}
     ${PROJECT_SOURCE_DIR}/include/client
+    ${CMAKE_CURRENT_BINARY_DIR}/../
+    ${PROJECT_SOURCE_DIR}/include/wayland
 )
 
 # gbm-kms.h and drm.h have trailing commas at the end of enum definitions
@@ -45,11 +47,7 @@ add_library(
   mutex.h
 )
 
-target_link_libraries(
-  mirplatformgraphicsgbmkmsobjects
-  PUBLIC
-    mirsharedgbmservercommon-static
-)
+add_dependencies(mirplatformgraphicsgbmkmsobjects mirsharedgbmservercommon-static)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/symbols.map.in
     ${CMAKE_CURRENT_BINARY_DIR}/symbols.map

--- a/src/platforms/gbm-kms/server/linux_dmabuf.cpp
+++ b/src/platforms/gbm-kms/server/linux_dmabuf.cpp
@@ -1,0 +1,846 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+
+#include "linux_dmabuf.h"
+
+#include "wayland_wrapper.h"
+#include "mir/graphics/egl_extensions.h"
+#include "mir/graphics/egl_error.h"
+#include "mir/renderer/gl/context.h"
+#include "mir/graphics/texture.h"
+#include "mir/graphics/program_factory.h"
+#include "mir/graphics/buffer.h"
+#include "mir/graphics/buffer_basic.h"
+#include "mir/executor.h"
+
+#define MIR_LOG_COMPONENT "linux-dmabuf-import"
+#include "mir/log.h"
+
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+#include <boost/range/combine.hpp>
+#include <mutex>
+#include <vector>
+#include <drm_fourcc.h>
+#include <wayland-server.h>
+
+namespace mg = mir::graphics;
+namespace mgg = mir::graphics::gbm;
+namespace mw = mir::wayland;
+namespace geom = mir::geometry;
+
+namespace
+{
+struct PlaneInfo
+{
+    mir::Fd fd;
+    uint32_t offset;
+    uint32_t stride;
+};
+
+/**
+ * Holds on to all imported dmabuf buffers, and allows looking up by wl_buffer
+ *
+ * \note This is not threadsafe, and should only be accessed on the Wayland thread
+ */
+class DmaBufBuffer : public mir::wayland::Buffer
+{
+public:
+    DmaBufBuffer(
+        EGLDisplay dpy,
+        std::shared_ptr<mg::EGLExtensions> egl_extensions,
+        wl_resource* wl_buffer,
+        int32_t width,
+        int32_t height,
+        uint32_t format,
+        uint32_t flags,
+        std::optional<uint64_t> modifier,
+        std::vector<PlaneInfo> plane_params)
+            : Buffer(wl_buffer, Version<1>{}),
+              dpy{dpy},
+              egl_extensions{std::move(egl_extensions)},
+              width{width},
+              height{height},
+              format_{format},
+              flags{flags},
+              modifier{modifier},
+              planes{std::move(plane_params)},
+              image{EGL_NO_IMAGE_KHR}
+    {
+        reimport_egl_image();
+    }
+
+    ~DmaBufBuffer()
+    {
+        if (image != EGL_NO_IMAGE_KHR)
+        {
+            egl_extensions->eglDestroyImageKHR(dpy, image);
+        }
+    }
+
+    static auto maybe_dmabuf_from_wl_buffer(wl_resource* buffer) -> DmaBufBuffer*
+    {
+        return dynamic_cast<DmaBufBuffer*>(Buffer::from(buffer));
+    }
+
+    auto size() -> geom::Size
+    {
+        return {width, height};
+    }
+
+    auto layout() -> mg::gl::Texture::Layout
+    {
+        if (flags & mw::LinuxBufferParamsV1::Flags::y_invert)
+        {
+            return mg::gl::Texture::Layout::TopRowFirst;
+        }
+        else
+        {
+            return mg::gl::Texture::Layout::GL;
+        }
+    }
+
+    auto format() -> uint32_t
+    {
+        return format_;
+    }
+    /**
+     * Reimport dmabufs into EGL
+     *
+     * This is necessary to call each time the buffer is re-submitted by the client,
+     * to ensure any state is properly synchronised.
+     *
+     * \return  An EGLImageKHR handle to the imported
+     * \throws  A std::system_error containing the EGL error on failure.
+     */
+    auto reimport_egl_image() -> EGLImageKHR
+    {
+        std::vector<EGLint> attributes;
+
+        attributes.push_back(EGL_WIDTH);
+        attributes.push_back(width);
+        attributes.push_back(EGL_HEIGHT);
+        attributes.push_back(height);
+        attributes.push_back(EGL_LINUX_DRM_FOURCC_EXT);
+        attributes.push_back(format());
+
+        for(auto i = 0u; i < planes.size(); ++i)
+        {
+            auto const& attrib_names = egl_attribs[i];
+            auto const& plane = planes[i];
+
+            attributes.push_back(attrib_names.fd);
+            attributes.push_back(static_cast<int>(plane.fd));
+            attributes.push_back(attrib_names.offset);
+            attributes.push_back(plane.offset);
+            attributes.push_back(attrib_names.pitch);
+            attributes.push_back(plane.stride);
+            if (modifier.value_or(DRM_FORMAT_MOD_INVALID) != DRM_FORMAT_MOD_INVALID)
+            {
+                attributes.push_back(attrib_names.modifier_lo);
+                attributes.push_back(*modifier & 0xFFFFFFFF);
+                attributes.push_back(attrib_names.modifier_hi);
+                attributes.push_back(*modifier >> 32);
+            }
+        }
+        attributes.push_back(EGL_NONE);
+        if (image != EGL_NO_IMAGE_KHR)
+        {
+            egl_extensions->eglDestroyImageKHR(dpy, image);
+        }
+        image = egl_extensions->eglCreateImageKHR(
+            dpy,
+            EGL_NO_CONTEXT,
+            EGL_LINUX_DMA_BUF_EXT,
+            nullptr,
+            attributes.data());
+
+        if (image == EGL_NO_IMAGE_KHR)
+        {
+            auto const msg = planes.size() > 1 ?
+                "Failed to import supplied dmabufs" :
+                "Failed to import supplied dmabuf";
+            BOOST_THROW_EXCEPTION((mg::egl_error(msg)));
+        }
+
+        return image;
+    }
+private:
+    void destroy() override
+    {
+        destroy_wayland_object();
+    }
+
+    EGLDisplay const dpy;
+    std::shared_ptr<mg::EGLExtensions> const egl_extensions;
+    int32_t const width, height;
+    uint32_t const format_;
+    [[maybe_unused]]
+    uint32_t const flags;
+    std::optional<uint64_t> const modifier;
+    std::vector<PlaneInfo> planes;
+    EGLImageKHR image;
+
+    struct EGLPlaneAttribs
+    {
+        EGLint fd;
+        EGLint offset;
+        EGLint pitch;
+        EGLint modifier_lo;
+        EGLint modifier_hi;
+    };
+    static constexpr std::array<EGLPlaneAttribs, 4> egl_attribs = {
+        EGLPlaneAttribs {
+            EGL_DMA_BUF_PLANE0_FD_EXT,
+            EGL_DMA_BUF_PLANE0_OFFSET_EXT,
+            EGL_DMA_BUF_PLANE0_PITCH_EXT,
+            EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT,
+            EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT
+        },
+        EGLPlaneAttribs {
+            EGL_DMA_BUF_PLANE1_FD_EXT,
+            EGL_DMA_BUF_PLANE1_OFFSET_EXT,
+            EGL_DMA_BUF_PLANE1_PITCH_EXT,
+            EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT,
+            EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT
+        },
+        EGLPlaneAttribs {
+            EGL_DMA_BUF_PLANE2_FD_EXT,
+            EGL_DMA_BUF_PLANE2_OFFSET_EXT,
+            EGL_DMA_BUF_PLANE2_PITCH_EXT,
+            EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT,
+            EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT
+        },
+        EGLPlaneAttribs {
+            EGL_DMA_BUF_PLANE3_FD_EXT,
+            EGL_DMA_BUF_PLANE3_OFFSET_EXT,
+            EGL_DMA_BUF_PLANE3_PITCH_EXT,
+            EGL_DMA_BUF_PLANE3_MODIFIER_LO_EXT,
+            EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT
+        }
+    };
+};
+
+class LinuxDmaBufParams : public mir::wayland::LinuxBufferParamsV1
+{
+public:
+    LinuxDmaBufParams(
+        wl_resource* new_resource,
+        EGLDisplay dpy,
+        std::shared_ptr<mg::EGLExtensions> egl_extensions)
+        : mir::wayland::LinuxBufferParamsV1(new_resource, Version<3>{}),
+          consumed{false},
+          dpy{dpy},
+          egl_extensions{std::move(egl_extensions)}
+    {
+    }
+
+private:
+    /* EGL_EXT_image_dma_buf_import allows up to 3 planes, and
+     * EGL_EXT_image_dma_buf_import_modifiers adds an extra plane.
+     */
+    std::array<PlaneInfo, 4> planes;
+    std::optional<uint64_t> modifier;
+    bool consumed;
+    EGLDisplay dpy;
+    std::shared_ptr<mg::EGLExtensions> egl_extensions;
+
+    void destroy() override
+    {
+        destroy_wayland_object();
+    }
+
+    void add(
+        mir::Fd fd,
+        uint32_t plane_idx,
+        uint32_t offset,
+        uint32_t stride,
+        uint32_t modifier_hi,
+        uint32_t modifier_lo) override
+    {
+        if (consumed)
+        {
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::already_used,
+                    "Params already used to create a buffer"}));
+        }
+        if (plane_idx >= planes.size())
+        {
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::plane_idx,
+                    "Plane index %u higher than maximum number of planes, %zu", plane_idx, planes.size()}));
+        }
+
+        if (planes[plane_idx].fd != mir::Fd::invalid)
+        {
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::plane_set,
+                    "Plane %u already has a dmabuf", plane_idx}));
+        }
+
+        planes[plane_idx].fd = std::move(fd);
+        planes[plane_idx].offset = offset;
+        planes[plane_idx].stride = stride;
+
+        if (wl_resource_get_version(resource) >= 3)
+        {
+            // The modifier event was added in v3, but due to a quirk of the wrapping generator
+            // we can't use a helper here (https://github.com/MirServer/mir/issues/1715)
+            auto const new_modifier = (static_cast<uint64_t>(modifier_hi) << 32) | modifier_lo;
+            if (modifier)
+            {
+                if (*modifier != new_modifier)
+                {
+                    BOOST_THROW_EXCEPTION((
+                        mw::ProtocolError{
+                            resource,
+                            Error::invalid_format,
+                            "Modifier %" PRIu64 " for plane %u doesn't match previously set"
+                            " modifier %" PRIu64 " - all planes must use the same modifier",
+                            new_modifier,
+                            plane_idx,
+                            *modifier}));
+                }
+            }
+            else
+            {
+                modifier = (static_cast<uint64_t>(modifier_hi) << 32) | modifier_lo;
+            }
+        }
+    }
+
+    /**
+     * Basic sanity check of the set plane properties
+     *
+     * \throws  A ProtocolError if any sanity checks fail.
+     * \return  An iterator pointing to the element past the end of the plane
+     *          infos
+     */
+    auto validate_and_count_planes() -> decltype(LinuxDmaBufParams::planes)::const_iterator
+    {
+        if (consumed)
+        {
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::already_used,
+                    "Params already used to create a buffer"}));
+        }
+        auto const plane_count =
+            std::count_if(
+                planes.begin(),
+                planes.end(),
+                [](auto const& plane) { return plane.fd != mir::Fd::invalid; });
+        if (plane_count == 0)
+        {
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::incomplete,
+                    "No dmabuf has been added to the params"}));
+        }
+        for (auto i = 0u; i < plane_count; ++i)
+        {
+            if (planes[i].fd == mir::Fd::invalid)
+            {
+                BOOST_THROW_EXCEPTION((
+                    mw::ProtocolError{
+                        resource,
+                        Error::incomplete,
+                        "Missing dmabuf for plane %u", i}));
+            }
+        }
+
+        // TODO: Basic verification of size & offset (see libweston/linux-dmabuf.c)
+        return planes.cbegin() + plane_count;
+    }
+
+    void validate_params(int32_t width, int32_t height, uint32_t /*format*/, uint32_t /*flags*/)
+    {
+        if (width < 1 || height < 1)
+        {
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::invalid_dimensions,
+                    "Width %i or height %i invalid; both must be >= 1!",
+                    width, height}));
+
+            // TODO: Validate format & flags
+        }
+    }
+
+    void create(int32_t width, int32_t height, uint32_t format, uint32_t flags) override
+    {
+        validate_params(width, height, format, flags);
+
+        try
+        {
+            auto const buffer_resource = wl_resource_create(client, &wl_buffer_interface, 1, 0);
+            if (!buffer_resource)
+            {
+                wl_client_post_no_memory(client);
+                return;
+            }
+            new DmaBufBuffer{
+                dpy,
+                egl_extensions,
+                buffer_resource,
+                width,
+                height,
+                format,
+                flags,
+                modifier,
+                {planes.cbegin(), validate_and_count_planes()}};
+            send_created_event(buffer_resource);
+        }
+        catch (std::system_error const& err)
+        {
+            if (err.code().category() != mg::egl_category())
+            {
+                throw;
+            }
+            /* The client should handle this fine, but let's make sure we can see
+             * any failures that might happen.
+             */
+            mir::log_debug("Failed to import client dmabufs: %s", err.what());
+            send_failed_event();
+        }
+        consumed = true;
+    }
+
+    void
+    create_immed(
+        struct wl_resource* buffer_id,
+        int32_t width,
+        int32_t height,
+        uint32_t format,
+        uint32_t flags) override
+    {
+        validate_params(width, height, format, flags);
+
+        try
+        {
+            new DmaBufBuffer{
+                dpy,
+                egl_extensions,
+                buffer_id,
+                width,
+                height,
+                format,
+                flags,
+                modifier,
+                {planes.cbegin(), validate_and_count_planes()}};
+        }
+        catch (std::system_error const& err)
+        {
+            if (err.code().category() != mg::egl_category())
+            {
+                throw;
+            }
+            /* The protocol gives implementations the choice of sending an invalid_wl_buffer
+             * protocol error and disconnecting the client here, or sending a failed() event
+             * and not disconnecting the client.
+             *
+             * Both Weston and GNOME Shell choose to disconnect the client, rather than possibly
+             * allowing them to attempt to use an invalid wl_buffer. Let's follow their lead.
+             */
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::invalid_wl_buffer,
+                    "Failed to import dmabuf: %s", err.what()
+                }));
+        }
+    }
+};
+
+GLuint get_tex_id()
+{
+    GLuint tex;
+    glGenTextures(1, &tex);
+    return tex;
+}
+
+bool drm_format_has_alpha(uint32_t format)
+{
+    /* TODO: We should really have something like libweston/pixel-formats.h
+     * We've said this multiple times before, so 🤷
+     */
+
+    switch (format)
+    {
+        /* This is only an optimisation, so pick a bunch of formats and hope that
+         * covers it…
+         */
+        case DRM_FORMAT_XBGR2101010:
+        case DRM_FORMAT_BGRX1010102:
+        case DRM_FORMAT_XBGR8888:
+        case DRM_FORMAT_BGRX8888:
+        case DRM_FORMAT_XRGB2101010:
+        case DRM_FORMAT_RGBX1010102:
+        case DRM_FORMAT_RGBX8888:
+        case DRM_FORMAT_XRGB8888:
+            return false;
+        default:
+        // TODO: I *think* true is a safe default, as it'll just mean we're blending something without alpha?
+            return true;
+    }
+}
+
+class WaylandDmabufTexBuffer :
+    public mg::BufferBasic,
+    public mg::NativeBufferBase,
+    public mg::gl::Texture
+{
+public:
+    // Note: Must be called with a current EGL context
+    WaylandDmabufTexBuffer(
+        DmaBufBuffer& source,
+        mg::EGLExtensions const& extensions,
+        std::shared_ptr<mir::renderer::gl::Context> ctx,
+        std::function<void()>&& on_consumed,
+        std::function<void()>&& on_release,
+        std::shared_ptr<mir::Executor> wayland_executor)
+        : ctx{std::move(ctx)},
+          tex{get_tex_id()},
+          on_consumed{std::move(on_consumed)},
+          on_release{std::move(on_release)},
+          size_{source.size()},
+          layout_{source.layout()},
+          has_alpha{drm_format_has_alpha(source.format())},
+          wayland_executor{std::move(wayland_executor)}
+    {
+        eglBindAPI(EGL_OPENGL_ES_API);
+
+        glBindTexture(GL_TEXTURE_2D, tex);
+        extensions.glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, source.reimport_egl_image());
+        // tex is now an EGLImage sibling, so we can free the EGLImage without
+        // freeing the backing data.
+
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    }
+
+    ~WaylandDmabufTexBuffer() override
+    {
+        wayland_executor->spawn(
+            [context = ctx, tex = tex]()
+            {
+              context->make_current();
+
+              glDeleteTextures(1, &tex);
+
+              context->release_current();
+            });
+
+        on_release();
+    }
+
+    std::shared_ptr<mir::graphics::NativeBuffer> native_buffer_handle() const override
+    {
+        return {nullptr};
+    }
+
+    mir::geometry::Size size() const override
+    {
+        return size_;
+    }
+
+    MirPixelFormat pixel_format() const override
+    {
+        // There's no way to implement this corectly…
+        if (has_alpha)
+        {
+            return mir_pixel_format_argb_8888;
+        }
+        else
+        {
+            return mir_pixel_format_xrgb_8888;
+        }
+    }
+
+    NativeBufferBase* native_buffer_base() override
+    {
+        return this;
+    }
+
+    mir::graphics::gl::Program const& shader(mir::graphics::gl::ProgramFactory& cache) const override
+    {
+        static int argb_shader{0};
+        return cache.compile_fragment_shader(
+            &argb_shader,
+            "",
+            "uniform sampler2D tex;\n"
+            "vec4 sample_to_rgba(in vec2 texcoord)\n"
+            "{\n"
+            "    return texture2D(tex, texcoord);\n"
+            "}\n");
+    }
+
+    Layout layout() const override
+    {
+        return layout_;
+    }
+
+    void bind() override
+    {
+        glBindTexture(GL_TEXTURE_2D, tex);
+
+        std::lock_guard<decltype(consumed_mutex)> lock(consumed_mutex);
+        on_consumed();
+        on_consumed = [](){};
+    }
+
+    void add_syncpoint() override
+    {
+    }
+private:
+    std::shared_ptr<mir::renderer::gl::Context> const ctx;
+    GLuint const tex;
+
+    std::mutex consumed_mutex;
+    std::function<void()> on_consumed;
+    std::function<void()> const on_release;
+
+    geom::Size const size_;
+    Layout const layout_;
+    bool const has_alpha;
+
+    std::shared_ptr<mir::Executor> const wayland_executor;
+};
+
+
+}
+
+bool format_is_simple_enough_for_us(uint32_t format)
+{
+    /* There's (some, not all that much) extra work required to support anything but RGB
+     * formats. Hopefully one of the formats that is left wil be good enough for the client!
+     */
+    switch (format)
+    {
+    case DRM_FORMAT_XRGB8888:
+    case DRM_FORMAT_XBGR8888:
+    case DRM_FORMAT_RGBX8888:
+    case DRM_FORMAT_BGRX8888:
+    case DRM_FORMAT_BGRX1010102:
+    case DRM_FORMAT_RGBX1010102:
+    case DRM_FORMAT_XBGR2101010:
+    case DRM_FORMAT_XRGB2101010:
+    case DRM_FORMAT_XRGB1555:
+    case DRM_FORMAT_XBGR1555:
+    case DRM_FORMAT_RGBX5551:
+    case DRM_FORMAT_BGRX5551:
+    case DRM_FORMAT_XRGB4444:
+    case DRM_FORMAT_XBGR4444:
+    case DRM_FORMAT_RGBX4444:
+    case DRM_FORMAT_BGRX4444:
+    case DRM_FORMAT_ARGB8888:
+    case DRM_FORMAT_ABGR8888:
+    case DRM_FORMAT_RGBA8888:
+    case DRM_FORMAT_BGRA8888:
+    case DRM_FORMAT_BGRA1010102:
+    case DRM_FORMAT_RGBA1010102:
+    case DRM_FORMAT_ABGR2101010:
+    case DRM_FORMAT_ARGB2101010:
+    case DRM_FORMAT_ARGB1555:
+    case DRM_FORMAT_ABGR1555:
+    case DRM_FORMAT_RGBA5551:
+    case DRM_FORMAT_BGRA5551:
+    case DRM_FORMAT_ARGB4444:
+    case DRM_FORMAT_ABGR4444:
+    case DRM_FORMAT_RGBA4444:
+    case DRM_FORMAT_BGRA4444:
+        return true;
+    default:
+        return false;
+    }
+}
+
+class mgg::LinuxDmaBufUnstable::Instance : public mir::wayland::LinuxDmabufV1
+{
+public:
+    Instance(
+        wl_resource* new_resource,
+        EGLDisplay dpy,
+        std::shared_ptr<EGLExtensions> egl_extensions,
+        EGLExtensions::EXTImageDmaBufImportModifiers const& dmabuf_ext)
+        : mir::wayland::LinuxDmabufV1(new_resource, Version<3>{}),
+          dpy{dpy},
+          egl_extensions{std::move(egl_extensions)}
+    {
+        EGLint num_formats;
+        if (dmabuf_ext.eglQueryDmaBufFormatsExt(dpy, 0, nullptr, &num_formats) != EGL_TRUE)
+        {
+            BOOST_THROW_EXCEPTION((mg::egl_error("Failed to query number of dma-buf formats")));
+        }
+        if (num_formats < 1)
+        {
+            BOOST_THROW_EXCEPTION((std::runtime_error{"No dma-buf formats supported"}));
+        }
+        DmaBufFormatDescriptors format_descriptors;
+        EGLint returned_formats;
+        format_descriptors.format.resize(num_formats);
+        format_descriptors.modifiers.resize(num_formats);
+        format_descriptors.external_only.resize(num_formats);
+        if (dmabuf_ext.eglQueryDmaBufFormatsExt(
+                dpy, num_formats, format_descriptors.format.data(), &returned_formats) != EGL_TRUE)
+        {
+            BOOST_THROW_EXCEPTION((mg::egl_error("Failed to list dma-buf formats")));
+        }
+        // Paranoia: what if the EGL returns a different number of formats in the second call?
+        format_descriptors.format.resize(returned_formats);
+        format_descriptors.modifiers.resize(returned_formats);
+        format_descriptors.external_only.resize(returned_formats);
+
+        for (auto i = 0u; i < format_descriptors.format.size(); ++i)
+        {
+            auto const& format = format_descriptors.format[i];
+            auto& modifiers = format_descriptors.modifiers[i];
+            auto& external_only = format_descriptors.external_only[i];
+
+            EGLint num_modifiers;
+            if (
+                dmabuf_ext.eglQueryDmaBufModifiersExt(
+                    dpy,
+                    format,
+                    0,
+                    nullptr,
+                    nullptr,
+                    &num_modifiers) != EGL_TRUE)
+            {
+                BOOST_THROW_EXCEPTION((mg::egl_error("Failed to query number of modifiers")));
+            }
+            modifiers.resize(num_modifiers);
+            external_only.resize(num_modifiers);
+
+            EGLint returned_modifiers;
+            if (
+                dmabuf_ext.eglQueryDmaBufModifiersExt(
+                    dpy,
+                    format,
+                    modifiers.size(),
+                    modifiers.data(),
+                    external_only.data(),
+                    &returned_modifiers) != EGL_TRUE)
+            {
+                BOOST_THROW_EXCEPTION((mg::egl_error("Failed to list modifiers")));
+            }
+            modifiers.resize(returned_modifiers);
+            external_only.resize(returned_modifiers);
+        }
+
+        for (auto i = 0u; i < format_descriptors.format.size(); ++i)
+        {
+            auto const& format = format_descriptors.format[i];
+            auto const& modifiers = format_descriptors.modifiers[i];
+            auto const& external_onlys = format_descriptors.external_only[i];
+
+            if (format_is_simple_enough_for_us(format))
+            {
+                send_format_event(format);
+                if (version_supports_modifier())
+                {
+                    for (auto j = 0u; j < modifiers.size(); ++j)
+                    {
+                        auto const& modifier = modifiers[i];
+                        auto const& external_only = external_onlys[i];
+                        if (external_only == EGL_FALSE)
+                        {
+                            // We can't (currently) handle external images
+                            send_modifier_event(
+                                format,
+                                modifier >> 32,
+                                modifier & 0xFFFFFFFF);
+                        }
+                    }
+                }
+            }
+        }
+    }
+private:
+    void destroy() override
+    {
+        destroy_wayland_object();
+    }
+
+    void create_params(struct wl_resource* params_id) override
+    {
+        new LinuxDmaBufParams{params_id, dpy, egl_extensions};
+    }
+
+    struct DmaBufFormatDescriptors
+    {
+        std::vector<EGLint> format;
+        std::vector<std::vector<EGLuint64KHR>> modifiers;
+        std::vector<std::vector<EGLBoolean>> external_only;
+    };
+
+    EGLDisplay const dpy;
+    std::shared_ptr<EGLExtensions> const egl_extensions;
+};
+
+mgg::LinuxDmaBufUnstable::LinuxDmaBufUnstable(
+    wl_display* display,
+    EGLDisplay dpy,
+    std::shared_ptr<EGLExtensions> egl_extensions,
+    EGLExtensions::EXTImageDmaBufImportModifiers dmabuf_ext)
+    : mir::wayland::LinuxDmabufV1::Global(display, Version<3>{}),
+      dpy{dpy},
+      egl_extensions{std::move(egl_extensions)},
+      dmabuf_ext{std::move(dmabuf_ext)}
+{
+}
+
+auto mgg::LinuxDmaBufUnstable::buffer_from_resource(
+    wl_resource* buffer,
+    std::shared_ptr<renderer::gl::Context> ctx,
+    std::function<void()>&& on_consumed,
+    std::function<void()>&& on_release,
+    std::shared_ptr<Executor> wayland_executor)
+    -> std::shared_ptr<Buffer>
+{
+    if (auto dmabuf = DmaBufBuffer::maybe_dmabuf_from_wl_buffer(buffer))
+    {
+        return std::make_shared<WaylandDmabufTexBuffer>(
+            *dmabuf,
+            *egl_extensions,
+            std::move(ctx),
+            std::move(on_consumed),
+            std::move(on_release),
+            std::move(wayland_executor));
+    }
+    return nullptr;
+}
+
+void mgg::LinuxDmaBufUnstable::bind(wl_resource* new_resource)
+{
+    new LinuxDmaBufUnstable::Instance{new_resource, dpy, egl_extensions, dmabuf_ext};
+}

--- a/src/platforms/gbm-kms/server/linux_dmabuf.cpp
+++ b/src/platforms/gbm-kms/server/linux_dmabuf.cpp
@@ -193,7 +193,6 @@ private:
     std::shared_ptr<mg::EGLExtensions> const egl_extensions;
     int32_t const width, height;
     uint32_t const format_;
-    [[maybe_unused]]
     uint32_t const flags;
     std::optional<uint64_t> const modifier;
     std::vector<PlaneInfo> planes;

--- a/src/platforms/gbm-kms/server/linux_dmabuf.h
+++ b/src/platforms/gbm-kms/server/linux_dmabuf.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef MIR_PLATFORM_GBM_KMS_LINUX_DMABUF_H_
+#define MIR_PLATFORM_GBM_KMS_LINUX_DMABUF_H_
+
+#include "linux-dmabuf-unstable-v1_wrapper.h"
+
+#include <EGL/egl.h>
+
+#include "mir/graphics/buffer.h"
+#include "mir/graphics/egl_extensions.h"
+
+
+namespace mir
+{
+class Executor;
+
+namespace renderer
+{
+namespace gl
+{
+class Context;
+}
+}
+
+namespace graphics
+{
+
+namespace gbm
+{
+class LinuxDmaBufUnstable : public wayland::LinuxDmabufV1::Global
+{
+public:
+    LinuxDmaBufUnstable(
+        wl_display* display,
+        EGLDisplay dpy,
+        std::shared_ptr<EGLExtensions> egl_extensions,
+        EGLExtensions::EXTImageDmaBufImportModifiers dmabuf_ext);
+
+    std::shared_ptr<Buffer> buffer_from_resource(
+        wl_resource* buffer,
+        std::shared_ptr<renderer::gl::Context> ctx,
+        std::function<void()>&& on_consumed,
+        std::function<void()>&& on_release,
+        std::shared_ptr<Executor> wayland_executor);
+
+private:
+    class Instance;
+    void bind(wl_resource* new_resource) override;
+
+    EGLDisplay const dpy;
+    std::shared_ptr<EGLExtensions> const egl_extensions;
+    EGLExtensions::EXTImageDmaBufImportModifiers const dmabuf_ext;
+};
+
+}
+}
+}
+
+#endif //MIR_PLATFORM_GBM_KMS_LINUX_DMABUF_H_

--- a/src/platforms/gbm-kms/server/linux_dmabuf.h
+++ b/src/platforms/gbm-kms/server/linux_dmabuf.h
@@ -44,6 +44,8 @@ namespace graphics
 
 namespace gbm
 {
+class DmaBufFormatDescriptors;
+
 class LinuxDmaBufUnstable : public wayland::LinuxDmabufV1::Global
 {
 public:
@@ -51,7 +53,7 @@ public:
         wl_display* display,
         EGLDisplay dpy,
         std::shared_ptr<EGLExtensions> egl_extensions,
-        EGLExtensions::EXTImageDmaBufImportModifiers dmabuf_ext);
+        EGLExtensions::EXTImageDmaBufImportModifiers const& dmabuf_ext);
 
     std::shared_ptr<Buffer> buffer_from_resource(
         wl_resource* buffer,
@@ -66,7 +68,7 @@ private:
 
     EGLDisplay const dpy;
     std::shared_ptr<EGLExtensions> const egl_extensions;
-    EGLExtensions::EXTImageDmaBufImportModifiers const dmabuf_ext;
+    std::shared_ptr<DmaBufFormatDescriptors> const formats;
 };
 
 }

--- a/src/platforms/gbm-kms/server/protocol/linux-dmabuf-unstable-v1.xml
+++ b/src/platforms/gbm-kms/server/protocol/linux-dmabuf-unstable-v1.xml
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="linux_dmabuf_unstable_v1">
+
+  <copyright>
+    Copyright © 2014, 2015 Collabora, Ltd.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwp_linux_dmabuf_v1" version="3">
+    <description summary="factory for creating dmabuf-based wl_buffers">
+      Following the interfaces from:
+      https://www.khronos.org/registry/egl/extensions/EXT/EGL_EXT_image_dma_buf_import.txt
+      https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import_modifiers.txt
+      and the Linux DRM sub-system's AddFb2 ioctl.
+
+      This interface offers ways to create generic dmabuf-based
+      wl_buffers. Immediately after a client binds to this interface,
+      the set of supported formats and format modifiers is sent with
+      'format' and 'modifier' events.
+
+      The following are required from clients:
+
+      - Clients must ensure that either all data in the dma-buf is
+        coherent for all subsequent read access or that coherency is
+        correctly handled by the underlying kernel-side dma-buf
+        implementation.
+
+      - Don't make any more attachments after sending the buffer to the
+        compositor. Making more attachments later increases the risk of
+        the compositor not being able to use (re-import) an existing
+        dmabuf-based wl_buffer.
+
+      The underlying graphics stack must ensure the following:
+
+      - The dmabuf file descriptors relayed to the server will stay valid
+        for the whole lifetime of the wl_buffer. This means the server may
+        at any time use those fds to import the dmabuf into any kernel
+        sub-system that might accept it.
+
+      To create a wl_buffer from one or more dmabufs, a client creates a
+      zwp_linux_dmabuf_params_v1 object with a zwp_linux_dmabuf_v1.create_params
+      request. All planes required by the intended format are added with
+      the 'add' request. Finally, a 'create' or 'create_immed' request is
+      issued, which has the following outcome depending on the import success.
+
+      The 'create' request,
+      - on success, triggers a 'created' event which provides the final
+        wl_buffer to the client.
+      - on failure, triggers a 'failed' event to convey that the server
+        cannot use the dmabufs received from the client.
+
+      For the 'create_immed' request,
+      - on success, the server immediately imports the added dmabufs to
+        create a wl_buffer. No event is sent from the server in this case.
+      - on failure, the server can choose to either:
+        - terminate the client by raising a fatal error.
+        - mark the wl_buffer as failed, and send a 'failed' event to the
+          client. If the client uses a failed wl_buffer as an argument to any
+          request, the behaviour is compositor implementation-defined.
+
+      Warning! The protocol described in this file is experimental and
+      backward incompatible changes may be made. Backward compatible changes
+      may be added together with the corresponding interface version bump.
+      Backward incompatible changes are done by bumping the version number in
+      the protocol and interface names and resetting the interface version.
+      Once the protocol is to be declared stable, the 'z' prefix and the
+      version number in the protocol and interface names are removed and the
+      interface version number is reset.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="unbind the factory">
+        Objects created through this interface, especially wl_buffers, will
+        remain valid.
+      </description>
+    </request>
+
+    <request name="create_params">
+      <description summary="create a temporary object for buffer parameters">
+        This temporary object is used to collect multiple dmabuf handles into
+        a single batch to create a wl_buffer. It can only be used once and
+        should be destroyed after a 'created' or 'failed' event has been
+        received.
+      </description>
+      <arg name="params_id" type="new_id" interface="zwp_linux_buffer_params_v1"
+           summary="the new temporary"/>
+    </request>
+
+    <event name="format">
+      <description summary="supported buffer format">
+        This event advertises one buffer format that the server supports.
+        All the supported formats are advertised once when the client
+        binds to this interface. A roundtrip after binding guarantees
+        that the client has received all supported formats.
+
+        For the definition of the format codes, see the
+        zwp_linux_buffer_params_v1::create request.
+
+        Warning: the 'format' event is likely to be deprecated and replaced
+        with the 'modifier' event introduced in zwp_linux_dmabuf_v1
+        version 3, described below. Please refrain from using the information
+        received from this event.
+      </description>
+      <arg name="format" type="uint" summary="DRM_FORMAT code"/>
+    </event>
+
+    <event name="modifier" since="3">
+      <description summary="supported buffer format modifier">
+        This event advertises the formats that the server supports, along with
+        the modifiers supported for each format. All the supported modifiers
+        for all the supported formats are advertised once when the client
+        binds to this interface. A roundtrip after binding guarantees that
+        the client has received all supported format-modifier pairs.
+
+        For legacy support, DRM_FORMAT_MOD_INVALID (that is, modifier_hi ==
+        0x00ffffff and modifier_lo == 0xffffffff) is allowed in this event.
+        It indicates that the server can support the format with an implicit
+        modifier. When a plane has DRM_FORMAT_MOD_INVALID as its modifier, it
+        is as if no explicit modifier is specified. The effective modifier
+        will be derived from the dmabuf.
+
+        For the definition of the format and modifier codes, see the
+        zwp_linux_buffer_params_v1::create and zwp_linux_buffer_params_v1::add
+        requests.
+      </description>
+      <arg name="format" type="uint" summary="DRM_FORMAT code"/>
+      <arg name="modifier_hi" type="uint"
+           summary="high 32 bits of layout modifier"/>
+      <arg name="modifier_lo" type="uint"
+           summary="low 32 bits of layout modifier"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_linux_buffer_params_v1" version="3">
+    <description summary="parameters for creating a dmabuf-based wl_buffer">
+      This temporary object is a collection of dmabufs and other
+      parameters that together form a single logical buffer. The temporary
+      object may eventually create one wl_buffer unless cancelled by
+      destroying it before requesting 'create'.
+
+      Single-planar formats only require one dmabuf, however
+      multi-planar formats may require more than one dmabuf. For all
+      formats, an 'add' request must be called once per plane (even if the
+      underlying dmabuf fd is identical).
+
+      You must use consecutive plane indices ('plane_idx' argument for 'add')
+      from zero to the number of planes used by the drm_fourcc format code.
+      All planes required by the format must be given exactly once, but can
+      be given in any order. Each plane index can be set only once.
+    </description>
+
+    <enum name="error">
+      <entry name="already_used" value="0"
+             summary="the dmabuf_batch object has already been used to create a wl_buffer"/>
+      <entry name="plane_idx" value="1"
+             summary="plane index out of bounds"/>
+      <entry name="plane_set" value="2"
+             summary="the plane index was already set"/>
+      <entry name="incomplete" value="3"
+             summary="missing or too many planes to create a buffer"/>
+      <entry name="invalid_format" value="4"
+             summary="format not supported"/>
+      <entry name="invalid_dimensions" value="5"
+             summary="invalid width or height"/>
+      <entry name="out_of_bounds" value="6"
+             summary="offset + stride * height goes out of dmabuf bounds"/>
+      <entry name="invalid_wl_buffer" value="7"
+             summary="invalid wl_buffer resulted from importing dmabufs via
+               the create_immed request on given buffer_params"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object, used or not">
+        Cleans up the temporary data sent to the server for dmabuf-based
+        wl_buffer creation.
+      </description>
+    </request>
+
+    <request name="add">
+      <description summary="add a dmabuf to the temporary set">
+        This request adds one dmabuf to the set in this
+        zwp_linux_buffer_params_v1.
+
+        The 64-bit unsigned value combined from modifier_hi and modifier_lo
+        is the dmabuf layout modifier. DRM AddFB2 ioctl calls this the
+        fb modifier, which is defined in drm_mode.h of Linux UAPI.
+        This is an opaque token. Drivers use this token to express tiling,
+        compression, etc. driver-specific modifications to the base format
+        defined by the DRM fourcc code.
+
+        Warning: It should be an error if the format/modifier pair was not
+        advertised with the modifier event. This is not enforced yet because
+        some implementations always accept DRM_FORMAT_MOD_INVALID. Also
+        version 2 of this protocol does not have the modifier event.
+
+        This request raises the PLANE_IDX error if plane_idx is too large.
+        The error PLANE_SET is raised if attempting to set a plane that
+        was already set.
+      </description>
+      <arg name="fd" type="fd" summary="dmabuf fd"/>
+      <arg name="plane_idx" type="uint" summary="plane index"/>
+      <arg name="offset" type="uint" summary="offset in bytes"/>
+      <arg name="stride" type="uint" summary="stride in bytes"/>
+      <arg name="modifier_hi" type="uint"
+           summary="high 32 bits of layout modifier"/>
+      <arg name="modifier_lo" type="uint"
+           summary="low 32 bits of layout modifier"/>
+    </request>
+
+    <enum name="flags">
+      <entry name="y_invert" value="1" summary="contents are y-inverted"/>
+      <entry name="interlaced" value="2" summary="content is interlaced"/>
+      <entry name="bottom_first" value="4" summary="bottom field first"/>
+    </enum>
+
+    <request name="create">
+      <description summary="create a wl_buffer from the given dmabufs">
+        This asks for creation of a wl_buffer from the added dmabuf
+        buffers. The wl_buffer is not created immediately but returned via
+        the 'created' event if the dmabuf sharing succeeds. The sharing
+        may fail at runtime for reasons a client cannot predict, in
+        which case the 'failed' event is triggered.
+
+        The 'format' argument is a DRM_FORMAT code, as defined by the
+        libdrm's drm_fourcc.h. The Linux kernel's DRM sub-system is the
+        authoritative source on how the format codes should work.
+
+        The 'flags' is a bitfield of the flags defined in enum "flags".
+        'y_invert' means the that the image needs to be y-flipped.
+
+        Flag 'interlaced' means that the frame in the buffer is not
+        progressive as usual, but interlaced. An interlaced buffer as
+        supported here must always contain both top and bottom fields.
+        The top field always begins on the first pixel row. The temporal
+        ordering between the two fields is top field first, unless
+        'bottom_first' is specified. It is undefined whether 'bottom_first'
+        is ignored if 'interlaced' is not set.
+
+        This protocol does not convey any information about field rate,
+        duration, or timing, other than the relative ordering between the
+        two fields in one buffer. A compositor may have to estimate the
+        intended field rate from the incoming buffer rate. It is undefined
+        whether the time of receiving wl_surface.commit with a new buffer
+        attached, applying the wl_surface state, wl_surface.frame callback
+        trigger, presentation, or any other point in the compositor cycle
+        is used to measure the frame or field times. There is no support
+        for detecting missed or late frames/fields/buffers either, and
+        there is no support whatsoever for cooperating with interlaced
+        compositor output.
+
+        The composited image quality resulting from the use of interlaced
+        buffers is explicitly undefined. A compositor may use elaborate
+        hardware features or software to deinterlace and create progressive
+        output frames from a sequence of interlaced input buffers, or it
+        may produce substandard image quality. However, compositors that
+        cannot guarantee reasonable image quality in all cases are recommended
+        to just reject all interlaced buffers.
+
+        Any argument errors, including non-positive width or height,
+        mismatch between the number of planes and the format, bad
+        format, bad offset or stride, may be indicated by fatal protocol
+        errors: INCOMPLETE, INVALID_FORMAT, INVALID_DIMENSIONS,
+        OUT_OF_BOUNDS.
+
+        Dmabuf import errors in the server that are not obvious client
+        bugs are returned via the 'failed' event as non-fatal. This
+        allows attempting dmabuf sharing and falling back in the client
+        if it fails.
+
+        This request can be sent only once in the object's lifetime, after
+        which the only legal request is destroy. This object should be
+        destroyed after issuing a 'create' request. Attempting to use this
+        object after issuing 'create' raises ALREADY_USED protocol error.
+
+        It is not mandatory to issue 'create'. If a client wants to
+        cancel the buffer creation, it can just destroy this object.
+      </description>
+      <arg name="width" type="int" summary="base plane width in pixels"/>
+      <arg name="height" type="int" summary="base plane height in pixels"/>
+      <arg name="format" type="uint" summary="DRM_FORMAT code"/>
+      <arg name="flags" type="uint" summary="see enum flags"/>
+    </request>
+
+    <event name="created">
+      <description summary="buffer creation succeeded">
+        This event indicates that the attempted buffer creation was
+        successful. It provides the new wl_buffer referencing the dmabuf(s).
+
+        Upon receiving this event, the client should destroy the
+        zlinux_dmabuf_params object.
+      </description>
+      <arg name="buffer" type="new_id" interface="wl_buffer"
+           summary="the newly created wl_buffer"/>
+    </event>
+
+    <event name="failed">
+      <description summary="buffer creation failed">
+        This event indicates that the attempted buffer creation has
+        failed. It usually means that one of the dmabuf constraints
+        has not been fulfilled.
+
+        Upon receiving this event, the client should destroy the
+        zlinux_buffer_params object.
+      </description>
+    </event>
+
+    <request name="create_immed" since="2">
+      <description summary="immediately create a wl_buffer from the given
+                     dmabufs">
+        This asks for immediate creation of a wl_buffer by importing the
+        added dmabufs.
+
+        In case of import success, no event is sent from the server, and the
+        wl_buffer is ready to be used by the client.
+
+        Upon import failure, either of the following may happen, as seen fit
+        by the implementation:
+        - the client is terminated with one of the following fatal protocol
+          errors:
+          - INCOMPLETE, INVALID_FORMAT, INVALID_DIMENSIONS, OUT_OF_BOUNDS,
+            in case of argument errors such as mismatch between the number
+            of planes and the format, bad format, non-positive width or
+            height, or bad offset or stride.
+          - INVALID_WL_BUFFER, in case the cause for failure is unknown or
+            plaform specific.
+        - the server creates an invalid wl_buffer, marks it as failed and
+          sends a 'failed' event to the client. The result of using this
+          invalid wl_buffer as an argument in any request by the client is
+          defined by the compositor implementation.
+
+        This takes the same arguments as a 'create' request, and obeys the
+        same restrictions.
+      </description>
+      <arg name="buffer_id" type="new_id" interface="wl_buffer"
+           summary="id for the newly created wl_buffer"/>
+      <arg name="width" type="int" summary="base plane width in pixels"/>
+      <arg name="height" type="int" summary="base plane height in pixels"/>
+      <arg name="format" type="uint" summary="DRM_FORMAT code"/>
+      <arg name="flags" type="uint" summary="see enum flags"/>
+    </request>
+
+  </interface>
+
+</protocol>

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -3,6 +3,7 @@ global:
   extern "C++" {
     mir::wayland::Buffer::*;
     non-virtual?thunk?to?mir::wayland::Buffer::*;
+    virtual?thunk?to?mir::wayland::Buffer::*;
     typeinfo?for?mir::wayland::Buffer;
     vtable?for?mir::wayland::Buffer;
     typeinfo?for?mir::wayland::Buffer::Global;


### PR DESCRIPTION
This is the new, improved way to do client buffer submission. Notably,
it features DRM modifier support, allowing clients to allocate fancy
driver-specific high-performance buffer formats.

Closes: #1663