### PR TITLE
Support software buffers on X11, Wayland and GBM/KMS

### DIFF
--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -294,7 +294,19 @@ void mgg::BufferAllocator::bind_display(wl_display* display, std::shared_ptr<Exe
         [this]() { ctx->release_current(); });
     auto dpy = eglGetCurrentDisplay();
 
-    mg::wayland::bind_display(dpy, display, *egl_extensions);
+    try
+    {
+        mg::wayland::bind_display(dpy, display, *egl_extensions);
+        egl_display_bound = true;
+    }
+    catch (...)
+    {
+        log(
+            logging::Severity::warning,
+            MIR_LOG_COMPONENT,
+            std::current_exception(),
+            "Failed to bind EGL Display to Wayland display, falling back to software buffers");
+    }
 
     try
     {
@@ -338,12 +350,15 @@ void mgg::BufferAllocator::bind_display(wl_display* display, std::shared_ptr<Exe
 
 void mgg::BufferAllocator::unbind_display(wl_display* display)
 {
-    auto context_guard = mir::raii::paired_calls(
-        [this]() { ctx->make_current(); },
-        [this]() { ctx->release_current(); });
-    auto dpy = eglGetCurrentDisplay();
+    if (egl_display_bound)
+    {
+        auto context_guard = mir::raii::paired_calls(
+            [this]() { ctx->make_current(); },
+            [this]() { ctx->release_current(); });
+        auto dpy = eglGetCurrentDisplay();
 
-    mg::wayland::unbind_display(dpy, display, *egl_extensions);
+        mg::wayland::unbind_display(dpy, display, *egl_extensions);
+    }
 }
 
 std::shared_ptr<mg::Buffer> mgg::BufferAllocator::buffer_from_resource(

--- a/src/platforms/gbm-kms/server/buffer_allocator.h
+++ b/src/platforms/gbm-kms/server/buffer_allocator.h
@@ -96,6 +96,7 @@ private:
     std::unique_ptr<LinuxDmaBufUnstable, std::function<void(LinuxDmaBufUnstable*)>> dmabuf_extension;
     gbm_device* const device;
     std::shared_ptr<EGLExtensions> const egl_extensions;
+    bool egl_display_bound{false};
 
     BypassOption const bypass_option;
     BufferImportMethod const buffer_import_method;

--- a/src/platforms/wayland/buffer_allocator.cpp
+++ b/src/platforms/wayland/buffer_allocator.cpp
@@ -24,6 +24,7 @@
 
 #include <mir/anonymous_shm_file.h>
 #include <mir/fatal.h>
+#include <mir/log.h>
 #include <mir/graphics/buffer_properties.h>
 #include <mir/graphics/egl_wayland_allocator.h>
 #include <mir/raii.h>
@@ -100,19 +101,34 @@ void mgw::BufferAllocator::bind_display(wl_display* display, std::shared_ptr<Exe
         [this]() { ctx->release_current(); });
     auto dpy = eglGetCurrentDisplay();
 
-    mg::wayland::bind_display(dpy, display, *egl_extensions);
+    try
+    {
+        mg::wayland::bind_display(dpy, display, *egl_extensions);
+        egl_display_bound = true;
+    }
+    catch (...)
+    {
+        log(
+            logging::Severity::warning,
+            MIR_LOG_COMPONENT,
+            std::current_exception(),
+            "Failed to bind EGL Display to Wayland display, falling back to software buffers");
+    }
 
     this->wayland_executor = std::move(wayland_executor);
 }
 
 void mgw::BufferAllocator::unbind_display(wl_display* display)
 {
-    auto context_guard = mir::raii::paired_calls(
-        [this]() { ctx->make_current(); },
-        [this]() { ctx->release_current(); });
-    auto dpy = eglGetCurrentDisplay();
+    if (egl_display_bound)
+    {
+        auto context_guard = mir::raii::paired_calls(
+            [this]() { ctx->make_current(); },
+            [this]() { ctx->release_current(); });
+        auto dpy = eglGetCurrentDisplay();
 
-    mg::wayland::unbind_display(dpy, display, *egl_extensions);
+        mg::wayland::unbind_display(dpy, display, *egl_extensions);
+    }
 }
 
 auto mgw::BufferAllocator::buffer_from_resource(

--- a/src/platforms/wayland/buffer_allocator.h
+++ b/src/platforms/wayland/buffer_allocator.h
@@ -65,6 +65,7 @@ private:
     std::shared_ptr<EGLExtensions> const egl_extensions;
     std::shared_ptr<renderer::gl::Context> const ctx;
     std::shared_ptr<common::EGLContextExecutor> const egl_delegate;
+    bool egl_display_bound{false};
 };
 }
 }

--- a/src/platforms/x11/graphics/buffer_allocator.cpp
+++ b/src/platforms/x11/graphics/buffer_allocator.cpp
@@ -139,19 +139,34 @@ void mgx::BufferAllocator::bind_display(wl_display* display, std::shared_ptr<Exe
         [this]() { ctx->release_current(); });
     auto dpy = eglGetCurrentDisplay();
 
-    mg::wayland::bind_display(dpy, display, *egl_extensions);
+    try
+    {
+        mg::wayland::bind_display(dpy, display, *egl_extensions);
+        egl_display_bound = true;
+    }
+    catch (...)
+    {
+        log(
+            logging::Severity::warning,
+            MIR_LOG_COMPONENT,
+            std::current_exception(),
+            "Failed to bind EGL Display to Wayland display, falling back to software buffers");
+    }
 
     this->wayland_executor = std::move(wayland_executor);
 }
 
 void mgx::BufferAllocator::unbind_display(wl_display* display)
 {
-    auto context_guard = mir::raii::paired_calls(
-        [this]() { ctx->make_current(); },
-        [this]() { ctx->release_current(); });
-    auto dpy = eglGetCurrentDisplay();
+    if (egl_display_bound)
+    {
+        auto context_guard = mir::raii::paired_calls(
+            [this]() { ctx->make_current(); },
+            [this]() { ctx->release_current(); });
+        auto dpy = eglGetCurrentDisplay();
 
-    mg::wayland::unbind_display(dpy, display, *egl_extensions);
+        mg::wayland::unbind_display(dpy, display, *egl_extensions);
+    }
 }
 
 std::shared_ptr<mg::Buffer> mgx::BufferAllocator::buffer_from_resource(

--- a/src/platforms/x11/graphics/buffer_allocator.h
+++ b/src/platforms/x11/graphics/buffer_allocator.h
@@ -75,6 +75,7 @@ private:
     std::shared_ptr<common::EGLContextExecutor> const egl_delegate;
     std::shared_ptr<Executor> wayland_executor;
     std::shared_ptr<EGLExtensions> const egl_extensions;
+    bool egl_display_bound{false};
 };
 
 }


### PR DESCRIPTION
Allow Mir to start without the Wayland EGL extensions on X11, Wayland and GBM/KMS. Only works in conjunction with #1806. Fixes #914.

miral-shell crashes shortly after startup (probably due to the spinner) but that can be addressed in another PR in another release. mir_demo_server works in a non-virgil VM with this and #1806.