### PR TITLE
[mir-kiosk] `run_with` the `ExternalClientLauncher`

### DIFF
--- a/examples/miral-kiosk/kiosk_main.cpp
+++ b/examples/miral-kiosk/kiosk_main.cpp
@@ -124,6 +124,7 @@ int main(int argc, char const* argv[])
             Keymap{},
             show_splash,
             startup_only,
+            launcher,
             CommandLineOption{run_startup_apps, "startup-apps", "Colon separated list of startup apps", ""},
             StartupInternalClient{splash}
         });


### PR DESCRIPTION
Answers the question "Why does `WAYLAND_DISPLAY=wayland-mir ./bin/miral-kiosk --startup-apps weston-terminal` (built from master) fail with "Cannot launch apps when server has not started?""