### PR TITLE
Fix missing #includes for GCC 11

### DIFF
--- a/src/core/geometry/rectangles.cpp
+++ b/src/core/geometry/rectangles.cpp
@@ -19,6 +19,7 @@
 #include "mir/geometry/rectangles.h"
 #include "mir/geometry/displacement.h"
 #include <algorithm>
+#include <limits>
 
 namespace geom = mir::geometry;
 

--- a/src/platform/graphics/gamma_curves.cpp
+++ b/src/platform/graphics/gamma_curves.cpp
@@ -20,6 +20,7 @@
 
 #include <boost/throw_exception.hpp>
 
+#include <limits>
 #include <algorithm>
 #include <stdexcept>
 


### PR DESCRIPTION
This is from an effort in Fedora to prepare for the GCC 11 rebase for Fedora 34.