### PR TITLE
Move destroy listener functionality to LifetimeTracker

### DIFF
--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -75,11 +75,19 @@ public:
     LifetimeTracker& operator=(LifetimeTracker const&) = delete;
 
     virtual ~LifetimeTracker();
+    /// The pointed-at bool contains false if this object is still alive and true if it has been destroyed.
     auto destroyed_flag() const -> std::shared_ptr<bool>;
+    /// The given function will be called just before the object is marked as destroyed. The returned ID can be used
+    /// to remove the listener in which case it is never called. DestroyListenerId{} (value 0) is never returned, and so
+    /// it can be used as a null ID. Destroy listener call order is undefined.
     auto add_destroy_listener(std::function<void()> listener) const -> DestroyListenerId;
+    /// If the given ID maps to a destroy listener, that listener is dropped without being called. If the listener has
+    /// already been dropped or never existed, this call is ignored.
     void remove_destroy_listener(DestroyListenerId id) const;
 
 protected:
+    /// Subclasses are not required to call this, but may do so during the destruction process if the object needs to
+    /// get marked as destroyed and fire its destroy listeners before some other part of the destructor runs.
     void mark_destroyed() const;
 
 private:

--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -76,7 +76,7 @@ public:
 
     virtual ~LifetimeTracker();
     /// The pointed-at bool contains false if this object is still alive and true if it has been destroyed.
-    auto destroyed_flag() const -> std::shared_ptr<bool>;
+    auto destroyed_flag() const -> std::shared_ptr<bool const>;
     /// The given function will be called just before the object is marked as destroyed. The returned ID can be used
     /// to remove the listener in which case it is never called. DestroyListenerId{} (value 0) is never returned, and so
     /// it can be used as a null ID. Destroy listener call order is undefined.
@@ -177,7 +177,7 @@ private:
     T* resource;
     /// Is null if and only if resource is null
     /// If the target bool is true then resrouce has been freed and should not be used
-    std::shared_ptr<bool> destroyed_flag;
+    std::shared_ptr<bool const> destroyed_flag;
 };
 
 template<typename T>

--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -23,7 +23,6 @@
 
 #include <boost/throw_exception.hpp>
 #include <memory>
-#include <map>
 #include <functional>
 #include <stdexcept>
 
@@ -70,7 +69,7 @@ typedef IntWrapper<detail::DestroyListenerIdTag> DestroyListenerId;
 class LifetimeTracker
 {
 public:
-    LifetimeTracker() = default;
+    LifetimeTracker();
     LifetimeTracker(LifetimeTracker const&) = delete;
     LifetimeTracker& operator=(LifetimeTracker const&) = delete;
 
@@ -91,9 +90,11 @@ protected:
     void mark_destroyed() const;
 
 private:
-    std::shared_ptr<bool> mutable destroyed{nullptr};
-    std::map<DestroyListenerId, std::function<void()>> mutable destroy_listeners;
-    DestroyListenerId mutable last_id{0};
+    struct Impl;
+
+    /// Since many Wayland objects are created and the features of this class are used for only a few, impl is created
+    /// lazily to conserve memory.
+    std::unique_ptr<Impl> mutable impl;
 };
 
 class Resource

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -39,13 +39,11 @@ namespace mi = mir::input;
 mf::WlKeyboard::WlKeyboard(
     wl_resource* new_resource,
     mir::input::Keymap const& initial_keymap,
-    std::function<void(WlKeyboard*)> const& on_destroy,
     std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state)
     : Keyboard(new_resource, Version<6>()),
       keymap{nullptr, &xkb_keymap_unref},
       state{nullptr, &xkb_state_unref},
       context{xkb_context_new(XKB_CONTEXT_NO_FLAGS), &xkb_context_unref},
-      on_destroy{on_destroy},
       acquire_current_keyboard_state{acquire_current_keyboard_state}
 {
     // TODO: We should really grab the keymap for the focused surface when
@@ -72,7 +70,6 @@ mf::WlKeyboard::~WlKeyboard()
     {
         focused_surface.value().remove_destroy_listener(destroy_listener_id);
     }
-    on_destroy(this);
 }
 
 void mf::WlKeyboard::key(std::chrono::milliseconds const& ms, WlSurface* surface, int scancode, bool down)

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -70,7 +70,7 @@ mf::WlKeyboard::~WlKeyboard()
 {
     if (focused_surface)
     {
-        focused_surface.value().remove_destroy_listener(this);
+        focused_surface.value().remove_destroy_listener(destroy_listener_id);
     }
     on_destroy(this);
 }
