### PR TITLE
Enable xdg_output_unstable_v1 by default

### DIFF
--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -181,7 +181,8 @@ auto mf::get_standard_extensions() -> std::vector<std::string>
     return std::vector<std::string>{
         mw::Shell::interface_name,
         mw::XdgWmBase::interface_name,
-        mw::XdgShellV6::interface_name};
+        mw::XdgShellV6::interface_name,
+        mw::XdgOutputManagerV1::interface_name};
 }
 
 auto mf::get_supported_extensions() -> std::vector<std::string>


### PR DESCRIPTION
In looking at XWayland HiDPI I was surprised to discover we don't enable the XDG output protocol by default. XDG Output helps XWayland handle scaled outputs, and fixes who knows what other usecases.

I see no potential drawbacks or security concerns to for enabling it. It doesn't allow clients to *do* anything or give any information about other clients, it just [gives additional information about outputs](https://github.com/MirServer/mir/blob/master/src/wayland/protocol/xdg-output-unstable-v1.xml).

The only reason I can think of a compositor wouldn't want to use it is to work around some client specific bug, or if the compositor didn't lay out outputs in a global coordinate space. Since Mir always has a global coordinate space and I know of no client bugs to work around, defaulting it on seems like an obvious decision.

Fixes #1897