### PR TITLE
Reflect changes to the draft desktop-launch interface

### DIFF
--- a/src/miral/external_client.cpp
+++ b/src/miral/external_client.cpp
@@ -136,21 +136,7 @@ void miral::ExternalClientLauncher::snapcraft_launch(const std::string& desktop_
         BOOST_THROW_EXCEPTION(std::logic_error("Cannot launch apps when server has not started"));
     }
 
-    std::vector<std::string> env{
-        "XDG_SESSION_DESKTOP=mir",
-        "XDG_SESSION_TYPE=wayland"};
-
-    if (auto const& wayland_display = self->server->wayland_display())
-    {
-        env.push_back("WAYLAND_DISPLAY=" + wayland_display.value());
-    }
-
-    if (auto const& x11_display = self->server->x11_display())
-    {
-        env.push_back("DISPLAY=" + x11_display.value());
-    }
-
-    open_desktop_entry(desktop_file, env);
+    open_desktop_entry(desktop_file);
 }
 
 miral::ExternalClientLauncher::~ExternalClientLauncher() = default;

--- a/src/miral/open_desktop_entry.cpp
+++ b/src/miral/open_desktop_entry.cpp
@@ -76,34 +76,29 @@ auto extract_id(std::string const& filename) -> std::string
 }
 }
 
-void miral::open_desktop_entry(std::string const& desktop_file, std::vector<std::string> const& env)
+void miral::open_desktop_entry(std::string const& desktop_file)
 {
     Connection const connection{g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, nullptr)};
 
     static char const* const dest = "io.snapcraft.Launcher";
     static char const* const object_path = "/io/snapcraft/Launcher";
-    static char const* const interface_name = "io.snapcraft.Launcher";
-    static char const* const method_name = "OpenDesktopEntryEnv";
+    static char const* const interface_name = "io.snapcraft.PrivilegedDesktopLauncher";
+    static char const* const method_name = "OpenDesktopEntry";
     auto const id = extract_id(desktop_file);
 
     GError* error = nullptr;
 
-    GVariantBuilder* const builder = g_variant_builder_new(G_VARIANT_TYPE ("as"));
-    for (auto const& e : env)
-        g_variant_builder_add (builder, "s", e.c_str());
-
-    if (auto const result = g_dbus_connection_call_sync(
-            connection,
-            dest,
-            object_path,
-            interface_name,
-            method_name,
-            g_variant_new("(sas)", id.c_str(), builder),
-            nullptr,
-            G_DBUS_CALL_FLAGS_NONE,
-            G_MAXINT,
-            nullptr,
-            &error))
+    if (auto const result = g_dbus_connection_call_sync(connection,
+                                                        dest,
+                                                        object_path,
+                                                        interface_name,
+                                                        method_name,
+                                                        g_variant_new("(s)", id.c_str()),
+                                                        nullptr,
+                                                        G_DBUS_CALL_FLAGS_NONE,
+                                                        G_MAXINT,
+                                                        nullptr,
+                                                        &error))
     {
         g_variant_unref(result);
     }
@@ -114,6 +109,4 @@ void miral::open_desktop_entry(std::string const& desktop_file, std::vector<std:
                       error->message, dest, object_path, interface_name, method_name, id.c_str());
         g_error_free(error);
     }
-
-    g_variant_builder_unref(builder);
 }

--- a/src/miral/open_desktop_entry.h
+++ b/src/miral/open_desktop_entry.h
@@ -24,7 +24,7 @@
 
 namespace miral
 {
-void open_desktop_entry(std::string const& desktop_file, std::vector<std::string> const& env);
+void open_desktop_entry(std::string const& desktop_file);
 }
 
 #endif //MIRAL_OPEN_DESKTOP_ENTRY_H


### PR DESCRIPTION
Update `ExternalClientLauncher::snapcraft_launch` to reflect changes to the draft desktop-launch interface.

(This matches the current state of https://github.com/snapcore/snapd/pull/8699)