### PR TITLE
Add XCBConnection::Handler

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -234,8 +234,8 @@ auto mf::XCBConnection::read_property(
         {
             try
             {
-                ErrorPtr error;
-                auto const reply = make_unique_cptr(xcb_get_property_reply(xcb_connection, cookie, error));
+                Error error;
+                auto const reply = make_unique_cptr(xcb_get_property_reply(xcb_connection, cookie, &error.ptr));
                 if (reply && reply->type != XCB_ATOM_NONE)
                 {
                     handler.on_success(reply.get());
@@ -246,7 +246,7 @@ auto mf::XCBConnection::read_property(
                 }
                 else
                 {
-                    handler.on_error(error_debug_string(error.error));
+                    handler.on_error(error_debug_string(error.ptr));
                 }
             }
             catch (...)

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -19,6 +19,7 @@
 #include "xcb_connection.h"
 
 #include "mir/log.h"
+#include "mir/c_memory.h"
 
 #include "boost/throw_exception.hpp"
 #include <sstream>
@@ -119,7 +120,7 @@ mf::XCBConnection::Atom::operator xcb_atom_t() const
         // The initial atomic check is faster, but we need to check again once we've got the lock
         if (atom == XCB_ATOM_NONE)
         {
-            std::unique_ptr<xcb_intern_atom_reply_t> const reply{xcb_intern_atom_reply(*connection, cookie, nullptr)};
+            auto const reply = make_unique_cptr(xcb_intern_atom_reply(*connection, cookie, nullptr));
             if (!reply)
                 BOOST_THROW_EXCEPTION(std::runtime_error("Failed to look up atom " + name_));
             atom = reply->atom;
@@ -161,7 +162,7 @@ auto mf::XCBConnection::query_name(xcb_atom_t atom) const -> std::string
     if (iter == atom_name_cache.end())
     {
         xcb_get_atom_name_cookie_t const cookie = xcb_get_atom_name(xcb_connection, atom);
-        std::unique_ptr<xcb_get_atom_name_reply_t> const reply{xcb_get_atom_name_reply(xcb_connection, cookie, nullptr)};
+        auto const reply = make_unique_cptr(xcb_get_atom_name_reply(xcb_connection, cookie, nullptr));
 
         std::string name;
 
@@ -234,7 +235,7 @@ auto mf::XCBConnection::read_property(
         {
             try
             {
-                std::unique_ptr<xcb_get_property_reply_t> reply{xcb_get_property_reply(xcb_connection, cookie, nullptr)};
+                auto const reply = make_unique_cptr(xcb_get_property_reply(xcb_connection, cookie, nullptr));
                 if (reply && reply->type != XCB_ATOM_NONE)
                 {
                     action(reply.get());

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -219,8 +219,7 @@ bool mf::XCBConnection::is_ours(uint32_t id) const
 auto mf::XCBConnection::read_property(
     xcb_window_t window,
     xcb_atom_t prop,
-    std::function<void(xcb_get_property_reply_t*)> action,
-    std::function<void()> on_error) const -> std::function<void()>
+    Handler<xcb_get_property_reply_t*>&& handler) const -> std::function<void()>
 {
     xcb_get_property_cookie_t cookie = xcb_get_property(
         xcb_connection,
@@ -231,18 +230,23 @@ auto mf::XCBConnection::read_property(
         0, // no offset
         2048); // big buffer
 
-    return [this, cookie, action, on_error, window, prop]()
+    return [this, cookie, handler=std::move(handler), window, prop]()
         {
             try
             {
+                ErrorPtr error;
                 auto const reply = make_unique_cptr(xcb_get_property_reply(xcb_connection, cookie, nullptr));
                 if (reply && reply->type != XCB_ATOM_NONE)
                 {
-                    action(reply.get());
+                    handler.on_success(reply.get());
+                }
+                else if (reply)
+                {
+                    handler.on_error("no reply data");
                 }
                 else
                 {
-                    on_error();
+                    handler.on_error(error_debug_string(error.error));
                 }
             }
             catch (...)
@@ -259,86 +263,89 @@ auto mf::XCBConnection::read_property(
 auto mf::XCBConnection::read_property(
     xcb_window_t window,
     xcb_atom_t prop,
-    std::function<void(std::string const&)> action,
-    std::function<void()> on_error) const -> std::function<void()>
+    Handler<std::string> handler) const -> std::function<void()>
 {
     return read_property(
         window,
         prop,
-        [this, action](xcb_get_property_reply_t const* reply)
         {
-            action(string_from(reply));
-        },
-        on_error);
+            [this, on_success=move(handler.on_success)](xcb_get_property_reply_t const* reply)
+            {
+                on_success(string_from(reply));
+            },
+            move(handler.on_error)
+        });
 }
 
 auto mf::XCBConnection::read_property(
     xcb_window_t window,
     xcb_atom_t prop,
-    std::function<void(uint32_t)> action,
-    std::function<void()> on_error) const -> std::function<void()>
+    Handler<uint32_t> handler) const -> std::function<void()>
 {
     return read_property(
         window,
         prop,
-        [this, prop, action](xcb_get_property_reply_t const* reply)
         {
-            uint8_t const expected_format = 32;
-            if (reply->format != expected_format)
+            [this, prop, on_success=move(handler.on_success)](xcb_get_property_reply_t const* reply)
             {
-                BOOST_THROW_EXCEPTION(std::runtime_error(
-                    "Failed to read " + query_name(prop) + " window property." +
-                    " Reply of type " + query_name(reply->type) +
-                    " has a format " + std::to_string(reply->format) +
-                    " instead of expected " + std::to_string(expected_format)));
-            }
+                uint8_t const expected_format = 32;
+                if (reply->format != expected_format)
+                {
+                    BOOST_THROW_EXCEPTION(std::runtime_error(
+                        "Failed to read " + query_name(prop) + " window property." +
+                        " Reply of type " + query_name(reply->type) +
+                        " has a format " + std::to_string(reply->format) +
+                        " instead of expected " + std::to_string(expected_format)));
+                }
 
-            // The length returned by xcb_get_property_value_length() is in bytes for some reason
-            size_t const len = xcb_get_property_value_length(reply) / sizeof(uint32_t);
+                // The length returned by xcb_get_property_value_length() is in bytes for some reason
+                size_t const len = xcb_get_property_value_length(reply) / sizeof(uint32_t);
 
-            if (len != 1)
-            {
-                BOOST_THROW_EXCEPTION(std::runtime_error(
-                    "Failed to read " + query_name(prop) + " window property." +
-                    " Reply of type " + query_name(reply->type) +
-                    " has a value length " + std::to_string(len) +
-                    " instead of expected 1"));
-            }
+                if (len != 1)
+                {
+                    BOOST_THROW_EXCEPTION(std::runtime_error(
+                        "Failed to read " + query_name(prop) + " window property." +
+                        " Reply of type " + query_name(reply->type) +
+                        " has a value length " + std::to_string(len) +
+                        " instead of expected 1"));
+                }
 
-            action(*static_cast<uint32_t const*>(xcb_get_property_value(reply)));
-        },
-        on_error);
+                on_success(*static_cast<uint32_t const*>(xcb_get_property_value(reply)));
+            },
+            move(handler.on_error)
+        });
 }
 
 auto mf::XCBConnection::read_property(
     xcb_window_t window,
     xcb_atom_t prop,
-    std::function<void(std::vector<uint32_t> const&)> action,
-    std::function<void()> on_error) const -> std::function<void()>
+    Handler<std::vector<uint32_t>> handler) const -> std::function<void()>
 {
     return read_property(
         window,
         prop,
-        [this, action](xcb_get_property_reply_t const* reply)
         {
-            uint8_t const expected_format = 32;
-            if (reply->format != expected_format)
+            [this, on_success=handler.on_success](xcb_get_property_reply_t const* reply)
             {
-                BOOST_THROW_EXCEPTION(std::runtime_error(
-                    "Reply of type " + query_name(reply->type) +
-                    " has a format " + std::to_string(reply->format) +
-                    " instead of expected " + std::to_string(expected_format)));
-            }
+                uint8_t const expected_format = 32;
+                if (reply->format != expected_format)
+                {
+                    BOOST_THROW_EXCEPTION(std::runtime_error(
+                        "Reply of type " + query_name(reply->type) +
+                        " has a format " + std::to_string(reply->format) +
+                        " instead of expected " + std::to_string(expected_format)));
+                }
 
-            auto const start = static_cast<uint32_t const*>(xcb_get_property_value(reply));
-            // The length returned by xcb_get_property_value_length() is in bytes for some reason
-            size_t const len = xcb_get_property_value_length(reply) / sizeof(uint32_t);
-            auto const end = start + len;
-            std::vector<uint32_t> const values{start, end};
+                auto const start = static_cast<uint32_t const*>(xcb_get_property_value(reply));
+                // The length returned by xcb_get_property_value_length() is in bytes for some reason
+                size_t const len = xcb_get_property_value_length(reply) / sizeof(uint32_t);
+                auto const end = start + len;
+                std::vector<uint32_t> const values{start, end};
 
-            action(values);
-        },
-        on_error);
+                on_success(values);
+            },
+            move(handler.on_error)
+        });
 }
 
 void mf::XCBConnection::configure_window(

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -235,7 +235,7 @@ auto mf::XCBConnection::read_property(
             try
             {
                 ErrorPtr error;
-                auto const reply = make_unique_cptr(xcb_get_property_reply(xcb_connection, cookie, nullptr));
+                auto const reply = make_unique_cptr(xcb_get_property_reply(xcb_connection, cookie, error));
                 if (reply && reply->type != XCB_ATOM_NONE)
                 {
                     handler.on_success(reply.get());

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -103,7 +103,7 @@ public:
 
         operator xcb_generic_error_t**() { return &error; }
 
-        xcb_generic_error_t* error;
+        xcb_generic_error_t* error{nullptr};
     };
 
     template<typename T>

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -91,21 +91,20 @@ public:
         std::atomic<xcb_atom_t> mutable atom{XCB_ATOM_NONE};
     };
 
-    struct ErrorPtr
+    struct Error
     {
-        ErrorPtr(ErrorPtr const&) = delete;
-        auto operator=(ErrorPtr const&) -> ErrorPtr const& = delete;
-        ~ErrorPtr()
+        Error() = default;
+        Error(Error const&) = delete;
+        auto operator=(Error const&) -> Error const& = delete;
+        ~Error()
         {
-            if (error)
+            if (ptr)
             {
-                free(error);
+                free(ptr);
             }
         }
 
-        operator xcb_generic_error_t**() { return &error; }
-
-        xcb_generic_error_t* error{nullptr};
+        xcb_generic_error_t* ptr{nullptr};
     };
 
     template<typename T>

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -93,6 +93,8 @@ public:
 
     struct ErrorPtr
     {
+        ErrorPtr(ErrorPtr const&) = delete;
+        auto operator=(ErrorPtr const&) -> ErrorPtr const& = delete;
         ~ErrorPtr()
         {
             if (error)

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -90,6 +90,21 @@ public:
         std::atomic<xcb_atom_t> mutable atom{XCB_ATOM_NONE};
     };
 
+    struct ErrorPtr
+    {
+        ~ErrorPtr()
+        {
+            if (error)
+            {
+                free(error);
+            }
+        }
+
+        operator xcb_generic_error_t**() { return &error; }
+
+        xcb_generic_error_t* error;
+    };
+
     explicit XCBConnection(Fd const& fd);
     ~XCBConnection();
 

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -465,14 +465,16 @@ void mf::XWaylandWM::manage_window(xcb_window_t window, geom::Rectangle const& g
                 functions.push_back(connection->read_property(
                     window,
                     atom,
-                    [this, log_prop](xcb_get_property_reply_t* reply)
                     {
-                        auto const reply_str = connection->reply_debug_string(reply);
-                        log_prop(reply_str);
-                    },
-                    [log_prop]()
-                    {
-                        log_prop("Error getting value");
+                        [this, log_prop](xcb_get_property_reply_t* reply)
+                        {
+                            auto const reply_str = connection->reply_debug_string(reply);
+                            log_prop(reply_str);
+                        },
+                        [log_prop](std::string const& message)
+                        {
+                            log_prop("error getting value: " + message);
+                        }
                     }));
             }
             free(props_reply);
@@ -609,14 +611,16 @@ void mf::XWaylandWM::handle_property_notify(xcb_property_notify_event_t *event)
             auto const reply_function = connection->read_property(
                 event->window,
                 event->atom,
-                [this, log_prop](xcb_get_property_reply_t* reply)
                 {
-                    auto const reply_str = connection->reply_debug_string(reply);
-                    log_prop(reply_str);
-                },
-                [log_prop]()
-                {
-                    log_prop("Error getting value");
+                    [this, log_prop](xcb_get_property_reply_t* reply)
+                    {
+                        auto const reply_str = connection->reply_debug_string(reply);
+                        log_prop(reply_str);
+                    },
+                    [log_prop](std::string const& message)
+                    {
+                        log_prop("error getting value: " + message);
+                    }
                 });
 
             reply_function();


### PR DESCRIPTION
Stacked on #1728. This simplifies passing around `on_success`/`on_error` callbacks. Starting to look similar to a future but I think it's still fine to have an XCB-specific concept here.