### PR TITLE
gbm-kms: Implement composite-bypass for Wayland clients

### DIFF
--- a/include/platform/mir/graphics/dmabuf_buffer.h
+++ b/include/platform/mir/graphics/dmabuf_buffer.h
@@ -32,7 +32,7 @@ namespace graphics
 /**
  * A logical buffer backed by one-or-more dmabuf buffers
  */
-class DMABufBuffer
+class DMABufBuffer : public NativeBufferBase
 {
 public:
     struct PlaneDescriptor

--- a/include/platform/mir/graphics/dmabuf_buffer.h
+++ b/include/platform/mir/graphics/dmabuf_buffer.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef MIR_GRAPHICS_DMABUF_BUFFER_H_
+#define MIR_GRAPHICS_DMABUF_BUFFER_H_
+
+#include <cstdint>
+#include <optional>
+
+#include "mir/graphics/buffer.h"
+#include "mir/fd.h"
+
+namespace mir
+{
+namespace graphics
+{
+/**
+ * A logical buffer backed by one-or-more dmabuf buffers
+ */
+class DMABufBuffer
+{
+public:
+    struct PlaneDescriptor
+    {
+        mir::Fd dma_buf;
+        uint32_t stride;
+        uint32_t offset;
+    };
+    virtual ~DMABufBuffer() = default;
+
+    /**
+     * The format of this logical buffer, as in <drm_fourcc.h>
+     */
+    virtual auto drm_fourcc() const -> uint32_t = 0;
+
+    /**
+     * The DRM modifier of this logical buffer
+     * \note    Both the DRM and Wayland APIs accept per-plane modifiers. However, this
+     *          doesn't actually make sense (the modifier modifies the *logical* buffer
+     *          format) and the kernel rejects any request where there are different
+     *          modifiers for different planes.
+     */
+    virtual auto modifier() const -> uint64_t = 0;
+
+    virtual auto planes() const -> std::vector<PlaneDescriptor> const& = 0;
+
+    virtual auto size() const -> geometry::Size = 0;
+};
+}
+}
+
+#endif //MIR_GRAPHICS_DMABUF_BUFFER_H_

--- a/src/platform/graphics/CMakeLists.txt
+++ b/src/platform/graphics/CMakeLists.txt
@@ -25,6 +25,7 @@ set(
   cpu_buffers.cpp
   egl_logger.cpp
   ${PROJECT_SOURCE_DIR}/include/platform/mir/graphics/egl_logger.h
+  ${PROJECT_SOURCE_DIR}/include/platform/mir/graphics/dmabuf_buffer.h
 )
 
 add_library(mirplatformgraphicscommon OBJECT

--- a/src/platforms/gbm-kms/server/kms/display_buffer.h
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.h
@@ -132,7 +132,7 @@ private:
 
     std::shared_ptr<graphics::Buffer> visible_bypass_frame, scheduled_bypass_frame;
     std::shared_ptr<Buffer> bypass_buf{nullptr};
-    FBHandle* bypass_bufobj{nullptr};
+    std::shared_ptr<FBHandle const> bypass_bufobj{nullptr};
     std::shared_ptr<DisplayReport> const listener;
     BypassOption bypass_option;
 
@@ -149,6 +149,9 @@ private:
 
     GBMOutputSurface::FrontBuffer visible_composite_frame;
     GBMOutputSurface::FrontBuffer scheduled_composite_frame;
+
+    std::shared_ptr<FBHandle const> scheduled_fb{nullptr};
+    std::shared_ptr<FBHandle const> visible_fb{nullptr};
 
     geometry::Rectangle area;
     glm::mat2 transform;

--- a/src/platforms/gbm-kms/server/kms/kms_output.h
+++ b/src/platforms/gbm-kms/server/kms/kms_output.h
@@ -24,6 +24,7 @@
 #include "mir/geometry/displacement.h"
 #include "mir/graphics/display_configuration.h"
 #include "mir/graphics/frame.h"
+#include "mir/graphics/dmabuf_buffer.h"
 #include "mir_toolkit/common.h"
 
 #include "kms-utils/drm_mode_resources.h"
@@ -92,7 +93,19 @@ public:
      *                                  is touched.
      */
     virtual void update_from_hardware_state(DisplayConfigurationOutput& to_update) const = 0;
-    virtual FBHandle* fb_for(gbm_bo* bo) const = 0;
+
+    // TODO: Move these to a DRM-device level object
+    /**
+     * Get a DRM FB backed by the buffer referred to by a gbm_bo.
+     *
+     * \param   [in] bo The GBM bo containing the image
+     * \return  An opaque handle to a DRM FB, usable in other KMSOutput calls.
+     *
+     * \note    As suggested by the shared_ptr return value, returned FB handle may be
+     *          a reference to an existing FB rather than a new import.
+     */
+    virtual auto fb_for(gbm_bo* bo) const -> std::shared_ptr<FBHandle const> = 0;
+    virtual auto fb_for(DMABufBuffer const& buffer) const -> std::shared_ptr<FBHandle const> = 0;
 
     /**
      * Check whether buffer need to be migrated to GPU-private memory for display.

--- a/src/platforms/gbm-kms/server/linux_dmabuf.cpp
+++ b/src/platforms/gbm-kms/server/linux_dmabuf.cpp
@@ -518,7 +518,6 @@ bool drm_format_has_alpha(uint32_t format)
 
 class WaylandDmabufTexBuffer :
     public mg::BufferBasic,
-    public mg::NativeBufferBase,
     public mg::gl::Texture,
     public mg::DMABufBuffer
 {

--- a/src/platforms/gbm-kms/server/linux_dmabuf.cpp
+++ b/src/platforms/gbm-kms/server/linux_dmabuf.cpp
@@ -27,6 +27,7 @@
 #include "mir/graphics/program_factory.h"
 #include "mir/graphics/buffer.h"
 #include "mir/graphics/buffer_basic.h"
+#include "mir/graphics/dmabuf_buffer.h"
 #include "mir/executor.h"
 
 #define MIR_LOG_COMPONENT "linux-dmabuf-import"
@@ -36,7 +37,6 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
-#include <boost/range/combine.hpp>
 #include <mutex>
 #include <vector>
 #include <drm_fourcc.h>
@@ -49,22 +49,17 @@ namespace geom = mir::geometry;
 
 namespace
 {
-struct PlaneInfo
-{
-    mir::Fd fd;
-    uint32_t offset;
-    uint32_t stride;
-};
+using PlaneInfo = mg::DMABufBuffer::PlaneDescriptor;
 
 /**
  * Holds on to all imported dmabuf buffers, and allows looking up by wl_buffer
  *
  * \note This is not threadsafe, and should only be accessed on the Wayland thread
  */
-class DmaBufBuffer : public mir::wayland::Buffer
+class WlDmaBufBuffer : public mir::wayland::Buffer
 {
 public:
-    DmaBufBuffer(
+    WlDmaBufBuffer(
         EGLDisplay dpy,
         std::shared_ptr<mg::EGLExtensions> egl_extensions,
         wl_resource* wl_buffer,
@@ -81,14 +76,14 @@ public:
               height{height},
               format_{format},
               flags{flags},
-              modifier{modifier},
-              planes{std::move(plane_params)},
+              modifier_{modifier},
+              planes_{std::move(plane_params)},
               image{EGL_NO_IMAGE_KHR}
     {
         reimport_egl_image();
     }
 
-    ~DmaBufBuffer()
+    ~WlDmaBufBuffer()
     {
         if (image != EGL_NO_IMAGE_KHR)
         {
@@ -96,9 +91,9 @@ public:
         }
     }
 
-    static auto maybe_dmabuf_from_wl_buffer(wl_resource* buffer) -> DmaBufBuffer*
+    static auto maybe_dmabuf_from_wl_buffer(wl_resource* buffer) -> WlDmaBufBuffer*
     {
-        return dynamic_cast<DmaBufBuffer*>(Buffer::from(buffer));
+        return dynamic_cast<WlDmaBufBuffer*>(Buffer::from(buffer));
     }
 
     auto size() -> geom::Size
@@ -142,23 +137,23 @@ public:
         attributes.push_back(EGL_LINUX_DRM_FOURCC_EXT);
         attributes.push_back(format());
 
-        for(auto i = 0u; i < planes.size(); ++i)
+        for(auto i = 0u; i < planes_.size(); ++i)
         {
             auto const& attrib_names = egl_attribs[i];
-            auto const& plane = planes[i];
+            auto const& plane = planes_[i];
 
             attributes.push_back(attrib_names.fd);
-            attributes.push_back(static_cast<int>(plane.fd));
+            attributes.push_back(static_cast<int>(plane.dma_buf));
             attributes.push_back(attrib_names.offset);
             attributes.push_back(plane.offset);
             attributes.push_back(attrib_names.pitch);
             attributes.push_back(plane.stride);
-            if (modifier != DRM_FORMAT_MOD_INVALID)
+            if (modifier_ != DRM_FORMAT_MOD_INVALID)
             {
                 attributes.push_back(attrib_names.modifier_lo);
-                attributes.push_back(modifier & 0xFFFFFFFF);
+                attributes.push_back(modifier_ & 0xFFFFFFFF);
                 attributes.push_back(attrib_names.modifier_hi);
-                attributes.push_back(modifier >> 32);
+                attributes.push_back(modifier_ >> 32);
             }
         }
         attributes.push_back(EGL_NONE);
@@ -175,7 +170,7 @@ public:
 
         if (image == EGL_NO_IMAGE_KHR)
         {
-            auto const msg = planes.size() > 1 ?
+            auto const msg = planes_.size() > 1 ?
                 "Failed to import supplied dmabufs" :
                 "Failed to import supplied dmabuf";
             BOOST_THROW_EXCEPTION((mg::egl_error(msg)));
@@ -184,7 +179,16 @@ public:
         return image;
     }
 
-    private:
+    auto modifier() -> uint64_t
+    {
+        return modifier_;
+    }
+
+    auto planes() -> std::vector<PlaneInfo> const&
+    {
+        return planes_;
+    }
+private:
     void destroy() override
     {
         destroy_wayland_object();
@@ -195,8 +199,8 @@ public:
     int32_t const width, height;
     uint32_t const format_;
     uint32_t const flags;
-    uint64_t const modifier;
-    std::vector<PlaneInfo> const planes;
+    uint64_t const modifier_;
+    std::vector<PlaneInfo> const planes_;
     EGLImageKHR image;
 
     struct EGLPlaneAttribs
@@ -293,7 +297,7 @@ private:
                     "Plane index %u higher than maximum number of planes, %zu", plane_idx, planes.size()}));
         }
 
-        if (planes[plane_idx].fd != mir::Fd::invalid)
+        if (planes[plane_idx].dma_buf != mir::Fd::invalid)
         {
             BOOST_THROW_EXCEPTION((
                 mw::ProtocolError{
@@ -302,7 +306,7 @@ private:
                     "Plane %u already has a dmabuf", plane_idx}));
         }
 
-        planes[plane_idx].fd = std::move(fd);
+        planes[plane_idx].dma_buf = std::move(fd);
         planes[plane_idx].offset = offset;
         planes[plane_idx].stride = stride;
 
@@ -354,7 +358,7 @@ private:
             std::count_if(
                 planes.begin(),
                 planes.end(),
-                [](auto const& plane) { return plane.fd != mir::Fd::invalid; });
+                [](auto const& plane) { return plane.dma_buf != mir::Fd::invalid; });
         if (plane_count == 0)
         {
             BOOST_THROW_EXCEPTION((
@@ -365,7 +369,7 @@ private:
         }
         for (auto i = 0; i != plane_count; ++i)
         {
-            if (planes[i].fd == mir::Fd::invalid)
+            if (planes[i].dma_buf == mir::Fd::invalid)
             {
                 BOOST_THROW_EXCEPTION((
                     mw::ProtocolError{
@@ -406,7 +410,7 @@ private:
                 wl_client_post_no_memory(client);
                 return;
             }
-            new DmaBufBuffer{
+            new WlDmaBufBuffer{
                 dpy,
                 egl_extensions,
                 buffer_resource,
@@ -445,7 +449,7 @@ private:
 
         try
         {
-            new DmaBufBuffer{
+            new WlDmaBufBuffer{
                 dpy,
                 egl_extensions,
                 buffer_id,
@@ -515,12 +519,13 @@ bool drm_format_has_alpha(uint32_t format)
 class WaylandDmabufTexBuffer :
     public mg::BufferBasic,
     public mg::NativeBufferBase,
-    public mg::gl::Texture
+    public mg::gl::Texture,
+    public mg::DMABufBuffer
 {
 public:
     // Note: Must be called with a current EGL context
     WaylandDmabufTexBuffer(
-        DmaBufBuffer& source,
+        WlDmaBufBuffer& source,
         mg::EGLExtensions const& extensions,
         std::shared_ptr<mir::renderer::gl::Context> ctx,
         std::function<void()>&& on_consumed,
@@ -533,6 +538,9 @@ public:
           size_{source.size()},
           layout_{source.layout()},
           has_alpha{drm_format_has_alpha(source.format())},
+          planes_{source.planes()},
+          modifier_{source.modifier()},
+          fourcc{source.format()},
           wayland_executor{std::move(wayland_executor)}
     {
         eglBindAPI(EGL_OPENGL_ES_API);
@@ -621,6 +629,22 @@ public:
     void add_syncpoint() override
     {
     }
+
+    auto drm_fourcc() const -> uint32_t override
+    {
+        return fourcc;
+    }
+
+    auto modifier() const -> uint64_t override
+    {
+        return modifier_;
+    }
+
+    auto planes() const -> std::vector<PlaneDescriptor> const& override
+    {
+        return planes_;
+    }
+
 private:
     std::shared_ptr<mir::renderer::gl::Context> const ctx;
     GLuint const tex;
@@ -632,6 +656,10 @@ private:
     geom::Size const size_;
     Layout const layout_;
     bool const has_alpha;
+
+    std::vector<mg::DMABufBuffer::PlaneDescriptor> const planes_;
+    uint64_t const modifier_;
+    uint32_t const fourcc;
 
     std::shared_ptr<mir::Executor> const wayland_executor;
 };
@@ -901,7 +929,7 @@ auto mgg::LinuxDmaBufUnstable::buffer_from_resource(
     std::shared_ptr<Executor> wayland_executor)
     -> std::shared_ptr<Buffer>
 {
-    if (auto dmabuf = DmaBufBuffer::maybe_dmabuf_from_wl_buffer(buffer))
+    if (auto dmabuf = WlDmaBufBuffer::maybe_dmabuf_from_wl_buffer(buffer))
     {
         return std::make_shared<WaylandDmabufTexBuffer>(
             *dmabuf,

--- a/tests/include/mir/test/doubles/mock_drm.h
+++ b/tests/include/mir/test/doubles/mock_drm.h
@@ -123,6 +123,9 @@ public:
                                     uint32_t pixel_format, uint32_t const bo_handles[4],
                                     uint32_t const pitches[4], uint32_t const offsets[4],
                                     uint32_t *buf_id, uint32_t flags));
+    MOCK_METHOD(int, drmModeAddFB2WithModifiers, (int fd, uint32_t width, uint32_t height,
+        uint32_t fourcc, uint32_t const handles[4], uint32_t const pitches[4],
+        uint32_t const offsets[4], uint64_t const modifiers[4], uint32_t *buf_id, uint32_t flags));
     MOCK_METHOD2(drmModeRmFB, int(int fd, uint32_t bufferId));
 
     MOCK_METHOD5(drmModePageFlip, int(int fd, uint32_t crtc_id, uint32_t fb_id,

--- a/tests/mir_test_doubles/mock_drm.cpp
+++ b/tests/mir_test_doubles/mock_drm.cpp
@@ -651,6 +651,22 @@ int drmModeAddFB2(int fd, uint32_t width, uint32_t height,
                                       buf_id, flags);
 }
 
+int drmModeAddFB2WithModifiers(
+    int fd,
+    uint32_t width,
+    uint32_t height,
+    uint32_t fourcc,
+    uint32_t const handles[4],
+    uint32_t const pitches[4],
+    uint32_t const offsets[4],
+    uint64_t const modifiers[4],
+    uint32_t *buf_id,
+    uint32_t flags)
+{
+    return global_mock->drmModeAddFB2WithModifiers(
+        fd, width, height, fourcc, handles, pitches, offsets, modifiers, buf_id, flags);
+}
+
 int drmModeRmFB(int fd, uint32_t bufferId)
 {
     return global_mock->drmModeRmFB(fd, bufferId);

--- a/tests/unit-tests/platforms/gbm-kms/kms/mock_kms_output.h
+++ b/tests/unit-tests/platforms/gbm-kms/kms/mock_kms_output.h
@@ -72,7 +72,8 @@ struct MockKMSOutput : public graphics::gbm::KMSOutput
     MOCK_METHOD0(refresh_hardware_state, void());
     MOCK_CONST_METHOD1(update_from_hardware_state, void(graphics::DisplayConfigurationOutput&));
 
-    MOCK_CONST_METHOD1(fb_for, graphics::gbm::FBHandle*(gbm_bo*));
+    MOCK_CONST_METHOD1(fb_for, std::shared_ptr<graphics::gbm::FBHandle const>(gbm_bo*));
+    MOCK_CONST_METHOD1(fb_for, std::shared_ptr<graphics::gbm::FBHandle const>(graphics::DMABufBuffer const&));
     MOCK_CONST_METHOD1(buffer_requires_migration, bool(gbm_bo*));
     MOCK_CONST_METHOD0(drm_fd, int());
 };

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_buffer.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_buffer.cpp
@@ -21,6 +21,7 @@
 #include "src/platforms/gbm-kms/server/kms/platform.h"
 #include "src/platforms/gbm-kms/server/kms/display_buffer.h"
 #include "src/platforms/gbm-kms/include/native_buffer.h"
+#include "mir/graphics/dmabuf_buffer.h"
 #include "src/server/report/null_report_factory.h"
 #include "mir/test/doubles/mock_egl.h"
 #include "mir/test/doubles/mock_gl.h"
@@ -48,6 +49,18 @@ using namespace mir::graphics;
 using namespace mir::graphics::gbm;
 using mir::report::null_display_report;
 
+namespace
+{
+class MockDMABufBuffer : public DMABufBuffer
+{
+public:
+    MOCK_METHOD(uint32_t, drm_fourcc, (), (const override));
+    MOCK_METHOD(uint64_t, modifier, (), (const override));
+    MOCK_METHOD(std::vector<PlaneDescriptor> const&, planes, (), (const override));
+    MOCK_METHOD(geometry::Size, size, (), (const override));
+};
+}
+
 class MesaDisplayBufferTest : public Test
 {
 public:
@@ -61,10 +74,6 @@ public:
              std::make_shared<FakeRenderable>(display_area)}
         , fake_software_renderable{
              std::make_shared<FakeRenderable>(display_area)}
-        , stub_gbm_native_buffer{
-             std::make_shared<StubGBMNativeBuffer>(display_area.size)}
-        , stub_shm_native_buffer{
-             std::make_shared<mir::graphics::gbm::NativeBuffer>()}
         , bypassable_list{fake_bypassable_renderable}
     {
         ON_CALL(mock_egl, eglChooseConfig(_,_,_,1,_))
@@ -98,21 +107,25 @@ public:
                 std::shared_ptr<FBHandle const>{
                     reinterpret_cast<FBHandle const*>(0x12ad),
                     [](auto) {}}));
+        ON_CALL(*mock_kms_output, fb_for(A<DMABufBuffer const&>()))
+            .WillByDefault(Return(
+                std::shared_ptr<FBHandle const>{
+                    reinterpret_cast<FBHandle const*>(0xe0e0),
+                    [](auto) {}}));
         ON_CALL(*mock_kms_output, buffer_requires_migration(_))
             .WillByDefault(Return(false));
 
         ON_CALL(*mock_bypassable_buffer, size())
             .WillByDefault(Return(display_area.size));
-        ON_CALL(*mock_bypassable_buffer, native_buffer_handle())
-            .WillByDefault(Return(stub_gbm_native_buffer));
+        ON_CALL(*mock_bypassable_buffer, native_buffer_base())
+            .WillByDefault(Return(&mock_dmabuf_buffer));
         fake_bypassable_renderable->set_buffer(mock_bypassable_buffer);
 
-        stub_shm_native_buffer->flags = 0;  // Is not a hardware/GBM buffer
+        ON_CALL(mock_drm, drmModeAddFB2WithModifiers)
+            .WillByDefault(Return(0));
 
         ON_CALL(*mock_software_buffer, size())
             .WillByDefault(Return(display_area.size));
-        ON_CALL(*mock_software_buffer, native_buffer_handle())
-            .WillByDefault(Return(stub_shm_native_buffer));
         fake_software_renderable->set_buffer(mock_software_buffer);
     }
 
@@ -138,11 +151,10 @@ protected:
     NiceMock<MockGL>  mock_gl;
     NiceMock<MockDRM> mock_drm; 
     std::shared_ptr<MockBuffer> mock_bypassable_buffer;
+    NiceMock<MockDMABufBuffer> mock_dmabuf_buffer;
     std::shared_ptr<MockBuffer> mock_software_buffer;
     std::shared_ptr<FakeRenderable> fake_bypassable_renderable;
     std::shared_ptr<FakeRenderable> fake_software_renderable;
-    std::shared_ptr<mir::graphics::gbm::NativeBuffer> stub_gbm_native_buffer;
-    std::shared_ptr<mir::graphics::gbm::NativeBuffer> stub_shm_native_buffer;
     gbm_bo*           fake_bo;
     gbm_bo_handle     fake_handle;
     UdevEnvironment   fake_devices;
@@ -280,7 +292,8 @@ auto fake_shared_ptr(intptr_t value) -> std::shared_ptr<T>
 TEST_F(MesaDisplayBufferTest, failed_bypass_falls_back_gracefully)
 {  // Regression test for LP: #1398296
     EXPECT_CALL(*mock_kms_output, fb_for(A<gbm_bo*>()))
-        .WillOnce(Return(fake_shared_ptr<FBHandle>(0xaabb)))  // During the DisplayBuffer constructor
+        .WillOnce(Return(fake_shared_ptr<FBHandle>(0xaabb)));  // During the DisplayBuffer constructor
+    EXPECT_CALL(*mock_kms_output, fb_for(A<DMABufBuffer const&>()))
         .WillOnce(Return(nullptr)) // Fail first bypass attempt
         .WillOnce(Return(fake_shared_ptr<FBHandle>(0xbbcc))); // Succeed second bypass attempt
 
@@ -301,8 +314,8 @@ TEST_F(MesaDisplayBufferTest, skips_bypass_because_of_lagging_resize)
 {  // Another regression test for LP: #1398296
     auto fullscreen = std::make_shared<FakeRenderable>(display_area);
     auto nonbypassable = std::make_shared<testing::NiceMock<MockBuffer>>();
-    ON_CALL(*nonbypassable, native_buffer_handle())
-        .WillByDefault(Return(stub_gbm_native_buffer));
+    ON_CALL(*nonbypassable, native_buffer_base())
+        .WillByDefault(Return(&mock_dmabuf_buffer));
     ON_CALL(*nonbypassable, size())
         .WillByDefault(Return(mir::geometry::Size{12,34}));
 
@@ -498,20 +511,4 @@ TEST_F(MesaDisplayBufferTest, skips_bypass_because_of_incompatible_bypass_buffer
         identity);
 
     EXPECT_FALSE(db.overlay(list));
-}
-
-TEST_F(MesaDisplayBufferTest, buffer_requiring_migration_is_ineligable_for_bypass)
-{
-    ON_CALL(*mock_kms_output, buffer_requires_migration(Eq(stub_gbm_native_buffer->bo)))
-        .WillByDefault(Return(true));
-
-    graphics::gbm::DisplayBuffer db(
-        graphics::gbm::BypassOption::allowed,
-        null_display_report(),
-        {mock_kms_output},
-        make_output_surface(),
-        display_area,
-        identity);
-
-    EXPECT_FALSE(db.overlay(bypassable_list));
 }


### PR DESCRIPTION
Client buffers submitted with the `zwp_linux_dmabuf_unstable_v1` are now possible candidates for composite-bypass.

This comes with a number of significant caveats.

Most significantly: there's no way for the compositor to suggest to the client that it should allocate buffers that are compatible with scanout (this requires [dmabuf-hints](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/8)), so whether or not a client *can* be bypassed is a function of whether or not the display hardware can cope with whatever buffer format the EGL driver chooses.

Furthermore, until we switch to the Atomic KMS API there's no way for us to usefully *query* the set of buffer formats the display hardware can scan out of, either.