### PR TITLE
Allow adding and dropping Wayland extensions

### DIFF
--- a/include/miral/miral/wayland_extensions.h
+++ b/include/miral/miral/wayland_extensions.h
@@ -38,9 +38,8 @@ class Window;
 
 /// Enable configuration of the Wayland extensions enabled at runtime.
 ///
-/// This adds the command line option '--wayland-extensions' the corresponding
-/// MIR_SERVER_WAYLAND_EXTENSIONS environment variable, and the wayland-extensions
-/// config line.
+/// This adds the command line options '--wayland-extensions', '--add-wayland-extensions', '--drop-wayland-extensions'
+/// and the corresponding MIR_SERVER_* environment variables and config file options.
 ///   * The server can add support for additional extensions
 ///   * The server can specify the configuration defaults
 ///   * Mir's option handling allows the defaults to be overridden

--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -51,8 +51,8 @@ extern char const* const composite_delay_opt;
 extern char const* const enable_key_repeat_opt;
 extern char const* const x11_display_opt;
 extern char const* const wayland_extensions_opt;
-extern char const* const add_extensions_opt;
-extern char const* const drop_extensions_opt;
+extern char const* const add_wayland_extensions_opt;
+extern char const* const drop_wayland_extensions_opt;
 extern char const* const enable_mirclient_opt;
 
 extern char const* const offscreen_opt;

--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -51,6 +51,8 @@ extern char const* const composite_delay_opt;
 extern char const* const enable_key_repeat_opt;
 extern char const* const x11_display_opt;
 extern char const* const wayland_extensions_opt;