@@ -116,7 +116,7 @@ void mf::WlKeyboard::focussed(WlSurface* surface, bool should_be_focused)
 
     if (focused_surface)
     {
-        focused_surface.value().remove_destroy_listener(this);
+        focused_surface.value().remove_destroy_listener(destroy_listener_id);
         auto const serial = wl_display_next_serial(wl_client_get_display(client));
         send_leave_event(serial, focused_surface.value().raw_resource());
     }
@@ -149,8 +149,7 @@ void mf::WlKeyboard::focussed(WlSurface* surface, bool should_be_focused)
                 keyboard_state.size() * sizeof(decltype(keyboard_state)::value_type));
         }
 
-        surface->add_destroy_listener(
-            this,
+        destroy_listener_id = surface->add_destroy_listener(
             [this, surface]()
             {
                 focussed(surface, false);
@@ -164,6 +163,7 @@ void mf::WlKeyboard::focussed(WlSurface* surface, bool should_be_focused)
     }
     else
     {
+        destroy_listener_id = {};
         focused_surface = {};
     }
 }

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -72,6 +72,7 @@ private:
     std::function<std::vector<uint32_t>()> const acquire_current_keyboard_state;
 
     wayland::Weak<WlSurface> focused_surface{};
+    wayland::DestroyListenerId destroy_listener_id{};
 
     uint32_t mods_depressed{0};
     uint32_t mods_latched{0};

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -50,7 +50,6 @@ public:
     WlKeyboard(
         wl_resource* new_resource,
         mir::input::Keymap const& initial_keymap,
-        std::function<void(WlKeyboard*)> const& on_destroy,
         std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state);
 
     ~WlKeyboard();
@@ -68,7 +67,6 @@ private:
     std::unique_ptr<xkb_state, void (*)(xkb_state *)> state;
     std::unique_ptr<xkb_context, void (*)(xkb_context *)> const context;
 
-    std::function<void(WlKeyboard*)> on_destroy;
     std::function<std::vector<uint32_t>()> const acquire_current_keyboard_state;
 
     wayland::Weak<WlSurface> focused_surface{};

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -101,12 +101,9 @@ struct NullCursor : mf::WlPointer::Cursor
 };
 }
 
-mf::WlPointer::WlPointer(
-    wl_resource* new_resource,
-    std::function<void(WlPointer*)> const& on_destroy)
+mf::WlPointer::WlPointer(wl_resource* new_resource)
     : Pointer(new_resource, Version<6>()),
       display{wl_client_get_display(client)},
-      on_destroy{on_destroy},
       cursor{std::make_unique<NullCursor>()}
 {
 }
