### PR TITLE
examples/mir_demo_server/server_example_input_filter.cpp: Typo fix in…

### DIFF
--- a/examples/mir_demo_server/server_example_input_filter.cpp
+++ b/examples/mir_demo_server/server_example_input_filter.cpp
@@ -124,7 +124,7 @@ struct PrintingEventFilter : public mi::EventFilter
             print_pointer_event(input_event);
             break;
         default:
-            std::cout << "unkown input event type: " << mir_input_event_get_type(input_event) << std::endl;
+            std::cout << "unknown input event type: " << mir_input_event_get_type(input_event) << std::endl;
             break;
         }
 


### PR DESCRIPTION
… stdout.