+extern char const* const add_extensions_opt;
+extern char const* const drop_extensions_opt;
 extern char const* const enable_mirclient_opt;
 
 extern char const* const offscreen_opt;

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -147,7 +147,11 @@ struct miral::WaylandExtensions::Self
 
         if (!errors.empty())
         {
-            throw mir::AbnormalExit{"Unsupported wayland extensions: " + serialize_colon_list(errors)};
+            throw mir::AbnormalExit{
+                "Unsupported wayland extensions: " +
+                serialize_colon_list(errors) +
+                ". Supported extensions are: " +
+                serialize_colon_list({begin(supported_extensions), end(supported_extensions)})};
         }
     }
 

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -198,11 +198,30 @@ void miral::WaylandExtensions::operator()(mir::Server& server) const
 {
     StaticExtensionTracker::add_server_extension(&server, self.get());
 
-    std::vector<std::string> extensions{self->supported_extensions.begin(), self->supported_extensions.end()};
+    std::vector<std::string> supported_extensions{self->supported_extensions.begin(), self->supported_extensions.end()};
+    std::vector<std::string> default_extensions{self->default_extensions.begin(), self->default_extensions.end()};
+    std::vector<std::string> non_default_extensions;
+    for (auto const& extension : self->supported_extensions)
+    {
+        if (self->default_extensions.find(extension) == self->default_extensions.end())
+        {
+            non_default_extensions.push_back(extension);
+        }
+    }
 
     server.add_configuration_option(
         mo::wayland_extensions_opt,
-        ("Wayland extensions to enable. [" + Self::serialize_colon_list(extensions) + "]"),
+        ("Exhaustive list of all Wayland extensions to enable. [" + Self::serialize_colon_list(supported_extensions) + "]"),
+        mir::OptionType::string);
+
+    server.add_configuration_option(
+        mo::add_extensions_opt,
+        ("Additional Wayland extensions to enable. [" + Self::serialize_colon_list(non_default_extensions) + "]"),
+        mir::OptionType::string);
+
+    server.add_configuration_option(
+        mo::drop_extensions_opt,
+        ("Wayland extensions to disable. [" + Self::serialize_colon_list(default_extensions) + "]"),
         mir::OptionType::string);
 
     server.add_pre_init_callback([self=self, &server]
@@ -248,6 +267,27 @@ void miral::WaylandExtensions::operator()(mir::Server& server) const
             {
                 selected_extensions = self->default_extensions;
             }
+
+            if (server.get_options()->is_set(mo::add_extensions_opt))
+            {
+                auto const added = Self::parse_extensions_option(
+                    server.get_options()->get<std::string>(mo::add_extensions_opt));
+                for (auto const& extension : added)
+                {
+                    selected_extensions.insert(extension);
+                }
+            }
+
+            if (server.get_options()->is_set(mo::drop_extensions_opt))
+            {
+                auto const dropped = Self::parse_extensions_option(
+                    server.get_options()->get<std::string>(mo::drop_extensions_opt));
+                for (auto const& extension : dropped)
+                {
+                    selected_extensions.erase(extension);
+                }
+            }
+
             self->validate(selected_extensions);
             server.set_enabled_wayland_extensions(
                 std::vector<std::string>{

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -219,12 +219,12 @@ void miral::WaylandExtensions::operator()(mir::Server& server) const
         mir::OptionType::string);
 
     server.add_configuration_option(
-        mo::add_extensions_opt,
+        mo::add_wayland_extensions_opt,
         ("Additional Wayland extensions to enable. [" + Self::serialize_colon_list(non_default_extensions) + "]"),
         mir::OptionType::string);
 
     server.add_configuration_option(
-        mo::drop_extensions_opt,
+        mo::drop_wayland_extensions_opt,
         ("Wayland extensions to disable. [" + Self::serialize_colon_list(default_extensions) + "]"),
         mir::OptionType::string);
 
@@ -272,20 +272,20 @@ void miral::WaylandExtensions::operator()(mir::Server& server) const
                 selected_extensions = self->default_extensions;
             }
 
-            if (server.get_options()->is_set(mo::add_extensions_opt))
+            if (server.get_options()->is_set(mo::add_wayland_extensions_opt))
             {
                 auto const added = Self::parse_extensions_option(
-                    server.get_options()->get<std::string>(mo::add_extensions_opt));
+                    server.get_options()->get<std::string>(mo::add_wayland_extensions_opt));
                 for (auto const& extension : added)
                 {
                     selected_extensions.insert(extension);
                 }
             }
 
-            if (server.get_options()->is_set(mo::drop_extensions_opt))
+            if (server.get_options()->is_set(mo::drop_wayland_extensions_opt))
             {
                 auto const dropped = Self::parse_extensions_option(
-                    server.get_options()->get<std::string>(mo::drop_extensions_opt));
+                    server.get_options()->get<std::string>(mo::drop_wayland_extensions_opt));
                 for (auto const& extension : dropped)
                 {
                     selected_extensions.erase(extension);

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -51,6 +51,8 @@ char const* const mo::composite_delay_opt         = "composite-delay";
 char const* const mo::enable_key_repeat_opt       = "enable-key-repeat";
 char const* const mo::x11_display_opt             = "enable-x11";
 char const* const mo::wayland_extensions_opt      = "wayland-extensions";
+char const* const mo::add_extensions_opt          = "add-extensions";
+char const* const mo::drop_extensions_opt         = "drop-extensions";
 char const* const mo::enable_mirclient_opt        = "enable-mirclient";
 
 char const* const mo::off_opt_value = "off";

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -51,8 +51,8 @@ char const* const mo::composite_delay_opt         = "composite-delay";
 char const* const mo::enable_key_repeat_opt       = "enable-key-repeat";
 char const* const mo::x11_display_opt             = "enable-x11";
 char const* const mo::wayland_extensions_opt      = "wayland-extensions";
-char const* const mo::add_extensions_opt          = "add-extensions";
-char const* const mo::drop_extensions_opt         = "drop-extensions";
+char const* const mo::add_wayland_extensions_opt  = "add-wayland-extensions";
+char const* const mo::drop_wayland_extensions_opt = "drop-wayland-extensions";
 char const* const mo::enable_mirclient_opt        = "enable-mirclient";
 
 char const* const mo::off_opt_value = "off";

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -185,7 +185,7 @@ MIRPLATFORM_2.1 {
 MIRPLATFORM_2.2 {
  global:
   extern "C++" {
-    mir::options::add_extensions_opt;
-    mir::options::drop_extensions_opt;
+    mir::options::add_wayland_extensions_opt;
+    mir::options::drop_wayland_extensions_opt;
  };
 } MIRPLATFORM_2.1;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -181,3 +181,11 @@ MIRPLATFORM_2.1 {
  };
  local: *;
 };
+
+MIRPLATFORM_2.2 {
+ global:
+  extern "C++" {
+    mir::options::add_extensions_opt;
+    mir::options::drop_extensions_opt;
+ };
+} MIRPLATFORM_2.1;

--- a/tests/miral/wayland_extensions.cpp
+++ b/tests/miral/wayland_extensions.cpp
@@ -496,7 +496,7 @@ TEST_F(WaylandExtensions, add_extensions_option_adds_extensions)
     miral::WaylandExtensions extensions;
     ClientGlobalEnumerator enumerator_client;
 
-    add_to_environment("MIR_SERVER_ADD_EXTENSIONS", "xdg_wm_base:zwlr_layer_shell_v1");
+    add_to_environment("MIR_SERVER_ADD_WAYLAND_EXTENSIONS", "xdg_wm_base:zwlr_layer_shell_v1");
 
     add_server_init(extensions);
     start_server();
@@ -513,7 +513,7 @@ TEST_F(WaylandExtensions, drop_extensions_option_removes_extensions)
     miral::WaylandExtensions extensions;
     ClientGlobalEnumerator enumerator_client;
 
-    add_to_environment("MIR_SERVER_DROP_EXTENSIONS", "xdg_wm_base:zwlr_layer_shell_v1");
+    add_to_environment("MIR_SERVER_DROP_WAYLAND_EXTENSIONS", "xdg_wm_base:zwlr_layer_shell_v1");
 
     add_server_init(extensions);
     start_server();

--- a/tests/miral/wayland_extensions.cpp
+++ b/tests/miral/wayland_extensions.cpp
@@ -490,3 +490,37 @@ TEST_F(WaylandExtensions, wayland_extensions_option_sets_extensions)
     EXPECT_THAT(*enumerator_client.interfaces, Contains(Eq("zwlr_layer_shell_v1")));
     EXPECT_THAT(*enumerator_client.interfaces, Not(Contains(Eq("wl_shell"))));
 }
+
+TEST_F(WaylandExtensions, add_extensions_option_adds_extensions)
+{
+    miral::WaylandExtensions extensions;
+    ClientGlobalEnumerator enumerator_client;
+
+    add_to_environment("MIR_SERVER_ADD_EXTENSIONS", "xdg_wm_base:zwlr_layer_shell_v1");
+
+    add_server_init(extensions);
+    start_server();
+
+    run_as_client(enumerator_client);
+
+    EXPECT_THAT(*enumerator_client.interfaces, Contains(Eq("wl_shell")));
+    EXPECT_THAT(*enumerator_client.interfaces, Contains(Eq("xdg_wm_base")));
+    EXPECT_THAT(*enumerator_client.interfaces, Contains(Eq("zwlr_layer_shell_v1")));
+}
+
+TEST_F(WaylandExtensions, drop_extensions_option_removes_extensions)
+{
+    miral::WaylandExtensions extensions;
+    ClientGlobalEnumerator enumerator_client;
+
+    add_to_environment("MIR_SERVER_DROP_EXTENSIONS", "xdg_wm_base:zwlr_layer_shell_v1");
+
+    add_server_init(extensions);
+    start_server();
+
+    run_as_client(enumerator_client);
+
+    EXPECT_THAT(*enumerator_client.interfaces, Contains(Eq("wl_shell")));
+    EXPECT_THAT(*enumerator_client.interfaces, Not(Contains(Eq("xdg_wm_base"))));
+    EXPECT_THAT(*enumerator_client.interfaces, Not(Contains(Eq("zwlr_layer_shell_v1"))));
+}

--- a/tests/miral/wayland_extensions.cpp
+++ b/tests/miral/wayland_extensions.cpp
@@ -473,3 +473,20 @@ TEST_F(WaylandExtensions, disable_can_disable_bespoke_extension)
 
     EXPECT_THAT(*enumerator_client.interfaces, Not(Contains(Eq(mir::examples::server_decoration_extension().name))));
 }
+
+TEST_F(WaylandExtensions, wayland_extensions_option_sets_extensions)
+{
+    miral::WaylandExtensions extensions;
+    ClientGlobalEnumerator enumerator_client;
+
+    add_to_environment("MIR_SERVER_WAYLAND_EXTENSIONS", "xdg_wm_base:zwlr_layer_shell_v1");
+
+    add_server_init(extensions);
+    start_server();
+
+    run_as_client(enumerator_client);
+
+    EXPECT_THAT(*enumerator_client.interfaces, Contains(Eq("xdg_wm_base")));
+    EXPECT_THAT(*enumerator_client.interfaces, Contains(Eq("zwlr_layer_shell_v1")));
+    EXPECT_THAT(*enumerator_client.interfaces, Not(Contains(Eq("wl_shell"))));
+}


### PR DESCRIPTION
This adds `--add-extensions` and `--drop-extension` options, which allow controlling enabled extensions without specifying an exhaustive list. Fixes #1757 