### PR TITLE
Improve HiDPI support for XWayland

### DIFF
--- a/include/client/mir/events/event_builders.h
+++ b/include/client/mir/events/event_builders.h
@@ -105,6 +105,7 @@ EventUPtr make_event(MirInputDeviceId device_id, std::chrono::nanoseconds timest
 
 EventUPtr clone_event(MirEvent const& event);
 void transform_positions(MirEvent& event, mir::geometry::Displacement const& movement);
+void scale_positions(MirEvent& event, float scale);
 void set_window_id(MirEvent& event, int window_id);
 
 EventUPtr make_start_drag_and_drop_event(frontend::SurfaceId const& surface_id, std::vector<uint8_t> const& handle);

--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -50,6 +50,7 @@ extern char const* const debug_opt;
 extern char const* const composite_delay_opt;
 extern char const* const enable_key_repeat_opt;
 extern char const* const x11_display_opt;
+extern char const* const x11_scale_opt;
 extern char const* const wayland_extensions_opt;
 extern char const* const add_wayland_extensions_opt;
 extern char const* const drop_wayland_extensions_opt;

--- a/src/client/events/event_builders.cpp
+++ b/src/client/events/event_builders.cpp
@@ -315,6 +315,29 @@ void mev::transform_positions(MirEvent& event, mir::geometry::Displacement const
     }
 }
 
+void mev::scale_positions(MirEvent& event, float scale)
+{
+    if (event.type() == mir_event_type_input)
+    {
+        auto const input_type = event.to_input()->input_type();
+        if (input_type == mir_input_event_type_pointer)
+        {
+            auto pev = event.to_input()->to_pointer();
+            pev->set_x(pev->x() * scale);
+            pev->set_y(pev->y() * scale);
+        }
+        else if (input_type == mir_input_event_type_touch)
+        {
+            auto tev = event.to_input()->to_touch();
+            for (unsigned i = 0; i < tev->pointer_count(); i++)
+            {
+                tev->set_x(i, tev->x(i) * scale);
+                tev->set_y(i, tev->y(i) * scale);
+            }
+        }
+    }
+}
+
 mir::EventUPtr mev::make_event(MirInputDeviceId device_id, std::chrono::nanoseconds timestamp,
                                std::vector<uint8_t> const& cookie, MirInputEventModifiers modifiers,
                                std::vector<mev::ContactState> const& contacts)

--- a/src/client/symbols.map
+++ b/src/client/symbols.map
@@ -532,6 +532,7 @@ MIR_CLIENT_DETAIL_2.0 {
       mir::client::DefaultConnectionConfiguration::the_error_handler*;
       mir::events::clone_event*;
       mir::events::transform_positions*;
+      mir::events::scale_positions*;
 
       mir::client::to_client_context*;
 

--- a/src/miral/x11_support.cpp
+++ b/src/miral/x11_support.cpp
@@ -43,6 +43,11 @@ void miral::X11Support::operator()(mir::Server& server) const
         "Enable X11 support", mir::OptionType::null);
 
     server.add_configuration_option(
+        mo::x11_scale_opt,
+        "The scale to assume X11 apps use. If unset uses the value of GDK_SCALE or 1. Can be fractional",
+        mir::OptionType::string);
+
+    server.add_configuration_option(
         "xwayland-path",
         "Path to Xwayland executable", "/usr/bin/Xwayland");
 

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -50,6 +50,7 @@ char const* const mo::debug_opt                   = "debug";
 char const* const mo::composite_delay_opt         = "composite-delay";
 char const* const mo::enable_key_repeat_opt       = "enable-key-repeat";
 char const* const mo::x11_display_opt             = "enable-x11";
+char const* const mo::x11_scale_opt               = "x11-scale";
 char const* const mo::wayland_extensions_opt      = "wayland-extensions";
 char const* const mo::add_wayland_extensions_opt  = "add-wayland-extensions";
 char const* const mo::drop_wayland_extensions_opt = "drop-wayland-extensions";

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -194,3 +194,10 @@ MIRPLATFORM_2.3 {
     mir::graphics::LinuxDmaBufUnstable::buffer_from_resource*;
   };
 } MIRPLATFORM_2.2;
