### PR TITLE
Precise pointer events for Wayland platform

### DIFF
--- a/include/core/mir/geometry/dimensions_generic.h
+++ b/include/core/mir/geometry/dimensions_generic.h
@@ -76,10 +76,15 @@ struct Value
 
         constexpr Wrapper() : value{} {}
 
-        template<typename W, typename std::enable_if<std::is_same<typename W::TagType, Tag>::value, bool>::type = true>
-        Wrapper& operator=(W const& that)
+        Wrapper& operator=(Wrapper const& that)
         {
-            value = static_cast<T>(that.value);
+            value = that.value;
+            return *this;
+        }
+
+        constexpr Wrapper(Wrapper const& that)
+            : value{that.value}
+        {
         }
 
         template<typename W, typename std::enable_if<std::is_same<typename W::TagType, Tag>::value, bool>::type = true>

--- a/include/core/mir/geometry/dimensions_generic.h
+++ b/include/core/mir/geometry/dimensions_generic.h
@@ -69,32 +69,32 @@ struct Value
             return this->value;
         }
 
-        constexpr T as_value() const
+        constexpr T as_value() const noexcept
         {
             return value;
         }
 
-        constexpr Wrapper() : value{} {}
+        constexpr Wrapper() noexcept : value{} {}
 
-        Wrapper& operator=(Wrapper const& that)
+        Wrapper& operator=(Wrapper const& that) noexcept
         {
             value = that.value;
             return *this;
         }
 
-        constexpr Wrapper(Wrapper const& that)
+        constexpr Wrapper(Wrapper const& that) noexcept
             : value{that.value}
         {
         }
 
         template<typename W, typename std::enable_if<std::is_same<typename W::TagType, Tag>::value, bool>::type = true>
-        explicit constexpr Wrapper(W const& value)
+        explicit constexpr Wrapper(W const& value) noexcept
             : value{static_cast<T>(value.as_value())}
         {
         }
 
         template<typename U, typename std::enable_if<std::is_scalar<U>::value, bool>::type = true>
-        explicit constexpr Wrapper(U const& value)
+        explicit constexpr Wrapper(U const& value) noexcept
             : value{static_cast<T>(value)}
         {
         }

--- a/include/core/mir/geometry/displacement_generic.h
+++ b/include/core/mir/geometry/displacement_generic.h
@@ -53,6 +53,13 @@ struct Displacement : detail::DisplacementBase
     constexpr Displacement(Displacement const&) = default;
     Displacement& operator=(Displacement const&) = default;
 
+    template<typename D, typename std::enable_if<std::is_base_of<detail::DisplacementBase, D>::value, bool>::type = true>
+    explicit constexpr Displacement(D const& other)
+        : dx{T<DeltaXTag>{other.dx}},
+          dy{T<DeltaYTag>{other.dy}}
+    {
+    }
+
     template<typename DeltaXType, typename DeltaYType>
     constexpr Displacement(DeltaXType&& dx, DeltaYType&& dy) : dx{dx}, dy{dy} {}
 

--- a/include/core/mir/geometry/displacement_generic.h
+++ b/include/core/mir/geometry/displacement_generic.h
@@ -54,7 +54,7 @@ struct Displacement : detail::DisplacementBase
     Displacement& operator=(Displacement const&) = default;
 
     template<typename D, typename std::enable_if<std::is_base_of<detail::DisplacementBase, D>::value, bool>::type = true>
