### PR TITLE
gbm-kms: Implement composite-bypass for Wayland clients

### DIFF
--- a/include/platform/mir/graphics/dmabuf_buffer.h
+++ b/include/platform/mir/graphics/dmabuf_buffer.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef MIR_GRAPHICS_DMABUF_BUFFER_H_
+#define MIR_GRAPHICS_DMABUF_BUFFER_H_
+
+#include <cstdint>
+#include <optional>
+
+#include "mir/graphics/buffer.h"
+#include "mir/fd.h"
+
+namespace mir
+{
+namespace graphics
+{
+/**
+ * A logical buffer backed by one-or-more dmabuf buffers
+ */
+class DMABufBuffer
+{
+public:
+    struct PlaneDescriptor
+    {
+        mir::Fd dma_buf;
+        uint32_t stride;
+        uint32_t offset;
+    };
+    virtual ~DMABufBuffer() = default;
+
+    /**
+     * The format of this logical buffer, as in <drm_fourcc.h>
+     */
+    virtual auto drm_fourcc() const -> uint32_t = 0;
+
+    /**
+     * The DRM modifier of this logical buffer, if specified.
+     * \note    Both the DRM and Wayland APIs accept per-plane modifiers. However, this
+     *          doesn't actually make sense (the modifier modifies the *logical* buffer
+     *          format) and the kernel rejects any request where there are different
+     *          modifiers for different planes.
+     */
+    virtual auto modifier() const -> std::optional<uint64_t> = 0;
+
+    virtual auto planes() const -> std::vector<PlaneDescriptor> const& = 0;
+
+    virtual auto size() const -> geometry::Size = 0;
+};
+}
+}
+
+#endif //MIR_GRAPHICS_DMABUF_BUFFER_H_

--- a/include/platform/mir/graphics/dmabuf_buffer.h
+++ b/include/platform/mir/graphics/dmabuf_buffer.h
@@ -32,7 +32,7 @@ namespace graphics
 /**
  * A logical buffer backed by one-or-more dmabuf buffers
  */