@@ -115,7 +112,6 @@ mf::WlPointer::~WlPointer()
 {
     if (surface_under_cursor)
         surface_under_cursor.value().remove_destroy_listener(destroy_listener_id);
-    on_destroy(this);
 }
 
 void mf::WlPointer::enter(

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -47,9 +47,7 @@ class WlPointer : public wayland::Pointer
 {
 public:
 
-    WlPointer(
-        wl_resource* new_resource,
-        std::function<void(WlPointer*)> const& on_destroy);
+    WlPointer(wl_resource* new_resource);
 
     ~WlPointer();
 
@@ -72,7 +70,6 @@ public:
 
 private:
     wl_display* const display;
-    std::function<void(WlPointer*)> on_destroy;
 
     bool can_send_frame{false};
     wayland::Weak<WlSurface> surface_under_cursor;

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -76,6 +76,7 @@ private:
 
     bool can_send_frame{false};
     wayland::Weak<WlSurface> surface_under_cursor;
+    wayland::DestroyListenerId destroy_listener_id;
 
     void send_update(
         std::chrono::milliseconds const& ms,

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -75,7 +75,7 @@ private:
     std::function<void(WlPointer*)> on_destroy;
 
     bool can_send_frame{false};
-    std::experimental::optional<WlSurface*> surface_under_cursor;
+    wayland::Weak<WlSurface> surface_under_cursor;
 
     void send_update(
         std::chrono::milliseconds const& ms,

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -287,14 +287,13 @@ void mf::WlSeat::Instance::get_keyboard(wl_resource* new_keyboard)
 
 void mf::WlSeat::Instance::get_touch(wl_resource* new_touch)
 {
-    seat->touch_listeners->register_listener(
-        client,
-        new WlTouch{
-            new_touch,
-            [listeners = seat->touch_listeners, client = client](WlTouch* listener)
-            {
-                listeners->unregister_listener(client, listener);
-            }});
+    auto const touch = new WlTouch{new_touch};
+    seat->touch_listeners->register_listener(client, touch);
+    touch->add_destroy_listener(
+        [listeners = seat->touch_listeners, listener = touch, client = client]()
+        {
+            listeners->unregister_listener(client, listener);
+        });
 }
 
 void mf::WlSeat::Instance::release()

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -236,14 +236,13 @@ mf::WlSeat::Instance::Instance(wl_resource* new_resource, mf::WlSeat* seat)
 
 void mf::WlSeat::Instance::get_pointer(wl_resource* new_pointer)
 {
-    seat->pointer_listeners->register_listener(
-        client,
-        new WlPointer{
-            new_pointer,
-            [listeners = seat->pointer_listeners, client = client](WlPointer* listener)
-            {
-                listeners->unregister_listener(client, listener);
-            }});
+    auto const pointer = new WlPointer{new_pointer};
+    seat->pointer_listeners->register_listener(client, pointer);
+    pointer->add_destroy_listener(
+        [listeners = seat->pointer_listeners, listener = pointer, client = client]()
+        {
+            listeners->unregister_listener(client, listener);
+        });
 }
 
 void mf::WlSeat::Instance::get_keyboard(wl_resource* new_keyboard)

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -248,41 +248,42 @@ void mf::WlSeat::Instance::get_pointer(wl_resource* new_pointer)
 
 void mf::WlSeat::Instance::get_keyboard(wl_resource* new_keyboard)
 {
-    seat->keyboard_listeners->register_listener(
-        client,
-        new WlKeyboard{
-            new_keyboard,
-            *seat->keymap,
-            [listeners = seat->keyboard_listeners, client = client](WlKeyboard* listener)
-            {
-                listeners->unregister_listener(client, listener);
-            },
-            [seat = seat->seat]()
-            {
-                std::unordered_set<uint32_t> pressed_keys;
+    auto const keyboard = new WlKeyboard{
+        new_keyboard,
+        *seat->keymap,
+        [seat = seat->seat]()
+        {
+            std::unordered_set<uint32_t> pressed_keys;
 
-                auto const ev = seat->create_device_state();
-                auto const state_event = mir_event_get_input_device_state_event(ev.get());
+            auto const ev = seat->create_device_state();
+            auto const state_event = mir_event_get_input_device_state_event(ev.get());
+            for (
+                auto dev = 0u;
+                dev < mir_input_device_state_event_device_count(state_event);
+                ++dev)
+            {
                 for (
-                    auto dev = 0u;
-                    dev < mir_input_device_state_event_device_count(state_event);
-                    ++dev)
+                    auto idx = 0u;
+                    idx < mir_input_device_state_event_device_pressed_keys_count(state_event, dev);
+                    ++idx)
                 {
-                    for (
-                        auto idx = 0u;
-                        idx < mir_input_device_state_event_device_pressed_keys_count(state_event, dev);
-                        ++idx)
-                    {
-                        pressed_keys.insert(
-                            mir_input_device_state_event_device_pressed_keys_for_index(
-                                state_event,
-                                dev,
-                                idx));
-                    }
+                    pressed_keys.insert(
+                        mir_input_device_state_event_device_pressed_keys_for_index(
+                            state_event,
+                            dev,
+                            idx));
                 }
+            }
 
-                return std::vector<uint32_t>{pressed_keys.begin(), pressed_keys.end()};
-            }});
+            return std::vector<uint32_t>{pressed_keys.begin(), pressed_keys.end()};
+        }};
+
+    seat->keyboard_listeners->register_listener(client, keyboard);
+    keyboard->add_destroy_listener(
+        [listeners = seat->keyboard_listeners, listener = keyboard, client = client]()
+        {
+            listeners->unregister_listener(client, listener);
+        });
 }
 
 void mf::WlSeat::Instance::get_touch(wl_resource* new_touch)

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -99,14 +99,6 @@ mf::WlSurface::WlSurface(
 
 mf::WlSurface::~WlSurface()
 {
-    // so that unregister_destroy_listener calls invoked from destroy listeners don't screw up the iterator
-    auto listeners = move(destroy_listeners);
-    destroy_listeners.clear();
-    for (auto listener: listeners)
-    {
-        listener.second();
-    }
-
     role->destroy();
     session->destroy_buffer_stream(stream);
 }
@@ -222,16 +214,6 @@ void mf::WlSurface::populate_surface_data(std::vector<shell::StreamSpecification
     {
         subsurface->populate_surface_data(buffer_streams, input_shape_accumulator, offset);
     }
-}
-
-void mf::WlSurface::add_destroy_listener(void const* key, std::function<void()> listener)
-{
-    destroy_listeners[key] = listener;
-}
-
-void mf::WlSurface::remove_destroy_listener(void const* key)
-{
-    destroy_listeners.erase(key);
 }
 
 mf::WlSurface* mf::WlSurface::from(wl_resource* resource)

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -134,8 +134,6 @@ public:
                                std::vector<mir::geometry::Rectangle>& input_shape_accumulator,
                                geometry::Displacement const& parent_offset) const;
     void commit(WlSurfaceState const& state);
-    void add_destroy_listener(void const* key, std::function<void()> listener);
-    void remove_destroy_listener(void const* key);
 
     std::shared_ptr<scene::Session> const session;
     std::shared_ptr<compositor::BufferStream> const stream;
@@ -155,7 +153,6 @@ private:
     std::experimental::optional<geometry::Size> buffer_size_;
     std::vector<std::shared_ptr<WlSurfaceState::Callback>> frame_callbacks;
     std::experimental::optional<std::vector<mir::geometry::Rectangle>> input_shape;
-    std::map<void const*, std::function<void()>> destroy_listeners;
 
     void send_frame_callbacks();
 

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -31,11 +31,8 @@ namespace mf = mir::frontend;
 namespace mw = mir::wayland;
 namespace geom = mir::geometry;
 
-mf::WlTouch::WlTouch(
-    wl_resource* new_resource,
-    std::function<void(WlTouch*)> const& on_destroy)
-    : Touch(new_resource, Version<6>()),
-      on_destroy{on_destroy}
+mf::WlTouch::WlTouch(wl_resource* new_resource)
+    : Touch(new_resource, Version<6>())
 {
 }
 
@@ -48,7 +45,6 @@ mf::WlTouch::~WlTouch()
             touch.second.surface.value().remove_destroy_listener(touch.second.destroy_listener_id);
         }
     }
-    on_destroy(this);
 }
 
 void mf::WlTouch::release()

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -59,16 +59,18 @@ public:
 
 private:
     std::function<void(WlTouch*)> on_destroy;