-    explicit constexpr Displacement(D const& other)
+    explicit constexpr Displacement(D const& other) noexcept
         : dx{T<DeltaXTag>{other.dx}},
           dy{T<DeltaYTag>{other.dy}}
     {

--- a/include/core/mir/geometry/point_generic.h
+++ b/include/core/mir/geometry/point_generic.h
@@ -51,7 +51,7 @@ struct Point : detail::PointBase
     Point& operator=(Point const&) = default;
 
     template<typename P, typename std::enable_if<std::is_base_of<detail::PointBase, P>::value, bool>::type = true>
-    explicit constexpr Point(P const& other)
+    explicit constexpr Point(P const& other) noexcept
         : x{T<XTag>{other.x}},
           y{T<YTag>{other.y}}
     {

--- a/include/core/mir/geometry/point_generic.h
+++ b/include/core/mir/geometry/point_generic.h
@@ -50,6 +50,13 @@ struct Point : detail::PointBase
     constexpr Point(Point const&) = default;
     Point& operator=(Point const&) = default;
 
+    template<typename P, typename std::enable_if<std::is_base_of<detail::PointBase, P>::value, bool>::type = true>
+    explicit constexpr Point(P const& other)
+        : x{T<XTag>{other.x}},
+          y{T<YTag>{other.y}}
+    {
+    }
+
     template<typename XType, typename YType>
     constexpr Point(XType&& x, YType&& y) : x(x), y(y) {}
 

--- a/include/core/mir/geometry/size_generic.h
+++ b/include/core/mir/geometry/size_generic.h
@@ -52,7 +52,7 @@ struct Size : detail::SizeBase
     Size& operator=(Size const&) noexcept = default;
 
     template<typename S, typename std::enable_if<std::is_base_of<detail::SizeBase, S>::value, bool>::type = true>
-    explicit constexpr Size(S const& other)
+    explicit constexpr Size(S const& other) noexcept
         : width{T<WidthTag>{other.width}},
           height{T<HeightTag>{other.height}}
     {

--- a/include/core/mir/geometry/size_generic.h
+++ b/include/core/mir/geometry/size_generic.h
@@ -51,6 +51,13 @@ struct Size : detail::SizeBase
     constexpr Size(Size const&) noexcept = default;
     Size& operator=(Size const&) noexcept = default;
 
+    template<typename S, typename std::enable_if<std::is_base_of<detail::SizeBase, S>::value, bool>::type = true>
+    explicit constexpr Size(S const& other)
+        : width{T<WidthTag>{other.width}},
+          height{T<HeightTag>{other.height}}
+    {
+    }
+
     template<typename WidthType, typename HeightType>
     constexpr Size(WidthType&& width, HeightType&& height) noexcept : width(width), height(height) {}
 

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -52,22 +52,22 @@ class NullPointerInput : public mir::input::wayland::PointerInput
 {
     void pointer_press(
         std::chrono::nanoseconds, int,
-        std::pair<float, float> const&,
-        std::pair<float, float> const&) override
+        geom::PointF const&,
+        geom::DisplacementF const&) override
     {
     }
 
     void pointer_release(
         std::chrono::nanoseconds, int,
-        std::pair<float, float> const&,
-        std::pair<float, float> const&) override
+        geom::PointF const&,
+        geom::DisplacementF const&) override
     {
     }
 
     void pointer_motion(
         std::chrono::nanoseconds,
-        std::pair<float, float> const&,
-        std::pair<float, float> const&) override
+        geom::PointF const&,
+        geom::DisplacementF const&) override
     {
     }
 };
