### PR TITLE
Check EGL extensions before using them

### DIFF
--- a/include/platform/mir/graphics/egl_extensions.h
+++ b/include/platform/mir/graphics/egl_extensions.h
@@ -247,7 +247,7 @@ struct EGLExtensions
     private:
         std::atomic<bool> mutable has_initialized{false};
         std::mutex mutable mutex;
-        EGLDisplay mutable cached_display{0};
+        EGLDisplay mutable cached_display{EGL_NO_DISPLAY};
         std::optional<Ext> mutable cached_ext;
     };
 

--- a/include/platform/mir/graphics/egl_extensions.h
+++ b/include/platform/mir/graphics/egl_extensions.h
@@ -44,7 +44,7 @@
 #ifndef MIR_GRAPHICS_EGL_EXTENSIONS_H_
 #define MIR_GRAPHICS_EGL_EXTENSIONS_H_
 
-#include <experimental/optional>
+#include <optional>
 
 #define EGL_EGLEXT_PROTOTYPES
 #include <EGL/egl.h>
@@ -223,7 +223,7 @@ struct EGLExtensions
         {
             if (cached_display && cached_display.value() != dpy)
             {
-                cached_ext = std::experimental::nullopt;
+                cached_ext = std::nullopt;
             }
 
             if (!cached_ext)
@@ -236,8 +236,8 @@ struct EGLExtensions
         }
 
     private:
-        std::experimental::optional<EGLDisplay> mutable cached_display;
-        std::experimental::optional<Ext> mutable cached_ext;
+        std::optional<EGLDisplay> mutable cached_display;
+        std::optional<Ext> mutable cached_ext;
     };
 
     EGLExtensions();
@@ -277,7 +277,7 @@ struct EGLExtensions
         PFNEGLGETPLATFORMDISPLAYEXTPROC const eglGetPlatformDisplay;
         PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC const eglCreatePlatformWindowSurface;
     };
-    std::experimental::optional<PlatformBaseEXT> const platform_base;
+    std::optional<PlatformBaseEXT> const platform_base;
 
     class DebugKHR
     {
@@ -285,7 +285,7 @@ struct EGLExtensions
         DebugKHR();
 
         static DebugKHR extension_or_null_object();
-        static std::experimental::optional<DebugKHR> maybe_debug_khr();
+        static std::optional<DebugKHR> maybe_debug_khr();
 
         PFNEGLDEBUGMESSAGECONTROLKHRPROC const eglDebugMessageControlKHR;
         PFNEGLLABELOBJECTKHRPROC const eglLabelObjectKHR;

--- a/src/platform/graphics/egl_extensions.cpp
+++ b/src/platform/graphics/egl_extensions.cpp
@@ -29,17 +29,6 @@ namespace mg=mir::graphics;
 
 namespace
 {
-std::experimental::optional<mg::EGLExtensions::WaylandExtensions> maybe_wayland_ext()
-{
-    try
-    {
-        return mg::EGLExtensions::WaylandExtensions{};
-    }
-    catch (std::runtime_error const&)
-    {
-        return {};
-    }
-}
 
 std::experimental::optional<mg::EGLExtensions::PlatformBaseEXT> maybe_platform_base_ext()
 {
@@ -56,11 +45,15 @@ std::experimental::optional<mg::EGLExtensions::PlatformBaseEXT> maybe_platform_b
 }
 
 mg::EGLExtensions::EGLExtensions() :
+    platform_base{maybe_platform_base_ext()}
+{
+}
+
+mg::EGLExtensions::BaseExtensions::BaseExtensions(EGLDisplay dpy) :
     eglCreateImageKHR{
         reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(eglGetProcAddress("eglCreateImageKHR"))},
     eglDestroyImageKHR{
         reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(eglGetProcAddress("eglDestroyImageKHR"))},
-
     /*
      * TODO: Find a non-ES GL equivalent for glEGLImageTargetTexture2DOES
      * It's the LAST remaining ES-specific function. Although Mesa lets you use
@@ -68,18 +61,21 @@ mg::EGLExtensions::EGLExtensions() :
      * mix ES and GL code. But other drivers won't be so lenient.
      */
     glEGLImageTargetTexture2DOES{
-        reinterpret_cast<PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(eglGetProcAddress("glEGLImageTargetTexture2DOES"))},
-    wayland{maybe_wayland_ext()},
-    platform_base{maybe_platform_base_ext()}
+        reinterpret_cast<PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(eglGetProcAddress("glEGLImageTargetTexture2DOES"))}
 {
-    if (!eglCreateImageKHR || !eglDestroyImageKHR)
-        BOOST_THROW_EXCEPTION(std::runtime_error("EGL implementation doesn't support EGLImage"));
+    auto const egl_extensions = eglQueryString(dpy, EGL_EXTENSIONS);
+    if (!egl_extensions || !strstr(egl_extensions, "EGL_KHR_image_base") || !eglCreateImageKHR || !eglDestroyImageKHR)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("EGL display doesn't support EGL_KHR_image_base"));
+    }
 
