### PR TITLE
Restore RPi build

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -65,10 +65,6 @@ jobs:
             {
               "spread-task": "fedora-rawhide-64:spread/build/fedora:amd64",
               "allow-fail": true
-            },
-            {
-              "spread-task": "google:ubuntu-20.04-64:spread/build/ubuntu:rpi",
-              "allow-fail": true
             }
           ]
         }

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -47,6 +47,7 @@ jobs:
             "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_groovy",
             "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu",
             "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_arm64",
+            "google:ubuntu-20.04-64:spread/build/ubuntu:rpi",
             "google:ubuntu-20.04-64:spread/build/ubuntu:clang",
             "google:fedora-32-64:spread/build/fedora:amd64",
             "google:fedora-33-64:spread/build/fedora:amd64"


### PR DESCRIPTION
Stop ignoring the build results for RPi stack