@@ -335,9 +335,7 @@ void mir::graphics::wayland::Display::pointer_motion(wl_pointer* pointer, uint32
 {
     {
         std::lock_guard<decltype(sink_mutex)> lock{sink_mutex};
-        pointer_pos = std::make_pair(
-            wl_fixed_to_double(x) + pointer_displacement.dx.as_int(),
-            wl_fixed_to_double(y) + pointer_displacement.dy.as_int());
+        pointer_pos = geom::PointF{wl_fixed_to_double(x), wl_fixed_to_double(y)} + geom::DisplacementF{pointer_displacement};
         pointer_time = std::chrono::milliseconds{time};
     }
 
@@ -372,11 +370,11 @@ void mir::graphics::wayland::Display::pointer_axis(wl_pointer* pointer, uint32_t
         switch (axis)
         {
         case WL_POINTER_AXIS_HORIZONTAL_SCROLL:
-            pointer_scroll.first = wl_fixed_to_double(value);
+            pointer_scroll.dx = geom::DeltaXF{wl_fixed_to_double(value)};
             break;
 
         case WL_POINTER_AXIS_VERTICAL_SCROLL:
-            pointer_scroll.second = wl_fixed_to_double(value);
+            pointer_scroll.dy = geom::DeltaYF{wl_fixed_to_double(value)};
             break;
         }
     }

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -51,20 +51,23 @@ class NullKeyboardInput : public mir::input::wayland::KeyboardInput
 class NullPointerInput : public mir::input::wayland::PointerInput
 {
     void pointer_press(
-        std::chrono::nanoseconds, int, mir::geometry::Point const&,
-        mir::geometry::Displacement) override
+        std::chrono::nanoseconds, int,
+        std::pair<float, float> const&,
+        std::pair<float, float> const&) override
     {
     }
 
     void pointer_release(
-        std::chrono::nanoseconds, int, mir::geometry::Point const&,
-        mir::geometry::Displacement) override
+        std::chrono::nanoseconds, int,
+        std::pair<float, float> const&,
+        std::pair<float, float> const&) override
     {
     }
 
     void pointer_motion(
-        std::chrono::nanoseconds, mir::geometry::Point const&,
-        mir::geometry::Displacement) override
+        std::chrono::nanoseconds,
+        std::pair<float, float> const&,
+        std::pair<float, float> const&) override
     {
     }
 };
@@ -332,8 +335,9 @@ void mir::graphics::wayland::Display::pointer_motion(wl_pointer* pointer, uint32
 {
     {
         std::lock_guard<decltype(sink_mutex)> lock{sink_mutex};
-        geom::Point const new_pointer{wl_fixed_to_int(x), wl_fixed_to_int(y)};
-        pointer_pos = new_pointer + pointer_displacement;
+        pointer_pos = std::make_pair(
+            wl_fixed_to_double(x) + pointer_displacement.dx.as_int(),
+            wl_fixed_to_double(y) + pointer_displacement.dy.as_int());
         pointer_time = std::chrono::milliseconds{time};
     }
 
@@ -367,12 +371,12 @@ void mir::graphics::wayland::Display::pointer_axis(wl_pointer* pointer, uint32_t
         std::lock_guard<decltype(sink_mutex)> lock{sink_mutex};
         switch (axis)
         {
-        case WL_POINTER_AXIS_VERTICAL_SCROLL:
-            pointer_scroll.dy = geom::DeltaY{wl_fixed_to_int(value)};
+        case WL_POINTER_AXIS_HORIZONTAL_SCROLL:
+            pointer_scroll.first = wl_fixed_to_double(value);
             break;
 
-        case WL_POINTER_AXIS_HORIZONTAL_SCROLL:
-            pointer_scroll.dx = geom::DeltaX{wl_fixed_to_int(value)};
+        case WL_POINTER_AXIS_VERTICAL_SCROLL:
+            pointer_scroll.second = wl_fixed_to_double(value);
             break;
         }
     }

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -21,10 +21,11 @@
 
 #include <mir/fd.h>
 #include <mir/events/contact_state.h>
-#include <mir/geometry/displacement.h>
 #include <mir/graphics/display.h>
 #include <mir/graphics/display_report.h>
 #include <mir/renderer/gl/context_source.h>
+#include <mir/geometry/point_f.h>
+#include <mir/geometry/displacement_f.h>
 
 #include <xkbcommon/xkbcommon.h>
 
@@ -137,8 +138,8 @@ private:
     std::shared_ptr<input::wayland::KeyboardInput> keyboard_sink;
     std::shared_ptr<input::wayland::PointerInput> pointer_sink;
     std::shared_ptr<input::wayland::TouchInput> touch_sink;
-    std::pair<float, float> pointer_pos;
-    std::pair<float, float> pointer_scroll;
+    geometry::PointF pointer_pos;
+    geometry::DisplacementF pointer_scroll;
     std::chrono::nanoseconds pointer_time;
     std::vector<events::ContactState> touch_contacts;
     std::chrono::nanoseconds touch_time;

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -137,8 +137,8 @@ private:
     std::shared_ptr<input::wayland::KeyboardInput> keyboard_sink;
     std::shared_ptr<input::wayland::PointerInput> pointer_sink;
     std::shared_ptr<input::wayland::TouchInput> touch_sink;
-    geometry::Point pointer_pos;
-    geometry::Displacement pointer_scroll;
+    std::pair<float, float> pointer_pos;
+    std::pair<float, float> pointer_scroll;
     std::chrono::nanoseconds pointer_time;
     std::vector<events::ContactState> touch_contacts;
     std::chrono::nanoseconds touch_time;

--- a/src/platforms/wayland/display_input.h
+++ b/src/platforms/wayland/display_input.h
@@ -19,7 +19,8 @@
 
 #include <mir/fd.h>
 #include <mir/events/contact_state.h>
-#include <mir/geometry/displacement.h>
+#include <mir/geometry/point_f.h>
+#include <mir/geometry/displacement_f.h>
 
 #include <xkbcommon/xkbcommon.h>
 
@@ -50,17 +51,17 @@ public:
     virtual void pointer_press(
         std::chrono::nanoseconds event_time,
         int button,
-        std::pair<float, float> const& pos,
-        std::pair<float, float> const& scroll) = 0;
+        geometry::PointF const& pos,
+        geometry::DisplacementF const& scroll) = 0;
     virtual void pointer_release(
         std::chrono::nanoseconds event_time,
         int button,
-        std::pair<float, float> const& pos,
-        std::pair<float, float> const& scroll) = 0;
+        geometry::PointF const& pos,
+        geometry::DisplacementF const& scroll) = 0;
     virtual void pointer_motion(
         std::chrono::nanoseconds event_time,
-        std::pair<float, float> const& pos,
-        std::pair<float, float> const& scroll) = 0;
+        geometry::PointF const& pos,
+        geometry::DisplacementF const& scroll) = 0;
 
     PointerInput() = default;
     virtual ~PointerInput() = default;

