### PR TITLE
Use the Wayland executor directly in more places

### DIFF
--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -208,10 +208,12 @@ private:
 
 mf::LayerShellV1::LayerShellV1(
     struct wl_display* display,
+    Executor& wayland_executor,
     std::shared_ptr<msh::Shell> shell,
     WlSeat& seat,
     OutputManager* output_manager)
     : Global(display, Version<3>()),
+      wayland_executor{wayland_executor},
       shell{shell},
       seat{seat},
       output_manager{output_manager}
@@ -279,6 +281,7 @@ mf::LayerSurfaceV1::LayerSurfaceV1(
     MirDepthLayer layer)
     : mw::LayerSurfaceV1(new_resource, Version<3>()),
       WindowWlSurfaceRole(
+          layer_shell.wayland_executor,
           &layer_shell.seat,
           wayland::LayerSurfaceV1::client,
           surface,

--- a/src/server/frontend_wayland/layer_shell_v1.h
+++ b/src/server/frontend_wayland/layer_shell_v1.h
@@ -23,6 +23,7 @@
 
 namespace mir
 {
+class Executor;
 namespace scene
 {
 class Surface;
@@ -42,12 +43,14 @@ class LayerShellV1 : public wayland::LayerShellV1::Global
 public:
     LayerShellV1(
         wl_display* display,
+        Executor& wayland_executor,
         std::shared_ptr<shell::Shell> shell,
         WlSeat& seat,
         OutputManager* output_manager);
 
     static auto get_window(wl_resource* surface) -> std::shared_ptr<scene::Surface>;
 
+    Executor& wayland_executor;
     std::shared_ptr<shell::Shell> const shell;
     WlSeat& seat;
     OutputManager* const output_manager;

--- a/src/server/frontend_wayland/pointer_constraints_unstable_v1.h
+++ b/src/server/frontend_wayland/pointer_constraints_unstable_v1.h
@@ -23,13 +23,17 @@ struct wl_display;
 
 namespace mir
 {
+class Executor;
 namespace shell { class Shell; }
 
 namespace frontend
 {
 class WlSeat;
 
-auto create_pointer_constraints_unstable_v1(wl_display* display, WlSeat* seat, std::shared_ptr<shell::Shell> shell) -> std::shared_ptr<void>;
+auto create_pointer_constraints_unstable_v1(
+    wl_display* display,
+    Executor& wayland_executor,
+    std::shared_ptr<shell::Shell> shell) -> std::shared_ptr<void>;
 
 }
 }

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -166,6 +166,7 @@ private:
 
 auto create_wl_shell(
     wl_display* display,
+    Executor& wayland_executor,
     std::shared_ptr<shell::Shell> const& shell,
     WlSeat* seat,
     OutputManager* const output_manager) -> std::shared_ptr<void>;

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -59,19 +59,47 @@ struct ExtensionBuilder
 std::vector<ExtensionBuilder> const internal_extension_builders = {
     {
         mw::Shell::interface_name, [](auto const& ctx) -> std::shared_ptr<void>
-            { return mf::create_wl_shell(ctx.display, ctx.shell, ctx.seat, ctx.output_manager); }
+            {
+                return mf::create_wl_shell(
+                    ctx.display,
+                    *ctx.wayland_executor,
+                    ctx.shell,
+                    ctx.seat,
+                    ctx.output_manager);
+            }
     },
     {
         mw::XdgShellV6::interface_name, [](auto const& ctx) -> std::shared_ptr<void>
-            { return std::make_shared<mf::XdgShellV6>(ctx.display, ctx.shell, *ctx.seat, ctx.output_manager); }
+            {
+                return std::make_shared<mf::XdgShellV6>(
+                    ctx.display,
+                    *ctx.wayland_executor,
+                    ctx.shell,
+                    *ctx.seat,
+                    ctx.output_manager);
+            }
     },
     {
         mw::XdgWmBase::interface_name, [](auto const& ctx) -> std::shared_ptr<void>
-            { return std::make_shared<mf::XdgShellStable>(ctx.display, ctx.shell, *ctx.seat, ctx.output_manager); }
+            {
+                return std::make_shared<mf::XdgShellStable>(
+                    ctx.display,
+                    *ctx.wayland_executor,
+                    ctx.shell,
+                    *ctx.seat,
+                    ctx.output_manager);
+            }
     },
     {
         mw::LayerShellV1::interface_name, [](auto const& ctx) -> std::shared_ptr<void>
-            { return std::make_shared<mf::LayerShellV1>(ctx.display, ctx.shell, *ctx.seat, ctx.output_manager); }
+            {
+                return std::make_shared<mf::LayerShellV1>(
+                    ctx.display,
+                    *ctx.wayland_executor,
+                    ctx.shell,
+                    *ctx.seat,
+                    ctx.output_manager);
+            }
     },
     {
         mw::XdgOutputManagerV1::interface_name, [](auto const& ctx) -> std::shared_ptr<void>
@@ -93,7 +121,7 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
     },
     {
         mw::PointerConstraintsV1::interface_name, [](auto const& ctx) -> std::shared_ptr<void>
-            { return mf::create_pointer_constraints_unstable_v1(ctx.display, ctx.seat, ctx.shell); }
+            { return mf::create_pointer_constraints_unstable_v1(ctx.display, *ctx.wayland_executor, ctx.shell); }
     },
 };
 

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -127,7 +127,13 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
 
 ExtensionBuilder const xwayland_builder {
     "x11-support", [](auto const& ctx) -> std::shared_ptr<void>
-        { return std::make_shared<mf::XWaylandWMShell>(ctx.shell, *ctx.seat, ctx.surface_stack); }
+        {
+            return std::make_shared<mf::XWaylandWMShell>(
+                ctx.wayland_executor,
+                ctx.shell,
+                *ctx.seat,
+                ctx.surface_stack);
+        }
 };
 
 struct WaylandExtensions : mf::WaylandExtensions

--- a/src/server/frontend_wayland/wayland_surface_observer.h
+++ b/src/server/frontend_wayland/wayland_surface_observer.h
@@ -32,6 +32,7 @@ struct wl_client;
 
 namespace mir
 {
+class Executor;
 namespace frontend
 {
 class WlSeat;
@@ -42,7 +43,7 @@ class WaylandInputDispatcher;
 class WaylandSurfaceObserver : public scene::NullSurfaceObserver
 {
 public:
-    WaylandSurfaceObserver(WlSeat* seat, WlSurface* surface, WindowWlSurfaceRole* window);
+    WaylandSurfaceObserver(Executor& wayland_executor, WlSeat* seat, WlSurface* surface, WindowWlSurfaceRole* window);
     ~WaylandSurfaceObserver();
 
     /// Overrides from scene::SurfaceObserver
@@ -104,7 +105,7 @@ private:
     void run_on_wayland_thread_unless_window_destroyed(
         std::function<void(Impl* impl, WindowWlSurfaceRole* window)>&& work);
 
-    WlSeat* const seat;
+    Executor& wayland_executor;
     /// shared_ptr so it can be captured by lambdas and possibly outlive this object
     std::shared_ptr<Impl> const impl;
 };

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -63,6 +63,7 @@ inline void clear_pending_if_unchanged(mir::optional_value<T>& pending, T& cache
 }
 
 mf::WindowWlSurfaceRole::WindowWlSurfaceRole(
+    Executor& wayland_executor,
     WlSeat* seat,
     wl_client* client,
     WlSurface* surface,
@@ -73,7 +74,7 @@ mf::WindowWlSurfaceRole::WindowWlSurfaceRole(
       shell{shell},
       session{get_session(client)},
       output_manager{output_manager},
-      observer{std::make_shared<WaylandSurfaceObserver>(seat, surface, this)},
+      observer{std::make_shared<WaylandSurfaceObserver>(wayland_executor, seat, surface, this)},
       params{std::make_unique<scene::SurfaceCreationParameters>(
           scene::SurfaceCreationParameters().of_type(mir_window_type_freestyle))},
       committed_min_size{0, 0},

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -36,6 +36,7 @@ struct wl_resource;
 
 namespace mir
 {
+class Executor;
 namespace scene
 {
 struct SurfaceCreationParameters;
@@ -59,8 +60,8 @@ class WindowWlSurfaceRole
       public virtual wayland::LifetimeTracker
 {
 public:
-
     WindowWlSurfaceRole(
+        Executor& wayland_executor,
         WlSeat* seat,
         wl_client* client,
         WlSurface* surface,

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -26,7 +26,6 @@
 #include "wl_pointer.h"
 #include "wl_touch.h"
 
-#include "mir/executor.h"
 #include "mir/client/event.h"
 
 #include "mir/input/input_device_observer.h"
@@ -43,11 +42,6 @@
 namespace mf = mir::frontend;
 namespace mi = mir::input;
 namespace mw = mir::wayland;
-
-namespace mir
-{
-class Executor;
-}
 
 template<class T>
 class mf::WlSeat::ListenerList
@@ -157,8 +151,7 @@ private:
 mf::WlSeat::WlSeat(
     wl_display* display,
     std::shared_ptr<mi::InputDeviceHub> const& input_hub,
-    std::shared_ptr<mi::Seat> const& seat,
-    std::shared_ptr<mir::Executor> const& executor)
+    std::shared_ptr<mi::Seat> const& seat)
     :   Global(display, Version<6>()),
         keymap{std::make_unique<input::Keymap>()},
         config_observer{
@@ -172,8 +165,7 @@ mf::WlSeat::WlSeat(
         keyboard_listeners{std::make_shared<ListenerList<WlKeyboard>>()},
         touch_listeners{std::make_shared<ListenerList<WlTouch>>()},
         input_hub{input_hub},
-        seat{seat},
-        executor{executor}
+        seat{seat}
 {
     input_hub->add_observer(config_observer);
     add_focus_listener(&focus);
@@ -212,11 +204,6 @@ void mf::WlSeat::notify_focus(wl_client *focus)
         for (auto const listener : focus_listeners)
             listener->focus_on(focus);
     }
-}
-
-void mf::WlSeat::spawn(std::function<void()>&& work)
-{
-    executor->spawn(std::move(work));
 }
 
 void mf::WlSeat::bind(wl_resource* new_wl_seat)

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -33,8 +33,6 @@ struct MirKeymapEvent;
 
 namespace mir
 {
-class Executor;
-
 namespace input
 {
 class InputDeviceHub;
@@ -53,8 +51,7 @@ public:
     WlSeat(
         wl_display* display,
         std::shared_ptr<mir::input::InputDeviceHub> const& input_hub,
-        std::shared_ptr<mir::input::Seat> const& seat,
-        std::shared_ptr<mir::Executor> const& executor);
+        std::shared_ptr<mir::input::Seat> const& seat);
 
     ~WlSeat();
 
@@ -63,8 +60,6 @@ public:
     void for_each_listener(wl_client* client, std::function<void(WlPointer*)> func);
     void for_each_listener(wl_client* client, std::function<void(WlKeyboard*)> func);
     void for_each_listener(wl_client* client, std::function<void(WlTouch*)> func);
-
-    void spawn(std::function<void()>&& work);
 
     class ListenerTracker
     {
@@ -115,10 +110,7 @@ private:
     std::shared_ptr<input::InputDeviceHub> const input_hub;
     std::shared_ptr<input::Seat> const seat;
 
-    std::shared_ptr<mir::Executor> const executor;
-
     void bind(wl_resource* new_wl_seat) override;
-
 };
 }
 }

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -149,10 +149,12 @@ private:
 
 mf::XdgShellStable::XdgShellStable(
     struct wl_display* display,
+    Executor& wayland_executor,
     std::shared_ptr<msh::Shell> shell,
     WlSeat& seat,
     OutputManager* output_manager)
     : Global(display, Version<1>()),
+      wayland_executor{wayland_executor},
       shell{shell},
       seat{seat},
       output_manager{output_manager}
@@ -288,6 +290,7 @@ mf::XdgPopupStable::XdgPopupStable(
     WlSurface* surface)
     : mw::XdgPopup(new_resource, Version<1>()),
       WindowWlSurfaceRole(
+          xdg_surface->xdg_shell.wayland_executor,
           &xdg_surface->xdg_shell.seat,
           mw::XdgPopup::client,
           surface,
@@ -401,6 +404,7 @@ auto mf::XdgPopupStable::from(wl_resource* resource) -> XdgPopupStable*
 mf::XdgToplevelStable::XdgToplevelStable(wl_resource* new_resource, XdgSurfaceStable* xdg_surface, WlSurface* surface)
     : mw::XdgToplevel(new_resource, Version<1>()),
       WindowWlSurfaceRole(
+          xdg_surface->xdg_shell.wayland_executor,
           &xdg_surface->xdg_shell.seat,
           mw::XdgToplevel::client,
           surface,

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -41,11 +41,14 @@ class XdgShellStable : public wayland::XdgWmBase::Global
 public:
     XdgShellStable(
         wl_display* display,
+        Executor& wayland_executor,
         std::shared_ptr<shell::Shell> shell,
         WlSeat& seat,
         OutputManager* output_manager);
 
     static auto get_window(wl_resource* surface) -> std::shared_ptr<scene::Surface>;
+
+    Executor& wayland_executor;
     std::shared_ptr<shell::Shell> const shell;
     WlSeat& seat;
     OutputManager* const output_manager;

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -195,10 +195,12 @@ void mf::XdgShellV6::Instance::pong(uint32_t serial)
 
 mf::XdgShellV6::XdgShellV6(
     struct wl_display* display,
+    Executor& wayland_executor,
     std::shared_ptr<msh::Shell> shell,
     WlSeat& seat,
     OutputManager* output_manager) :
     Global(display, Version<1>()),
+    wayland_executor{wayland_executor},
     shell{shell},
     seat{seat},
     output_manager{output_manager}
@@ -290,6 +292,7 @@ mf::XdgPopupV6::XdgPopupV6(
     WlSurface* surface)
     : mw::XdgPopupV6(new_resource, Version<1>()),
       WindowWlSurfaceRole(
+          xdg_surface->xdg_shell.wayland_executor,
           &xdg_surface->xdg_shell.seat,
           mw::XdgPopupV6::client,
           surface,
@@ -356,6 +359,7 @@ void mf::XdgPopupV6::handle_close_request()
 mf::XdgToplevelV6::XdgToplevelV6(struct wl_resource* new_resource, XdgSurfaceV6* xdg_surface, WlSurface* surface)
     : mw::XdgToplevelV6(new_resource, Version<1>()),
       WindowWlSurfaceRole(
+          xdg_surface->xdg_shell.wayland_executor,
           &xdg_surface->xdg_shell.seat,
           mw::XdgToplevelV6::client,
           surface,

--- a/src/server/frontend_wayland/xdg_shell_v6.h
+++ b/src/server/frontend_wayland/xdg_shell_v6.h
@@ -23,6 +23,7 @@
 
 namespace mir
 {
+class Executor;
 namespace scene
 {
 class Surface;
@@ -39,8 +40,14 @@ class OutputManager;
 class XdgShellV6 : public wayland::XdgShellV6::Global
 {
 public:
-    XdgShellV6(wl_display* display, std::shared_ptr<shell::Shell> shell, WlSeat& seat, OutputManager* output_manager);
+    XdgShellV6(
+        wl_display* display,
+        Executor& wayland_executor,
+        std::shared_ptr<shell::Shell> shell,
+        WlSeat& seat,
+        OutputManager* output_manager);
 
+    Executor& wayland_executor;
     std::shared_ptr<shell::Shell> const shell;
     WlSeat& seat;
     OutputManager* const output_manager;

--- a/src/server/frontend_xwayland/xwayland_connector.h
+++ b/src/server/frontend_xwayland/xwayland_connector.h
@@ -26,6 +26,7 @@
 
 namespace mir
 {
+class Executor;
 namespace dispatch
 {
 class ReadableFd;

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -52,8 +52,7 @@ public:
     XWaylandSurface(
         XWaylandWM *wm,
         std::shared_ptr<XCBConnection> const& connection,
-        WlSeat& seat,
-        std::shared_ptr<shell::Shell> const& shell,
+        XWaylandWMShell const& wm_shell,
         std::shared_ptr<XWaylandClientManager> const& client_manager,
         xcb_window_t window,
         geometry::Rectangle const& geometry,
@@ -106,7 +105,6 @@ private:
     void scene_surface_resized(geometry::Size const& new_size) override;
     void scene_surface_moved_to(geometry::Point const& new_top_left) override;
     void scene_surface_close_requested() override;
-    void run_on_wayland_thread(std::function<void()>&& work) override;
     /// @}
 
     /// Overrides from XWaylandSurfaceRoleSurface
@@ -149,7 +147,7 @@ private:
 
     XWaylandWM* const xwm;
     std::shared_ptr<XCBConnection> const connection;
-    WlSeat& seat;
+    XWaylandWMShell const& wm_shell;
     std::shared_ptr<shell::Shell> const shell;
     std::shared_ptr<XWaylandClientManager> const client_manager;
     xcb_window_t const window;

--- a/src/server/frontend_xwayland/xwayland_surface_observer.h
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.h
@@ -45,6 +45,7 @@ class XWaylandSurfaceObserver
 {
 public:
     XWaylandSurfaceObserver(
+        Executor& wayland_executor,
         WlSeat& seat,
         WlSurface* wl_surface,
         XWaylandSurfaceObserverSurface* wm_surface);
@@ -83,6 +84,7 @@ private:
     };
 
     XWaylandSurfaceObserverSurface* const wm_surface;
+    Executor& wayland_executor;
     std::shared_ptr<ThreadsafeInputDispatcher> const input_dispatcher;
 
     /// Runs work on the Wayland thread if the input dispatcher still exists

--- a/src/server/frontend_xwayland/xwayland_surface_observer_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface_observer_surface.h
@@ -40,7 +40,6 @@ public:
     virtual void scene_surface_resized(geometry::Size const& new_size) = 0;
     virtual void scene_surface_moved_to(geometry::Point const& new_top_left) = 0;
     virtual void scene_surface_close_requested() = 0;
-    virtual void run_on_wayland_thread(std::function<void()>&& work) = 0;
 
 private:
     XWaylandSurfaceObserverSurface(XWaylandSurfaceObserverSurface const&) = delete;

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -56,7 +56,10 @@ private:
 
 public:
     /// Takes ownership of the given FD
-    XWaylandWM(std::shared_ptr<WaylandConnector> wayland_connector, wl_client* wayland_client, Fd const& fd);
+    XWaylandWM(
+        std::shared_ptr<WaylandConnector> wayland_connector,
+        wl_client* wayland_client,
+        Fd const& fd);
     ~XWaylandWM();
 
     /// Called by the XWayland connector when there may be new events
@@ -67,7 +70,6 @@ public:
     void set_focus(xcb_window_t xcb_window, bool should_be_focused);
     void remember_scene_surface(std::weak_ptr<scene::Surface> const& scene_surface, xcb_window_t window);
     void forget_scene_surface(std::weak_ptr<scene::Surface> const& scene_surface);
-    void run_on_wayland_thread(std::function<void()>&& work);
 
     void surfaces_reordered(scene::SurfaceSet const& affected_surfaces);
 
@@ -99,6 +101,7 @@ private:
     std::shared_ptr<WaylandConnector> const wayland_connector;
     wl_client* const wayland_client;
     std::shared_ptr<XWaylandWMShell> const wm_shell;
+    Executor& wayland_executor;
     std::unique_ptr<XWaylandCursors> const cursors;
     xcb_window_t const wm_window;
     std::shared_ptr<XWaylandSceneObserver> const scene_observer;

--- a/src/server/frontend_xwayland/xwayland_wm_shell.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shell.h
@@ -23,6 +23,7 @@
 
 namespace mir
 {
+class Executor;
 namespace shell
 {
 class Shell;
@@ -39,15 +40,18 @@ class XWaylandWMShell
 {
 public:
     XWaylandWMShell(
+        std::shared_ptr<Executor> const& wayland_executor,
         std::shared_ptr<shell::Shell> const& shell,
         WlSeat& seat,
         std::shared_ptr<SurfaceStack> const& surface_stack)
-        : shell{shell},
+        : wayland_executor{wayland_executor},
+          shell{shell},
           seat{seat},
           surface_stack{surface_stack}
     {
     }
 
+    std::shared_ptr<Executor> const wayland_executor;
     std::shared_ptr<shell::Shell> const shell;
     WlSeat& seat;
     std::shared_ptr<SurfaceStack> const surface_stack;


### PR DESCRIPTION
This removes `WlSeat::spawn()` and switches all of its users over to using the Wayland executor directly. There was never any reason for running on the Wayland thread to be tied to the seat. In fact, that's the only thing the seat even had an executor for. It also switches around the XWayland frontend a bit to use executors directly where it makes sense.