### PR TITLE
linux-dmabuf: Support the full range of driver-exposed formats

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -47,7 +47,6 @@ jobs:
             "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_groovy",
             "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu",
             "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_arm64",
-            "google:ubuntu-20.04-64:spread/build/ubuntu:rpi",
             "google:ubuntu-20.04-64:spread/build/ubuntu:clang",
             "google:fedora-32-64:spread/build/fedora:amd64",
             "google:fedora-33-64:spread/build/fedora:amd64"

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -65,6 +65,10 @@ jobs:
             {
               "spread-task": "fedora-rawhide-64:spread/build/fedora:amd64",
               "allow-fail": true
+            },
+            {
+              "spread-task": "google:ubuntu-20.04-64:spread/build/ubuntu:rpi",
+              "allow-fail": true
             }
           ]
         }

--- a/include/platform/mir/graphics/program_factory.h
+++ b/include/platform/mir/graphics/program_factory.h
@@ -57,7 +57,7 @@ public:
      * \return  A reference to the fully compiled and linked Program
      */
     virtual Program& compile_fragment_shader(
-        void* id,
+        void const* id,
         char const* extension_fragment,
         char const* fragment_fragment) = 0;
 };

--- a/src/platform/graphics/CMakeLists.txt
+++ b/src/platform/graphics/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(DMABUF_PROTO_HEADER ${CMAKE_CURRENT_BINARY_DIR}/linux-dmabuf-unstable-v1_wrapper.h)
 set(DMABUF_PROTO_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/linux-dmabuf-unstable-v1_wrapper.cpp)
 
+set(DRM_FORMATS_FILE ${CMAKE_CURRENT_BINARY_DIR}/drm-formats)
+set(DRM_FORMATS_BIG_ENDIAN_FILE ${CMAKE_CURRENT_BINARY_DIR}/drm-formats-big-endian)
+
 add_library(mirplatformgraphicscommon OBJECT
 
   egl_extensions.cpp
@@ -29,6 +32,8 @@ add_library(mirplatformgraphicscommon OBJECT
   ${DMABUF_PROTO_SOURCE}
   ${PROJECT_SOURCE_DIR}/include/platform/mir/graphics/linux_dmabuf.h
   linux_dmabuf.cpp
+  ${DRM_FORMATS_FILE}
+  ${DRM_FORMATS_BIG_ENDIAN_FILE}
 )
 
 set(LINUX_DMABUF_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/protocol/linux-dmabuf-unstable-v1.xml")
@@ -55,6 +60,52 @@ add_custom_command(
   DEPENDS
   ${LINUX_DMABUF_PROTO}
   mir_wayland_generator
+)
+
+add_custom_command(
+  OUTPUT
+    drm-formats
+  VERBATIM
+  COMMAND
+    "sh" "-c"
+      "grep \"#define DRM_FORMAT\" /usr/include/libdrm/drm_fourcc.h | \
+       grep -v DRM_FORMAT_BIG_ENDIAN |                             \
+       grep -v MOD |                                               \
+       grep -v DRM_FORMAT_RESERVED |                               \
+       tr -s [:blank:] ' ' |                                       \
+       cut -f2 -d' ' |                                             \
+       sed \"s/\\(.*\\)/STRINGIFY(\\1)/\" >                        \
+       ${DRM_FORMATS_FILE}"
+)
+add_custom_command(
+  OUTPUT
+    drm-formats-big-endian
+  VERBATIM
+  COMMAND
+    "sh" "-c"
+      "grep \"#define DRM_FORMAT\" /usr/include/libdrm/drm_fourcc.h | \
+       grep -v DRM_FORMAT_BIG_ENDIAN |                             \
+       grep -v MOD |                                               \
+       grep -v DRM_FORMAT_RESERVED |                               \
+       tr -s [:blank:] ' ' |                                       \
+       cut -f2 -d' ' |                                             \
+       sed \"s/\\(.*\\)/STRINGIFY_BIG_ENDIAN(\\1)/\" >             \
+       ${DRM_FORMATS_BIG_ENDIAN_FILE}"
+)
+
+# Here for posterity; the DRM modifier format #defines are a little too
+# weird to easily parse via grep ;)
+add_custom_command(
+  OUTPUT
+    drm-modifiers
+  VERBATIM
+  COMMAND
+    "sh" "-c"
+      "grep \"#define [[:alnum:]]*_FORMAT_MOD_\\([[:alnum:]]\\|_\\)*[[:space:]]\" /usr/include/drm/drm_fourcc.h | \
+       tr -s [:blank:] ' ' |                                              \
+       cut -f2 -d' ' |                                                    \
+       sed \"s/\\(.*\\)/STRINGIFY(\\1)/\" >                               \
+       ${DRM_MODIFIERS_FILE}"
 )
 
 target_include_directories(

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -751,7 +751,12 @@ private:
             mw::ProtocolError{
                 resource,
                 Error::invalid_format,
-                "Format/modifier combination unsupported"}));
+                "Client requested unsupported format/modifier combination %s/%s (%u/%u,%u)",
+                drm_format_to_string(format),
+                drm_modifier_to_string(modifier.value_or(DRM_FORMAT_MOD_INVALID)),
+                format,
+                static_cast<uint32_t>(modifier.value_or(DRM_FORMAT_MOD_INVALID) >> 32),
+                static_cast<uint32_t>(modifier.value_or(DRM_FORMAT_MOD_INVALID) & 0xFFFFFFFF)}));
     }
 
     void create(int32_t width, int32_t height, uint32_t format, uint32_t flags) override

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -48,671 +48,6 @@ namespace mg = mir::graphics;
 namespace mw = mir::wayland;
 namespace geom = mir::geometry;
 