--- a/src/platforms/wayland/display_input.h
+++ b/src/platforms/wayland/display_input.h
@@ -47,9 +47,20 @@ public:
 class PointerInput
 {
 public:
-    virtual void pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) = 0;
-    virtual void pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) = 0;
-    virtual void pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll) = 0;
+    virtual void pointer_press(
+        std::chrono::nanoseconds event_time,
+        int button,
+        std::pair<float, float> const& pos,
+        std::pair<float, float> const& scroll) = 0;
+    virtual void pointer_release(
+        std::chrono::nanoseconds event_time,
+        int button,
+        std::pair<float, float> const& pos,
+        std::pair<float, float> const& scroll) = 0;
+    virtual void pointer_motion(
+        std::chrono::nanoseconds event_time,
+        std::pair<float, float> const& pos,
+        std::pair<float, float> const& scroll) = 0;
 
     PointerInput() = default;
     virtual ~PointerInput() = default;

--- a/src/platforms/wayland/input_device.cpp
+++ b/src/platforms/wayland/input_device.cpp
@@ -34,6 +34,7 @@
 
 namespace mi = mir::input;
 namespace miw = mi::wayland;
+namespace geom = mir::geometry;
 
 namespace
 {
@@ -163,25 +164,25 @@ miw::PointerInputDevice::PointerInputDevice(std::shared_ptr<dispatch::ActionQueu
 void miw::PointerInputDevice::pointer_press(
     std::chrono::nanoseconds event_time,
     int button,
-    std::pair<float, float> const& pos,
-    std::pair<float, float> const& scroll)
+    geom::PointF const& pos,
+    geom::DisplacementF const& scroll)
 {
     enqueue([=](EventBuilder* b)
     {
         button_state |= to_pointer_button(button, mir_pointer_handedness_right);
 
-        auto const movement = std::make_pair(pos.first - cached_pos.first, pos.second - cached_pos.second);
+        auto const movement = pos - cached_pos;
         cached_pos = pos;
         return b->pointer_event(
             event_time,
             mir_pointer_action_button_down,
             button_state,
-            cached_pos.first,
-            cached_pos.second,
-            scroll.first,
-            scroll.second,
-            movement.first,
-            movement.second
+            cached_pos.x.as_value(),
+            cached_pos.y.as_value(),
+            scroll.dx.as_value(),
+            scroll.dy.as_value(),
+            movement.dx.as_value(),
+            movement.dy.as_value()
         );
     });
 }
@@ -189,48 +190,48 @@ void miw::PointerInputDevice::pointer_press(
 void miw::PointerInputDevice::pointer_release(
     std::chrono::nanoseconds event_time,
     int button,
-    std::pair<float, float> const& pos,
-    std::pair<float, float> const& scroll)
+    geom::PointF const& pos,
+    geom::DisplacementF const& scroll)
 {
     enqueue([=](EventBuilder* b)
     {
         button_state &= ~to_pointer_button(button, mir_pointer_handedness_right);
 
-        auto const movement = std::make_pair(pos.first - cached_pos.first, pos.second - cached_pos.second);
+        auto const movement = pos - cached_pos;
         cached_pos = pos;
         return b->pointer_event(
             event_time,
             mir_pointer_action_button_up,
             button_state,
-            cached_pos.first,
-            cached_pos.second,
-            scroll.first,
-            scroll.second,
-            movement.first,
-            movement.second
+            cached_pos.x.as_value(),
+            cached_pos.y.as_value(),
+            scroll.dx.as_value(),
+            scroll.dy.as_value(),
+            movement.dx.as_value(),
+            movement.dy.as_value()
         );
     });
 }
 
 void miw::PointerInputDevice::pointer_motion(
     std::chrono::nanoseconds event_time,
-    std::pair<float, float> const& pos,
-    std::pair<float, float> const& scroll)
+    geom::PointF const& pos,
+    geom::DisplacementF const& scroll)
 {
     enqueue([=](EventBuilder* b)
     {
-        auto const movement = std::make_pair(pos.first - cached_pos.first, pos.second - cached_pos.second);
+        auto const movement = pos - cached_pos;
         cached_pos = pos;
         return b->pointer_event(
             event_time,
             mir_pointer_action_motion,
             button_state,
-            cached_pos.first,
-            cached_pos.second,
-            scroll.first,
-            scroll.second,
-            movement.first,
-            movement.second
+            cached_pos.x.as_value(),
+            cached_pos.y.as_value(),
+            scroll.dx.as_value(),
+            scroll.dy.as_value(),
+            movement.dx.as_value(),
+            movement.dy.as_value()
         );
     });
 }

