### PR TITLE
wl_display_roundtrip() should be called before starting the Wayland thread

### DIFF
--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -99,8 +99,6 @@ mgw::Display::Display(
         std::lock_guard<decltype(the_display_mtx)> lock{the_display_mtx};
         the_display = this;
     }
-
-    wl_display_roundtrip(display);
 }
 
 auto mgw::Display::configuration() const -> std::unique_ptr<DisplayConfiguration>

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -467,6 +467,8 @@ mgw::DisplayClient::DisplayClient(
     eglctx = eglCreateContext(egldisplay, eglconfig, EGL_NO_CONTEXT, ctxattribs);
     if (eglctx == EGL_NO_CONTEXT)
         BOOST_THROW_EXCEPTION(egl_error("eglCreateContext failed"));
+
+    wl_display_roundtrip(display);
 }
 
 void mgw::DisplayClient::on_output_changed(Output const* /*output*/)


### PR DESCRIPTION
Same reasoning as #1777 applied correctly