+
+MIRPLATFORM_2.4 {
+ global:
+  extern "C++" {
+    mir::options::x11_scale_opt;
+  };
+} MIRPLATFORM_2.3;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -192,12 +192,6 @@ MIRPLATFORM_2.3 {
     mir::graphics::LinuxDmaBufUnstable::LinuxDmaBufUnstable*;
     mir::graphics::LinuxDmaBufUnstable::?LinuxDmaBufUnstable*;
     mir::graphics::LinuxDmaBufUnstable::buffer_from_resource*;
-  };
-} MIRPLATFORM_2.2;
-
-MIRPLATFORM_2.4 {
- global:
-  extern "C++" {
     mir::options::x11_scale_opt;
   };
-} MIRPLATFORM_2.3;
+} MIRPLATFORM_2.2;

--- a/src/platforms/x11/graphics/platform.cpp
+++ b/src/platforms/x11/graphics/platform.cpp
@@ -41,9 +41,13 @@ auto parse_size_dimension(std::string const& str) -> int
             BOOST_THROW_EXCEPTION(std::runtime_error("Output dimensions must be greater than zero"));
         return value;
     }
-    catch (std::invalid_argument const &e)
+    catch (std::invalid_argument const &)
     {
         BOOST_THROW_EXCEPTION(std::runtime_error("Output dimension \"" + str + "\" is not a valid number"));
+    }
+    catch (std::out_of_range const &)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("Output dimension \"" + str + "\" is out of range"));
     }
 }
 
@@ -59,9 +63,13 @@ auto parse_scale(std::string const& str) -> float
             BOOST_THROW_EXCEPTION(std::runtime_error("Scale must be greater than zero"));
         return value;
     }
-    catch (std::invalid_argument const &e)
+    catch (std::invalid_argument const &)
     {
         BOOST_THROW_EXCEPTION(std::runtime_error("Scale \"" + str + "\" is not a valid float"));
+    }
+    catch (std::out_of_range const &)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("Scale \"" + str + "\" is out of range"));
     }
 }
 

--- a/src/server/frontend_wayland/wl_client.h
+++ b/src/server/frontend_wayland/wl_client.h
@@ -67,6 +67,13 @@ public:
     /// individual apps.
     auto client_session() const -> std::shared_ptr<scene::Session> { return session; }
 
+    /// The XDG output protocol implementation sends the Mir-internal logical position and scale of outputs multiplied
+    /// by this. It's currently just used by XWayland.
+    /// @{
+    auto set_output_geometry_scale(float scale) { output_geometry_scale_ = scale; }
+    auto output_geometry_scale() -> float { return output_geometry_scale_; }
+    /// @}
+
 private:
     WlClient(wl_client* client, std::shared_ptr<scene::Session> const& session, shell::Shell* shell);
 
@@ -76,6 +83,8 @@ private:
     shell::Shell* const shell;
     wl_client* const client;
     std::shared_ptr<scene::Session> const session;
+
+    float output_geometry_scale_{1};
 };
 }
 }

--- a/src/server/frontend_wayland/xdg_output_v1.cpp
+++ b/src/server/frontend_wayland/xdg_output_v1.cpp
@@ -19,6 +19,7 @@
 #include "xdg_output_v1.h"
 
 #include "wl_surface.h"
+#include "wl_client.h"
 #include "xdg-output-unstable-v1_wrapper.h"
 #include "mir/log.h"
 #include "output_manager.h"
@@ -68,6 +69,8 @@ public:
 
 private:
     void destroy();
+
+    float const geometry_scale;
 };
 
 }
@@ -138,11 +141,16 @@ mf::XdgOutputV1::XdgOutputV1(
     wl_resource* new_resource,
     mg::DisplayConfigurationOutput const& config,
     wl_resource* wl_output_resource)