--- a/src/platforms/wayland/input_device.cpp
+++ b/src/platforms/wayland/input_device.cpp
@@ -160,66 +160,77 @@ miw::PointerInputDevice::PointerInputDevice(std::shared_ptr<dispatch::ActionQueu
 {
 }
 
-void miw::PointerInputDevice::pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll)
+void miw::PointerInputDevice::pointer_press(
+    std::chrono::nanoseconds event_time,
+    int button,
+    std::pair<float, float> const& pos,
+    std::pair<float, float> const& scroll)
 {
     enqueue([=](EventBuilder* b)
     {
         button_state |= to_pointer_button(button, mir_pointer_handedness_right);
 
-        auto const movement = pos - pointer_pos;
-        pointer_pos = pos;
+        auto const movement = std::make_pair(pos.first - cached_pos.first, pos.second - cached_pos.second);
+        cached_pos = pos;
         return b->pointer_event(
             event_time,
             mir_pointer_action_button_down,
             button_state,
-            pointer_pos.x.as_int(),
-            pointer_pos.y.as_int(),
-            scroll.dx.as_int(),
-            scroll.dy.as_int(),
-            movement.dx.as_int(),
-            movement.dy.as_int()
+            cached_pos.first,
+            cached_pos.second,
+            scroll.first,
+            scroll.second,
+            movement.first,
+            movement.second
         );
     });
 }
 
