### PR TITLE
Fix build with MIR_ENABLE_WLCS_TESTS=ON and wlcs in non-standard prefix

### DIFF
--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -27,6 +27,7 @@ string (REPLACE " -flto " " " CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 
 if (MIR_ENABLE_WLCS_TESTS)
     set(MIR_WLCS_TEST_FRAMEWORK test_wlcs_display_server.cpp ${PROJECT_SOURCE_DIR}/include/test/miral/test_wlcs_display_server.h)
+    include_directories(${WLCS_INCLUDE_DIRS})
 endif()
 
 add_library(mir-public-test-framework OBJECT


### PR DESCRIPTION
When trying to build Mir with wlcs installed into a prefix in my /home, I'm
getting the following error:

    In file included from /home/amezin/mir-egmde/mir/tests/mir_test_framework/test_wlcs_display_server.cpp:20:
    /home/amezin/mir-egmde/mir/include/test/miral/test_wlcs_display_server.h:24:10: fatal error: wlcs/display_server.h: No such file or directory
       24 | #include <wlcs/display_server.h>
          |          ^~~~~~~~~~~~~~~~~~~~~~~
    compilation terminated.

It seems that wlcs include directory is missing from include paths (because
it was never added).

Signed-off-by: Aleksandr Mezin <mezin.alexander@gmail.com>