-    : mw::XdgOutputV1(new_resource, Version<3>())
+    : mw::XdgOutputV1(new_resource, Version<3>()),
+      geometry_scale{WlClient::from(client)->output_geometry_scale()}
 {
     auto extents = config.extents();
-    send_logical_position_event(extents.left().as_int(), extents.top().as_int());
-    send_logical_size_event(extents.size.width.as_int(), extents.size.height.as_int());
+    send_logical_position_event(
+        extents.top_left.x.as_int() * geometry_scale,
+        extents.top_left.y.as_int() * geometry_scale);
+    send_logical_size_event(
+        extents.size.width.as_int() * geometry_scale,
+        extents.size.height.as_int() * geometry_scale);
     if (version_supports_name())
     {
         // TODO: Better output names that are consistant between sessions

--- a/src/server/frontend_xwayland/CMakeLists.txt
+++ b/src/server/frontend_xwayland/CMakeLists.txt
@@ -15,6 +15,7 @@ set(
   xwayland_surface_observer.cpp xwayland_surface_observer.h
                           xwayland_surface_observer_surface.h
   xwayland_wm_shell.cpp   xwayland_wm_shell.h
+  scaled_buffer_stream.cpp scaled_buffer_stream.h
 )
 
 add_definitions(-DMIR_LOG_COMPONENT="xwayland")

--- a/src/server/frontend_xwayland/scaled_buffer_stream.cpp
+++ b/src/server/frontend_xwayland/scaled_buffer_stream.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "scaled_buffer_stream.h"
+#include "mir/log.h"
+
+namespace mf = mir::frontend;
+
+mf::ScaledBufferStream::ScaledBufferStream(std::shared_ptr<compositor::BufferStream>&& inner, float scale)
+    : inner{std::move(inner)},
+      inv_scale{1.0f / scale}
+{
+}
+
+void mf::ScaledBufferStream::submit_buffer(std::shared_ptr<graphics::Buffer> const& buffer)
+{
+    inner->submit_buffer(buffer);
+}
+
+void mf::ScaledBufferStream::set_frame_posted_callback(std::function<void(geometry::Size const&)> const& callback)
+{
+    // Does this need to be scaled? I don't ? think ? so? compositor::Stream seems to leave it unscaled.
+    inner->set_frame_posted_callback(callback);
+}
+
+void mf::ScaledBufferStream::with_most_recent_buffer_do(std::function<void(graphics::Buffer&)> const& exec)
+{
+    inner->with_most_recent_buffer_do(exec);
+}
+
+MirPixelFormat mf::ScaledBufferStream::pixel_format() const
+{
+    return inner->pixel_format();
+}
+
+void mf::ScaledBufferStream::allow_framedropping(bool allow)
+{
+    inner->allow_framedropping(allow);
+}
+
+void mf::ScaledBufferStream::set_scale(float scale)
+{
+    // Pass on the given scale to the inner stream, this is unrelated from the scale we apply.
+    inner->set_scale(scale);
+}
+
+auto mf::ScaledBufferStream::lock_compositor_buffer(void const* user_id) -> std::shared_ptr<graphics::Buffer>
+{
+    return inner->lock_compositor_buffer(user_id);
+}
+
+auto mf::ScaledBufferStream::stream_size() -> geometry::Size
+{
+    // This is it. This is what the whole class is for.
+    return inner->stream_size() * inv_scale;
+}
+
+auto mf::ScaledBufferStream::buffers_ready_for_compositor(void const* user_id) const -> int
+{
+    return inner->buffers_ready_for_compositor(user_id);
+}
+
+void mf::ScaledBufferStream::drop_old_buffers()
+{
+    inner->drop_old_buffers();
+}
+
+auto mf::ScaledBufferStream::has_submitted_buffer() const -> bool
+{
+    return inner->has_submitted_buffer();
+}
+
+auto mf::ScaledBufferStream::framedropping() const -> bool
+{
+    return inner->framedropping();
+}
+
+

--- a/src/server/frontend_xwayland/scaled_buffer_stream.h
+++ b/src/server/frontend_xwayland/scaled_buffer_stream.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_FRONTEND_SCALED_BUFFER_STREAM_H
+#define MIR_FRONTEND_SCALED_BUFFER_STREAM_H
+
+#include "mir/compositor/buffer_stream.h"
+
+namespace mir
+{
+namespace frontend
+{
+/// Wrappes another buffer stream and scales it's size, which is required for scaling XWayland surfaces without messing
+/// with the scale of the buffer stream owned by the underlying WlSurface.
+///
+/// Note that even though shell->modify_surface() takes a frontend::BufferStream, this must implement
+/// compositor::BufferStream as well because some dynamic casting happens somewhere.
+class ScaledBufferStream : public compositor::BufferStream
+{
+public:
+    ScaledBufferStream(std::shared_ptr<compositor::BufferStream>&& inner, float scale);
+
+    /// Overrides from frontend::BufferStream
+    /// @{
+    void submit_buffer(std::shared_ptr<graphics::Buffer> const& buffer);
+    void set_frame_posted_callback(std::function<void(geometry::Size const&)> const& callback);
+    void with_most_recent_buffer_do(std::function<void(graphics::Buffer&)> const& exec);
+    MirPixelFormat pixel_format() const;
+    void allow_framedropping(bool allow);
+    void set_scale(float scale);
+    /// @}
+
+    /// Overrides from compositor::BufferStream
+    /// @{
+    auto lock_compositor_buffer(void const* user_id) -> std::shared_ptr<graphics::Buffer>;
+    auto stream_size() -> geometry::Size;
+    auto buffers_ready_for_compositor(void const* user_id) const -> int;
+    void drop_old_buffers();
+    auto has_submitted_buffer() const -> bool;
+    auto framedropping() const -> bool;
+    /// @}
+
+private:
+    std::shared_ptr<compositor::BufferStream> const inner;
+    float const inv_scale;
+};
+}
+}
+
+#endif // MIR_FRONTEND_SCALED_BUFFER_STREAM_H

--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -35,9 +35,11 @@ namespace md = mir::dispatch;
 
 mf::XWaylandConnector::XWaylandConnector(
     std::shared_ptr<WaylandConnector> const& wayland_connector,
-    std::string const& xwayland_path)
+    std::string const& xwayland_path,
+    float scale)
     : wayland_connector{wayland_connector},
-      xwayland_path{xwayland_path}
+      xwayland_path{xwayland_path},
+      scale{scale}
 {
     if (access(xwayland_path.c_str(), F_OK | X_OK) != 0)
     {

--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -188,7 +188,8 @@ void mf::XWaylandConnector::spawn()
         wm = std::make_unique<XWaylandWM>(
             wayland_connector,
             server->client(),
-            x11_socket_pair.first);
+            x11_socket_pair.first,
+            scale);
         mir::log_info("XWayland is running");
     }
     catch (...)

--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -181,7 +181,8 @@ void mf::XWaylandConnector::spawn()
             *spawner,
             xwayland_path,
             wayland_socket_pair,
-            x11_socket_pair.second);
+            x11_socket_pair.second,
+            scale);
         wm = std::make_unique<XWaylandWM>(
             wayland_connector,
             server->client(),

--- a/src/server/frontend_xwayland/xwayland_connector.h
+++ b/src/server/frontend_xwayland/xwayland_connector.h
@@ -41,9 +41,15 @@ class XWaylandWM;
 class XWaylandConnector : public Connector
 {
 public:
+    /// Scale is a little complicated. It controls how big apps appear but *probably* not the scale they render at
+    /// (unless they respect the X11 DPI, which most don't). For sharp, correctly sized apps the output scale, XWayland
+    /// scale and the scale the application uses should all match. Application scale needs to be configured on a per-app
+    /// or even per-toolkit basis. GDK_SCALE is used by default for XWayland scale because many apps respect it, so it's
+    /// generally as correct as anything.
     XWaylandConnector(
         std::shared_ptr<WaylandConnector> const& wayland_connector,
-        std::string const& xwayland_path);
+        std::string const& xwayland_path,
+        float scale);
     ~XWaylandConnector();
 
     void start() override;
@@ -58,7 +64,7 @@ public:
 private:
     std::shared_ptr<WaylandConnector> const wayland_connector;
     std::string const xwayland_path;
-    float const scale{1};
+    float const scale;
 
     void spawn();
 

--- a/src/server/frontend_xwayland/xwayland_connector.h
+++ b/src/server/frontend_xwayland/xwayland_connector.h
@@ -58,6 +58,7 @@ public:
 private:
     std::shared_ptr<WaylandConnector> const wayland_connector;
     std::string const xwayland_path;
+    float const scale{1};
 
     void spawn();
 

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -43,7 +43,8 @@ public:
         XWaylandSpawner const& spawner,
         std::string const& xwayland_path,
         std::pair<mir::Fd, mir::Fd> const& wayland_socket_pair,
-        mir::Fd const& x11_server_fd);
+        mir::Fd const& x11_server_fd,
+        float scale);
     ~XWaylandServer();
 
     auto client() const -> wl_client* { return wayland_client; }

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -214,13 +214,15 @@ mf::XWaylandSurface::XWaylandSurface(
     std::shared_ptr<XWaylandClientManager> const& client_manager,
     xcb_window_t window,
     geometry::Rectangle const& geometry,
-    bool override_redirect)
+    bool override_redirect,
+    float scale)
     : xwm(wm),
       connection{connection},
       wm_shell{wm_shell},
       shell{wm_shell.shell},
       client_manager{client_manager},
       window(window),
