### PR TITLE
linux-dmabuf: Fix sending invalid modifiers.

### DIFF
--- a/src/platforms/gbm-kms/server/linux_dmabuf.cpp
+++ b/src/platforms/gbm-kms/server/linux_dmabuf.cpp
@@ -851,8 +851,8 @@ public:
                 {
                     for (auto j = 0u; j < modifiers.size(); ++j)
                     {
-                        auto const& modifier = modifiers[i];
-                        auto const& external = external_only[i];
+                        auto const modifier = modifiers[j];
+                        auto const external = external_only[j];
                         if (external == EGL_FALSE)
                         {
                             // We can't (currently) handle external images


### PR DESCRIPTION
When iteration over nested containers it's important to use the correct
iteration variable. Otherwise you might accidentally read uninitialised
memory and send that as a modifier to the client!

Fixes the weird “invalid modifier” client errors we've recently seen.