### PR TITLE
Clamp window resize to min/max

### DIFF
--- a/examples/example-server-lib/tiling_window_manager.cpp
+++ b/examples/example-server-lib/tiling_window_manager.cpp
@@ -178,6 +178,19 @@ void reset(mir::optional_value<ValueType>& option)
 {
     if (option.is_set()) option.consume();
 }
+
+template<typename ValueType>
+void set_if_needed(mir::optional_value<ValueType>& pending, ValueType const& current, ValueType const& correct)
+{
+    if (current == correct)
+    {
+        reset(pending);
+    }
+    else
+    {
+        pending = correct;
+    }
+}
 }
 
 void TilingWindowManagerPolicy::handle_modify_window(
@@ -209,6 +222,11 @@ void TilingWindowManagerPolicy::constrain_size_and_place(
 {
     auto& info = tools.info_for(window);
     info.clip_area(tile);
+
+    set_if_needed(mods.min_width(), info.min_width(), Width{0});
+    set_if_needed(mods.min_height(), info.min_height(), Height{0});
+    set_if_needed(mods.max_width(), info.max_width(), Width{std::numeric_limits<int>::max()});
+    set_if_needed(mods.max_height(), info.max_height(), Height{std::numeric_limits<int>::max()});
 
     if ((mods.state().is_set() ? mods.state().value() : info.state()) == mir_window_state_maximized)
     {

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -67,21 +67,31 @@ struct WindowInfo
 
     auto children() const -> std::vector <Window> const&;
 
+    /// These constrain the sizes a window may be resized to (both interactively and pragmatically). Clients can request
+    /// a min/max size, but it can be overridden by the window management policy. By default, minimum values are 0 and
+    /// maximum values are `std::numeric_limits<int>::max()`.
+    /// @{
     auto min_width() const -> mir::geometry::Width;
-
     auto min_height() const -> mir::geometry::Height;
-
     auto max_width() const -> mir::geometry::Width;
-
     auto max_height() const -> mir::geometry::Height;
+    /// @}
 
+    /// These control the size increments of the window. This is used in cases like a terminal that can only be resized
+    /// character-by-character. Current Wayland protocols do not support this property, so it generally wont be
+    /// requested by clients. By default, both are 1.
+    /// @{
     auto width_inc() const -> mir::geometry::DeltaX;
-
     auto height_inc() const -> mir::geometry::DeltaY;
+    /// @}
 
+    /// These constrain the possible aspect ratio of the window. Current Wayland protocols to not support this property,
+    /// so it generally wont be requested by clients. By default, min_aspect is
+    /// `{0U, std::numeric_limits<unsigned>::max()}` and max_aspect is `{std::numeric_limits<unsigned>::max(), 0U}`.
+    /// @{
     auto min_aspect() const -> AspectRatio;
-
     auto max_aspect() const -> AspectRatio;
+    /// @}
 
     bool has_output_id() const;
     auto output_id() const -> int;

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -90,6 +90,10 @@ public:
     auto userdata() const -> mir::optional_value<std::shared_ptr<void>> const&;
 
     auto top_left() -> mir::optional_value<Point>&;
+    /// The new size of the window frame (including any decorations). Will be adjusted based on min_width(),
+    /// WindowInfo::max_width(), WindowInfo::min_height(), WindowInfo::max_height(), WindowInfo::min_aspect(),
+    /// WindowInfo::max_aspect(), WindowInfo::width_inc() and WindowInfo::height_inc(). Set these to properties to their
+    /// default values if they should be ignored.
     auto size() -> mir::optional_value<Size>&;
     auto name() -> mir::optional_value<std::string>&;
     auto output_id() -> mir::optional_value<int>&;
@@ -103,6 +107,9 @@ public:
     auto window_placement_gravity() -> mir::optional_value<MirPlacementGravity>&;
     auto aux_rect_placement_gravity() -> mir::optional_value<MirPlacementGravity>&;
     auto aux_rect_placement_offset() -> mir::optional_value<Displacement>&;
+
+    /// Constrains how a window can be resized, see the corresponding properties on WindowInfo for details.
+    /// @{
     auto min_width() -> mir::optional_value<Width>&;
     auto min_height() -> mir::optional_value<Height>&;
     auto max_width() -> mir::optional_value<Width>&;
@@ -111,6 +118,8 @@ public:
     auto height_inc() -> mir::optional_value<DeltaY>&;
     auto min_aspect() -> mir::optional_value<AspectRatio>&;
     auto max_aspect() -> mir::optional_value<AspectRatio>&;
+    /// @}
+
     auto parent() -> mir::optional_value<std::weak_ptr<mir::scene::Surface>>&;
     auto input_shape() -> mir::optional_value<std::vector<Rectangle>>&;
     auto input_mode() -> mir::optional_value<InputReceptionMode>&;

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1124,24 +1124,17 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
         }
     }
 
-    Point new_pos = modifications.top_left().is_set() ? modifications.top_left().value() : window.top_left();
-
-    if (modifications.size().is_set())
+    if (modifications.size().is_set() || modifications.top_left().is_set() ||
+        modifications.min_width().is_set() || modifications.min_height().is_set() ||
+        modifications.max_width().is_set() || modifications.max_height().is_set() ||
+        modifications.width_inc().is_set() || modifications.height_inc().is_set())
     {
-        place_and_size(window_info, new_pos, modifications.size().value());
-    }
-    else if (modifications.min_width().is_set() || modifications.min_height().is_set() ||
-             modifications.max_width().is_set() || modifications.max_height().is_set() ||
-             modifications.width_inc().is_set() || modifications.height_inc().is_set())
-    {
-        Size new_size = window.size();
+        Point new_pos = modifications.top_left().is_set() ? modifications.top_left().value() : window.top_left();
+        Size new_size = modifications.size().is_set() ? modifications.size().value() : window.size();
 
+        // The new size constraints have already been applied to window_info and constrain_resize() will use them
         window_info.constrain_resize(new_pos, new_size);
         place_and_size(window_info, new_pos, new_size);
-    }
-    else if (modifications.top_left().is_set())
-    {
-        place_and_size(window_info, new_pos, window.size());
     }
 
     if (modifications.placement_hints().is_set())

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -247,38 +247,6 @@ void miral::WindowInfo::constrain_resize(Point& requested_pos, Size& requested_s
 
     // placeholder - constrain onscreen
 
-    switch (state())
-    {
-    case mir_window_state_restored:
-    case mir_window_state_attached:
-        break;
-
-        // "A vertically maximised window is anchored to the top and bottom of
-        // the available workspace and can have any width."
-    case mir_window_state_vertmaximized:
-        new_pos.y = self->window.top_left().y;
-        new_size.height = self->window.size().height;
-        break;
-
-        // "A horizontally maximised window is anchored to the left and right of
-        // the available workspace and can have any height"
-    case mir_window_state_horizmaximized:
-        new_pos.x = self->window.top_left().x;
-        new_size.width = self->window.size().width;
-        break;
-
-        // "A maximised window is anchored to the top, bottom, left and right of the
-        // available workspace. For example, if the launcher is always-visible then
-        // the left-edge of the window is anchored to the right-edge of the launcher."
-    case mir_window_state_maximized:
-    default:
-        new_pos.x = self->window.top_left().x;
-        new_pos.y = self->window.top_left().y;
-        new_size.width = self->window.size().width;
-        new_size.height = self->window.size().height;
-        break;
-    }
-
     requested_pos = new_pos;
     requested_size = new_size;
 }

--- a/tests/miral/CMakeLists.txt
+++ b/tests/miral/CMakeLists.txt
@@ -45,6 +45,7 @@ mir_add_wrapped_executable(miral-test-internal NOINSTALL
     initial_window_placement.cpp
     window_placement_attached.cpp
     window_placement_fullscreen.cpp
+    resize_and_move.cpp
     ignored_requests.cpp
     ${MIRAL_TEST_SOURCES}
 )

--- a/tests/miral/resize_and_move.cpp
+++ b/tests/miral/resize_and_move.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "test_window_manager_tools.h"
+
+using namespace miral;
+using namespace testing;
+namespace mt = mir::test;
+namespace mg = mir::graphics;
+
+namespace
+{
+Rectangle const display_area{{}, {1280, 720}};
+
+struct ResizeAndMove : mt::TestWindowManagerTools
+{
+    void SetUp() override
+    {
+        notify_configuration_applied(create_fake_display_configuration({display_area}));
+        basic_window_manager.add_session(session);
+    }
+
+    auto create_window(mir::scene::SurfaceCreationParameters creation_parameters) -> Window
+    {
+        Window result;
+
+        EXPECT_CALL(*window_manager_policy, advise_new_window(_))
+            .WillOnce(
+                Invoke(
+                    [&result](WindowInfo const& window_info)
+                        { result = window_info.window(); }));
+
+        basic_window_manager.add_surface(session, creation_parameters, &create_surface);
+        basic_window_manager.select_active_window(result);
+
+        // Clear the expectations used to capture the window
+        Mock::VerifyAndClearExpectations(window_manager_policy);
+
+        return result;
+    }
+};
+
+}
+
+TEST_F(ResizeAndMove, can_move_window)
+{
+    Point const start{20, 20};
+    Point const end{200, 340};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.top_left = start;
+        params.size = Size{50, 50};
+        window = create_window(params);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.top_left() = end;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(window.top_left(), Eq(end));
+}
+
+TEST_F(ResizeAndMove, can_resize)
+{
+    Size const start{100, 100};
+    Size const end{48, 320};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.size = start;
+        window = create_window(params);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.size() = end;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(window.size(), Eq(end));
+}
+
+TEST_F(ResizeAndMove, can_not_be_resized_smaller_than_min_size)
+{
+    Size const start{100, 200};
+    Size const min{75, 80};
+    Size const attempt{50, 60};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.size = start;
+        params.min_width = min.width;
+        params.min_height = min.height;
+        window = create_window(params);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.size() = attempt;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(window.size(), Eq(min));
+}
+
+TEST_F(ResizeAndMove, can_not_be_resized_larger_than_max_size)
+{
+    Size const start{100, 200};
+    Size const max{320, 250};
+    Size const attempt{600, 700};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.size = start;
+        params.max_width = max.width;
+        params.max_height = max.height;
+        window = create_window(params);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.size() = attempt;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(window.size(), Eq(max));
+}
+
+TEST_F(ResizeAndMove, min_width_can_be_set_without_height)
+{
+    Size const start{100, 200};
+    Width const min_width{75};
+    Size const attempt{50, 60};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.size = start;
+        params.min_width = min_width;
+        window = create_window(params);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.size() = attempt;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(window.size(), Eq(Size{min_width, attempt.height}));
+}
+
+TEST_F(ResizeAndMove, min_height_can_be_set_without_width)
+{
+    Size const start{100, 200};
+    Height const min_height{80};
+    Size const attempt{50, 60};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.size = start;
+        params.min_height = min_height;
+        window = create_window(params);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.size() = attempt;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(window.size(), Eq(Size{attempt.width, min_height}));
+}
+
+TEST_F(ResizeAndMove, max_width_can_be_set_without_height)
+{
+    Size const start{100, 200};
+    Width const max_width{300};
+    Size const attempt{400, 450};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.size = start;
+        params.max_width = max_width;
+        window = create_window(params);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.size() = attempt;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(window.size(), Eq(Size{max_width, attempt.height}));
+}
+
+TEST_F(ResizeAndMove, max_height_can_be_set_without_width)
+{
+    Size const start{100, 200};
+    Height const max_height{250};
+    Size const attempt{400, 450};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.size = start;
+        params.max_height = max_height;
+        window = create_window(params);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.size() = attempt;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(window.size(), Eq(Size{attempt.width, max_height}));
+}
+
+TEST_F(ResizeAndMove, min_size_applied_when_set)
+{
+    Size const start{50, 60};
+    Size const min{75, 80};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.size = start;
+        window = create_window(params);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.min_width() = min.width;
+        spec.min_height() = min.height;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(window.size(), Eq(min));
+}
+
+TEST_F(ResizeAndMove, max_size_applied_when_set)
+{
+    Size const start{600, 700};
+    Size const max{320, 250};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.size = start;
+        window = create_window(params);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.max_width() = max.width;
+        spec.max_height() = max.height;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(window.size(), Eq(max));
+}
+
+TEST_F(ResizeAndMove, min_size_respected_when_set_in_same_commit_as_resize)
+{
+    Size const start{100, 200};
+    Size const min{75, 80};
+    Size const attempt{50, 60};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.size = start;
+        window = create_window(params);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.min_width() = min.width;
+        spec.min_height() = min.height;
+        spec.size() = attempt;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(window.size(), Eq(min));
+}
+
+TEST_F(ResizeAndMove, max_size_respected_when_set_in_same_commit_as_resize)
+{
+    Size const start{50, 50};
+    Size const max{320, 250};
+    Size const attempt{600, 700};
+
+    Window window;
+    {
+        mir::scene::SurfaceCreationParameters params;
+        params.size = start;
+        window = create_window(params);
+    }
+
+    {
+        WindowSpecification spec;
+        spec.max_width() = max.width;
+        spec.max_height() = max.height;
+        spec.size() = attempt;
+        window_manager_tools.modify_window(window, spec);
+    }
+
+    EXPECT_THAT(window.size(), Eq(max));
+}
+
+// TODO: test that window is positioned correctly on clamped resize in all directions


### PR DESCRIPTION
Fixes #1821. Since interactive resize and programmatic policy resize looks the same to the window manager, both are clamped. The policy can, however, change the min/max size to whatever it wants. It's documented that that is required and the tiling window manager has been updated to do that.

There was previously logic to prevent maximized windows from being moved or resized. This was untested, and it seems to be unnecessary. It has been dropped because it was breaking the tiling window manager after I made my changes. Manually moving maximized windows is still impossible in both window managers.