-    if (!glEGLImageTargetTexture2DOES)
+    if (!egl_extensions || !strstr(egl_extensions, "GL_OES_EGL_image") || !glEGLImageTargetTexture2DOES)
+    {
         BOOST_THROW_EXCEPTION(std::runtime_error("GLES2 implementation doesn't support updating a texture from an EGLImage"));
+    }
 }
 
-mg::EGLExtensions::WaylandExtensions::WaylandExtensions() :
+mg::EGLExtensions::WaylandExtensions::WaylandExtensions(EGLDisplay dpy) :
     eglBindWaylandDisplayWL{
         reinterpret_cast<PFNEGLBINDWAYLANDDISPLAYWL>(eglGetProcAddress("eglBindWaylandDisplayWL"))
     },
@@ -90,13 +86,19 @@ mg::EGLExtensions::WaylandExtensions::WaylandExtensions() :
         reinterpret_cast<PFNEGLQUERYWAYLANDBUFFERWL>(eglGetProcAddress("eglQueryWaylandBufferWL"))
     }
 {
+    auto const egl_extensions = eglQueryString(dpy, EGL_EXTENSIONS);
+    if (!egl_extensions || !strstr(egl_extensions, "EGL_WL_bind_wayland_display"))
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("EGL display doesn't support EGL_WL_bind_wayland_display"));
+    }
+
     if (!eglBindWaylandDisplayWL || !eglUnbindWaylandDisplayWL || !eglQueryWaylandBufferWL)
     {
-        BOOST_THROW_EXCEPTION(std::runtime_error("EGL implementation doesn't support EGL_WL_bind_wayland_display"));
+        BOOST_THROW_EXCEPTION(std::runtime_error("EGL_WL_bind_wayland_display functions are null"));
     }
 }
 
-mg::EGLExtensions::NVStreamAttribExtensions::NVStreamAttribExtensions() :
+mg::EGLExtensions::NVStreamAttribExtensions::NVStreamAttribExtensions(EGLDisplay dpy) :
     eglCreateStreamAttribNV{
         reinterpret_cast<PFNEGLCREATESTREAMATTRIBNVPROC>(eglGetProcAddress("eglCreateStreamAttribNV"))
     },
@@ -105,9 +107,15 @@ mg::EGLExtensions::NVStreamAttribExtensions::NVStreamAttribExtensions() :
             eglGetProcAddress("eglStreamConsumerAcquireAttribNV"))
     }
 {
+    auto const egl_extensions = eglQueryString(dpy, EGL_EXTENSIONS);
+    if (!egl_extensions || !strstr(egl_extensions, "EGL_NV_stream_attrib"))
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("EGL display doesn't support EGL_NV_stream_attrib"));
+    }
+
     if (!eglCreateStreamAttribNV || !eglStreamConsumerAcquireAttribNV)
     {
-        BOOST_THROW_EXCEPTION((std::runtime_error{"EGL implementation doesn't support EGL_NV_stream_attrib"}));
+        BOOST_THROW_EXCEPTION((std::runtime_error{"EGL_NV_stream_attrib functions are null"}));
     }
 }
 

