### PR TITLE
Use standard key repeat values

### DIFF
--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -60,9 +60,10 @@ mf::WlKeyboard::WlKeyboard(
      */
     set_keymap(initial_keymap);
 
-    // I don't know where to get "real" rate and delay args. These are better than nothing.
+    // 25 rate and 600 delay are the default in Weston and Sway
+    // At some point we will want to make this configurable
     if (version_supports_repeat_info())
-        send_repeat_info_event(30, 200);
+        send_repeat_info_event(25, 600);
 }
 
 mf::WlKeyboard::~WlKeyboard()


### PR DESCRIPTION
This solves a minor annoyance I've had for a while. Both Weston and Sway use these values by default. GNOME-on-Wayland, on the other hand uses 33 and 500, which I would also be open to. Mostly, the delay just needs to go up.

Of course this will eventually need be configurable for accessability reasons and general preference, but building an input configuration system is a job for another day,