### PR TITLE
performance-tests: Use a EGL visual with no alpha channel.

### DIFF
--- a/tests/performance-tests/test_glmark2-es2.cpp
+++ b/tests/performance-tests/test_glmark2-es2.cpp
@@ -114,7 +114,7 @@ struct GLMark2Xwayland : AbstractGLMark2Test
     char const* command() override
     {
         add_to_environment("DISPLAY", server.x11_display().value().c_str());
-        static char const* const command = "glmark2-es2";
+        static char const* const command = "glmark2-es2 --visual-config \"alpha=0\"";
         return command;
     }
 };
@@ -129,7 +129,7 @@ struct GLMark2Wayland : AbstractGLMark2Test
 
     char const* command() override
     {
-        static char const* const command = "glmark2-es2-wayland";
+        static char const* const command = "glmark2-es2-wayland --visual-config \"alpha=0\"";
         return command;
     }
 };


### PR DESCRIPTION
This makes more sense as a performance test, as very few windows
are going to want to blend their EGL rendering with what's behind them.

Also, this makes GLMark2 eligible for composite-bypass, when that is implemented,
and that's a very interesting optimisation to be able to see when it
works (and doesn't).