--- a/src/platform/graphics/egl_extensions.cpp
+++ b/src/platform/graphics/egl_extensions.cpp
@@ -30,7 +30,7 @@ namespace mg=mir::graphics;
 namespace
 {
 
-std::experimental::optional<mg::EGLExtensions::PlatformBaseEXT> maybe_platform_base_ext()
+auto maybe_platform_base_ext() -> std::optional<mg::EGLExtensions::PlatformBaseEXT>
 {
     try
     {
@@ -179,7 +179,7 @@ auto mg::EGLExtensions::DebugKHR::extension_or_null_object() -> DebugKHR
     };
 }
 
-auto mg::EGLExtensions::DebugKHR::maybe_debug_khr() -> std::experimental::optional<DebugKHR>
+auto mg::EGLExtensions::DebugKHR::maybe_debug_khr() -> std::optional<DebugKHR>
 {
     try
     {

--- a/src/platform/graphics/egl_extensions.cpp
+++ b/src/platform/graphics/egl_extensions.cpp
@@ -69,7 +69,7 @@ mg::EGLExtensions::BaseExtensions::BaseExtensions(EGLDisplay dpy) :
         BOOST_THROW_EXCEPTION(std::runtime_error("EGL display doesn't support EGL_KHR_image_base"));
     }
 
-    if (!egl_extensions || !strstr(egl_extensions, "GL_OES_EGL_image") || !glEGLImageTargetTexture2DOES)
+    if (!glEGLImageTargetTexture2DOES)
     {
         BOOST_THROW_EXCEPTION(std::runtime_error("GLES2 implementation doesn't support updating a texture from an EGLImage"));
     }

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -19,6 +19,7 @@ MIRPLATFORM_2.2 {
     mir::graphics::EGLContextStore::EGLContextStore*;
     mir::graphics::EGLContextStore::EGLContextStore*;
     mir::graphics::EGLContextStore::operator*;
+    mir::graphics::EGLExtensions::BaseExtensions::BaseExtensions*;
     mir::graphics::EGLExtensions::DebugKHR::DebugKHR*;
     mir::graphics::EGLExtensions::DebugKHR::extension_or_null_object*;
     mir::graphics::EGLExtensions::DebugKHR::maybe_debug_khr*;

--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -327,7 +327,7 @@ void mge::BufferAllocator::create_buffer_eglstream_resource(
     allocator->wayland_ctx->make_current();
     auto dpy = eglGetCurrentDisplay();
 
-    auto stream = allocator->nv_extensions.eglCreateStreamAttribNV(dpy, attribs);
+    auto stream = allocator->nv_extensions(dpy).eglCreateStreamAttribNV(dpy, attribs);
 
     if (stream == EGL_NO_STREAM_KHR)
     {
@@ -386,7 +386,7 @@ void mir::graphics::eglstream::BufferAllocator::bind_display(
 
     auto dpy = eglGetCurrentDisplay();
 
-    if (extensions.eglBindWaylandDisplayWL(dpy, display) != EGL_TRUE)
+    if (extensions(dpy).eglBindWaylandDisplayWL(dpy, display) != EGL_TRUE)
     {
         BOOST_THROW_EXCEPTION((mg::egl_error("Failed to bind Wayland EGL display")));
     }
@@ -424,7 +424,7 @@ void mir::graphics::eglstream::BufferAllocator::unbind_display(wl_display* displ
         [this]() { wayland_ctx->release_current(); });
     auto dpy = eglGetCurrentDisplay();
 
-    if (extensions.eglUnbindWaylandDisplayWL(dpy, display) != EGL_TRUE)
+    if (extensions(dpy).eglUnbindWaylandDisplayWL(dpy, display) != EGL_TRUE)
     {
         BOOST_THROW_EXCEPTION((mg::egl_error("Failed to unbind Wayland EGL display")));
     }
@@ -527,11 +527,11 @@ mir::graphics::eglstream::BufferAllocator::buffer_from_resource(
     auto dpy = eglGetCurrentDisplay();
 
     EGLint width, height;
-    if (extensions.eglQueryWaylandBufferWL(dpy, buffer, EGL_WIDTH, &width) != EGL_TRUE)
+    if (extensions(dpy).eglQueryWaylandBufferWL(dpy, buffer, EGL_WIDTH, &width) != EGL_TRUE)
     {
         BOOST_THROW_EXCEPTION(mg::egl_error("Failed to query Wayland buffer width"));
     }
-    if (extensions.eglQueryWaylandBufferWL(dpy, buffer, EGL_HEIGHT, &height) != EGL_TRUE)
+    if (extensions(dpy).eglQueryWaylandBufferWL(dpy, buffer, EGL_HEIGHT, &height) != EGL_TRUE)
     {
         BOOST_THROW_EXCEPTION(mg::egl_error("Failed to query Wayland buffer height"));
     }
@@ -539,7 +539,7 @@ mir::graphics::eglstream::BufferAllocator::buffer_from_resource(
         [&]()
         {
             EGLint y_inverted;
-            if (extensions.eglQueryWaylandBufferWL(dpy, buffer, EGL_WAYLAND_Y_INVERTED_WL, &y_inverted) != EGL_TRUE)
+            if (extensions(dpy).eglQueryWaylandBufferWL(dpy, buffer, EGL_WAYLAND_Y_INVERTED_WL, &y_inverted) != EGL_TRUE)
             {
                 // If querying Y_INVERTED fails, we must have the default, GL, layout
                 return mg::gl::Texture::Layout::GL;

--- a/src/platforms/eglstream-kms/server/buffer_allocator.h
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.h
@@ -85,8 +85,8 @@ private:
         uint32_t version,
         uint32_t id);
 
-    EGLExtensions::WaylandExtensions const extensions;
-    EGLExtensions::NVStreamAttribExtensions const nv_extensions;
+    EGLExtensions::LazyDisplayExtensions<EGLExtensions::WaylandExtensions> const extensions;
+    EGLExtensions::LazyDisplayExtensions<EGLExtensions::NVStreamAttribExtensions> const nv_extensions;
     std::shared_ptr<renderer::gl::Context> const wayland_ctx;
     std::shared_ptr<common::EGLContextExecutor> const egl_delegate;
     std::unique_ptr<gl::Program> shader;

--- a/src/platforms/eglstream-kms/server/display.cpp
+++ b/src/platforms/eglstream-kms/server/display.cpp
@@ -268,7 +268,7 @@ public:
             EGL_DRM_FLIP_EVENT_DATA_NV, reinterpret_cast<EGLAttrib>(event_handler->drm_event_data()),
             EGL_NONE
         };
-        if (nv_stream.eglStreamConsumerAcquireAttribNV(dpy, output_stream, acquire_attribs) != EGL_TRUE)
+        if (nv_stream(dpy).eglStreamConsumerAcquireAttribNV(dpy, output_stream, acquire_attribs) != EGL_TRUE)
         {
             BOOST_THROW_EXCEPTION(mg::egl_error("Failed to submit frame from EGLStream for display"));
         }
@@ -296,7 +296,7 @@ private:
     mir::Fd const drm_node;
     std::shared_ptr<mge::DRMEventHandler> const event_handler;
     std::future<void> pending_flip;
-    mg::EGLExtensions::NVStreamAttribExtensions nv_stream;
+    mg::EGLExtensions::LazyDisplayExtensions<mg::EGLExtensions::NVStreamAttribExtensions> nv_stream;
     std::shared_ptr<mg::DisplayReport> const display_report;
 };
 

--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -80,7 +80,7 @@ public:
     ~EGLImageBufferTextureBinder()
     {
         if (egl_image != EGL_NO_IMAGE_KHR)
-            egl_extensions->eglDestroyImageKHR(egl_display, egl_image);
+            egl_extensions->base(egl_display).eglDestroyImageKHR(egl_display, egl_image);
     }
 
 
@@ -88,7 +88,7 @@ public:
     {
         ensure_egl_image();
 
-        egl_extensions->glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, egl_image);
+        egl_extensions->base(egl_display).glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, egl_image);
     }
 
 protected:
@@ -124,11 +124,12 @@ private:
                 EGL_NONE
             };
 
-            egl_image = egl_extensions->eglCreateImageKHR(egl_display,
-                                                          EGL_NO_CONTEXT,
-                                                          EGL_NATIVE_PIXMAP_KHR,
-                                                          reinterpret_cast<void*>(bo_raw),
-                                                          image_attrs);
+            egl_image = egl_extensions->base(egl_display).eglCreateImageKHR(
+                egl_display,
+                EGL_NO_CONTEXT,
+                EGL_NATIVE_PIXMAP_KHR,
+                reinterpret_cast<void*>(bo_raw),
+                image_attrs);
             if (egl_image == EGL_NO_IMAGE_KHR)
                 BOOST_THROW_EXCEPTION(mg::egl_error("Failed to create EGLImage"));
         }
@@ -179,11 +180,12 @@ private:
                 EGL_NONE
             };
 
-            egl_image = egl_extensions->eglCreateImageKHR(egl_display,
-                                                          EGL_NO_CONTEXT,
-                                                          EGL_LINUX_DMA_BUF_EXT,
-                                                          static_cast<EGLClientBuffer>(nullptr),
-                                                          image_attrs_X);
+            egl_image = egl_extensions->base(egl_display).eglCreateImageKHR(
+                egl_display,
+                EGL_NO_CONTEXT,
+                EGL_LINUX_DMA_BUF_EXT,
+                static_cast<EGLClientBuffer>(nullptr),
+                image_attrs_X);
             if (egl_image == EGL_NO_IMAGE_KHR)
                 BOOST_THROW_EXCEPTION(mg::egl_error("Failed to create EGLImage"));
         }

--- a/src/platforms/gbm-kms/server/linux_dmabuf.cpp
+++ b/src/platforms/gbm-kms/server/linux_dmabuf.cpp
@@ -87,7 +87,7 @@ public:
     {
         if (image != EGL_NO_IMAGE_KHR)
         {
-            egl_extensions->eglDestroyImageKHR(dpy, image);
+            egl_extensions->base(dpy).eglDestroyImageKHR(dpy, image);
         }
     }
 
@@ -159,9 +159,9 @@ public:
         attributes.push_back(EGL_NONE);
         if (image != EGL_NO_IMAGE_KHR)
         {
-            egl_extensions->eglDestroyImageKHR(dpy, image);
+            egl_extensions->base(dpy).eglDestroyImageKHR(dpy, image);
         }
-        image = egl_extensions->eglCreateImageKHR(
+        image = egl_extensions->base(dpy).eglCreateImageKHR(
             dpy,
             EGL_NO_CONTEXT,
             EGL_LINUX_DMA_BUF_EXT,
@@ -527,6 +527,7 @@ public:
         WlDmaBufBuffer& source,
         mg::EGLExtensions const& extensions,
         std::shared_ptr<mir::renderer::gl::Context> ctx,
+        EGLDisplay dpy,
         std::function<void()>&& on_consumed,
         std::function<void()>&& on_release,
         std::shared_ptr<mir::Executor> wayland_executor)
@@ -545,7 +546,7 @@ public:
         eglBindAPI(EGL_OPENGL_ES_API);
 
         glBindTexture(GL_TEXTURE_2D, tex);
-        extensions.glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, source.reimport_egl_image());
+        extensions.base(dpy).glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, source.reimport_egl_image());
         // tex is now an EGLImage sibling, so we can free the EGLImage without
         // freeing the backing data.
 