-class DMABufBuffer
+class DMABufBuffer : public NativeBufferBase
 {
 public:
     struct PlaneDescriptor

--- a/src/platform/graphics/CMakeLists.txt
+++ b/src/platform/graphics/CMakeLists.txt
@@ -25,6 +25,7 @@ set(
   cpu_buffers.cpp
   egl_logger.cpp
   ${PROJECT_SOURCE_DIR}/include/platform/mir/graphics/egl_logger.h
+  ${PROJECT_SOURCE_DIR}/include/platform/mir/graphics/dmabuf_buffer.h
 )
 
 add_library(mirplatformgraphicscommon OBJECT

--- a/src/platforms/gbm-kms/server/kms/display_buffer.h
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.h
@@ -132,7 +132,7 @@ private:
 
     std::shared_ptr<graphics::Buffer> visible_bypass_frame, scheduled_bypass_frame;
     std::shared_ptr<Buffer> bypass_buf{nullptr};
-    FBHandle* bypass_bufobj{nullptr};
+    std::shared_ptr<FBHandle const> bypass_bufobj{nullptr};
     std::shared_ptr<DisplayReport> const listener;
     BypassOption bypass_option;
 
@@ -149,6 +149,9 @@ private:
 
     GBMOutputSurface::FrontBuffer visible_composite_frame;
     GBMOutputSurface::FrontBuffer scheduled_composite_frame;
+
+    std::shared_ptr<FBHandle const> scheduled_fb{nullptr};
+    std::shared_ptr<FBHandle const> visible_fb{nullptr};
 
     geometry::Rectangle area;
     glm::mat2 transform;

--- a/src/platforms/gbm-kms/server/kms/kms_output.h
+++ b/src/platforms/gbm-kms/server/kms/kms_output.h
@@ -24,6 +24,7 @@
 #include "mir/geometry/displacement.h"
 #include "mir/graphics/display_configuration.h"
 #include "mir/graphics/frame.h"
+#include "mir/graphics/dmabuf_buffer.h"
 #include "mir_toolkit/common.h"
 
 #include "kms-utils/drm_mode_resources.h"
@@ -92,7 +93,19 @@ public:
      *                                  is touched.
      */
     virtual void update_from_hardware_state(DisplayConfigurationOutput& to_update) const = 0;
-    virtual FBHandle* fb_for(gbm_bo* bo) const = 0;
+
+    // TODO: Move these to a DRM-device level object
+    /**
+     * Get a DRM FB backed by the buffer referred to by a gbm_bo.
+     *
+     * \param   [in] bo The GBM bo containing the image
+     * \return  An opaque handle to a DRM FB, usable in other KMSOutput calls.
+     *
+     * \note    As suggested by the shared_ptr return value, returned FB handle may be
+     *          a reference to an existing FB rather than a new import.
+     */
+    virtual auto fb_for(gbm_bo* bo) const -> std::shared_ptr<FBHandle const> = 0;
+    virtual auto fb_for(DMABufBuffer const& buffer) const -> std::shared_ptr<FBHandle const> = 0;
 
     /**
      * Check whether buffer need to be migrated to GPU-private memory for display.

--- a/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
+++ b/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
@@ -37,39 +37,27 @@ namespace geom = mir::geometry;
 class mgg::FBHandle
 {
 public:
-    FBHandle(gbm_bo* bo, uint32_t drm_fb_id)
-        : bo{bo}, drm_fb_id{drm_fb_id}
+    FBHandle(int drm_fd, uint32_t fb_id)
+        : drm_fd{drm_fd},
+          fb_id{fb_id}
     {
     }
 
     ~FBHandle()
     {
-        if (drm_fb_id)
-        {
-            int drm_fd = gbm_device_get_fd(gbm_bo_get_device(bo));
-            drmModeRmFB(drm_fd, drm_fb_id);
-        }
+        // TODO: Some sort of logging on failure?
+        drmModeRmFB(drm_fd, fb_id);
     }
 
-    uint32_t get_drm_fb_id() const
+    auto get_drm_fb_id() const -> uint32_t
     {
-        return drm_fb_id;
+        return fb_id;
     }
-
 private:
-    gbm_bo *bo;
-    uint32_t drm_fb_id;
+    int const drm_fd;
+    uint32_t const fb_id;
 };
 
-namespace
-{
-void bo_user_data_destroy(gbm_bo* /*bo*/, void *data)
-{
-    auto bufobj = static_cast<mgg::FBHandle*>(data);
-    delete bufobj;
-}
-
-}
 
 mgg::RealKMSOutput::RealKMSOutput(
     int drm_fd,
@@ -625,7 +613,17 @@ void mgg::RealKMSOutput::update_from_hardware_state(
     output.edid = edid;
 }
 
-mgg::FBHandle* mgg::RealKMSOutput::fb_for(gbm_bo* bo) const
+namespace
+{
+void bo_user_data_destroy(gbm_bo* /*bo*/, void *data)
+{
+    auto bufobj = static_cast<std::shared_ptr<mgg::FBHandle const>*>(data);
+    delete bufobj;
+}
+}
+
+auto mgg::RealKMSOutput::FBRegistry::lookup_or_create(int const drm_fd, gbm_bo* bo)
+    -> std::shared_ptr<FBHandle const>
 {
     if (!bo)
         return nullptr;
@@ -634,9 +632,11 @@ mgg::FBHandle* mgg::RealKMSOutput::fb_for(gbm_bo* bo) const
      * Check if we have already set up this gbm_bo (the gbm-kms implementation is
      * free to reuse gbm_bos). If so, return the associated FBHandle.
      */
-    auto bufobj = static_cast<FBHandle*>(gbm_bo_get_user_data(bo));
+    auto bufobj = static_cast<std::shared_ptr<FBHandle const>*>(gbm_bo_get_user_data(bo));
     if (bufobj)
-        return bufobj;
+    {
+        return *bufobj;
+    }
 
     uint32_t fb_id{0};
     uint32_t handles[4] = {gbm_bo_get_handle(bo).u32, 0, 0, 0};
@@ -657,16 +657,166 @@ mgg::FBHandle* mgg::RealKMSOutput::fb_for(gbm_bo* bo) const
     auto const height = gbm_bo_get_height(bo);
 
     /* Create a KMS FB object with the gbm_bo attached to it. */
-    auto ret = drmModeAddFB2(drm_fd_, width, height, format,
+    auto ret = drmModeAddFB2(drm_fd, width, height, format,
                              handles, strides, offsets, &fb_id, 0);
     if (ret)
         return nullptr;
 
     /* Create a FBHandle and associate it with the gbm_bo */
-    bufobj = new FBHandle{bo, fb_id};
+
+    bufobj = new std::shared_ptr<FBHandle const>(new FBHandle{drm_fd, fb_id});
     gbm_bo_set_user_data(bo, bufobj, bo_user_data_destroy);
 
-    return bufobj;
+    return *bufobj;
+}
+
+auto mgg::RealKMSOutput::fb_for(gbm_bo* bo) const -> std::shared_ptr<FBHandle const>
+{
+    return framebuffers.lookup_or_create(drm_fd(), bo);
+}
+
+struct mgg::RealKMSOutput::FBRegistry::DMABufFB
+{
+    std::array<Fd, 4> const fds;
+    std::array<uint32_t, 4> const bo_handles;
+    std::weak_ptr<FBHandle const> handle;
+
+    DMABufFB(
+        std::array<Fd, 4> fds,
+        std::array<uint32_t, 4> bo_handles,
+        std::weak_ptr<FBHandle const> handle)
+        : fds{std::move(fds)},
+          bo_handles{bo_handles},
+          handle{std::move(handle)}
+    {
+    }
+};
+
+auto mgg::RealKMSOutput::FBRegistry::lookup_or_create(
+    const int drm_fd,
+    const DMABufBuffer& image) -> std::shared_ptr<FBHandle const>
+{
+    // The DRM API expects a bunch of 4-element arrays, with unused elements set to 0
+    std::array<uint32_t, 4> handles = {0, 0, 0, 0};
+    std::array<uint32_t, 4> strides = {0, 0, 0, 0};
+    std::array<uint32_t, 4> offsets = {0, 0, 0, 0};
+    std::array<uint64_t, 4> modifiers = {0, 0, 0, 0};
+
+    std::array<Fd, 4> dma_bufs;
+
+    auto const& planes = image.planes();
+    for (auto i = 0u; i < planes.size() ; ++i)
+    {
+        strides[i] = planes[i].stride;
+        offsets[i] = planes[i].offset;
+        dma_bufs[i] = planes[i].dma_buf;
+    }
+
+    // If we've got this FB already imported, we can just return that…
+    auto const existing_fb = std::find_if(
+        dmabuf_fbs.begin(),
+        dmabuf_fbs.end(),
+        [&dma_bufs](auto const& candidate)
+        {
+            for (auto i = 0u; i < dma_bufs.size(); ++i)
+            {
+                /* We can do a numerical compare here because the DMAbufFB structs keep a
+                 * reference to their fds open, so any newly imported buffer will have
+                 * a different integer fd handle; they can't accidentally alias.
+                 *
+                 * And the Wayland protocol only imports the FDs once, and then the client
+                 * references the wl_buffer, so we can expect the FDs of a particular buffer
+                 * to be numerically stable.
+                 */
+                if (static_cast<int>(dma_bufs[i]) != static_cast<int>(candidate->fds[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+    uint32_t const* imported_handles;
+    if (existing_fb != dmabuf_fbs.end())
+    {
+        if (auto const handle = (*existing_fb)->handle.lock())
+        {
+            /* We have already imported the DMA-bufs *and* have a current FB for them.
+             * We can just return that.
+             */
+            return handle;
+        }
+        /* We've imported the DMA-bufs, but have already deleted the FB associated with
+         * them. Grab the previously-imported handles, then re-create a FB.
+         */
+        imported_handles = (*existing_fb)->bo_handles.data();
+    }
+    else
+    {
+        // Otherwise, we need to import the DMA-bufs
+        for (auto i = 0u; i < planes.size(); ++i)
+        {
+            if (auto const error = drmPrimeFDToHandle(drm_fd, dma_bufs[i], &handles[i]))
+            {
+                BOOST_THROW_EXCEPTION((
+                                          std::system_error{
+                                              error,
+                                              std::system_category(),
+                                              "Failed to acquire GEM handle for DMA-BUF"}));
+            }
+        }
+        imported_handles = handles.data();
+    }
+
+
+    // If there's a modifier set, propagate it to all components.
+    if (image.modifier().has_value())
+    {
+        for (auto i = 0u; i < planes.size(); ++i)
+        {
+            modifiers[i] = image.modifier().value();
+        }
+    }
+
+    uint32_t drm_fb_id;
+    auto const ret = drmModeAddFB2WithModifiers(
+        drm_fd,
+        image.size().width.as_uint32_t(),
+        image.size().height.as_uint32_t(),
+        image.drm_fourcc(),
+        imported_handles,
+        strides.data(),
+        offsets.data(),
+        image.modifier().has_value() ? modifiers.data() : nullptr,
+        &drm_fb_id,
+        image.modifier().has_value() ? DRM_MODE_FB_MODIFIERS : 0);
+
+    if (ret)
+    {
+        mir::log_debug(
+            "Failed to import dmabuf-based image as FB: %s",
+            std::system_category().message(ret).c_str());
+        return nullptr;
+    }
+
+    auto fb_handle = std::make_shared<FBHandle>(drm_fd, drm_fb_id);
+
+    if (existing_fb != dmabuf_fbs.end())
+    {
+        // We already have the buffer data; we just need to re-create a handle
+        (*existing_fb)->handle = fb_handle;
+    }
+    else
+    {
+        dmabuf_fbs.push_back(std::make_shared<DMABufFB>(std::move(dma_bufs), handles, fb_handle));
+    }
+
+    return fb_handle;
+}
+
+auto mgg::RealKMSOutput::fb_for(mg::DMABufBuffer const& image) const -> std::shared_ptr<FBHandle const>
+{
+    return framebuffers.lookup_or_create(drm_fd(), image);
 }
 
 bool mgg::RealKMSOutput::buffer_requires_migration(gbm_bo* bo) const

--- a/src/platforms/gbm-kms/server/linux_dmabuf.cpp
+++ b/src/platforms/gbm-kms/server/linux_dmabuf.cpp
@@ -518,7 +518,6 @@ bool drm_format_has_alpha(uint32_t format)
 
 class WaylandDmabufTexBuffer :
     public mg::BufferBasic,
-    public mg::NativeBufferBase,
     public mg::gl::Texture,
     public mg::DMABufBuffer
 {

--- a/tests/include/mir/test/doubles/mock_drm.h
+++ b/tests/include/mir/test/doubles/mock_drm.h
@@ -123,6 +123,9 @@ public:
                                     uint32_t pixel_format, uint32_t const bo_handles[4],
                                     uint32_t const pitches[4], uint32_t const offsets[4],
                                     uint32_t *buf_id, uint32_t flags));
+    MOCK_METHOD(int, drmModeAddFB2WithModifiers, (int fd, uint32_t width, uint32_t height,
+        uint32_t fourcc, uint32_t const handles[4], uint32_t const pitches[4],
+        uint32_t const offsets[4], uint64_t const modifiers[4], uint32_t *buf_id, uint32_t flags));
     MOCK_METHOD2(drmModeRmFB, int(int fd, uint32_t bufferId));
 
     MOCK_METHOD5(drmModePageFlip, int(int fd, uint32_t crtc_id, uint32_t fb_id,

--- a/tests/include/mir/test/doubles/mock_drm.h
+++ b/tests/include/mir/test/doubles/mock_drm.h
@@ -125,7 +125,7 @@ public:
                                     uint32_t *buf_id, uint32_t flags));
     MOCK_METHOD(int, drmModeAddFB2WithModifiers, (int fd, uint32_t width, uint32_t height,
         uint32_t fourcc, uint32_t const handles[4], uint32_t const pitches[4],
-        uint32_t const offsets[4], uint64_t const modifiers[4], uint32_t *buf_id, uint32_t flags));
+        uint32_t const offsets[4], uint64_t const modifiers[4], uint32_t *buf_id, uint32_t flags), ());
     MOCK_METHOD2(drmModeRmFB, int(int fd, uint32_t bufferId));
 
     MOCK_METHOD5(drmModePageFlip, int(int fd, uint32_t crtc_id, uint32_t fb_id,

--- a/tests/include/mir/test/doubles/mock_drm.h
+++ b/tests/include/mir/test/doubles/mock_drm.h
@@ -123,9 +123,9 @@ public:
                                     uint32_t pixel_format, uint32_t const bo_handles[4],
                                     uint32_t const pitches[4], uint32_t const offsets[4],
                                     uint32_t *buf_id, uint32_t flags));
-    MOCK_METHOD(int, drmModeAddFB2WithModifiers, (int fd, uint32_t width, uint32_t height,
+    MOCK_METHOD10(drmModeAddFB2WithModifiers, int(int fd, uint32_t width, uint32_t height,
         uint32_t fourcc, uint32_t const handles[4], uint32_t const pitches[4],
-        uint32_t const offsets[4], uint64_t const modifiers[4], uint32_t *buf_id, uint32_t flags), ());
+        uint32_t const offsets[4], uint64_t const modifiers[4], uint32_t *buf_id, uint32_t flags));
     MOCK_METHOD2(drmModeRmFB, int(int fd, uint32_t bufferId));
 
     MOCK_METHOD5(drmModePageFlip, int(int fd, uint32_t crtc_id, uint32_t fb_id,

--- a/tests/mir_test_doubles/mock_drm.cpp
+++ b/tests/mir_test_doubles/mock_drm.cpp
@@ -651,6 +651,22 @@ int drmModeAddFB2(int fd, uint32_t width, uint32_t height,
                                       buf_id, flags);
 }
 
+int drmModeAddFB2WithModifiers(
+    int fd,
+    uint32_t width,
+    uint32_t height,
+    uint32_t fourcc,
+    uint32_t const handles[4],
+    uint32_t const pitches[4],
+    uint32_t const offsets[4],
+    uint64_t const modifiers[4],
+    uint32_t *buf_id,
+    uint32_t flags)
+{
+    return global_mock->drmModeAddFB2WithModifiers(
+        fd, width, height, fourcc, handles, pitches, offsets, modifiers, buf_id, flags);
+}
+
 int drmModeRmFB(int fd, uint32_t bufferId)
 {
     return global_mock->drmModeRmFB(fd, bufferId);

--- a/tests/unit-tests/platforms/gbm-kms/kms/mock_kms_output.h
+++ b/tests/unit-tests/platforms/gbm-kms/kms/mock_kms_output.h
@@ -72,7 +72,8 @@ struct MockKMSOutput : public graphics::gbm::KMSOutput
     MOCK_METHOD0(refresh_hardware_state, void());
     MOCK_CONST_METHOD1(update_from_hardware_state, void(graphics::DisplayConfigurationOutput&));
 
-    MOCK_CONST_METHOD1(fb_for, graphics::gbm::FBHandle*(gbm_bo*));
+    MOCK_CONST_METHOD1(fb_for, std::shared_ptr<graphics::gbm::FBHandle const>(gbm_bo*));
+    MOCK_CONST_METHOD1(fb_for, std::shared_ptr<graphics::gbm::FBHandle const>(graphics::DMABufBuffer const&));
     MOCK_CONST_METHOD1(buffer_requires_migration, bool(gbm_bo*));
     MOCK_CONST_METHOD0(drm_fd, int());
 };

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_buffer.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_buffer.cpp
@@ -54,10 +54,10 @@ namespace
 class MockDMABufBuffer : public DMABufBuffer
 {
 public:
-    MOCK_METHOD(uint32_t, drm_fourcc, (), (const override));
-    MOCK_METHOD(std::optional<uint64_t>, modifier, (), (const override));
-    MOCK_METHOD(std::vector<PlaneDescriptor> const&, planes, (), (const override));
-    MOCK_METHOD(geometry::Size, size, (), (const override));
+    MOCK_CONST_METHOD0(drm_fourcc, uint32_t());
+    MOCK_CONST_METHOD0(modifier, std::optional<uint64_t>());
+    MOCK_CONST_METHOD0(planes, std::vector<PlaneDescriptor> const&());
+    MOCK_CONST_METHOD0(size, geometry::Size());
 };
 }
 
@@ -121,7 +121,7 @@ public:
             .WillByDefault(Return(&mock_dmabuf_buffer));
         fake_bypassable_renderable->set_buffer(mock_bypassable_buffer);
 
-        ON_CALL(mock_drm, drmModeAddFB2WithModifiers)
+        ON_CALL(mock_drm, drmModeAddFB2WithModifiers(_,_,_,_,_,_,_,_,_,_))
             .WillByDefault(Return(0));
 
         ON_CALL(*mock_software_buffer, size())

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_buffer.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_buffer.cpp
@@ -21,6 +21,7 @@
 #include "src/platforms/gbm-kms/server/kms/platform.h"
 #include "src/platforms/gbm-kms/server/kms/display_buffer.h"
 #include "src/platforms/gbm-kms/include/native_buffer.h"
+#include "mir/graphics/dmabuf_buffer.h"
 #include "src/server/report/null_report_factory.h"
 #include "mir/test/doubles/mock_egl.h"
 #include "mir/test/doubles/mock_gl.h"
@@ -48,6 +49,18 @@ using namespace mir::graphics;
 using namespace mir::graphics::gbm;
 using mir::report::null_display_report;
 
+namespace
+{
+class MockDMABufBuffer : public DMABufBuffer
+{
+public:
+    MOCK_METHOD(uint32_t, drm_fourcc, (), (const override));
+    MOCK_METHOD(std::optional<uint64_t>, modifier, (), (const override));
+    MOCK_METHOD(std::vector<PlaneDescriptor> const&, planes, (), (const override));
+    MOCK_METHOD(geometry::Size, size, (), (const override));
+};
+}
+
 class MesaDisplayBufferTest : public Test
 {
 public:
@@ -61,10 +74,6 @@ public:
              std::make_shared<FakeRenderable>(display_area)}
         , fake_software_renderable{
              std::make_shared<FakeRenderable>(display_area)}
-        , stub_gbm_native_buffer{
-             std::make_shared<StubGBMNativeBuffer>(display_area.size)}
-        , stub_shm_native_buffer{
-             std::make_shared<mir::graphics::gbm::NativeBuffer>()}
         , bypassable_list{fake_bypassable_renderable}
     {
         ON_CALL(mock_egl, eglChooseConfig(_,_,_,1,_))
@@ -98,21 +107,25 @@ public:
                 std::shared_ptr<FBHandle const>{
                     reinterpret_cast<FBHandle const*>(0x12ad),
                     [](auto) {}}));
+        ON_CALL(*mock_kms_output, fb_for(A<DMABufBuffer const&>()))
+            .WillByDefault(Return(
+                std::shared_ptr<FBHandle const>{
+                    reinterpret_cast<FBHandle const*>(0xe0e0),
+                    [](auto) {}}));
         ON_CALL(*mock_kms_output, buffer_requires_migration(_))
             .WillByDefault(Return(false));
 
         ON_CALL(*mock_bypassable_buffer, size())
             .WillByDefault(Return(display_area.size));
-        ON_CALL(*mock_bypassable_buffer, native_buffer_handle())
-            .WillByDefault(Return(stub_gbm_native_buffer));
+        ON_CALL(*mock_bypassable_buffer, native_buffer_base())
+            .WillByDefault(Return(&mock_dmabuf_buffer));
         fake_bypassable_renderable->set_buffer(mock_bypassable_buffer);
 
-        stub_shm_native_buffer->flags = 0;  // Is not a hardware/GBM buffer
+        ON_CALL(mock_drm, drmModeAddFB2WithModifiers)
+            .WillByDefault(Return(0));
 
         ON_CALL(*mock_software_buffer, size())
             .WillByDefault(Return(display_area.size));
-        ON_CALL(*mock_software_buffer, native_buffer_handle())
-            .WillByDefault(Return(stub_shm_native_buffer));
         fake_software_renderable->set_buffer(mock_software_buffer);
     }
 
@@ -138,11 +151,10 @@ protected:
     NiceMock<MockGL>  mock_gl;
     NiceMock<MockDRM> mock_drm; 
     std::shared_ptr<MockBuffer> mock_bypassable_buffer;
+    NiceMock<MockDMABufBuffer> mock_dmabuf_buffer;
     std::shared_ptr<MockBuffer> mock_software_buffer;
     std::shared_ptr<FakeRenderable> fake_bypassable_renderable;
     std::shared_ptr<FakeRenderable> fake_software_renderable;
-    std::shared_ptr<mir::graphics::gbm::NativeBuffer> stub_gbm_native_buffer;
-    std::shared_ptr<mir::graphics::gbm::NativeBuffer> stub_shm_native_buffer;
     gbm_bo*           fake_bo;
     gbm_bo_handle     fake_handle;
     UdevEnvironment   fake_devices;
@@ -280,7 +292,8 @@ auto fake_shared_ptr(intptr_t value) -> std::shared_ptr<T>
 TEST_F(MesaDisplayBufferTest, failed_bypass_falls_back_gracefully)
 {  // Regression test for LP: #1398296
     EXPECT_CALL(*mock_kms_output, fb_for(A<gbm_bo*>()))
-        .WillOnce(Return(fake_shared_ptr<FBHandle>(0xaabb)))  // During the DisplayBuffer constructor
+        .WillOnce(Return(fake_shared_ptr<FBHandle>(0xaabb)));  // During the DisplayBuffer constructor
+    EXPECT_CALL(*mock_kms_output, fb_for(A<DMABufBuffer const&>()))
         .WillOnce(Return(nullptr)) // Fail first bypass attempt
         .WillOnce(Return(fake_shared_ptr<FBHandle>(0xbbcc))); // Succeed second bypass attempt
 
@@ -301,8 +314,8 @@ TEST_F(MesaDisplayBufferTest, skips_bypass_because_of_lagging_resize)
 {  // Another regression test for LP: #1398296
     auto fullscreen = std::make_shared<FakeRenderable>(display_area);
     auto nonbypassable = std::make_shared<testing::NiceMock<MockBuffer>>();
-    ON_CALL(*nonbypassable, native_buffer_handle())
-        .WillByDefault(Return(stub_gbm_native_buffer));
+    ON_CALL(*nonbypassable, native_buffer_base())
+        .WillByDefault(Return(&mock_dmabuf_buffer));
     ON_CALL(*nonbypassable, size())
         .WillByDefault(Return(mir::geometry::Size{12,34}));
 
@@ -498,20 +511,4 @@ TEST_F(MesaDisplayBufferTest, skips_bypass_because_of_incompatible_bypass_buffer
         identity);
 
     EXPECT_FALSE(db.overlay(list));
-}
-
-TEST_F(MesaDisplayBufferTest, buffer_requiring_migration_is_ineligable_for_bypass)
-{
-    ON_CALL(*mock_kms_output, buffer_requires_migration(Eq(stub_gbm_native_buffer->bo)))
-        .WillByDefault(Return(true));
-
-    graphics::gbm::DisplayBuffer db(
-        graphics::gbm::BypassOption::allowed,
-        null_display_report(),
-        {mock_kms_output},
-        make_output_surface(),
-        display_area,
-        identity);
-
-    EXPECT_FALSE(db.overlay(bypassable_list));
 }


### PR DESCRIPTION
Client buffers submitted with the `zwp_linux_dmabuf_unstable_v1` are now possible candidates for composite-bypass.

This comes with a number of significant caveats.

Most significantly: there's no way for the compositor to suggest to the client that it should allocate buffers that are compatible with scanout (this requires [dmabuf-hints](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/8)), so whether or not a client *can* be bypassed is a function of whether or not the display hardware can cope with whatever buffer format the EGL driver chooses.

Furthermore, until we switch to the Atomic KMS API there's no way for us to usefully *query* the set of buffer formats the display hardware can scan out of, either.