-namespace
-{
-using PlaneInfo = mg::DMABufBuffer::PlaneDescriptor;
-
-/**
- * Holds on to all imported dmabuf buffers, and allows looking up by wl_buffer
- *
- * \note This is not threadsafe, and should only be accessed on the Wayland thread
- */
-class WlDmaBufBuffer : public mir::wayland::Buffer
-{
-public:
-    WlDmaBufBuffer(
-        EGLDisplay dpy,
-        std::shared_ptr<mg::EGLExtensions> egl_extensions,
-        wl_resource* wl_buffer,
-        int32_t width,
-        int32_t height,
-        uint32_t format,
-        uint32_t flags,
-        uint64_t modifier,
-        std::vector<PlaneInfo> plane_params)
-            : Buffer(wl_buffer, Version<1>{}),
-              dpy{dpy},
-              egl_extensions{std::move(egl_extensions)},
-              width{width},
-              height{height},
-              format_{format},
-              flags{flags},
-              modifier_{modifier},
-              planes_{std::move(plane_params)},
-              image{EGL_NO_IMAGE_KHR}
-    {
-        reimport_egl_image();
-    }
-
-    ~WlDmaBufBuffer()
-    {
-        if (image != EGL_NO_IMAGE_KHR)
-        {
-            egl_extensions->base(dpy).eglDestroyImageKHR(dpy, image);
-        }
-    }
-
-    static auto maybe_dmabuf_from_wl_buffer(wl_resource* buffer) -> WlDmaBufBuffer*
-    {
-        return dynamic_cast<WlDmaBufBuffer*>(Buffer::from(buffer));
-    }
-
-    auto size() -> geom::Size
-    {
-        return {width, height};
-    }
-
-    auto layout() -> mg::gl::Texture::Layout
-    {
-        if (flags & mw::LinuxBufferParamsV1::Flags::y_invert)
-        {
-            return mg::gl::Texture::Layout::TopRowFirst;
-        }
-        else
-        {
-            return mg::gl::Texture::Layout::GL;
-        }
-    }
-
-    auto format() -> uint32_t
-    {
-        return format_;
-    }
-    /**
-     * Reimport dmabufs into EGL
-     *
-     * This is necessary to call each time the buffer is re-submitted by the client,
-     * to ensure any state is properly synchronised.
-     *
-     * \return  An EGLImageKHR handle to the imported
-     * \throws  A std::system_error containing the EGL error on failure.
-     */
-    auto reimport_egl_image() -> EGLImageKHR
-    {
-        std::vector<EGLint> attributes;
-
-        attributes.push_back(EGL_WIDTH);
-        attributes.push_back(width);
-        attributes.push_back(EGL_HEIGHT);
-        attributes.push_back(height);
-        attributes.push_back(EGL_LINUX_DRM_FOURCC_EXT);
-        attributes.push_back(format());
-
-        for(auto i = 0u; i < planes_.size(); ++i)
-        {
-            auto const& attrib_names = egl_attribs[i];
-            auto const& plane = planes()[i];
-
-            attributes.push_back(attrib_names.fd);
-            attributes.push_back(static_cast<int>(plane.dma_buf));
-            attributes.push_back(attrib_names.offset);
-            attributes.push_back(plane.offset);
-            attributes.push_back(attrib_names.pitch);
-            attributes.push_back(plane.stride);
-            if (modifier() != DRM_FORMAT_MOD_INVALID)
-            {
-                attributes.push_back(attrib_names.modifier_lo);
-                attributes.push_back(modifier() & 0xFFFFFFFF);
-                attributes.push_back(attrib_names.modifier_hi);
-                attributes.push_back(modifier() >> 32);
-            }
-        }
-        attributes.push_back(EGL_NONE);
-        if (image != EGL_NO_IMAGE_KHR)
-        {
-            egl_extensions->base(dpy).eglDestroyImageKHR(dpy, image);
-        }
-        image = egl_extensions->base(dpy).eglCreateImageKHR(
-            dpy,
-            EGL_NO_CONTEXT,
-            EGL_LINUX_DMA_BUF_EXT,
-            nullptr,
-            attributes.data());
-
-        if (image == EGL_NO_IMAGE_KHR)
-        {
-            auto const msg = planes_.size() > 1 ?
-                "Failed to import supplied dmabufs" :
-                "Failed to import supplied dmabuf";
-            BOOST_THROW_EXCEPTION((mg::egl_error(msg)));
-        }
-
-        return image;
-    }
-
-    auto modifier() -> uint64_t
-    {
-        return modifier_;
-    }
-
-    auto planes() -> std::vector<PlaneInfo> const&
-    {
-        return planes_;
-    }
-private:
-    void destroy() override
-    {
-        destroy_wayland_object();
-    }
-
-    EGLDisplay const dpy;
-    std::shared_ptr<mg::EGLExtensions> const egl_extensions;
-    int32_t const width, height;
-    uint32_t const format_;
-    uint32_t const flags;
-    uint64_t const modifier_;
-    std::vector<PlaneInfo> const planes_;
-    EGLImageKHR image;
-
-    struct EGLPlaneAttribs
-    {
-        EGLint fd;
-        EGLint offset;
-        EGLint pitch;
-        EGLint modifier_lo;
-        EGLint modifier_hi;
-    };
-    static constexpr std::array<EGLPlaneAttribs, 4> egl_attribs = {
-        EGLPlaneAttribs {
-            EGL_DMA_BUF_PLANE0_FD_EXT,
-            EGL_DMA_BUF_PLANE0_OFFSET_EXT,
-            EGL_DMA_BUF_PLANE0_PITCH_EXT,
-            EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT,
-            EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT
-        },
-        EGLPlaneAttribs {
-            EGL_DMA_BUF_PLANE1_FD_EXT,
-            EGL_DMA_BUF_PLANE1_OFFSET_EXT,
-            EGL_DMA_BUF_PLANE1_PITCH_EXT,
-            EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT,
-            EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT
-        },
-        EGLPlaneAttribs {
-            EGL_DMA_BUF_PLANE2_FD_EXT,
-            EGL_DMA_BUF_PLANE2_OFFSET_EXT,
-            EGL_DMA_BUF_PLANE2_PITCH_EXT,
-            EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT,
-            EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT
-        },
-        EGLPlaneAttribs {
-            EGL_DMA_BUF_PLANE3_FD_EXT,
-            EGL_DMA_BUF_PLANE3_OFFSET_EXT,
-            EGL_DMA_BUF_PLANE3_PITCH_EXT,
-            EGL_DMA_BUF_PLANE3_MODIFIER_LO_EXT,
-            EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT
-        }
-    };
-};
-
-class LinuxDmaBufParams : public mir::wayland::LinuxBufferParamsV1
-{
-public:
-    LinuxDmaBufParams(
-        wl_resource* new_resource,
-        EGLDisplay dpy,
-        std::shared_ptr<mg::EGLExtensions> egl_extensions)
-        : mir::wayland::LinuxBufferParamsV1(new_resource, Version<3>{}),
-          consumed{false},
-          dpy{dpy},
-          egl_extensions{std::move(egl_extensions)}
-    {
-    }
-
-private:
-    /* EGL_EXT_image_dma_buf_import allows up to 3 planes, and
-     * EGL_EXT_image_dma_buf_import_modifiers adds an extra plane.
-     */
-    std::array<PlaneInfo, 4> planes;
-    std::optional<uint64_t> modifier;
-    bool consumed;
-    EGLDisplay dpy;
-    std::shared_ptr<mg::EGLExtensions> egl_extensions;
-
-    void destroy() override
-    {
-        destroy_wayland_object();
-    }
-
-    void add(
-        mir::Fd fd,
-        uint32_t plane_idx,
-        uint32_t offset,
-        uint32_t stride,
-        uint32_t modifier_hi,
-        uint32_t modifier_lo) override
-    {
-        if (consumed)
-        {
-            BOOST_THROW_EXCEPTION((
-                mw::ProtocolError{
-                    resource,
-                    Error::already_used,
-                    "Params already used to create a buffer"}));
-        }
-        if (plane_idx >= planes.size())
-        {
-            BOOST_THROW_EXCEPTION((
-                mw::ProtocolError{
-                    resource,
-                    Error::plane_idx,
-                    "Plane index %u higher than maximum number of planes, %zu", plane_idx, planes.size()}));
-        }
-
-        if (planes[plane_idx].dma_buf != mir::Fd::invalid)
-        {
-            BOOST_THROW_EXCEPTION((
-                mw::ProtocolError{
-                    resource,
-                    Error::plane_set,
-                    "Plane %u already has a dmabuf", plane_idx}));
-        }
-
-        planes[plane_idx].dma_buf = std::move(fd);
-        planes[plane_idx].offset = offset;
-        planes[plane_idx].stride = stride;
-
-        if (wl_resource_get_version(resource) >= 3)
-        {
-            // The modifier event was added in v3, but due to a quirk of the wrapping generator
-            // we can't use a helper here (https://github.com/MirServer/mir/issues/1715)
-            auto const new_modifier = (static_cast<uint64_t>(modifier_hi) << 32) | modifier_lo;
-            if (modifier)
-            {
-                if (*modifier != new_modifier)
-                {
-                    BOOST_THROW_EXCEPTION((
-                        mw::ProtocolError{
-                            resource,
-                            Error::invalid_format,
-                            "Modifier %" PRIu64 " for plane %u doesn't match previously set"
-                            " modifier %" PRIu64 " - all planes must use the same modifier",
-                            new_modifier,
-                            plane_idx,
-                            *modifier}));
-                }
-            }
-            else
-            {
-                modifier = (static_cast<uint64_t>(modifier_hi) << 32) | modifier_lo;
-            }
-        }
-    }
-
-    /**
-     * Basic sanity check of the set plane properties
-     *
-     * \throws  A ProtocolError if any sanity checks fail.
-     * \return  An iterator pointing to the element past the end of the plane
-     *          infos
-     */
-    auto validate_and_count_planes() -> decltype(LinuxDmaBufParams::planes)::const_iterator
-    {
-        if (consumed)
-        {
-            BOOST_THROW_EXCEPTION((
-                mw::ProtocolError{
-                    resource,
-                    Error::already_used,
-                    "Params already used to create a buffer"}));
-        }
-        auto const plane_count =
-            std::count_if(
-                planes.begin(),
-                planes.end(),
-                [](auto const& plane) { return plane.dma_buf != mir::Fd::invalid; });
-        if (plane_count == 0)
-        {
-            BOOST_THROW_EXCEPTION((
-                mw::ProtocolError{
-                    resource,
-                    Error::incomplete,
-                    "No dmabuf has been added to the params"}));
-        }
-        for (auto i = 0; i != plane_count; ++i)
-        {
-            if (planes[i].dma_buf == mir::Fd::invalid)
-            {
-                BOOST_THROW_EXCEPTION((
-                    mw::ProtocolError{
-                        resource,
-                        Error::incomplete,
-                        "Missing dmabuf for plane %u", i}));
-            }
-        }
-
-        // TODO: Basic verification of size & offset (see libweston/linux-dmabuf.c)
-        return planes.cbegin() + plane_count;
-    }
-
-    void validate_params(int32_t width, int32_t height, uint32_t /*format*/, uint32_t /*flags*/)
-    {
-        if (width < 1 || height < 1)
-        {
-            BOOST_THROW_EXCEPTION((
-                mw::ProtocolError{
-                    resource,
-                    Error::invalid_dimensions,
-                    "Width %i or height %i invalid; both must be >= 1!",
-                    width, height}));
-
-            // TODO: Validate format & flags
-        }
-    }
-
-    void create(int32_t width, int32_t height, uint32_t format, uint32_t flags) override
-    {
-        validate_params(width, height, format, flags);
-
-        try
-        {
-            auto const buffer_resource = wl_resource_create(client, &wl_buffer_interface, 1, 0);
-            if (!buffer_resource)
-            {
-                wl_client_post_no_memory(client);
-                return;
-            }
-            new WlDmaBufBuffer{
-                dpy,
-                egl_extensions,
-                buffer_resource,
-                width,
-                height,
-                format,
-                flags,
-                modifier.value_or(DRM_FORMAT_MOD_INVALID),
-                {planes.cbegin(), validate_and_count_planes()}};
-            send_created_event(buffer_resource);
-        }
-        catch (std::system_error const& err)
-        {
-            if (err.code().category() != mg::egl_category())
-            {
-                throw;
-            }
-            /* The client should handle this fine, but let's make sure we can see
-             * any failures that might happen.
-             */
-            mir::log_debug("Failed to import client dmabufs: %s", err.what());
-            send_failed_event();
-        }
-        consumed = true;
-    }
-
-    void
-    create_immed(
-        struct wl_resource* buffer_id,
-        int32_t width,
-        int32_t height,
-        uint32_t format,
-        uint32_t flags) override
-    {
-        validate_params(width, height, format, flags);
-
-        try
-        {
-            new WlDmaBufBuffer{
-                dpy,
-                egl_extensions,
-                buffer_id,
-                width,
-                height,
-                format,
-                flags,
-                modifier.value_or(DRM_FORMAT_MOD_INVALID),
-                {planes.cbegin(), validate_and_count_planes()}};
-        }
-        catch (std::system_error const& err)
-        {
-            if (err.code().category() != mg::egl_category())
-            {
-                throw;
-            }
-            /* The protocol gives implementations the choice of sending an invalid_wl_buffer
-             * protocol error and disconnecting the client here, or sending a failed() event
-             * and not disconnecting the client.
-             *
-             * Both Weston and GNOME Shell choose to disconnect the client, rather than possibly
-             * allowing them to attempt to use an invalid wl_buffer. Let's follow their lead.
-             */
-            BOOST_THROW_EXCEPTION((
-                mw::ProtocolError{
-                    resource,
-                    Error::invalid_wl_buffer,
-                    "Failed to import dmabuf: %s", err.what()
-                }));
-        }
-    }
-};
-
-GLuint get_tex_id()
-{
-    GLuint tex;
-    glGenTextures(1, &tex);
-    return tex;
-}
-
-bool drm_format_has_alpha(uint32_t format)
-{
-    /* TODO: We should really have something like libweston/pixel-formats.h
-     * We've said this multiple times before, so 🤷
-     */
-
-    switch (format)
-    {
-        /* This is only an optimisation, so pick a bunch of formats and hope that
-         * covers it…
-         */
-        case DRM_FORMAT_XBGR2101010:
-        case DRM_FORMAT_BGRX1010102:
-        case DRM_FORMAT_XBGR8888:
-        case DRM_FORMAT_BGRX8888:
-        case DRM_FORMAT_XRGB2101010:
-        case DRM_FORMAT_RGBX1010102:
-        case DRM_FORMAT_RGBX8888:
-        case DRM_FORMAT_XRGB8888:
-            return false;
-        default:
-        // TODO: I *think* true is a safe default, as it'll just mean we're blending something without alpha?
-            return true;
-    }
-}
-
-class WaylandDmabufTexBuffer :
-    public mg::BufferBasic,
-    public mg::gl::Texture,
-    public mg::DMABufBuffer
-{
-public:
-    // Note: Must be called with a current EGL context
-    WaylandDmabufTexBuffer(
-        WlDmaBufBuffer& source,
-        mg::EGLExtensions const& extensions,
-        std::shared_ptr<mir::renderer::gl::Context> ctx,
-        EGLDisplay dpy,
-        std::function<void()>&& on_consumed,
-        std::function<void()>&& on_release,
-        std::shared_ptr<mir::Executor> wayland_executor)
-        : ctx{std::move(ctx)},
-          tex{get_tex_id()},
-          on_consumed{std::move(on_consumed)},
-          on_release{std::move(on_release)},
-          size_{source.size()},
-          layout_{source.layout()},
-          has_alpha{drm_format_has_alpha(source.format())},
-          planes_{source.planes()},
-          modifier_{source.modifier()},
-          fourcc{source.format()},
-          wayland_executor{std::move(wayland_executor)}
-    {
-        eglBindAPI(EGL_OPENGL_ES_API);
-
-        glBindTexture(GL_TEXTURE_2D, tex);
-        extensions.base(dpy).glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, source.reimport_egl_image());
-        // tex is now an EGLImage sibling, so we can free the EGLImage without
-        // freeing the backing data.
-
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    }
-
-    ~WaylandDmabufTexBuffer() override
-    {
-        wayland_executor->spawn(
-            [context = ctx, tex = tex]()
-            {
-              context->make_current();
-
-              glDeleteTextures(1, &tex);
-
-              context->release_current();
-            });
-
-        on_release();
-    }
-
-    std::shared_ptr<mir::graphics::NativeBuffer> native_buffer_handle() const override
-    {
-        return {nullptr};
-    }
-
-    mir::geometry::Size size() const override
-    {
-        return size_;
-    }
-
-    MirPixelFormat pixel_format() const override
-    {
-        // There's no way to implement this corectly…
-        if (has_alpha)
-        {
-            return mir_pixel_format_argb_8888;
-        }
-        else
-        {
-            return mir_pixel_format_xrgb_8888;
-        }
-    }
-
-    NativeBufferBase* native_buffer_base() override
-    {
-        return this;
-    }
-
-    mir::graphics::gl::Program const& shader(mir::graphics::gl::ProgramFactory& cache) const override
-    {
-        static int argb_shader{0};
-        return cache.compile_fragment_shader(
-            &argb_shader,
-            "",
-            "uniform sampler2D tex;\n"
-            "vec4 sample_to_rgba(in vec2 texcoord)\n"
-            "{\n"
-            "    return texture2D(tex, texcoord);\n"
-            "}\n");
-    }
-
-    Layout layout() const override
-    {
-        return layout_;
-    }
-
-    void bind() override
-    {
-        glBindTexture(GL_TEXTURE_2D, tex);
-
-        std::lock_guard<decltype(consumed_mutex)> lock(consumed_mutex);
-        on_consumed();
-        on_consumed = [](){};
-    }
-
-    void add_syncpoint() override
-    {
-    }
-
-    auto drm_fourcc() const -> uint32_t override
-    {
-        return fourcc;
-    }
-
-    auto modifier() const -> std::optional<uint64_t> override
-    {
-        return modifier_;
-    }
-
-    auto planes() const -> std::vector<PlaneDescriptor> const& override
-    {
-        return planes_;
-    }
-
-private:
-    std::shared_ptr<mir::renderer::gl::Context> const ctx;
-    GLuint const tex;
-
-    std::mutex consumed_mutex;
-    std::function<void()> on_consumed;
-    std::function<void()> const on_release;
-
-    geom::Size const size_;
-    Layout const layout_;
-    bool const has_alpha;
-
-    std::vector<mg::DMABufBuffer::PlaneDescriptor> const planes_;
-    std::optional<uint64_t> const modifier_;
-    uint32_t const fourcc;
-
-    std::shared_ptr<mir::Executor> const wayland_executor;
-};
-
-
-}
-
-bool format_is_simple_enough_for_us(uint32_t format)
-{
-    /* There's (some, not all that much) extra work required to support anything but RGB
-     * formats. Hopefully one of the formats that is left wil be good enough for the client!
-     */
-    switch (format)
-    {
-    case DRM_FORMAT_XRGB8888:
-    case DRM_FORMAT_XBGR8888:
-    case DRM_FORMAT_RGBX8888:
-    case DRM_FORMAT_BGRX8888:
-    case DRM_FORMAT_BGRX1010102:
-    case DRM_FORMAT_RGBX1010102:
-    case DRM_FORMAT_XBGR2101010:
-    case DRM_FORMAT_XRGB2101010:
-    case DRM_FORMAT_XRGB1555:
-    case DRM_FORMAT_XBGR1555:
-    case DRM_FORMAT_RGBX5551:
-    case DRM_FORMAT_BGRX5551:
-    case DRM_FORMAT_XRGB4444:
-    case DRM_FORMAT_XBGR4444:
-    case DRM_FORMAT_RGBX4444:
-    case DRM_FORMAT_BGRX4444:
-    case DRM_FORMAT_ARGB8888:
-    case DRM_FORMAT_ABGR8888:
-    case DRM_FORMAT_RGBA8888:
-    case DRM_FORMAT_BGRA8888:
-    case DRM_FORMAT_BGRA1010102:
-    case DRM_FORMAT_RGBA1010102:
-    case DRM_FORMAT_ABGR2101010:
-    case DRM_FORMAT_ARGB2101010:
-    case DRM_FORMAT_ARGB1555:
-    case DRM_FORMAT_ABGR1555:
-    case DRM_FORMAT_RGBA5551:
-    case DRM_FORMAT_BGRA5551:
-    case DRM_FORMAT_ARGB4444:
-    case DRM_FORMAT_ABGR4444:
-    case DRM_FORMAT_RGBA4444:
-    case DRM_FORMAT_BGRA4444:
-        return true;
-    default:
-        return false;
-    }
-}
-
 class mg::DmaBufFormatDescriptors
 {
 public:
@@ -857,6 +192,699 @@ private:
     std::vector<std::vector<EGLBoolean>> external_only_for_format;
 };
 