-void miw::PointerInputDevice::pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll)
+void miw::PointerInputDevice::pointer_release(
+    std::chrono::nanoseconds event_time,
+    int button,
+    std::pair<float, float> const& pos,
+    std::pair<float, float> const& scroll)
 {
     enqueue([=](EventBuilder* b)
     {
         button_state &= ~to_pointer_button(button, mir_pointer_handedness_right);
 
-        auto const movement = pos - pointer_pos;
-        pointer_pos = pos;
+        auto const movement = std::make_pair(pos.first - cached_pos.first, pos.second - cached_pos.second);
+        cached_pos = pos;
         return b->pointer_event(
             event_time,
             mir_pointer_action_button_up,
             button_state,
-            pointer_pos.x.as_int(),
-            pointer_pos.y.as_int(),
-            scroll.dx.as_int(),
-            scroll.dy.as_int(),
-            movement.dx.as_int(),
-            movement.dy.as_int()
+            cached_pos.first,
+            cached_pos.second,
+            scroll.first,
+            scroll.second,
+            movement.first,
+            movement.second
         );
     });
 }
 
-void miw::PointerInputDevice::pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll)
+void miw::PointerInputDevice::pointer_motion(
+    std::chrono::nanoseconds event_time,
+    std::pair<float, float> const& pos,
+    std::pair<float, float> const& scroll)
 {
     enqueue([=](EventBuilder* b)
     {
-        auto const movement = pos - pointer_pos;
-        pointer_pos = pos;
+        auto const movement = std::make_pair(pos.first - cached_pos.first, pos.second - cached_pos.second);
+        cached_pos = pos;
         return b->pointer_event(
             event_time,
             mir_pointer_action_motion,
             button_state,
-            pointer_pos.x.as_int(),
-            pointer_pos.y.as_int(),
-            scroll.dx.as_int(),
-            scroll.dy.as_int(),
-            movement.dx.as_int(),
-            movement.dy.as_int()
+            cached_pos.first,
+            cached_pos.second,
+            scroll.first,
+            scroll.second,
+            movement.first,
+            movement.second
         );
     });
 }

--- a/src/platforms/wayland/input_device.h
+++ b/src/platforms/wayland/input_device.h
@@ -21,8 +21,6 @@
 #include "display_input.h"
 
 #include <mir/events/event_builders.h>
-#include <mir/geometry/point.h>
-#include <mir/geometry/displacement.h>
 #include <mir/input/input_device.h>
 #include <mir/input/input_device_info.h>
 
@@ -99,22 +97,22 @@ public:
 
 private:
     MirPointerButtons button_state{0};
-    std::pair<float, float> cached_pos;
+    geometry::PointF cached_pos;
 
     void pointer_press(
         std::chrono::nanoseconds event_time,
         int button,
-        std::pair<float, float> const& pos,
-        std::pair<float, float> const& scroll) override;
+        geometry::PointF const& pos,
+        geometry::DisplacementF const& scroll) override;
     void pointer_release(
         std::chrono::nanoseconds event_time,
         int button,
-        std::pair<float, float> const& pos,
-        std::pair<float, float> const& scroll) override;
+        geometry::PointF const& pos,
+        geometry::DisplacementF const& scroll) override;
     void pointer_motion(
         std::chrono::nanoseconds event_time,
-        std::pair<float, float> const& pos,
-        std::pair<float, float> const& scroll) override;
+        geometry::PointF const& pos,
+        geometry::DisplacementF const& scroll) override;
 };
 
 class TouchInputDevice : public GenericInputDevice, public TouchInput

--- a/src/platforms/wayland/input_device.h
+++ b/src/platforms/wayland/input_device.h
@@ -99,11 +99,22 @@ public:
 
 private:
     MirPointerButtons button_state{0};
-    geometry::Point pointer_pos;
+    std::pair<float, float> cached_pos;
 