@@ -934,6 +935,7 @@ auto mgg::LinuxDmaBufUnstable::buffer_from_resource(
             *dmabuf,
             *egl_extensions,
             std::move(ctx),
+            dpy,
             std::move(on_consumed),
             std::move(on_release),
             std::move(wayland_executor));

--- a/src/platforms/rpi-dispmanx/buffer_allocator.cpp
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.cpp
@@ -380,12 +380,7 @@ void mg::rpi::BufferAllocator::bind_display(wl_display* display, std::shared_ptr
         [this]() { ctx->release_current(); });
     auto dpy = eglGetCurrentDisplay();
 
-    if (!egl_extensions->wayland)
-    {
-        BOOST_THROW_EXCEPTION((std::runtime_error{"No EGL_WL_bind_wayland_display support"}));
-    }
-
-    if (egl_extensions->wayland->eglBindWaylandDisplayWL(dpy, display) == EGL_FALSE)
+    if (egl_extensions->wayland(dpy).eglBindWaylandDisplayWL(dpy, display) == EGL_FALSE)
     {
         BOOST_THROW_EXCEPTION(mg::egl_error("Failed to bind Wayland EGL display"));
     }

--- a/src/platforms/rpi-dispmanx/buffer_allocator.cpp
+++ b/src/platforms/rpi-dispmanx/buffer_allocator.cpp
@@ -398,12 +398,7 @@ void mg::rpi::BufferAllocator::unbind_display(wl_display* display)
         [this]() { ctx->release_current(); });
     auto dpy = eglGetCurrentDisplay();
 
