### PR TITLE
Fix more missing #includes for GCC 11

### DIFF
--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -40,6 +40,7 @@
 
 #include <mutex>
 #include <vector>
+#include <optional>
 #include <drm_fourcc.h>
 #include <wayland-server.h>
 

--- a/src/server/input/default_input_manager.cpp
+++ b/src/server/input/default_input_manager.cpp
@@ -29,6 +29,7 @@
 #include "mir/terminate_with_current_exception.h"
 
 #include <future>
+#include <memory>
 
 namespace mi = mir::input;
 

--- a/tests/unit-tests/input/test_default_input_manager.cpp
+++ b/tests/unit-tests/input/test_default_input_manager.cpp
@@ -33,6 +33,7 @@
 #include <gmock/gmock.h>
 #include <chrono>
 #include <list>
+#include <memory>
 
 namespace mt = mir::test;
 namespace md = mir::dispatch;


### PR DESCRIPTION
This is from an effort in Fedora to prepare for the GCC 11 rebase for Fedora 34.

Followup to #1771.