### PR TITLE
Add 'group' option to display config yaml

### DIFF
--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -42,6 +42,7 @@ char const* const position = "position";
 char const* const mode = "mode";
 char const* const orientation = "orientation";
 char const* const scale = "scale";
+char const* const group = "group";
 char const* const orientation_value[] = { "normal", "left", "inverted", "right" };
 
 auto as_string(MirOrientation orientation) -> char const*
@@ -186,6 +187,11 @@ try
                     if (auto const pos = port_config[position])
                     {
                         output_config.position = Point{pos[0].as<int>(), pos[1].as<int>()};
+                    }
+
+                    if (auto const group_id = port_config[group])
+                    {
+                        output_config.group_id = group_id.as<int>();
                     }
 
                     if (auto const m = port_config[mode])
@@ -348,6 +354,15 @@ void miral::StaticDisplayConfig::apply_to(mg::DisplayConfiguration& conf)
                 {
                     conf_output.orientation = conf.orientation.value();
                 }
+
+                if (conf.group_id.is_set())
+                {
+                    conf_output.logical_group_id = mg::DisplayConfigurationLogicalGroupId{conf.group_id.value()};
+                }
+                else
+                {
+                    conf_output.logical_group_id = mg::DisplayConfigurationLogicalGroupId{};
+                }
             }
             else
             {
@@ -385,7 +400,9 @@ void miral::StaticDisplayConfig::apply_to(mg::DisplayConfiguration& conf)
                         << "\t# Defaults to [0, 0]"
                            "\n        # orientation: " << as_string(conf_output.orientation)
                         << "\t# {normal, left, right, inverted}, defaults to normal"
-                           "\n        # scale: " << conf_output.scale;
+                           "\n        # scale: " << conf_output.scale
+                        << "\n        # group: " << conf_output.logical_group_id.as_value()
+                        << "\t# Outputs with the same non-zero value are treated as a single display";
                 }
             }
             else

--- a/src/miral/static_display_config.h
+++ b/src/miral/static_display_config.h
@@ -58,6 +58,7 @@ private:
         mir::optional_value<double> refresh;
         mir::optional_value<float>  scale;
         mir::optional_value<MirOrientation>  orientation;
+        mir::optional_value<int> group_id;
     };
 
     using Id2Config = std::map<Id, Config>;

--- a/tests/miral/static_display_config.cpp
+++ b/tests/miral/static_display_config.cpp
@@ -394,3 +394,18 @@ TEST_F(StaticDisplayConfig, ill_formed_status_causes_AbnormalExit)
 
     EXPECT_THROW((sdc.load_config(ill_formed, "")), mir::AbnormalExit);
 }
+
+TEST_F(StaticDisplayConfig, group_can_be_set)
+{
+    std::istringstream stream{
+        "layouts:\n"
+        "  default:\n"
+        "    cards:\n"
+        "    - HDMI-A-1:\n"
+        "        group: 2\n"};
+
+    sdc.load_config(stream, "");
+    sdc.apply_to(dc);
+
+    EXPECT_THAT(hdmi1.logical_group_id, Eq(mg::DisplayConfigurationLogicalGroupId{2}));
+}


### PR DESCRIPTION
This allows mir-kiosk and other servers that use the YAML display config system to put outputs in logical groups (aka display walls). I can change the option name to `wall`, `display-wall` or something else if preferable, but IMO `group` is the most obvious.