-    if (!egl_extensions->wayland)
-    {
-        BOOST_THROW_EXCEPTION((std::runtime_error{"No EGL_WL_bind_wayland_display support"}));
-    }
-
-    if (egl_extensions->wayland->eglUnbindWaylandDisplayWL(dpy, display) == EGL_FALSE)
+    if (egl_extensions->wayland(dpy).eglUnbindWaylandDisplayWL(dpy, display) == EGL_FALSE)
     {
         BOOST_THROW_EXCEPTION(mg::egl_error("Failed to unbind Wayland EGL display"));
     }

--- a/tests/mir_test_doubles/mock_egl.cpp
+++ b/tests/mir_test_doubles/mock_egl.cpp
@@ -200,6 +200,7 @@ void mtd::MockEGL::provide_egl_extensions()
         "EGL_KHR_image "
         "EGL_KHR_image_base "
         "EGL_KHR_image_pixmap "
+        "GL_OES_EGL_image "
         "EGL_EXT_image_dma_buf_import "
         "EGL_WL_bind_wayland_display "
         "EGL_EXT_platform_base";

--- a/tests/unit-tests/graphics/test_egl_extensions.cpp
+++ b/tests/unit-tests/graphics/test_egl_extensions.cpp
@@ -34,6 +34,7 @@ class EGLExtensions  : public ::testing::Test
 protected:
     virtual void SetUp()
     {
+        mock_egl.provide_egl_extensions();
     }
 
     testing::NiceMock<mtd::MockEGL> mock_egl;