+namespace
+{
+using PlaneInfo = mg::DMABufBuffer::PlaneDescriptor;
+
+struct BufferGLDescription
+{
+    GLenum target;
+    char const* extension_fragment;
+    char const* fragment_fragment;
+};
+
+BufferGLDescription const Tex2D = {
+    GL_TEXTURE_2D,
+    "",
+    "uniform sampler2D tex;\n"
+    "vec4 sample_to_rgba(in vec2 texcoord)\n"
+    "{\n"
+    "    return texture2D(tex, texcoord);\n"
+    "}\n"
+};
+
+BufferGLDescription const ExternalOES = {
+    GL_TEXTURE_EXTERNAL_OES,
+    "#ifdef GL_ES\n"
+    "#extension GL_OES_EGL_image_external : require\n"
+    "#endif\n",
+    "uniform samplerExternalOES tex;\n"
+    "vec4 sample_to_rgba(in vec2 texcoord)\n"
+    "{\n"
+    "    return texture2D(tex, texcoord);\n"
+    "}\n"
+};
+
+/**
+ * Holds on to all imported dmabuf buffers, and allows looking up by wl_buffer
+ *
+ * \note This is not threadsafe, and should only be accessed on the Wayland thread
+ */
+class WlDmaBufBuffer : public mir::wayland::Buffer
+{
+public:
+    WlDmaBufBuffer(
+        EGLDisplay dpy,
+        std::shared_ptr<mg::EGLExtensions> egl_extensions,
+        BufferGLDescription const& desc,
+        wl_resource* wl_buffer,
+        int32_t width,
+        int32_t height,
+        uint32_t format,
+        uint32_t flags,
+        uint64_t modifier,
+        std::vector<PlaneInfo> plane_params)
+            : Buffer(wl_buffer, Version<1>{}),
+              dpy{dpy},
+              egl_extensions{std::move(egl_extensions)},
+              desc{desc},
+              width{width},
+              height{height},
+              format_{format},
+              flags{flags},
+              modifier_{modifier},
+              planes_{std::move(plane_params)},
+              image{EGL_NO_IMAGE_KHR}
+    {
+        reimport_egl_image();
+    }
+
+    ~WlDmaBufBuffer()
+    {
+        if (image != EGL_NO_IMAGE_KHR)
+        {
+            egl_extensions->base(dpy).eglDestroyImageKHR(dpy, image);
+        }
+    }
+
+    static auto maybe_dmabuf_from_wl_buffer(wl_resource* buffer) -> WlDmaBufBuffer*
+    {
+        return dynamic_cast<WlDmaBufBuffer*>(Buffer::from(buffer));
+    }
+
+    auto size() -> geom::Size
+    {
+        return {width, height};
+    }
+
+    auto layout() -> mg::gl::Texture::Layout
+    {
+        if (flags & mw::LinuxBufferParamsV1::Flags::y_invert)
+        {
+            return mg::gl::Texture::Layout::TopRowFirst;
+        }
+        else
+        {
+            return mg::gl::Texture::Layout::GL;
+        }
+    }
+
+    auto format() -> uint32_t
+    {
+        return format_;
+    }
+
+    auto descriptor() const -> BufferGLDescription const&
+    {
+        return desc;
+    }
+    /**
+     * Reimport dmabufs into EGL
+     *
+     * This is necessary to call each time the buffer is re-submitted by the client,
+     * to ensure any state is properly synchronised.
+     *
+     * \return  An EGLImageKHR handle to the imported
+     * \throws  A std::system_error containing the EGL error on failure.
+     */
+    auto reimport_egl_image() -> EGLImageKHR
+    {
+        std::vector<EGLint> attributes;
+
+        attributes.push_back(EGL_WIDTH);
+        attributes.push_back(width);
+        attributes.push_back(EGL_HEIGHT);
+        attributes.push_back(height);
+        attributes.push_back(EGL_LINUX_DRM_FOURCC_EXT);
+        attributes.push_back(format());
+
+        for(auto i = 0u; i < planes_.size(); ++i)
+        {
+            auto const& attrib_names = egl_attribs[i];
+            auto const& plane = planes()[i];
+
+            attributes.push_back(attrib_names.fd);
+            attributes.push_back(static_cast<int>(plane.dma_buf));
+            attributes.push_back(attrib_names.offset);
+            attributes.push_back(plane.offset);
+            attributes.push_back(attrib_names.pitch);
+            attributes.push_back(plane.stride);
+            if (modifier() != DRM_FORMAT_MOD_INVALID)
+            {
+                attributes.push_back(attrib_names.modifier_lo);
+                attributes.push_back(modifier() & 0xFFFFFFFF);
+                attributes.push_back(attrib_names.modifier_hi);
+                attributes.push_back(modifier() >> 32);
+            }
+        }
+        attributes.push_back(EGL_NONE);
+        if (image != EGL_NO_IMAGE_KHR)
+        {
+            egl_extensions->base(dpy).eglDestroyImageKHR(dpy, image);
+        }
+        image = egl_extensions->base(dpy).eglCreateImageKHR(
+            dpy,
+            EGL_NO_CONTEXT,
+            EGL_LINUX_DMA_BUF_EXT,
+            nullptr,
+            attributes.data());
+
+        if (image == EGL_NO_IMAGE_KHR)
+        {
+            auto const msg = planes_.size() > 1 ?
+                "Failed to import supplied dmabufs" :
+                "Failed to import supplied dmabuf";
+            BOOST_THROW_EXCEPTION((mg::egl_error(msg)));
+        }
+
+        return image;
+    }
+
+    auto modifier() -> uint64_t
+    {
+        return modifier_;
+    }
+
+    auto planes() -> std::vector<PlaneInfo> const&
+    {
+        return planes_;
+    }
+private:
+    void destroy() override
+    {
+        destroy_wayland_object();
+    }
+
+    EGLDisplay const dpy;
+    std::shared_ptr<mg::EGLExtensions> const egl_extensions;
+    BufferGLDescription const& desc;
+    int32_t const width, height;
+    uint32_t const format_;
+    uint32_t const flags;
+    uint64_t const modifier_;
+    std::vector<PlaneInfo> const planes_;
+    EGLImageKHR image;
+
+    struct EGLPlaneAttribs
+    {
+        EGLint fd;
+        EGLint offset;
+        EGLint pitch;
+        EGLint modifier_lo;
+        EGLint modifier_hi;
+    };
+    static constexpr std::array<EGLPlaneAttribs, 4> egl_attribs = {
+        EGLPlaneAttribs {
+            EGL_DMA_BUF_PLANE0_FD_EXT,
+            EGL_DMA_BUF_PLANE0_OFFSET_EXT,
+            EGL_DMA_BUF_PLANE0_PITCH_EXT,
+            EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT,
+            EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT
+        },
+        EGLPlaneAttribs {
+            EGL_DMA_BUF_PLANE1_FD_EXT,
+            EGL_DMA_BUF_PLANE1_OFFSET_EXT,
+            EGL_DMA_BUF_PLANE1_PITCH_EXT,
+            EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT,
+            EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT
+        },
+        EGLPlaneAttribs {
+            EGL_DMA_BUF_PLANE2_FD_EXT,
+            EGL_DMA_BUF_PLANE2_OFFSET_EXT,
+            EGL_DMA_BUF_PLANE2_PITCH_EXT,
+            EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT,
+            EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT
+        },
+        EGLPlaneAttribs {
+            EGL_DMA_BUF_PLANE3_FD_EXT,
+            EGL_DMA_BUF_PLANE3_OFFSET_EXT,
+            EGL_DMA_BUF_PLANE3_PITCH_EXT,
+            EGL_DMA_BUF_PLANE3_MODIFIER_LO_EXT,
+            EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT
+        }
+    };
+};
+
+class LinuxDmaBufParams : public mir::wayland::LinuxBufferParamsV1
+{
+public:
+    LinuxDmaBufParams(
+        wl_resource* new_resource,
+        EGLDisplay dpy,
+        std::shared_ptr<mg::EGLExtensions> egl_extensions,
+        std::shared_ptr<mg::DmaBufFormatDescriptors const> formats)
+        : mir::wayland::LinuxBufferParamsV1(new_resource, Version<3>{}),
+          consumed{false},
+          dpy{dpy},
+          egl_extensions{std::move(egl_extensions)},
+          formats{std::move(formats)}
+    {
+    }
+
+private:
+    /* EGL_EXT_image_dma_buf_import allows up to 3 planes, and
+     * EGL_EXT_image_dma_buf_import_modifiers adds an extra plane.
+     */
+    std::array<PlaneInfo, 4> planes;
+    std::optional<uint64_t> modifier;
+    bool consumed;
+    EGLDisplay dpy;
+    std::shared_ptr<mg::EGLExtensions> egl_extensions;
+    std::shared_ptr<mg::DmaBufFormatDescriptors const> const formats;
+
+    void destroy() override
+    {
+        destroy_wayland_object();
+    }
+
+    void add(
+        mir::Fd fd,
+        uint32_t plane_idx,
+        uint32_t offset,
+        uint32_t stride,
+        uint32_t modifier_hi,
+        uint32_t modifier_lo) override
+    {
+        if (consumed)
+        {
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::already_used,
+                    "Params already used to create a buffer"}));
+        }
+        if (plane_idx >= planes.size())
+        {
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::plane_idx,
+                    "Plane index %u higher than maximum number of planes, %zu", plane_idx, planes.size()}));
+        }
+
+        if (planes[plane_idx].dma_buf != mir::Fd::invalid)
+        {
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::plane_set,
+                    "Plane %u already has a dmabuf", plane_idx}));
+        }
+
+        planes[plane_idx].dma_buf = std::move(fd);
+        planes[plane_idx].offset = offset;
+        planes[plane_idx].stride = stride;
+
+        if (wl_resource_get_version(resource) >= 3)
+        {
+            // The modifier event was added in v3, but due to a quirk of the wrapping generator
+            // we can't use a helper here (https://github.com/MirServer/mir/issues/1715)
+            auto const new_modifier = (static_cast<uint64_t>(modifier_hi) << 32) | modifier_lo;
+            if (modifier)
+            {
+                if (*modifier != new_modifier)
+                {
+                    BOOST_THROW_EXCEPTION((
+                        mw::ProtocolError{
+                            resource,
+                            Error::invalid_format,
+                            "Modifier %" PRIu64 " for plane %u doesn't match previously set"
+                            " modifier %" PRIu64 " - all planes must use the same modifier",
+                            new_modifier,
+                            plane_idx,
+                            *modifier}));
+                }
+            }
+            else
+            {
+                modifier = (static_cast<uint64_t>(modifier_hi) << 32) | modifier_lo;
+            }
+        }
+    }
+
+    /**
+     * Basic sanity check of the set plane properties
+     *
+     * \throws  A ProtocolError if any sanity checks fail.
+     * \return  An iterator pointing to the element past the end of the plane
+     *          infos
+     */
+    auto validate_and_count_planes() -> decltype(LinuxDmaBufParams::planes)::const_iterator
+    {
+        if (consumed)
+        {
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::already_used,
+                    "Params already used to create a buffer"}));
+        }
+        auto const plane_count =
+            std::count_if(
+                planes.begin(),
+                planes.end(),
+                [](auto const& plane) { return plane.dma_buf != mir::Fd::invalid; });
+        if (plane_count == 0)
+        {
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::incomplete,
+                    "No dmabuf has been added to the params"}));
+        }
+        for (auto i = 0; i != plane_count; ++i)
+        {
+            if (planes[i].dma_buf == mir::Fd::invalid)
+            {
+                BOOST_THROW_EXCEPTION((
+                    mw::ProtocolError{
+                        resource,
+                        Error::incomplete,
+                        "Missing dmabuf for plane %u", i}));
+            }
+        }
+
+        // TODO: Basic verification of size & offset (see libweston/linux-dmabuf.c)
+        return planes.cbegin() + plane_count;
+    }
+
+    void validate_params(int32_t width, int32_t height, uint32_t /*format*/, uint32_t /*flags*/)
+    {
+        if (width < 1 || height < 1)
+        {
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::invalid_dimensions,
+                    "Width %i or height %i invalid; both must be >= 1!",
+                    width, height}));
+
+            // TODO: Validate format & flags
+        }
+    }
+
+    BufferGLDescription const& descriptor_for_format_and_modifiers(uint32_t format)
+    {
+        for (auto i = 0u; i < formats->num_formats(); ++i)
+        {
+            auto const& [supported_format, modifiers, external_only] = (*formats)[i];
+
+            for (auto j = 0u ; j < modifiers.size(); ++j)
+            {
+                auto const supported_modifier = modifiers[j];
+
+                if (static_cast<uint32_t>(supported_format) == format &&
+                    supported_modifier == modifier.value_or(DRM_FORMAT_MOD_INVALID))
+                {
+                    if (external_only[j])
+                    {
+                        return ExternalOES;
+                    }
+                    return Tex2D;
+                }
+            }
+        }
+        BOOST_THROW_EXCEPTION((
+            mw::ProtocolError{
+                resource,
+                Error::invalid_format,
+                "Format/modifier combination unsupported"}));
+    }
+
+    void create(int32_t width, int32_t height, uint32_t format, uint32_t flags) override
+    {
+        validate_params(width, height, format, flags);
+
+        try
+        {
+            auto const buffer_resource = wl_resource_create(client, &wl_buffer_interface, 1, 0);
+            if (!buffer_resource)
+            {
+                wl_client_post_no_memory(client);
+                return;
+            }
+            new WlDmaBufBuffer{
+                dpy,
+                egl_extensions,
+                descriptor_for_format_and_modifiers(format),
+                buffer_resource,
+                width,
+                height,
+                format,
+                flags,
+                modifier.value_or(DRM_FORMAT_MOD_INVALID),
+                {planes.cbegin(), validate_and_count_planes()}};
+            send_created_event(buffer_resource);
+        }
+        catch (std::system_error const& err)
+        {
+            if (err.code().category() != mg::egl_category())
+            {
+                throw;
+            }
+            /* The client should handle this fine, but let's make sure we can see
+             * any failures that might happen.
+             */
+            mir::log_debug("Failed to import client dmabufs: %s", err.what());
+            send_failed_event();
+        }
+        consumed = true;
+    }
+
+    void
+    create_immed(
+        struct wl_resource* buffer_id,
+        int32_t width,
+        int32_t height,
+        uint32_t format,
+        uint32_t flags) override
+    {
+        validate_params(width, height, format, flags);
+
+        try
+        {
+            new WlDmaBufBuffer{
+                dpy,
+                egl_extensions,
+                descriptor_for_format_and_modifiers(format),
+                buffer_id,
+                width,
+                height,
+                format,
+                flags,
+                modifier.value_or(DRM_FORMAT_MOD_INVALID),
+                {planes.cbegin(), validate_and_count_planes()}};
+        }
+        catch (std::system_error const& err)
+        {
+            if (err.code().category() != mg::egl_category())
+            {
+                throw;
+            }
+            /* The protocol gives implementations the choice of sending an invalid_wl_buffer
+             * protocol error and disconnecting the client here, or sending a failed() event
+             * and not disconnecting the client.
+             *
+             * Both Weston and GNOME Shell choose to disconnect the client, rather than possibly
+             * allowing them to attempt to use an invalid wl_buffer. Let's follow their lead.
+             */
+            BOOST_THROW_EXCEPTION((
+                mw::ProtocolError{
+                    resource,
+                    Error::invalid_wl_buffer,
+                    "Failed to import dmabuf: %s", err.what()
+                }));
+        }
+    }
+};
+
+GLuint get_tex_id()
+{
+    GLuint tex;
+    glGenTextures(1, &tex);
+    return tex;
+}
+
+bool drm_format_has_alpha(uint32_t format)
+{
+    /* TODO: We should really have something like libweston/pixel-formats.h
+     * We've said this multiple times before, so 🤷
+     */
+
+    switch (format)
+    {
+        /* This is only an optimisation, so pick a bunch of formats and hope that
+         * covers it…
+         */
+        case DRM_FORMAT_XBGR2101010:
+        case DRM_FORMAT_BGRX1010102:
+        case DRM_FORMAT_XBGR8888:
+        case DRM_FORMAT_BGRX8888:
+        case DRM_FORMAT_XRGB2101010:
+        case DRM_FORMAT_RGBX1010102:
+        case DRM_FORMAT_RGBX8888:
+        case DRM_FORMAT_XRGB8888:
+            return false;
+        default:
+        // TODO: I *think* true is a safe default, as it'll just mean we're blending something without alpha?
+            return true;
+    }
+}
+
+class WaylandDmabufTexBuffer :
+    public mg::BufferBasic,
+    public mg::gl::Texture,
+    public mg::DMABufBuffer
+{
+public:
+    // Note: Must be called with a current EGL context
+    WaylandDmabufTexBuffer(
+        WlDmaBufBuffer& source,
+        mg::EGLExtensions const& extensions,
+        std::shared_ptr<mir::renderer::gl::Context> ctx,
+        EGLDisplay dpy,
+        std::function<void()>&& on_consumed,
+        std::function<void()>&& on_release,
+        std::shared_ptr<mir::Executor> wayland_executor)
+        : ctx{std::move(ctx)},
+          tex{get_tex_id()},
+          desc{source.descriptor()},
+          on_consumed{std::move(on_consumed)},
+          on_release{std::move(on_release)},
+          size_{source.size()},
+          layout_{source.layout()},
+          has_alpha{drm_format_has_alpha(source.format())},
+          planes_{source.planes()},
+          modifier_{source.modifier()},
+          fourcc{source.format()},
+          wayland_executor{std::move(wayland_executor)}
+    {
+        eglBindAPI(EGL_OPENGL_ES_API);
+
+        auto const target = source.descriptor().target;
+
+        glBindTexture(target, tex);
+        extensions.base(dpy).glEGLImageTargetTexture2DOES(target, source.reimport_egl_image());
+        // tex is now an EGLImage sibling, so we can free the EGLImage without
+        // freeing the backing data.
+
+        glTexParameteri(target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameteri(target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    }
+
+    ~WaylandDmabufTexBuffer() override
+    {
+        wayland_executor->spawn(
+            [context = ctx, tex = tex]()
+            {
+              context->make_current();
+
+              glDeleteTextures(1, &tex);
+
+              context->release_current();
+            });
+
+        on_release();
+    }
+
+    std::shared_ptr<mir::graphics::NativeBuffer> native_buffer_handle() const override
+    {
+        return {nullptr};
+    }
+
+    mir::geometry::Size size() const override
+    {
+        return size_;
+    }
+
+    MirPixelFormat pixel_format() const override
+    {
+        // There's no way to implement this corectly…
+        if (has_alpha)
+        {
+            return mir_pixel_format_argb_8888;
+        }
+        else
+        {
+            return mir_pixel_format_xrgb_8888;
+        }
+    }
+
+    NativeBufferBase* native_buffer_base() override
+    {
+        return this;
+    }
+
+    mir::graphics::gl::Program const& shader(mir::graphics::gl::ProgramFactory& cache) const override
+    {
+        /* We rely on the fact that `desc` is a reference to a statically-allocated namespaced
+         * variable, and so taking the address will give us the address of the static instance,
+         * making the cache compile only once for each `desc`.
+         */
+        return cache.compile_fragment_shader(
+            &desc,
+            desc.extension_fragment,
+            desc.fragment_fragment);
+    }
+
+    Layout layout() const override
+    {
+        return layout_;
+    }
+
+    void bind() override
+    {
+        glBindTexture(desc.target, tex);
+
+        std::lock_guard<decltype(consumed_mutex)> lock(consumed_mutex);
+        on_consumed();
+        on_consumed = [](){};
+    }
+
+    void add_syncpoint() override
+    {
+    }
+
+    auto drm_fourcc() const -> uint32_t override
+    {
+        return fourcc;
+    }
+
+    auto modifier() const -> std::optional<uint64_t> override
+    {
+        return modifier_;
+    }
+
+    auto planes() const -> std::vector<PlaneDescriptor> const& override
+    {
+        return planes_;
+    }
+
+private:
+    std::shared_ptr<mir::renderer::gl::Context> const ctx;
+    GLuint const tex;
+    BufferGLDescription const& desc;
+
+    std::mutex consumed_mutex;
+    std::function<void()> on_consumed;
+    std::function<void()> const on_release;
+
+    geom::Size const size_;
+    Layout const layout_;
+    bool const has_alpha;
+
+    std::vector<mg::DMABufBuffer::PlaneDescriptor> const planes_;
+    std::optional<uint64_t> const modifier_;
+    uint32_t const fourcc;
+
+    std::shared_ptr<mir::Executor> const wayland_executor;
+};
+
+
+}
+
 class mg::LinuxDmaBufUnstable::Instance : public mir::wayland::LinuxDmabufV1
 {
 public:
@@ -864,33 +892,26 @@ public:
         wl_resource* new_resource,
         EGLDisplay dpy,
         std::shared_ptr<EGLExtensions> egl_extensions,
-        DmaBufFormatDescriptors const& formats)
+        std::shared_ptr<DmaBufFormatDescriptors const> formats)
         : mir::wayland::LinuxDmabufV1(new_resource, Version<3>{}),
           dpy{dpy},
