### PR TITLE
Disable natural scrolling

### DIFF
--- a/spread/build/fedora/task.yaml
+++ b/spread/build/fedora/task.yaml
@@ -46,7 +46,7 @@ execute: |
         libdrm-devel
 
     BUILD_DIR=$(mktemp --directory)
-    cmake -H$SPREAD_PATH -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DMIR_USE_LD_GOLD=ON -DMIR_ENABLE_WLCS_TESTS=OFF
+    cmake -H$SPREAD_PATH -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DMIR_USE_LD=gold -DMIR_ENABLE_WLCS_TESTS=OFF
     # Run cmake again to pick up wlcs?!?!?!?!
     cmake $BUILD_DIR
     export VERBOSE=1

--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -279,7 +279,7 @@ mir::EventUPtr mie::LibInputDevice::convert_axis_event(libinput_event_pointer* p
             hscroll_value = horizontal_scroll_scale * libinput_event_pointer_get_axis_value_discrete(
                                                           pointer, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL);
         if (libinput_event_pointer_has_axis(pointer, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-            vscroll_value = -vertical_scroll_scale * libinput_event_pointer_get_axis_value_discrete(
+            vscroll_value = vertical_scroll_scale * libinput_event_pointer_get_axis_value_discrete(
                                                         pointer, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL);
     }
     else
@@ -294,7 +294,7 @@ mir::EventUPtr mie::LibInputDevice::convert_axis_event(libinput_event_pointer* p
                             scroll_units_to_ticks;
 
         if (libinput_event_pointer_has_axis(pointer, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-            vscroll_value = -vertical_scroll_scale *
+            vscroll_value = vertical_scroll_scale *
                             libinput_event_pointer_get_axis_value(pointer, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL) /
                             scroll_units_to_ticks;
     }

--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -271,32 +271,21 @@ mir::EventUPtr mie::LibInputDevice::convert_axis_event(libinput_event_pointer* p
     auto const relative_x_value = 0.0f;
     auto const relative_y_value = 0.0f;
 
+    // TODO: Add descrete scroll to pointer events and source it from libinput_event_pointer_get_axis_value_discrete()
+    // if libinput_event_pointer_get_axis_source(pointer) == LIBINPUT_POINTER_AXIS_SOURCE_WHEEL
+
     auto hscroll_value = 0.0f;
     auto vscroll_value = 0.0f;
-    if (libinput_event_pointer_get_axis_source(pointer) == LIBINPUT_POINTER_AXIS_SOURCE_WHEEL)
+    if (libinput_event_pointer_has_axis(pointer, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
     {
-        if (libinput_event_pointer_has_axis(pointer, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
-            hscroll_value = horizontal_scroll_scale * libinput_event_pointer_get_axis_value_discrete(
-                                                          pointer, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL);
-        if (libinput_event_pointer_has_axis(pointer, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-            vscroll_value = vertical_scroll_scale * libinput_event_pointer_get_axis_value_discrete(
-                                                        pointer, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL);
+        hscroll_value = horizontal_scroll_scale *
+                        libinput_event_pointer_get_axis_value(pointer, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL);
     }
-    else
-    {
-        // by default libinput assumes that wheel ticks represent a rotation of 15 degrees. This relation
-        // is used to map wheel rotations to 'scroll units'. To map the immediate scroll units received
-        // from gesture based scrolling we invert that transformation here.
-        auto const scroll_units_to_ticks = 15.0f;
-        if (libinput_event_pointer_has_axis(pointer, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
-            hscroll_value = horizontal_scroll_scale *
-                            libinput_event_pointer_get_axis_value(pointer, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL) /
-                            scroll_units_to_ticks;
 
-        if (libinput_event_pointer_has_axis(pointer, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-            vscroll_value = vertical_scroll_scale *
-                            libinput_event_pointer_get_axis_value(pointer, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL) /
-                            scroll_units_to_ticks;
+    if (libinput_event_pointer_has_axis(pointer, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+    {
+        vscroll_value = vertical_scroll_scale *
+                        libinput_event_pointer_get_axis_value(pointer, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL);
     }
 
     report->received_event_from_kernel(time.count(), EV_REL, 0, 0);

--- a/src/platforms/x11/input/input_platform.cpp
+++ b/src/platforms/x11/input/input_platform.cpp
@@ -262,8 +262,8 @@ void mix::XInputPlatform::process_input_event()
                         core_pointer->pointer_motion(
                             event_time,
                             pos,
-                            geom::Displacement{xbev.button == right ? 1 : xbev.button == left ? -1 : 0,
-                                               xbev.button == down ? 1 : xbev.button == up ? -1 : 0});
+                            geom::Displacement{xbev.button == right ? 10 : xbev.button == left ? -10 : 0,
+                                               xbev.button == down ? 10 : xbev.button == up ? -10 : 0});
                     }
                     else
                     {

--- a/src/platforms/x11/input/input_platform.cpp
+++ b/src/platforms/x11/input/input_platform.cpp
@@ -263,7 +263,7 @@ void mix::XInputPlatform::process_input_event()
                             event_time,
                             pos,
                             geom::Displacement{xbev.button == right ? 1 : xbev.button == left ? -1 : 0,
-                                               xbev.button == up ? 1 : xbev.button == down ? -1 : 0});
+                                               xbev.button == down ? 1 : xbev.button == up ? -1 : 0});
                     }
                     else
                     {

--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -220,8 +220,8 @@ void mf::WaylandInputDispatcher::handle_pointer_motion_event(
         mir_pointer_event_axis_value(event, mir_pointer_axis_x),
         mir_pointer_event_axis_value(event, mir_pointer_axis_y));
     auto const axis_motion = std::make_pair(
-        mir_pointer_event_axis_value(event, mir_pointer_axis_hscroll) * 10,
-        mir_pointer_event_axis_value(event, mir_pointer_axis_vscroll) * 10);
+        mir_pointer_event_axis_value(event, mir_pointer_axis_hscroll),
+        mir_pointer_event_axis_value(event, mir_pointer_axis_vscroll));
     bool const send_motion = (!last_pointer_position || position != last_pointer_position.value());
     bool const send_axis = (axis_motion.first || axis_motion.second);
 

--- a/tests/mir_test_doubles/mock_libinput.cpp
+++ b/tests/mir_test_doubles/mock_libinput.cpp
@@ -823,6 +823,10 @@ libinput_event* mtd::MockLibInput::setup_axis_event(libinput_device* dev, uint64
         .WillByDefault(Return(vertical));
     ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
         .WillByDefault(Return(horizontal));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+        .WillByDefault(Return(vertical));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
+        .WillByDefault(Return(horizontal));
     return event;
 }
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -510,7 +510,7 @@ TEST_F(LibInputDeviceOnMouse, process_event_handles_scroll)
     EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_hscroll, 5.0f)));
 
     mouse.start(&mock_sink, &mock_builder);
-    env.mock_libinput.setup_axis_event(fake_device, event_time_1, 0.0, 20.0);
+    env.mock_libinput.setup_axis_event(fake_device, event_time_1, 0.0, -20.0);
     env.mock_libinput.setup_axis_event(fake_device, event_time_2, 5.0, 0.0);
     process_events(mouse);
 }
@@ -708,7 +708,7 @@ TEST_F(LibInputDeviceOnMouse, scroll_speed_scales_scroll_events)
     settings.horizontal_scroll_scale = 5.0;
     mouse.apply_settings(settings);
 
-    env.mock_libinput.setup_axis_event(fake_device, event_time_1, 0.0, 3.0);
+    env.mock_libinput.setup_axis_event(fake_device, event_time_1, 0.0, -3.0);
     env.mock_libinput.setup_axis_event(fake_device, event_time_2, -2.0, 0.0);
 
     mouse.start(&mock_sink, &mock_builder);
@@ -734,8 +734,8 @@ TEST_F(LibInputDeviceOnTouchpad, process_event_handles_scroll)
                 pointer_event(time_stamp_2, mir_pointer_action_motion, 0, 1.0f, 0.0f, 0.0f, 0.0f));
     EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_hscroll, 1.0f)));
 
-    env.mock_libinput.setup_finger_axis_event(fake_device, event_time_1, 0.0, 150.0);
-    env.mock_libinput.setup_finger_axis_event(fake_device, event_time_2, 15.0, 0.0);
+    env.mock_libinput.setup_finger_axis_event(fake_device, event_time_1, 0.0, -10.0);
+    env.mock_libinput.setup_finger_axis_event(fake_device, event_time_2, 1.0, 0.0);
     touchpad.start(&mock_sink, &mock_builder);
     process_events(touchpad);
 


### PR DESCRIPTION
Fixes #1813. This stops flipping vertical scroll direction on the X11 and libinput platforms. It was already unflipped on the Wayland platform.

On X11 I think this is an easy decision. I believe it's currently *always* the inverse of the host X11 environment. If that's correct, I think that's obviously wrong. IMO even when we have input settings they should not effect Mir running nested. Instead, we should respect the configuration of the host system.

For libinput, This just changes the default behavior. Normal (as opposed to natural) scrolling is the default on most Linux systems, so I think that is reasonable.