### PR TITLE
gbm-kms: Disable bypass by default.

### DIFF
--- a/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
@@ -82,7 +82,7 @@ void add_graphics_platform_options(boost::program_options::options_description& 
     mir::assert_entry_point_signature<mg::AddPlatformOptions>(&add_graphics_platform_options);
     config.add_options()
         (bypass_option_name,
-         boost::program_options::value<bool>()->default_value(true),
+         boost::program_options::value<bool>()->default_value(false),
          "[platform-specific] utilize the bypass optimization for fullscreen surfaces.");
 }
 


### PR DESCRIPTION
This triggers a GPU OOM (issue #1801) on the Pi3 when used with default settings.
There may be due to us hanging on to buffers longer than they need to be, but
it's not clear yet.

Users who want the performance boost and are running on known hardware can
set `--bypass=true`, but by default use the safe option of `false`.