-          egl_extensions{std::move(egl_extensions)}
+          egl_extensions{std::move(egl_extensions)},
+          formats{std::move(formats)}
     {
-        for (auto i = 0u; i < formats.num_formats(); ++i)
+        for (auto i = 0u; i < this->formats->num_formats(); ++i)
         {
-            auto [format, modifiers, external_only] = formats[i];
+            auto [format, modifiers, external_only] = (*(this->formats))[i];
 
-            if (format_is_simple_enough_for_us(format))
+            send_format_event(format);
+            if (version_supports_modifier())
             {
-                send_format_event(format);
-                if (version_supports_modifier())
+                for (auto j = 0u; j < modifiers.size(); ++j)
                 {
-                    for (auto j = 0u; j < modifiers.size(); ++j)
-                    {
-                        auto const modifier = modifiers[j];
-                        auto const external = external_only[j];
-                        if (external == EGL_FALSE)
-                        {
-                            // We can't (currently) handle external images
-                            send_modifier_event(
-                                format,
-                                modifier >> 32,
-                                modifier & 0xFFFFFFFF);
-                        }
-                    }
+                    auto const modifier = modifiers[j];
+                    send_modifier_event(
+                        format,
+                        modifier >> 32,
+                        modifier & 0xFFFFFFFF);
                 }
             }
         }
@@ -903,11 +924,12 @@ private:
 
     void create_params(struct wl_resource* params_id) override
     {
-        new LinuxDmaBufParams{params_id, dpy, egl_extensions};
+        new LinuxDmaBufParams{params_id, dpy, egl_extensions, formats};
     }
 
     EGLDisplay const dpy;
     std::shared_ptr<EGLExtensions> const egl_extensions;
+    std::shared_ptr<DmaBufFormatDescriptors const> const formats;
 };
 
 mg::LinuxDmaBufUnstable::LinuxDmaBufUnstable(
@@ -946,5 +968,5 @@ auto mg::LinuxDmaBufUnstable::buffer_from_resource(
 
 void mg::LinuxDmaBufUnstable::bind(wl_resource* new_resource)
 {
-    new LinuxDmaBufUnstable::Instance{new_resource, dpy, egl_extensions, *formats};
+    new LinuxDmaBufUnstable::Instance{new_resource, dpy, egl_extensions, formats};
 }

--- a/src/renderers/gl/renderer.cpp
+++ b/src/renderers/gl/renderer.cpp
@@ -206,7 +206,7 @@ public:
 
     mir::graphics::gl::Program&
         compile_fragment_shader(
-            void* id,
+            void const* id,
             char const* extension_fragment,
             char const* fragment_fragment) override
     {
@@ -324,7 +324,7 @@ private:
     }
 
     ShaderHandle const vertex_shader;
-    std::vector<std::pair<void*, std::unique_ptr<::Program>>> programs;
+    std::vector<std::pair<void const*, std::unique_ptr<::Program>>> programs;
     // GL requires us to synchronise multi-threaded access to the shader APIs.
     std::mutex compilation_mutex;
 };

--- a/src/renderers/gl/renderer.cpp
+++ b/src/renderers/gl/renderer.cpp
@@ -224,12 +224,12 @@ public:
 
         std::stringstream opaque_fragment;
         opaque_fragment
+            << extension_fragment
+            << "\n"
             <<
             "#ifdef GL_ES\n"
             "precision mediump float;\n"
             "#endif\n"
-            << "\n"
-            << extension_fragment
             << "\n"
             << fragment_fragment
             << "\n"
@@ -241,12 +241,12 @@ public:
 
         std::stringstream alpha_fragment;
         alpha_fragment
+            << extension_fragment
+            << "\n"
             <<
             "#ifdef GL_ES\n"
             "precision mediump float;\n"
             "#endif\n"
-            << "\n"
-            << extension_fragment
             << "\n"
             << fragment_fragment
             << "\n"


### PR DESCRIPTION
Some of the formats¹ exposed by `EGL_EXT_image_dma_buf_import_modifiers` are
available only as `GL_OES_EGL_image_external` targets, which require some
different code in GL rendering.

We were filtering these formats out in the first cut of dmabuf support.

This implements the GL necessary to render out of external images,
so we can now expose all the formats the driver supports through to clients.

¹: Notably, multi-planar (eg: YUV) are often only supported with external images.