+
+    struct TouchedSurface
+    {
+        wayland::Weak<WlSurface> surface;
+        wayland::DestroyListenerId destroy_listener_id;
+    };
+
     /// Maps touch IDs to the surfaces the touch is on
-    std::unordered_map<int32_t, wayland::Weak<WlSurface>> touch_id_to_surface;
+    std::unordered_map<int32_t, TouchedSurface> touch_id_to_surface;
     bool can_send_frame{false};
 
     void release() override;
-
-    /// Maps every touch_id for every WlTouch to a stable and globally unique pointer
-    /// Used for surface destory listener keys
-    /// The returned pointer should only be used as a key, it will not necessarily point to anything meaningful/valid
-    void const* unique_key_for(int32_t touch_id) const;
 };
 
 }

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -38,9 +38,7 @@ class WlSurface;
 class WlTouch : public wayland::Touch
 {
 public:
-    WlTouch(
-        wl_resource* new_resource,
-        std::function<void(WlTouch*)> const& on_destroy);
+    WlTouch(wl_resource* new_resource);
 
     ~WlTouch();
 
@@ -58,8 +56,6 @@ public:
     void frame();
 
 private:
-    std::function<void(WlTouch*)> on_destroy;
-
     struct TouchedSurface
     {
         wayland::Weak<WlSurface> surface;

--- a/src/wayland/wayland_base.cpp
+++ b/src/wayland/wayland_base.cpp
@@ -63,7 +63,7 @@ mw::LifetimeTracker::~LifetimeTracker()
     mark_destroyed();
 }
 
-auto mw::LifetimeTracker::destroyed_flag() const -> std::shared_ptr<bool>
+auto mw::LifetimeTracker::destroyed_flag() const -> std::shared_ptr<bool const>
 {
     if (!destroyed)
     {

--- a/tests/unit-tests/wayland/CMakeLists.txt
+++ b/tests/unit-tests/wayland/CMakeLists.txt
@@ -1,6 +1,7 @@
 list(APPEND UNIT_TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/test_wayland_executor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_wayland_weak.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_lifetime_tracker.cpp
 )
 
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/tests/unit-tests/wayland/test_lifetime_tracker.cpp
+++ b/tests/unit-tests/wayland/test_lifetime_tracker.cpp
@@ -80,7 +80,7 @@ TEST_F(LifetimeTrackerTest, is_still_alive_when_destroy_listener_called)
 {
     mw::Weak<MockTracker> weak{&tracker};
     tracker.add_destroy_listener([&](){ listener.callback(); });
-    EXPECT_CALL(listener, callback()).Times(1).WillOnce(Invoke([&]()
+    EXPECT_CALL(listener, callback()).Times(1).WillOnce(Invoke([weak]()
         {
             EXPECT_THAT(weak, IsTrue());
         }));

--- a/tests/unit-tests/wayland/test_lifetime_tracker.cpp
+++ b/tests/unit-tests/wayland/test_lifetime_tracker.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "mir/wayland/wayland_base.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace mw = mir::wayland;
+
+using namespace testing;
+
+class MockTracker : public virtual mw::LifetimeTracker
+{
+public:
+    // Expose protected method
+    void mark_destroyed() const
+    {
+        LifetimeTracker::mark_destroyed();
+    }
+};
+
+TEST(LifetimeTrackerTest, first_destroy_listener_id_is_not_zero)
+{
+    MockTracker tracker;
+    auto const id = tracker.add_destroy_listener([](){});
+    EXPECT_THAT(id.as_value(), Ne(0));
+}
+
+TEST(LifetimeTrackerTest, destroy_listener_is_called)
+{
+    int call_count = 0;
+    {
+        MockTracker tracker;
+        tracker.add_destroy_listener([&](){ call_count++; });
+    }
+    EXPECT_THAT(call_count, Eq(1));
+}
+
+TEST(LifetimeTrackerTest, destroy_listener_only_called_once_when_marked_as_destroyed)
+{
+    int call_count = 0;
+    {
+        MockTracker tracker;
+        tracker.add_destroy_listener([&](){ call_count++; });
+        tracker.mark_destroyed();
+    }
+    EXPECT_THAT(call_count, Eq(1));
+}
+
+TEST(LifetimeTrackerTest, destroy_listener_can_be_removed)
+{
+    int call_count_a = 0;
+    int call_count_b = 0;
+    {
+        MockTracker tracker;
+        auto const id_a = tracker.add_destroy_listener([&](){ call_count_a++; });
+        tracker.add_destroy_listener([&](){ call_count_b++; });
+        tracker.remove_destroy_listener(id_a);
+    }
+    EXPECT_THAT(call_count_a, Eq(0));
+    EXPECT_THAT(call_count_b, Eq(1));
+}
+
+TEST(LifetimeTrackerTest, is_still_alive_when_destroy_listener_called)
+{
+    int call_count = 0;
+    {
+        MockTracker tracker;
+        mw::Weak<MockTracker> weak{&tracker};
+        tracker.add_destroy_listener(
+            [&]()
+            {
+                call_count++;
+                EXPECT_THAT(weak, IsTrue());
+            });
+    }
+    EXPECT_THAT(call_count, Eq(1));
+}
+
+TEST(LifetimeTrackerTest, can_be_marked_as_destroyed_from_within_listener)
+{
+    int call_count = 0;
+    {
+        MockTracker tracker;
+        tracker.add_destroy_listener(
+            [&]()
+            {
+                call_count++;
+                // why would you want to do this? idk, but you can!
+                tracker.mark_destroyed();
+            });
+    }
+    EXPECT_THAT(call_count, Eq(1));
+}
+
+TEST(LifetimeTrackerTest, removing_invalid_destroy_listener_ids_does_not_cause_problem)
+{
+    MockTracker tracker;
+    tracker.remove_destroy_listener(mw::DestroyListenerId{0});
+    tracker.remove_destroy_listener(mw::DestroyListenerId{125});
+}


### PR DESCRIPTION
Previously we had a mix of ways to be notified when a Wayland object was destroyed including a destroy listener system on `WlSurface` and a callback argument to the constructor of input device objects. This standardizes the process of adding and removing destroy listeners and makes it available to any wayland object or other `LifetimeTracker` subclass. This also fixes a dirty hack where we were generating bad pointers to use as IDs in `WlTouch`.