### PR TITLE
Fixes for building with LTO-by-default in Fedora

### DIFF
--- a/benchmarks/frame-uniformity/CMakeLists.txt
+++ b/benchmarks/frame-uniformity/CMakeLists.txt
@@ -1,9 +1,3 @@
-
-string(REPLACE "-flto" "" NO_LTO_FLAGS ${CMAKE_C_FLAGS})
-set(CMAKE_C_FLAGS ${NO_LTO_FLAGS})
-string(REPLACE "-flto" "" NO_LTO_FLAGS ${CMAKE_CXX_FLAGS})
-set(CMAKE_CXX_FLAGS ${NO_LTO_FLAGS})
-
 include_directories(
   ${PROJECT_SOURCE_DIR}/include/common
   ${PROJECT_SOURCE_DIR}/include/platform

--- a/src/client/lttng/CMakeLists.txt
+++ b/src/client/lttng/CMakeLists.txt
@@ -10,11 +10,6 @@ add_library(
   perf_report.cpp
 )
 
-# Using LTO on the lttng DSO causes a gcc ICE.
-# Since LTO is reasonably uninteresting for the lttng tracer, disable it.
-string(REPLACE "-flto" "" NO_LTO_FLAGS ${CMAKE_C_FLAGS})
-set(CMAKE_C_FLAGS ${NO_LTO_FLAGS})
-
 # lttng-ust uses urcu headers which contain code blocks inside expressions 
 # this is a gnu extension.
 string(REPLACE "-pedantic" "" NO_PEDANTIC_CHECK_FLAGS ${CMAKE_CXX_FLAGS})

--- a/src/server/report/lttng/CMakeLists.txt
+++ b/src/server/report/lttng/CMakeLists.txt
@@ -9,11 +9,6 @@ add_compile_options(
   -Wno-error=unused-parameter
 )
 
-# Using LTO on the lttng DSO causes a gcc ICE.
-# Since LTO is reasonably uninteresting for the lttng tracer, disable it.
-string(REPLACE "-flto" "" NO_LTO_FLAGS ${CMAKE_C_FLAGS})
-set(CMAKE_C_FLAGS ${NO_LTO_FLAGS})
-
 if (LTTNG_UST_VERSION VERSION_GREATER 2.9)
     add_definitions(-DMIR_LTTNG_HAS_VOID_TRACEPOINTS)
 endif()


### PR DESCRIPTION
This fixes the build for Mir in Fedora with our [LTO-by-default setup for package builds](https://fedoraproject.org/wiki/LTOByDefault).