+      scale{scale},
       property_handlers{
           property_handler<std::string>(
               connection,

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -21,6 +21,7 @@
 #include "xwayland_surface_observer.h"
 #include "xwayland_client_manager.h"
 #include "xwayland_wm_shell.h"
+#include "xwayland_surface_role.h"
 
 #include "mir/frontend/wayland.h"
 #include "mir/scene/surface_creation_parameters.h"
@@ -605,6 +606,7 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
 
     WindowState state;
     shell::SurfaceSpecification spec;
+    std::vector<std::shared_ptr<void>> keep_alive_until_spec_is_used;
 
     auto const observer = std::make_shared<XWaylandSurfaceObserver>(
         *wm_shell.wayland_executor,
@@ -624,12 +626,8 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
         state = cached.state;
         state.withdrawn = false;
 
-        spec.streams = std::vector<shell::StreamSpecification>{};
-        spec.input_shape = std::vector<geom::Rectangle>{};
-        wl_surface->populate_surface_data(
-            spec.streams.value(),
-            spec.input_shape.value(),
-            {});
+        XWaylandSurfaceRole::populate_surface_data_scaled(wl_surface, scale, spec, keep_alive_until_spec_is_used);
+
         spec.width = cached.size.width;
         spec.height = cached.size.height;
         spec.top_left = cached.top_left;

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -631,7 +631,8 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
         *wm_shell.wayland_executor,
         wm_shell.seat,
         wl_surface,
-        this);
+        this,
+        scale);
 
     {
         std::lock_guard<std::mutex> lock{mutex};

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -140,10 +140,26 @@ private:
     /// Appplies any mods in nullable_pending_spec to the scene_surface (if any)
     void apply_any_mods_to_scene_surface();
 
+    /// Sets the position specified by the spec. top_left is always in global XWayland coordinates, even if parent is
+    /// not null. If parent is given, it is set as the parent and an aux rect for relative placement is calculated. if
+    /// parent is null, the location is specified in the global XWayland coordinates given. As always, you should call
+    /// scale_surface_spec() before sending this spec to Mir.
+    void surface_spec_set_position(
+        shell::SurfaceSpecification& spec,
+        scene::Surface* parent,
+        geometry::Point top_left);
+
     /// One-stop-shop for scaling window modifications. Unlike with scaled Wayland surfaces, all the data going to and
     /// from the client is in raw pixels, but Mir internally deals with scaled coordinates. This means before punting
     /// our data off to Mir we need to scale it, which is what this function is for.
     void scale_surface_spec(shell::SurfaceSpecification& mods);
+
+    /// Return data from any surface scaled to XWayland coordinates
+    /// @{
+    auto scaled_top_left_of(scene::Surface const& surface) -> geometry::Point;
+    auto scaled_content_offset_of(scene::Surface const& surface) -> geometry::Displacement;
+    auto scaled_content_size_of(scene::Surface const& surface) -> geometry::Size;
+    /// @}
 
     void window_type(std::vector<xcb_atom_t> const& wm_types);
     void set_parent(xcb_window_t xcb_window, std::lock_guard<std::mutex> const&);

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -56,7 +56,8 @@ public:
         std::shared_ptr<XWaylandClientManager> const& client_manager,
         xcb_window_t window,
         geometry::Rectangle const& geometry,
-        bool override_redirect);
+        bool override_redirect,
+        float scale);
     ~XWaylandSurface();
 
     void map();