-    void pointer_press(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) override;
-    void pointer_release(std::chrono::nanoseconds event_time, int button, geometry::Point const& pos, geometry::Displacement scroll) override;
-    void pointer_motion(std::chrono::nanoseconds event_time, geometry::Point const& pos, geometry::Displacement scroll) override;
+    void pointer_press(
+        std::chrono::nanoseconds event_time,
+        int button,
+        std::pair<float, float> const& pos,
+        std::pair<float, float> const& scroll) override;
+    void pointer_release(
+        std::chrono::nanoseconds event_time,
+        int button,
+        std::pair<float, float> const& pos,
+        std::pair<float, float> const& scroll) override;
+    void pointer_motion(
+        std::chrono::nanoseconds event_time,
+        std::pair<float, float> const& pos,
+        std::pair<float, float> const& scroll) override;
 };
 
 class TouchInputDevice : public GenericInputDevice, public TouchInput

--- a/tests/unit-tests/geometry/test-displacement.cpp
+++ b/tests/unit-tests/geometry/test-displacement.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "mir/geometry/displacement.h"
+#include "mir/geometry/displacement_f.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -81,4 +82,26 @@ TEST(geometry, displacement_point_arithmetic)
     EXPECT_EQ(expected_pd_sub2, pd_sub2);
     EXPECT_EQ(expected_pp_sub, pp_sub);
     EXPECT_EQ(expected_pp_sub2, pp_sub2);
+}
+
+TEST(geometry, displacement_can_be_converted_from_int_to_float)
+{
+    using namespace geom;
+
+    Displacement const i{1, 3};
+    DisplacementF const f{i};
+
+    EXPECT_EQ(DeltaXF(1.0), f.dx);
+    EXPECT_EQ(DeltaYF(3.0), f.dy);
+}
+
+TEST(geometry, displacement_can_be_converted_from_float_to_int)
+{
+    using namespace geom;
+
+    DisplacementF const f{1.2, 3.0};
+    Displacement const i{f};
+
+    EXPECT_EQ(DeltaX(1), i.dx);
+    EXPECT_EQ(DeltaY(3), i.dy);
 }

--- a/tests/unit-tests/geometry/test-point.cpp
+++ b/tests/unit-tests/geometry/test-point.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "mir/geometry/point.h"
+#include "mir/geometry/point_f.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -53,4 +54,26 @@ TEST(geometry, point_is_usable)
 
     EXPECT_EQ(X(x), p.x);
     EXPECT_EQ(Y(y), p.y);
+}
+
+TEST(geometry, point_can_be_converted_from_int_to_float)
+{
+    using namespace geom;
+
+    Point const i{1, 3};
+    PointF const f{i};
+
+    EXPECT_EQ(XF(1.0), f.x);
+    EXPECT_EQ(YF(3.0), f.y);
+}
+
+TEST(geometry, point_can_be_converted_from_float_to_int)
+{
+    using namespace geom;
+
+    PointF const f{1.2, 3.0};
+    Point const i{f};
+
+    EXPECT_EQ(X(1), i.x);
+    EXPECT_EQ(Y(3), i.y);
 }

--- a/tests/unit-tests/geometry/test-size.cpp
+++ b/tests/unit-tests/geometry/test-size.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "mir/geometry/size.h"
+#include "mir/geometry/size_f.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -40,4 +41,26 @@ TEST(geometry, size)
     EXPECT_EQ(Width(0), defaultValue.width);
     EXPECT_EQ(Height(0), defaultValue.height);
     EXPECT_NE(size2x4, defaultValue);
+}
+
+TEST(geometry, size_can_be_converted_from_int_to_float)
+{
+    using namespace geom;
+
+    Size const i{1, 3};
+    SizeF const f{i};
+
+    EXPECT_EQ(WidthF(1.0), f.width);
+    EXPECT_EQ(HeightF(3.0), f.height);
+}
+
+TEST(geometry, size_can_be_converted_from_float_to_int)
+{
+    using namespace geom;
+
+    SizeF const f{1.2, 3.0};
+    Size const i{f};
+
+    EXPECT_EQ(Width(1), i.width);
+    EXPECT_EQ(Height(3), i.height);
 }


### PR DESCRIPTION
This adds support for floating point pointer motion and scrolling to the Wayland platform. It appears touches were already precise. Fixes #1852. There's still a notable problem, where scrolling events don't *appear* to be precise because they are arbitrarily multiplied by 10 by the Wayland frontend. This will be fixed in a different PR.