### PR TITLE
Replace `exit()` with a signal-safe function.

### DIFF
--- a/examples/client/spinner.cpp
+++ b/examples/client/spinner.cpp
@@ -22,7 +22,8 @@
 
 static void shutdown(int)
 {
-    exit(EXIT_SUCCESS);
+    // NB we can't safely call exit() from a signal handler
+    _Exit(EXIT_SUCCESS);
 }
 
 int main()


### PR DESCRIPTION
Replace `exit()` with a signal-safe function.

See, for example, https://man7.org/linux/man-pages/man7/signal-safety.7.html