@@ -151,6 +152,7 @@ private:
     std::shared_ptr<shell::Shell> const shell;
     std::shared_ptr<XWaylandClientManager> const client_manager;
     xcb_window_t const window;
+    float const scale;
     std::map<xcb_window_t, std::function<std::function<void()>()>> const property_handlers;
 
     std::mutex mutable mutex;

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -140,6 +140,11 @@ private:
     /// Appplies any mods in nullable_pending_spec to the scene_surface (if any)
     void apply_any_mods_to_scene_surface();
 
+    /// One-stop-shop for scaling window modifications. Unlike with scaled Wayland surfaces, all the data going to and
+    /// from the client is in raw pixels, but Mir internally deals with scaled coordinates. This means before punting
+    /// our data off to Mir we need to scale it, which is what this function is for.
+    void scale_surface_spec(shell::SurfaceSpecification& mods);
+
     void window_type(std::vector<xcb_atom_t> const& wm_types);
     void set_parent(xcb_window_t xcb_window, std::lock_guard<std::mutex> const&);
     void fix_parent_if_necessary(const std::lock_guard<std::mutex>& lock);

--- a/src/server/frontend_xwayland/xwayland_surface_observer.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.cpp
@@ -40,11 +40,13 @@ mf::XWaylandSurfaceObserver::XWaylandSurfaceObserver(
     Executor& wayland_executor,
     WlSeat& seat,
     WlSurface* wl_surface,
-    XWaylandSurfaceObserverSurface* wm_surface)
+    XWaylandSurfaceObserverSurface* wm_surface,
+    float scale)
     : wm_surface{wm_surface},
       wayland_executor{wayland_executor},
       input_dispatcher{std::make_shared<ThreadsafeInputDispatcher>(
-          std::make_unique<WaylandInputDispatcher>(&seat, wl_surface))}
+          std::make_unique<WaylandInputDispatcher>(&seat, wl_surface))},
+      scale{scale}
 {
 }
 
