### PR TITLE
Fix spread options on Fedora

### DIFF
--- a/spread/build/fedora/task.yaml
+++ b/spread/build/fedora/task.yaml
@@ -46,7 +46,7 @@ execute: |
         libdrm-devel
 
     BUILD_DIR=$(mktemp --directory)
-    cmake -H$SPREAD_PATH -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DMIR_USE_LD_GOLD=ON -DMIR_ENABLE_WLCS_TESTS=OFF
+    cmake -H$SPREAD_PATH -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DMIR_USE_LD=gold -DMIR_ENABLE_WLCS_TESTS=OFF
     # Run cmake again to pick up wlcs?!?!?!?!
     cmake $BUILD_DIR
     export VERBOSE=1


### PR DESCRIPTION
Looks like CMake option `MIR_USE_LD_GOLD` has been replaced, but the usage wasn't updated.