### PR TITLE
Process events in device classes

### DIFF
--- a/include/client/mir_toolkit/events/input/input_event.h
+++ b/include/client/mir_toolkit/events/input/input_event.h
@@ -54,6 +54,14 @@ MirInputDeviceId mir_input_event_get_device_id(MirInputEvent const* event);
 int64_t mir_input_event_get_event_time(MirInputEvent const* event);
 
 /**
+ * Retrieve the event time as a Wayland timestamp.
+ *
+ * \param [in] event The input event
+ * \return           A wayland-compatible timestamp (miliseconds-since-epoch)
+ */
+uint32_t mir_input_event_get_wayland_timestamp(MirInputEvent const* event);
+
+/**
  * Retrieve the type of an input event. E.g. key, touch...
  *
  * \param [in] event The input event

--- a/src/client/input/input_event.cpp
+++ b/src/client/input/input_event.cpp
@@ -87,6 +87,15 @@ int64_t mir_input_event_get_event_time(MirInputEvent const* ev) MIR_HANDLE_EVENT
     return ev->event_time().count();
 })
 
+uint32_t mir_input_event_get_wayland_timestamp(MirInputEvent const* ev) MIR_HANDLE_EVENT_EXCEPTION(
+{
+    expect_event_type(ev, mir_event_type_input);
+
+    auto const ns = ev->event_time();
+    auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(ns);
+    return ms.count();
+})
+
 MirInputEvent const* mir_pointer_event_input_event(MirPointerEvent const* event)
 {
     return reinterpret_cast<MirInputEvent const*>(event);

--- a/src/client/symbols.map
+++ b/src/client/symbols.map
@@ -495,6 +495,8 @@ MIR_CLIENT_DETAIL_2.0 {
     mir_presentation_chain_set_queueing_mode;
     mir_presentation_chain_set_dropping_mode;
 
+    mir_input_event_get_wayland_timestamp;
+
     extern "C++" {
       mir::events::make_event*;
       mir::events::add_touch*;

--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -23,7 +23,6 @@
 #include "wl_keyboard.h"
 #include "wl_touch.h"
 
-#include <mir/input/xkb_mapper.h>
 #include <mir/input/keymap.h>
 #include <mir/log.h>
 
@@ -70,7 +69,7 @@ void mf::WaylandInputDispatcher::set_focus(bool has_focus)
 
     seat->for_each_listener(client, [&](WlKeyboard* keyboard)
         {
-            keyboard->focussed(&wl_surface.value(), has_focus);
+            keyboard->focussed(wl_surface.value(), has_focus);
         });
 }
 
@@ -81,18 +80,22 @@ void mf::WaylandInputDispatcher::handle_event(MirInputEvent const* event)
         return;
     }
 
-    auto const ns = std::chrono::nanoseconds{mir_input_event_get_event_time(event)};
-    auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(ns);
-
     // Remember the timestamp of any events "signed" with a cookie
     if (mir_input_event_has_cookie(event))
-        timestamp = ns;
+    {
+        timestamp = std::chrono::nanoseconds{mir_input_event_get_event_time(event)};
+    }
 
     switch (mir_input_event_get_type(event))
     {
     case mir_input_event_type_key:
-        handle_keyboard_event(ms, mir_input_event_get_keyboard_event(event));
-        break;
+    {
+        auto const keyboard_event = mir_input_event_get_keyboard_event(event);
+        seat->for_each_listener(client, [&](WlKeyboard* keyboard)
+            {
+                keyboard->event(keyboard_event, wl_surface.value());
+            });
+    }   break;
 
     case mir_input_event_type_pointer:
     {
@@ -114,24 +117,5 @@ void mf::WaylandInputDispatcher::handle_event(MirInputEvent const* event)
 
     default:
         break;
-    }
-}
-
-void mf::WaylandInputDispatcher::handle_keyboard_event(std::chrono::milliseconds const& ms, MirKeyboardEvent const* event)
-{
-    if (!wl_surface)
-    {
-        fatal_error("wl_surface should have already been checked");
-    }
-
-    MirKeyboardAction const action = mir_keyboard_event_action(event);
-    if (action == mir_keyboard_action_down || action == mir_keyboard_action_up)
-    {
-        int const scancode = mir_keyboard_event_scan_code(event);
-        bool const down = action == mir_keyboard_action_down;
-        seat->for_each_listener(client, [&](WlKeyboard* keyboard)
-            {
-                keyboard->key(ms, &wl_surface.value(), scancode, down);
-            });
     }
 }

--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -104,8 +104,13 @@ void mf::WaylandInputDispatcher::handle_event(MirInputEvent const* event)
     }   break;
 
     case mir_input_event_type_touch:
-        handle_touch_event(ms, mir_input_event_get_touch_event(event));
-        break;
+    {
+        auto const touch_event = mir_input_event_get_touch_event(event);
+        seat->for_each_listener(client, [&](WlTouch* touch)
+            {
+                touch->event(touch_event, wl_surface.value());
+            });
+    }   break;
 
     default:
         break;
@@ -129,51 +134,4 @@ void mf::WaylandInputDispatcher::handle_keyboard_event(std::chrono::milliseconds
                 keyboard->key(ms, &wl_surface.value(), scancode, down);
             });
     }
-}
-
-void mf::WaylandInputDispatcher::handle_touch_event(
-    std::chrono::milliseconds const& ms,
-    MirTouchEvent const* event)
-{
-    if (!wl_surface)
-    {
-        fatal_error("wl_surface should have already been checked");
-    }
-
-    for (auto i = 0u; i < mir_touch_event_point_count(event); ++i)
-    {
-        auto const position = std::make_pair(
-            mir_touch_event_axis_value(event, i, mir_touch_axis_x),
-            mir_touch_event_axis_value(event, i, mir_touch_axis_y));
-        int const touch_id = mir_touch_event_id(event, i);
-        MirTouchAction const action = mir_touch_event_action(event, i);
-
-        switch (action)
-        {
-        case mir_touch_action_down:
-            seat->for_each_listener(client, [&](WlTouch* touch)
-                {
-                    touch->down(ms, touch_id, &wl_surface.value(), position);
-                });
-            break;
-        case mir_touch_action_up:
-            seat->for_each_listener(client, [&](WlTouch* touch)
-                {
-                    touch->up(ms, touch_id);
-                });
-            break;
-        case mir_touch_action_change:
-            seat->for_each_listener(client, [&](WlTouch* touch)
-                {
-                    touch->motion(ms, touch_id, &wl_surface.value(), position);
-                });
-            break;
-        case mir_touch_actions:;
-        }
-    }
-
-    seat->for_each_listener(client, [](WlTouch* touch)
-        {
-            touch->frame();
-        });
 }

--- a/src/server/frontend_wayland/wayland_input_dispatcher.h
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.h
@@ -66,15 +66,10 @@ private:
     wayland::Weak<WlSurface> const wl_surface;
 
     std::chrono::nanoseconds timestamp{0};
-    MirPointerButtons last_pointer_buttons{0};
-    std::experimental::optional<std::pair<float, float>> last_pointer_position;
 
     /// Handle user input events
     ///@{
     void handle_keyboard_event(std::chrono::milliseconds const& ms, MirKeyboardEvent const* event);
-    void handle_pointer_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
-    void handle_pointer_button_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
-    void handle_pointer_motion_event(std::chrono::milliseconds const& ms, MirPointerEvent const* event);
     void handle_touch_event(std::chrono::milliseconds const& ms, MirTouchEvent const* event);
     ///@}
 };

--- a/src/server/frontend_wayland/wayland_input_dispatcher.h
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.h
@@ -70,7 +70,6 @@ private:
     /// Handle user input events
     ///@{
     void handle_keyboard_event(std::chrono::milliseconds const& ms, MirKeyboardEvent const* event);
-    void handle_touch_event(std::chrono::milliseconds const& ms, MirTouchEvent const* event);
     ///@}
 };
 }

--- a/src/server/frontend_wayland/wayland_input_dispatcher.h
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.h
@@ -66,11 +66,6 @@ private:
     wayland::Weak<WlSurface> const wl_surface;
 
     std::chrono::nanoseconds timestamp{0};
-
-    /// Handle user input events
-    ///@{
-    void handle_keyboard_event(std::chrono::milliseconds const& ms, MirKeyboardEvent const* event);
-    ///@}
 };
 }
 }

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -92,7 +92,7 @@ void mf::WlKeyboard::event(MirKeyboardEvent const* event, WlSurface& surface)
     }
 
     auto const serial = wl_display_next_serial(wl_client_get_display(client));
-    auto const timestamp = WlSeat::timestamp_of(event);
+    auto const timestamp = mir_input_event_get_wayland_timestamp(mir_keyboard_event_input_event(event));
     int const scancode = mir_keyboard_event_scan_code(event);
     uint32_t const wayland_state = down ? KeyState::pressed : KeyState::released;
     send_key_event(serial, timestamp, scancode, wayland_state);

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -20,10 +20,12 @@
 
 #include "wayland_utils.h"
 #include "wl_surface.h"
+#include "wl_seat.h"
 
 #include "mir/executor.h"
 #include "mir/anonymous_shm_file.h"
 #include "mir/input/keymap.h"
+#include "mir/input/xkb_mapper.h"
 #include "mir/log.h"
 #include "mir/fatal.h"
 
@@ -72,13 +74,30 @@ mf::WlKeyboard::~WlKeyboard()
     }
 }
 
-void mf::WlKeyboard::key(std::chrono::milliseconds const& ms, WlSurface* surface, int scancode, bool down)
+void mf::WlKeyboard::event(MirKeyboardEvent const* event, WlSurface& surface)
 {
-    auto const serial = wl_display_next_serial(wl_client_get_display(client));
-    auto const wayland_state = down ? KeyState::pressed : KeyState::released;
-    send_key_event(serial, ms.count(), scancode, wayland_state);
+    bool down;
+    switch (mir_keyboard_event_action(event))
+    {
+    case mir_keyboard_action_down:
+        down = true;
+        break;
 
-    if (as_nullable_ptr(focused_surface) == surface)
+    case mir_keyboard_action_up:
+        down = false;
+        break;
+
+    default:
+        return;
+    }
+
+    auto const serial = wl_display_next_serial(wl_client_get_display(client));
+    auto const timestamp = WlSeat::timestamp_of(event);
+    int const scancode = mir_keyboard_event_scan_code(event);
+    uint32_t const wayland_state = down ? KeyState::pressed : KeyState::released;
+    send_key_event(serial, timestamp, scancode, wayland_state);
+
+    if (as_nullable_ptr(focused_surface) == &surface)
     {
         /*
          * HACK! Maintain our own XKB state, so we can serialise it for
@@ -93,20 +112,20 @@ void mf::WlKeyboard::key(std::chrono::milliseconds const& ms, WlSurface* surface
     {
         log_warning(
             "Sending key 0x%2.2x %s to wl_surface@%u even though it was not explicitly given keyboard focus",
-            scancode, down ? "press" : "release", wl_resource_get_id(surface->resource));
+            scancode, down ? "press" : "release", wl_resource_get_id(surface.resource));
 
         focussed(surface, true);
     }
 }
 
-void mf::WlKeyboard::focussed(WlSurface* surface, bool should_be_focused)
+void mf::WlKeyboard::focussed(WlSurface& surface, bool should_be_focused)
 {
-    if (client != surface->client)
+    if (client != surface.client)
     {
         fatal_error("WlKeyboard::focussed() called with a surface of the wrong client");
     }
 
-    bool const is_currently_focused = (focused_surface && &focused_surface.value() == surface);
+    bool const is_currently_focused = (focused_surface && &focused_surface.value() == &surface);
 
     if (should_be_focused == is_currently_focused)
         return;
@@ -146,17 +165,17 @@ void mf::WlKeyboard::focussed(WlSurface* surface, bool should_be_focused)
                 keyboard_state.size() * sizeof(decltype(keyboard_state)::value_type));
         }
 
-        destroy_listener_id = surface->add_destroy_listener(
-            [this, surface]()
+        destroy_listener_id = surface.add_destroy_listener(
+            [this, &surface]()
             {
                 focussed(surface, false);
             });
 
         auto const serial = wl_display_next_serial(wl_client_get_display(client));
-        send_enter_event(serial, surface->raw_resource(), &key_state);
+        send_enter_event(serial, surface.raw_resource(), &key_state);
         wl_array_release(&key_state);
 
-        focused_surface = mw::make_weak(surface);
+        focused_surface = mw::make_weak(&surface);
     }
     else
     {

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -25,6 +25,8 @@
 #include <functional>
 #include <chrono>
 
+struct MirKeyboardEvent;
+
 // from <xkbcommon/xkbcommon.h>
 struct xkb_keymap;
 struct xkb_state;
@@ -54,8 +56,8 @@ public:
 
     ~WlKeyboard();
 
-    void key(std::chrono::milliseconds const& ms, WlSurface* surface, int scancode, bool down);
-    void focussed(WlSurface* surface, bool should_be_focused);
+    void event(MirKeyboardEvent const* event, WlSurface& surface);
+    void focussed(WlSurface& surface, bool should_be_focused);
     void set_keymap(mir::input::Keymap const& new_keymap);
     void resync_keyboard();
 
@@ -69,8 +71,8 @@ private:
 
     std::function<std::vector<uint32_t>()> const acquire_current_keyboard_state;
 
-    wayland::Weak<WlSurface> focused_surface{};
-    wayland::DestroyListenerId destroy_listener_id{};
+    wayland::Weak<WlSurface> focused_surface;
+    wayland::DestroyListenerId destroy_listener_id;
 
     uint32_t mods_depressed{0};
     uint32_t mods_latched{0};

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -20,6 +20,7 @@
 
 #include "wayland_utils.h"
 #include "wl_surface.h"
+#include "wl_seat.h"
 #include "relative-pointer-unstable-v1_wrapper.h"
 
 #include "mir/log.h"
@@ -77,6 +78,17 @@ private:
     std::unique_ptr<mrs::Mapping<unsigned char const>> const mapping;
     geom::Displacement const hotspot_;
 };
+
+static auto const button_mapping = {
+    std::make_pair(mir_pointer_button_primary, BTN_LEFT),
+    std::make_pair(mir_pointer_button_secondary, BTN_RIGHT),
+    std::make_pair(mir_pointer_button_tertiary, BTN_MIDDLE),
+    std::make_pair(mir_pointer_button_back, BTN_BACK),
+    std::make_pair(mir_pointer_button_forward, BTN_FORWARD),
+    std::make_pair(mir_pointer_button_side, BTN_SIDE),
+    std::make_pair(mir_pointer_button_task, BTN_TASK),
+    std::make_pair(mir_pointer_button_extra, BTN_EXTRA)
+};
 }
 
 struct mf::WlPointer::Cursor
@@ -115,18 +127,41 @@ mf::WlPointer::~WlPointer()
         surface_under_cursor.value().remove_destroy_listener(destroy_listener_id);
 }
 
-void mf::WlPointer::enter(
-    std::chrono::milliseconds const& ms,
-    WlSurface* root_surface,
-    std::pair<float, float> const& root_position)
+void mir::frontend::WlPointer::set_relative_pointer(mir::wayland::RelativePointerV1* relative_ptr)
 {
-    geom::Point root_point{root_position.first, root_position.second};
-    auto const target_surface = root_surface->subsurface_at(root_point).value_or(root_surface);
-    send_update(ms, target_surface, root_position);
+    relative_pointer = make_weak(relative_ptr);
 }
 
-void mf::WlPointer::leave()
+void mir::frontend::WlPointer::event(MirPointerEvent const* event, WlSurface& root_surface)
 {
+    switch(mir_pointer_event_action(event))
+    {
+        case mir_pointer_action_button_down:
+        case mir_pointer_action_button_up:
+            buttons(event);
+            break;
+        case mir_pointer_action_enter:
+            leave(event); // If we're currently on a surface, leave it
+            enter_or_motion(event, root_surface);
+            break;
+        case mir_pointer_action_leave:
+            leave(event);
+            break;
+        case mir_pointer_action_motion:
+            enter_or_motion(event, root_surface);
+            relative_motion(event);
+            axis(event);
+            break;
+        case mir_pointer_actions:
+            break;
+    }
+
+    maybe_frame();
+}
+
+void mf::WlPointer::leave(std::optional<MirPointerEvent const*> event)
+{
+    (void)event;
     if (!surface_under_cursor)
         return;
     surface_under_cursor.value().remove_destroy_listener(destroy_listener_id);
@@ -134,111 +169,86 @@ void mf::WlPointer::leave()
     send_leave_event(
         serial,
         surface_under_cursor.value().raw_resource());
-    can_send_frame = true;
+    current_position = std::experimental::nullopt;
+    // Don't clear current_buttons, their state can survive leaving and entering surfaces (note we currently have logic
+    // to prevent changing surfaces while buttons are pressed, we wouln't need to clear current_buttons regardless)
+    needs_frame = true;
     surface_under_cursor = {};
     destroy_listener_id = {};
 }
 
-void mf::WlPointer::button(std::chrono::milliseconds const& ms, uint32_t button, bool pressed)
+void mf::WlPointer::buttons(MirPointerEvent const* event)
 {
-    if (pressed)
+    MirPointerButtons const event_buttons = mir_pointer_event_buttons(event);
+
+    for (auto const& mapping : button_mapping)
     {
-        if (!pressed_buttons.insert(button).second)
+        // Check if the state of this button changed
+        if (mapping.first & (event_buttons ^ current_buttons))
         {
-            log_warning(
-                "Got pressed event for wl_pointer@%d button %d when already down",
-                wl_resource_get_id(resource),
-                button);
-            return;
+            bool const pressed = (mapping.first & event_buttons);
+            auto const state = pressed ? ButtonState::pressed : ButtonState::released;
+            auto const serial = wl_display_next_serial(display);
+            send_button_event(serial, WlSeat::timestamp_of(event), mapping.second, state);
+            needs_frame = true;
         }
+    }
+
+    current_buttons = event_buttons;
+}
+
+void mf::WlPointer::axis(MirPointerEvent const* event)
+{
+    auto const h_scroll = mir_pointer_event_axis_value(event, mir_pointer_axis_hscroll);
+    auto const v_scroll = mir_pointer_event_axis_value(event, mir_pointer_axis_vscroll);
+
+    if (h_scroll)
+    {
+        send_axis_event(
+            WlSeat::timestamp_of(event),
+            Axis::horizontal_scroll,
+            h_scroll);
+        needs_frame = true;
+    }
+
+    if (v_scroll)
+    {
+        send_axis_event(
+            WlSeat::timestamp_of(event),
+            Axis::vertical_scroll,
+            v_scroll);
+        needs_frame = true;
+    }
+}
+
+void mf::WlPointer::enter_or_motion(MirPointerEvent const* event, WlSurface& root_surface)
+{
+    auto const root_position = std::make_pair(
+        mir_pointer_event_axis_value(event, mir_pointer_axis_x),
+        mir_pointer_event_axis_value(event, mir_pointer_axis_y));
+
+    WlSurface* target_surface;
+    if (current_buttons != 0 && surface_under_cursor)
+    {
+        // If there are pressed buttons, we let the pointer move outside the current surface without leaving it
+        target_surface = &surface_under_cursor.value();
     }
     else
     {
-        if (!pressed_buttons.erase(button))
-        {
-            log_warning(
-                "Got unpressed event for wl_pointer@%d button %d when already up",
-                wl_resource_get_id(resource),
-                button);
-            return;
-        }
-    }
-
-    auto const serial = wl_display_next_serial(display);
-    auto const state = pressed ? ButtonState::pressed : ButtonState::released;
-
-    send_button_event(serial, ms.count(), button, state);
-    can_send_frame = true;
-}
-
-void mf::WlPointer::position(
-    std::chrono::milliseconds const& ms,
-    WlSurface* root_surface,
-    std::pair<float, float> const& root_position)
-{
-    WlSurface* target_surface = surface_under_cursor ? &surface_under_cursor.value() : nullptr;
-    if (!target_surface || pressed_buttons.empty())
-    {
-        // if pressed_buttons is empty there is no grab, so choose whatever surface we are over
+        // Else choose whatever subsurface we are over top of
         geom::Point root_point{root_position.first, root_position.second};
-        target_surface = root_surface->subsurface_at(root_point).value_or(root_surface);
+        target_surface = root_surface.subsurface_at(root_point).value_or(&root_surface);
     }
 
-    if (!relative_pointer)
-    {
-        send_update(ms, target_surface, root_position);
-    }
-}
-
-void mf::WlPointer::axis(std::chrono::milliseconds const& ms, std::pair<float, float> const& scroll)
-{
-    if (scroll.first)
-    {
-        send_axis_event(
-            ms.count(),
-            Axis::horizontal_scroll,
-            scroll.first);
-        can_send_frame = true;
-    }
-
-    if (scroll.second)
-    {
-        send_axis_event(
-            ms.count(),
-            Axis::vertical_scroll,
-            scroll.second);
-        can_send_frame = true;
-    }
-}
-
-void mf::WlPointer::frame()
-{
-    if (can_send_frame && version_supports_frame())
-        send_frame_event();
-    can_send_frame = false;
-}
-
-void mf::WlPointer::send_update(
-    std::chrono::milliseconds const& ms,
-    WlSurface* target_surface,
-    std::pair<float, float> const& root_position)
-{
     auto const offset = target_surface->total_offset();
     auto const position_on_target = std::make_pair(
         root_position.first - offset.dx.as_int(),
         root_position.second - offset.dy.as_int());
 
-    if (surface_under_cursor && &surface_under_cursor.value() == target_surface)
+    if (!surface_under_cursor || &surface_under_cursor.value() != target_surface)
     {
-        send_motion_event(
-            ms.count(),
-            position_on_target.first,
-            position_on_target.second);
-        can_send_frame = true;
-    }
-    else
-    {
-        leave();
+        // We need to switch surfaces
+        leave(event); // If we're currently on a surface, leave it
         auto const serial = wl_display_next_serial(display);
         cursor->apply_to(target_surface);
         send_enter_event(
@@ -246,15 +256,54 @@ void mf::WlPointer::send_update(
             target_surface->raw_resource(),
             position_on_target.first,
             position_on_target.second);
-        can_send_frame = true;
+        current_position = position_on_target;
+        needs_frame = true;
         destroy_listener_id = target_surface->add_destroy_listener(
             [this]()
             {
-                leave();
+                leave(std::nullopt);
+                maybe_frame();
             });
         surface_under_cursor = mw::make_weak(target_surface);
-
     }
+    else if (!relative_pointer && position_on_target != current_position)
+    {
+        send_motion_event(
+            WlSeat::timestamp_of(event),
+            position_on_target.first,
+            position_on_target.second);
+        current_position = position_on_target;
+        needs_frame = true;
+    }
+}
+
+void mf::WlPointer::relative_motion(MirPointerEvent const* event)
+{
+    if (!relative_pointer)
+    {
+        return;
+    }
+    auto const motion = std::make_pair(
+        mir_pointer_event_axis_value(event, mir_pointer_axis_relative_x),
+        mir_pointer_event_axis_value(event, mir_pointer_axis_relative_y));
+    if (motion.first || motion.second)
+    {
+        auto const timestamp = WlSeat::timestamp_of(event);
+        relative_pointer.value().send_relative_motion_event(
+            timestamp, timestamp,
+            motion.first, motion.second,
+            motion.first, motion.second);
+        needs_frame = true;
+    }
+}
+
+void mf::WlPointer::maybe_frame()
+{
+    if (needs_frame && version_supports_frame())
+    {
+        send_frame_event();
+    }
+    needs_frame = false;
 }
 
 namespace
@@ -323,22 +372,6 @@ void mf::WlPointer::set_cursor(
 void mf::WlPointer::release()
 {
     destroy_wayland_object();
-}
-
-void mir::frontend::WlPointer::set_relative_pointer(mir::wayland::RelativePointerV1* relative_ptr)
-{
-    relative_pointer = make_weak(relative_ptr);
-}
-
-void mir::frontend::WlPointer::motion(const std::chrono::milliseconds& ms, std::pair<float, float> const movement)
-{
-    if (relative_pointer)
-    {
-        relative_pointer.value().send_relative_motion_event(
-            ms.count(), ms.count(),
-            movement.first, movement.second,
-            movement.first, movement.second);
-    }
 }
 
 WlSurfaceCursor::WlSurfaceCursor(mf::WlSurface* surface, geom::Displacement hotspot)

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -189,7 +189,8 @@ void mf::WlPointer::buttons(MirPointerEvent const* event)
             bool const pressed = (mapping.first & event_buttons);
             auto const state = pressed ? ButtonState::pressed : ButtonState::released;
             auto const serial = wl_display_next_serial(display);
-            send_button_event(serial, WlSeat::timestamp_of(event), mapping.second, state);
+            auto const timestamp = mir_input_event_get_wayland_timestamp(mir_pointer_event_input_event(event));
+            send_button_event(serial, timestamp, mapping.second, state);
             needs_frame = true;
         }
     }
@@ -201,11 +202,12 @@ void mf::WlPointer::axis(MirPointerEvent const* event)
 {
     auto const h_scroll = mir_pointer_event_axis_value(event, mir_pointer_axis_hscroll);
     auto const v_scroll = mir_pointer_event_axis_value(event, mir_pointer_axis_vscroll);
+    auto const timestamp = mir_input_event_get_wayland_timestamp(mir_pointer_event_input_event(event));
 
     if (h_scroll)
     {
         send_axis_event(
-            WlSeat::timestamp_of(event),
+            timestamp,
             Axis::horizontal_scroll,
             h_scroll);
         needs_frame = true;
@@ -214,7 +216,7 @@ void mf::WlPointer::axis(MirPointerEvent const* event)
     if (v_scroll)
     {
         send_axis_event(
-            WlSeat::timestamp_of(event),
+            timestamp,
             Axis::vertical_scroll,
             v_scroll);
         needs_frame = true;
@@ -268,8 +270,9 @@ void mf::WlPointer::enter_or_motion(MirPointerEvent const* event, WlSurface& roo
     }
     else if (!relative_pointer && position_on_target != current_position)
     {
+        auto const timestamp = mir_input_event_get_wayland_timestamp(mir_pointer_event_input_event(event));
         send_motion_event(
-            WlSeat::timestamp_of(event),
+            timestamp,
             position_on_target.first,
             position_on_target.second);
         current_position = position_on_target;
@@ -288,7 +291,7 @@ void mf::WlPointer::relative_motion(MirPointerEvent const* event)
         mir_pointer_event_axis_value(event, mir_pointer_axis_relative_y));
     if (motion.first || motion.second)
     {
-        auto const timestamp = WlSeat::timestamp_of(event);
+        auto const timestamp = mir_input_event_get_wayland_timestamp(mir_pointer_event_input_event(event));
         relative_pointer.value().send_relative_motion_event(
             timestamp, timestamp,
             motion.first, motion.second,

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -54,35 +54,25 @@ public:
 
     void set_relative_pointer(wayland::RelativePointerV1* relative_ptr);
 
-    /// Handles finding the correct subsurface and position on that subsurface if needed
-    /// Giving it an already transformed surface and position is also fine
-    void enter(
-        std::chrono::milliseconds const& ms,
-        WlSurface* root_surface,
-        std::pair<float, float> const& root_position);
-    void leave();
-    void button(std::chrono::milliseconds const& ms, uint32_t button, bool pressed);
-    void position(
-        std::chrono::milliseconds const& ms,
-        WlSurface* root_surface,
-        std::pair<float, float> const& root_position);
-    void axis(std::chrono::milliseconds const& ms, std::pair<float, float> const& scroll);
-    void motion(const std::chrono::milliseconds& ms, std::pair<float, float> const movement);
-    void frame();
+    /// Convert the Mir event into Wayland events and send them to the client. root_surface is the one that received
+    /// the Mir event, but the final Wayland event may be sent to a subsurface.
+    void event(MirPointerEvent const* event, WlSurface& root_surface);
 
     struct Cursor;
 
 private:
     wl_display* const display;
 
-    bool can_send_frame{false};
-    wayland::Weak<WlSurface> surface_under_cursor;
-    wayland::DestroyListenerId destroy_listener_id;
-
-    void send_update(
-        std::chrono::milliseconds const& ms,
-        WlSurface* target_surface,
-        std::pair<float, float> const& root_position);
+    void leave(std::optional<MirPointerEvent const*> event);
+    void buttons(MirPointerEvent const* event);
+    void axis(MirPointerEvent const* event);
+    /// Handles finding the correct subsurface and position on that subsurface if needed
+    /// Giving it an already transformed surface and position is also fine
+    void enter_or_motion(MirPointerEvent const* event, WlSurface& root_surface);
+    /// Sends relative motion only if the relative pointer is set
+    void relative_motion(MirPointerEvent const* event);
+    /// Sends a frame event only if needed, leaves needs_frame false
+    void maybe_frame();
 
     /// Wayland request handlers
     ///@{
@@ -94,7 +84,11 @@ private:
     void release() override;
     ///@}
 
-    std::set<uint32_t> pressed_buttons;
+    wayland::Weak<WlSurface> surface_under_cursor;
+    wayland::DestroyListenerId destroy_listener_id; ///< ID of this pointer's destroy listener on surface_under_cursor
+    bool needs_frame{false};
+    MirPointerButtons current_buttons{0};
+    std::experimental::optional<std::pair<float, float>> current_position;
     std::unique_ptr<Cursor> cursor;
     wayland::Weak<wayland::RelativePointerV1> relative_pointer;
 };

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -189,28 +189,6 @@ auto mf::WlSeat::from(struct wl_resource* seat) -> WlSeat*
     return static_cast<mf::WlSeat::Instance*>(wayland::Seat::from(seat))->seat;
 }
 
-auto mf::WlSeat::timestamp_of(MirInputEvent const* event) -> uint32_t
-{
-    auto const ns = std::chrono::nanoseconds{mir_input_event_get_event_time(event)};
-    auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(ns);
-    return ms.count();
-}
-
-auto mf::WlSeat::timestamp_of(MirKeyboardEvent const* event) -> uint32_t
-{
-    return timestamp_of(mir_keyboard_event_input_event(event));
-}
-
-auto mf::WlSeat::timestamp_of(MirPointerEvent const* event) -> uint32_t
-{
-    return timestamp_of(mir_pointer_event_input_event(event));
-}
-
-auto mf::WlSeat::timestamp_of(MirTouchEvent const* event) -> uint32_t
-{
-    return timestamp_of(mir_touch_event_input_event(event));
-}
-
 void mf::WlSeat::for_each_listener(wl_client* client, std::function<void(WlPointer*)> func)
 {
     pointer_listeners->for_each(client, func);

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -189,6 +189,28 @@ auto mf::WlSeat::from(struct wl_resource* seat) -> WlSeat*
     return static_cast<mf::WlSeat::Instance*>(wayland::Seat::from(seat))->seat;
 }
 
+auto mf::WlSeat::timestamp_of(MirInputEvent const* event) -> uint32_t
+{
+    auto const ns = std::chrono::nanoseconds{mir_input_event_get_event_time(event)};
+    auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(ns);
+    return ms.count();
+}
+
+auto mf::WlSeat::timestamp_of(MirKeyboardEvent const* event) -> uint32_t
+{
+    return timestamp_of(mir_keyboard_event_input_event(event));
+}
+
+auto mf::WlSeat::timestamp_of(MirPointerEvent const* event) -> uint32_t
+{
+    return timestamp_of(mir_pointer_event_input_event(event));
+}
+
+auto mf::WlSeat::timestamp_of(MirTouchEvent const* event) -> uint32_t
+{
+    return timestamp_of(mir_touch_event_input_event(event));
+}
+
 void mf::WlSeat::for_each_listener(wl_client* client, std::function<void(WlPointer*)> func)
 {
     pointer_listeners->for_each(client, func);

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -63,14 +63,6 @@ public:
 
     static auto from(struct wl_resource* seat) -> WlSeat*;
 
-    /// Returns the timestamp of the event in milliseconds, suitable for Wayland events
-    /// @{
-    static auto timestamp_of(MirInputEvent const* event) -> uint32_t;
-    static auto timestamp_of(MirKeyboardEvent const* event) -> uint32_t;
-    static auto timestamp_of(MirPointerEvent const* event) -> uint32_t;
-    static auto timestamp_of(MirTouchEvent const* event) -> uint32_t;
-    /// @}
-
     void for_each_listener(wl_client* client, std::function<void(WlPointer*)> func);
     void for_each_listener(wl_client* client, std::function<void(WlKeyboard*)> func);
     void for_each_listener(wl_client* client, std::function<void(WlTouch*)> func);

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -27,6 +27,9 @@
 
 // from "mir_toolkit/events/event.h"
 struct MirInputEvent;
+struct MirKeyboardEvent;
+struct MirPointerEvent;
+struct MirTouchEvent;
 struct MirSurfaceEvent;
 typedef struct MirSurfaceEvent MirWindowEvent;
 struct MirKeymapEvent;
@@ -59,6 +62,14 @@ public:
     ~WlSeat();
 
     static auto from(struct wl_resource* seat) -> WlSeat*;
+
+    /// Returns the timestamp of the event in milliseconds, suitable for Wayland events
+    /// @{
+    static auto timestamp_of(MirInputEvent const* event) -> uint32_t;
+    static auto timestamp_of(MirKeyboardEvent const* event) -> uint32_t;
+    static auto timestamp_of(MirPointerEvent const* event) -> uint32_t;
+    static auto timestamp_of(MirTouchEvent const* event) -> uint32_t;
+    /// @}
 
     void for_each_listener(wl_client* client, std::function<void(WlPointer*)> func);
     void for_each_listener(wl_client* client, std::function<void(WlKeyboard*)> func);

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -50,7 +50,7 @@ mf::WlTouch::~WlTouch()
 
 void mf::WlTouch::event(MirTouchEvent const* event, WlSurface& root_surface)
 {
-    std::chrono::milliseconds timestamp{WlSeat::timestamp_of(event)};
+    std::chrono::milliseconds timestamp{mir_input_event_get_wayland_timestamp(mir_touch_event_input_event(event))};
 
     for (auto i = 0u; i < mir_touch_event_point_count(event); ++i)
     {


### PR DESCRIPTION
Lot of code churn, but the logic stays roughly the same. This sends the Mir events into `WlKeyboard`/`WlPointer`/`WlTouch` instead of extracting information from them. This is step in the direction of addressing #1792. We want to attach serials to input events, and this moves the events to where we'll need them to do that.