@@ -81,12 +83,12 @@ void mf::XWaylandSurfaceObserver::attrib_changed(ms::Surface const*, MirWindowAt
 
 void mf::XWaylandSurfaceObserver::content_resized_to(ms::Surface const*, geom::Size const& content_size)
 {
-    wm_surface->scene_surface_resized(content_size);
+    wm_surface->scene_surface_resized(content_size * scale);
 }
 
 void mf::XWaylandSurfaceObserver::moved_to(ms::Surface const*, geom::Point const& top_left)
 {
-    wm_surface->scene_surface_moved_to(top_left);
+    wm_surface->scene_surface_moved_to(as_point(as_displacement(top_left) * scale));
 }
 
 void mf::XWaylandSurfaceObserver::client_surface_close_requested(ms::Surface const*)

--- a/src/server/frontend_xwayland/xwayland_surface_observer.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.cpp
@@ -119,6 +119,7 @@ void mf::XWaylandSurfaceObserver::input_consumed(ms::Surface const*, MirEvent co
     if (mir_event_get_type(event) == mir_event_type_input)
     {
         std::shared_ptr<MirEvent> owned_event = mev::clone_event(*event);
+        mev::scale_positions(*owned_event, scale);
 
         aquire_input_dispatcher(
             [owned_event](auto input_dispatcher)

--- a/src/server/frontend_xwayland/xwayland_surface_observer.h
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.h
@@ -48,7 +48,8 @@ public:
         Executor& wayland_executor,
         WlSeat& seat,
         WlSurface* wl_surface,
-        XWaylandSurfaceObserverSurface* wm_surface);
+        XWaylandSurfaceObserverSurface* wm_surface,
+        float scale);
     ~XWaylandSurfaceObserver();
 
     /// Overrides from scene::SurfaceObserver
@@ -86,6 +87,7 @@ private:
     XWaylandSurfaceObserverSurface* const wm_surface;
     Executor& wayland_executor;
     std::shared_ptr<ThreadsafeInputDispatcher> const input_dispatcher;
+    float const scale;
 
     /// Runs work on the Wayland thread if the input dispatcher still exists
     /// Does nothing if the input dispatcher has already been destroyed

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -33,11 +33,14 @@ namespace geom = mir::geometry;
 mf::XWaylandSurfaceRole::XWaylandSurfaceRole(
     std::shared_ptr<shell::Shell> const& shell,
     std::shared_ptr<XWaylandSurfaceRoleSurface> const& wm_surface,
-    WlSurface* wl_surface)
+    WlSurface* wl_surface,
+    float scale)
     : shell{shell},
       weak_wm_surface{wm_surface},
-      wl_surface{wl_surface}
+      wl_surface{wl_surface},
+      scale{scale}
 {
+    (void)this->scale;
     wl_surface->set_role(this);
     if (verbose_xwayland_logging_enabled())
     {

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -82,11 +82,19 @@ void mf::XWaylandSurfaceRole::populate_surface_data(shell::SurfaceSpecification&
         stream.displacement = stream.displacement * inv_scale;
     }
 
+    // we *should* be scaling the input shape, however when it's not set explicitly (which it doesn't seem to be for
+    // XWayland apps) the surface is setting it based on the buffer size. Since we're scaling the buffer stream, it's
+    // seeing it's buffer size in Mir coordinates rather than XWayland ones (it should be XWayland). This might cause
+    // other problems (especially around selecting the right subsurface to dispatch input to), but that doesn't seem to
+    // be an issue at this time (probably because XWayland doesn't make subsurfaces either). Anyway, we need to sort
+    // this all out but it makes sense to wait until we've made subsurfaces real surfaces and simplified all that logic.
+    /*
     for (auto& rect : spec.input_shape.value())
     {
         rect.top_left = as_point(as_displacement(rect.top_left) * inv_scale);
         rect.size = rect.size * inv_scale;
     }
+    */
 }
 
 auto mf::XWaylandSurfaceRole::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>

--- a/src/server/frontend_xwayland/xwayland_surface_role.h
+++ b/src/server/frontend_xwayland/xwayland_surface_role.h
@@ -32,6 +32,7 @@ class Surface;
 namespace shell
 {
 class Shell;
+struct SurfaceSpecification;
 }
 namespace frontend
 {
@@ -55,6 +56,10 @@ private:
     std::weak_ptr<XWaylandSurfaceRoleSurface> const weak_wm_surface;
     WlSurface* const wl_surface;
     float const scale;
+
+    /// Populates the data from the surface and scales it from XWayland coordinates (which the XWayland-connected
+    /// WlSurface uses) to Mir coordinates
+    void populate_surface_data(shell::SurfaceSpecification& spec);
 
     /// Overrides from WlSurfaceRole
     /// @{

--- a/src/server/frontend_xwayland/xwayland_surface_role.h
+++ b/src/server/frontend_xwayland/xwayland_surface_role.h
@@ -21,8 +21,6 @@
 
 #include "wl_surface_role.h"
 
-#include <mutex>
-
 namespace mir
 {
 namespace scene
@@ -51,15 +49,21 @@ public:
         float scale);
     ~XWaylandSurfaceRole(); ///< Must be called on the Wayland thread!
 
+    /// Populates the buffer streams and input shape from the surface into the spec. Scales both as needed. If scale is
+    /// not 1.0 it wraps the surface's buffer streams in scaled buffer streams. These are stored in the spec as
+    /// weak_ptrs, so they are also pushed onto keep_alive_until_spec_is_used. Once you call modify_surface()
+    /// or otherwise use the spec, shared_ptrs will have been created and this can be dropped.
+    static void populate_surface_data_scaled(
+        WlSurface* wl_surface,
+        float scale,
+        shell::SurfaceSpecification& spec,
+        std::vector<std::shared_ptr<void>>& keep_alive_until_spec_is_used);
+
 private:
     std::shared_ptr<shell::Shell> const shell;
     std::weak_ptr<XWaylandSurfaceRoleSurface> const weak_wm_surface;
     WlSurface* const wl_surface;
     float const scale;
-
-    /// Populates the data from the surface and scales it from XWayland coordinates (which the XWayland-connected
-    /// WlSurface uses) to Mir coordinates
-    void populate_surface_data(shell::SurfaceSpecification& spec);
 
     /// Overrides from WlSurfaceRole
     /// @{

--- a/src/server/frontend_xwayland/xwayland_surface_role.h
+++ b/src/server/frontend_xwayland/xwayland_surface_role.h
@@ -46,13 +46,15 @@ public:
     XWaylandSurfaceRole(
         std::shared_ptr<shell::Shell> const& shell,
         std::shared_ptr<XWaylandSurfaceRoleSurface> const& wm_surface,
-        WlSurface* wl_surface);
+        WlSurface* wl_surface,
+        float scale);
     ~XWaylandSurfaceRole(); ///< Must be called on the Wayland thread!
 
 private:
     std::shared_ptr<shell::Shell> const shell;
     std::weak_ptr<XWaylandSurfaceRoleSurface> const weak_wm_surface;
     WlSurface* const wl_surface;
+    float const scale;
 
     /// Overrides from WlSurfaceRole
     /// @{

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -779,11 +779,12 @@ void mf::XWaylandWM::handle_surface_id(
     wayland_executor.spawn([
             wayland_connector = wayland_connector,
             client=wayland_client,
+            scale=assumed_surface_scale,
             id,
             weak_surface,
             weak_shell = std::weak_ptr<shell::Shell>{wm_shell->shell}]()
         {
-            wayland_connector->on_surface_created(client, id, [weak_surface, weak_shell](WlSurface* wl_surface)
+            wayland_connector->on_surface_created(client, id, [scale, weak_surface, weak_shell](WlSurface* wl_surface)
                 {
                     auto const surface = weak_surface.lock();
                     auto const shell = weak_shell.lock();
@@ -792,7 +793,7 @@ void mf::XWaylandWM::handle_surface_id(
                         surface->attach_wl_surface(wl_surface);
 
                         // Will destroy itself
-                        new XWaylandSurfaceRole{shell, surface, wl_surface};
+                        new XWaylandSurfaceRole{shell, surface, wl_surface, scale};
                     }
                     else
                     {

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -506,7 +506,8 @@ void mf::XWaylandWM::manage_window(xcb_window_t window, geom::Rectangle const& g
         client_manager,
         window,
         geometry,
-        override_redirect);
+        override_redirect,
+        assumed_surface_scale);
 }
 
 void mf::XWaylandWM::handle_event(xcb_generic_event_t* event)

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -133,7 +133,8 @@ public:
 mf::XWaylandWM::XWaylandWM(
     std::shared_ptr<WaylandConnector> wayland_connector,
     wl_client* wayland_client,
-    Fd const& fd)
+    Fd const& fd,
+    float assumed_surface_scale)
     : connection{std::make_shared<XCBConnection>(fd)},
       wayland_connector(wayland_connector),
       wayland_client{wayland_client},
@@ -142,7 +143,8 @@ mf::XWaylandWM::XWaylandWM(
       cursors{std::make_unique<XWaylandCursors>(connection)},
       wm_window{create_wm_window(*connection)},
       scene_observer{std::make_shared<XWaylandSceneObserver>(this)},
-      client_manager{std::make_shared<XWaylandClientManager>(wm_shell->shell)}
+      client_manager{std::make_shared<XWaylandClientManager>(wm_shell->shell)},
+      assumed_surface_scale{assumed_surface_scale}
 {
     check_xfixes(*connection);
 

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -59,7 +59,8 @@ public:
     XWaylandWM(
         std::shared_ptr<WaylandConnector> wayland_connector,
         wl_client* wayland_client,
-        Fd const& fd);
+        Fd const& fd,
+        float assumed_surface_scale);
     ~XWaylandWM();
 
     /// Called by the XWayland connector when there may be new events
@@ -106,6 +107,10 @@ private:
     xcb_window_t const wm_window;
     std::shared_ptr<XWaylandSceneObserver> const scene_observer;
     std::shared_ptr<XWaylandClientManager> const client_manager;
+    /// The scale we assume applications are rendering at. If this doesn't match the scale an app is actually rendering
+    /// at the app will appear the wrong size. If this matches the app but both are smaller than the output scale, the
+    /// app will appear the correct size but blurry.
+    float const assumed_surface_scale;
 
     std::mutex mutex;
     std::map<xcb_window_t, std::shared_ptr<XWaylandSurface>> surfaces;


### PR DESCRIPTION
NOTE: there is still a rather serious problem where the window frame is too big and input comes in in the wrong place, thus the draftness of the PR.

Until the X11 PRs noted in #1367 get merged, the whole stack is inherently a little jank. There is no standard way to ask X11 apps to scale, and there is no way to know which apps are scaling. The only way to make sure everything's the right size is to turn scaling off for everything and let Mir stretch apps, but that's obviously not preferable.

Most modern apps and toolkits do support scaling one way or another (the [Arch Wiki page](https://wiki.archlinux.org/index.php/HiDPI#IntelliJ_IDEA) is the best resource for getting them all working), so it makes sense to allow the user to set up app scaling for themselves and then tell Mir to assume all apps are scaled.

With this PR, the user can explicitly specify a scale with the `--x11-scale` option. If that's unset, Mir will pull the scale from `GDK_SCALE`, or default to 1 if that's also unset. `GDK_SCALE` is as close to a standard as we've got. GTK3 apps, Steam, and Various Java apps including Intellij respect it,

Fixes #1367 (as good as it can be currently). 