### PR TITLE
Respect motif decoration hint

### DIFF
--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -72,6 +72,32 @@ enum class NetWmMoveresize: uint32_t
     CANCEL = 11,        /* cancel operation */
 };
 
+// Any standard for the motif hints seems to be lost to time, but Weston has a reasonable definition:
+// https://github.com/wayland-project/weston/blob/f7f8f5f1a87dd697ad6de74a885493bcca920cde/xwayland/window-manager.c#L78
+namespace MotifWmHintsIndices
+{
+enum MotifWmHintsIndices: unsigned
+{
+    FLAGS,
+    FUNCTIONS,
+    DECORATIONS,
+    INPUT_MODE,
+    STATUS,
+    END,
+};
+}
+
+namespace MotifWmHintsFlags
+{
+enum MotifWmHintsFlags: uint32_t
+{
+    FUNCTIONS = (1L << 0),
+    DECORATIONS = (1L << 1),
+    INPUT_MODE = (1L << 2),
+    STATUS = (1L << 3),
+};
+}
+
 auto wm_resize_edge_to_mir_resize_edge(NetWmMoveresize wm_resize_edge) -> std::experimental::optional<MirResizeEdge>
 {
     switch (wm_resize_edge)
@@ -221,6 +247,14 @@ mf::XWaylandSurface::XWaylandSurface(
                       std::lock_guard<std::mutex> lock{mutex};
                       this->cached.supported_wm_protocols.clear();
                   }
+              }),
+          property_handler<std::vector<uint32_t>>(
+              connection,
+              window,
+              connection->_MOTIF_WM_HINTS,
+              [this](auto hints)
+              {
+                  motif_wm_hints(hints);
               })}
 {
     cached.top_left = geometry.top_left;
@@ -567,7 +601,6 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
         params.top_left = cached.top_left;
         params.type = mir_window_type_freestyle;
         params.state = state.mir_window_state();
-        params.server_side_decorated = !cached.override_redirect;
     }
 
     std::vector<std::function<void()>> reply_functions;
@@ -616,6 +649,8 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
         {
             params.update_from(*spec.value());
         }
+
+        params.server_side_decorated = !cached.override_redirect && !cached.motif_decorations_disabled;
     }
 
     auto const surface = shell->create_surface(session, params, observer);
@@ -1150,5 +1185,20 @@ void mf::XWaylandSurface::fix_parent_if_necessary(const std::lock_guard<std::mut
             }
             set_parent(focused_window.value(), lock);
         }
+    }
+}
+
+void mf::XWaylandSurface::motif_wm_hints(std::vector<uint32_t> const& hints)
+{
+    std::lock_guard<std::mutex> lock{mutex};
+    if (hints.size() != MotifWmHintsIndices::END)
+    {
+        log_error("_MOTIF_WM_HINTS value has incorrect size %lu", hints.size());
+        return;
+    }
+    if (MotifWmHintsFlags::DECORATIONS & hints[MotifWmHintsIndices::FLAGS])
+    {
+        // Disable decorations only if all flags are off
+        cached.motif_decorations_disabled = (hints[MotifWmHintsIndices::DECORATIONS] == 0);
     }
 }

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -1193,7 +1193,7 @@ void mf::XWaylandSurface::motif_wm_hints(std::vector<uint32_t> const& hints)
     std::lock_guard<std::mutex> lock{mutex};
     if (hints.size() != MotifWmHintsIndices::END)
     {
-        log_error("_MOTIF_WM_HINTS value has incorrect size %lu", hints.size());
+        log_error("_MOTIF_WM_HINTS value has incorrect size %zu", hints.size());
         return;
     }
     if (MotifWmHintsFlags::DECORATIONS & hints[MotifWmHintsIndices::FLAGS])

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -144,6 +144,7 @@ private:
     void window_type(std::vector<xcb_atom_t> const& wm_types);
     void set_parent(xcb_window_t xcb_window, std::lock_guard<std::mutex> const&);
     void fix_parent_if_necessary(const std::lock_guard<std::mutex>& lock);
+    void motif_wm_hints(std::vector<uint32_t> const& hints);
 
     XWaylandWM* const xwm;
     std::shared_ptr<XCBConnection> const connection;
@@ -169,6 +170,9 @@ private:
 
         /// The contents of the _NET_SUPPORTED property set by the client
         std::set<xcb_atom_t> supported_wm_protocols;
+
+        /// True if server-side decorations have been explicitly disabled with motif hints
+        bool motif_decorations_disabled{false};
     } cached;
 
     /// Set in set_wl_surface and cleared when a scene surface is created from it


### PR DESCRIPTION
This allows a window to request to be undecorated by setting the decorations element of the `_MOTIF_WM_HINTS` property to 0. This fixes #1758, as well as well as removing the double-decorations seen on gedit.