@@ -46,18 +47,24 @@ TEST_F(EGLExtensions, constructor_throws_if_egl_image_not_supported)
     ON_CALL(mock_egl, eglGetProcAddress(StrEq("eglDestroyImageKHR")))
         .WillByDefault(Return(reinterpret_cast<func_ptr_t>(0)));
 
+    mg::EGLExtensions extensions;
+    EGLDisplay dpy = eglGetDisplay(nullptr);
+
     EXPECT_THROW({
-        mg::EGLExtensions extensions;
+        extensions.base(dpy);
     }, std::runtime_error);
 }
 
-TEST_F(EGLExtensions, constructor_throws_if_gl_oes_egl_image_not_supported)
+TEST_F(EGLExtensions, base_throws_if_gl_oes_egl_image_not_supported)
 {
     ON_CALL(mock_egl, eglGetProcAddress(StrEq("glEGLImageTargetTexture2DOES")))
         .WillByDefault(Return(reinterpret_cast<func_ptr_t>(0)));
 
+    mg::EGLExtensions extensions;
+    EGLDisplay dpy = eglGetDisplay(nullptr);
+
     EXPECT_THROW({
-        mg::EGLExtensions extensions;
+        extensions.base(dpy);
     }, std::runtime_error);
 }
 

--- a/tests/unit-tests/graphics/test_egl_extensions.cpp
+++ b/tests/unit-tests/graphics/test_egl_extensions.cpp
@@ -64,7 +64,8 @@ TEST_F(EGLExtensions, constructor_throws_if_gl_oes_egl_image_not_supported)
 TEST_F(EGLExtensions, success_has_sane_function_hooks)
 {
     mg::EGLExtensions extensions;
-    EXPECT_NE(nullptr, extensions.eglCreateImageKHR);
-    EXPECT_NE(nullptr, extensions.eglDestroyImageKHR);
-    EXPECT_NE(nullptr, extensions.glEGLImageTargetTexture2DOES);
+    EGLDisplay dpy = eglGetDisplay(nullptr);
+    EXPECT_NE(nullptr, extensions.base(dpy).eglCreateImageKHR);
+    EXPECT_NE(nullptr, extensions.base(dpy).eglDestroyImageKHR);
+    EXPECT_NE(nullptr, extensions.base(dpy).glEGLImageTargetTexture2DOES);
 }


### PR DESCRIPTION
I've taken a number of stabs at this. Unfortunately the variadic template function pointer variant didn't work out so well so we're left with this. It solves the problem reasonably well in a relatively small diff, so good enough. Related to #914 and improved alternative to #1804.