### PR TITLE
Add WlClient class

### DIFF
--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -10,6 +10,7 @@ set(
   mir_display.cpp               mir_display.h
   wayland_default_configuration.cpp
   wayland_connector.cpp         wayland_connector.h
+  wl_client.cpp                 wl_client.h
   wayland_executor.cpp          wayland_executor.h
   null_event_sink.cpp           null_event_sink.h
   wayland_surface_observer.cpp  wayland_surface_observer.h

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -18,6 +18,7 @@
 
 #include "wayland_connector.h"
 
+#include "wl_client.h"
 #include "wl_data_device_manager.h"
 #include "wayland_utils.h"
 #include "wl_surface_role.h"
@@ -27,15 +28,12 @@
 #include "wl_seat.h"
 #include "wl_region.h"
 
-#include "null_event_sink.h"
 #include "output_manager.h"
 #include "wayland_executor.h"
 
 #include "wayland_wrapper.h"
 
 #include "mir/frontend/surface.h"
-#include "mir/frontend/session_credentials.h"
-#include "mir/frontend/session_authorizer.h"
 #include "mir/frontend/wayland.h"
 
 #include "mir/compositor/buffer_stream.h"
@@ -101,136 +99,6 @@ namespace mir
 {
 namespace frontend
 {
-
-namespace
-{
-struct ClientPrivate
-{
-    ClientPrivate(std::shared_ptr<ms::Session> const& session, msh::Shell* shell)
-        : session{session},
-          shell{shell}
-    {
-    }
-
-    ~ClientPrivate()
-    {
-        shell->close_session(session);
-        /*
-         * This ensures that further calls to
-         * wl_client_get_destroy_listener(client, &cleanup_private)
-         * - and hence session_for_client(client) - return nullptr.
-         */
-        wl_list_remove(&destroy_listener.link);
-    }
-
-    wl_listener destroy_listener;
-    std::shared_ptr<ms::Session> const session;
-    /*
-     * This shell is owned by the ClientSessionConstructor, which outlives all clients.
-     */
-    msh::Shell* const shell;
-};
-
-static_assert(
-    std::is_standard_layout<ClientPrivate>::value,
-    "ClientPrivate must be standard layout for wl_container_of to be defined behaviour");
-
-ClientPrivate* private_from_listener(wl_listener* listener)
-{
-    ClientPrivate* userdata;
-    return wl_container_of(listener, userdata, destroy_listener);
-}
-
-void cleanup_private(wl_listener* listener, void* /*data*/)
-{
-    delete private_from_listener(listener);
-}
-
-struct ClientSessionConstructor
-{
-    ClientSessionConstructor(std::shared_ptr<msh::Shell> const& shell,
-                             std::shared_ptr<mf::SessionAuthorizer> const& session_authorizer,
-                             std::unordered_map<int, std::function<void(std::shared_ptr<scene::Session> const& session)>>* connect_handlers)
-        : shell{shell},
-          session_authorizer{session_authorizer},
-          connect_handlers{connect_handlers}
-    {
-    }
-
-    wl_listener construction_listener;
-    wl_listener destruction_listener;
-    std::shared_ptr<msh::Shell> const shell;
-    std::shared_ptr<mf::SessionAuthorizer> const session_authorizer;
-    std::unordered_map<int, std::function<void(std::shared_ptr<scene::Session> const& session)>>* connect_handlers;
-
-};
-
-static_assert(
-    std::is_standard_layout<ClientSessionConstructor>::value,
-    "ClientSessionConstructor must be standard layout for wl_container_of to be "
-    "defined behaviour.");
-
-void create_client_session(wl_listener* listener, void* data)
-{
-    auto client = reinterpret_cast<wl_client*>(data);
-
-    ClientSessionConstructor* construction_context;
-    construction_context =
-        wl_container_of(listener, construction_context, construction_listener);
-
-    auto const handler_iter = construction_context->connect_handlers->find(wl_client_get_fd(client));
-
-    std::function<void(std::shared_ptr<scene::Session> const& session)> const connection_handler =
-        (handler_iter != std::end(*construction_context->connect_handlers)) ? handler_iter->second : [](auto){};
-
-    if (handler_iter != std::end(*construction_context->connect_handlers))
-        construction_context->connect_handlers->erase(handler_iter);
-
-    pid_t client_pid;
-    uid_t client_uid;
-    gid_t client_gid;
-    wl_client_get_credentials(client, &client_pid, &client_uid, &client_gid);
-
-    if (!construction_context->session_authorizer->connection_is_allowed({client_pid, client_uid, client_gid}))
-    {
-        wl_client_destroy(client);
-        return;
-    }
-
-    auto session = construction_context->shell->open_session(
-        client_pid,
-        "",
-        std::make_shared<NullEventSink>());
-
-    auto client_context = new ClientPrivate{session, construction_context->shell.get()};
-    client_context->destroy_listener.notify = &cleanup_private;
-    wl_client_add_destroy_listener(client, &client_context->destroy_listener);
-
-    connection_handler(session);
-}
-
-void cleanup_client_handler(wl_listener* listener, void*)
-{
-    ClientSessionConstructor* construction_context;
-    construction_context = wl_container_of(listener, construction_context, destruction_listener);
-
-    delete construction_context;
-}
-
-void setup_new_client_handler(wl_display* display, std::shared_ptr<msh::Shell> const& shell,
-                              std::shared_ptr<mf::SessionAuthorizer> const& session_authorizer,
-                              std::unordered_map<int, std::function<void(std::shared_ptr<scene::Session> const& session)>>* connect_handlers)
-{
-    auto context = new ClientSessionConstructor{shell, session_authorizer, connect_handlers};
-    context->construction_listener.notify = &create_client_session;
-
-    wl_display_add_client_created_listener(display, &context->construction_listener);
-
-    context->destruction_listener.notify = &cleanup_client_handler;
-    wl_display_add_destroy_listener(display, &context->destruction_listener);
-}
-}
-
 class WlCompositor : public wayland::Compositor::Global
 {
 public:
@@ -715,7 +583,18 @@ mf::WaylandConnector::WaylandConnector(
 
     auto wayland_loop = wl_display_get_event_loop(display.get());
 
-    setup_new_client_handler(display.get(), shell, session_authorizer, &connect_handlers);
+    WlClient::setup_new_client_handler(display.get(), shell, session_authorizer, [this](WlClient& client)
+        {
+            int const fd = wl_client_get_fd(client.raw_client);
+            auto const handler_iter = connect_handlers.find(fd);
+
+            if (handler_iter != std::end(connect_handlers))
+            {
+                auto const callback = handler_iter->second;
+                connect_handlers.erase(handler_iter);
+                callback(client.client_session);
+            }
+        });
 
     pause_source = wl_event_loop_add_fd(wayland_loop, pause_signal, WL_EVENT_READABLE, &halt_eventloop, display.get());
 }
@@ -883,21 +762,16 @@ bool mf::WaylandConnector::wl_display_global_filter_func(wl_client const* client
 #endif
 }
 
-auto mir::frontend::get_session(wl_client* client) -> std::shared_ptr<scene::Session>
+auto mir::frontend::get_session(wl_client* wl_client) -> std::shared_ptr<scene::Session>
 {
-    auto listener = wl_client_get_destroy_listener(client, &cleanup_private);
-
-    if (listener)
-    {
-        auto client_private = private_from_listener(listener);
-        return client_private->session;
-    }
-
-    return {};
+    auto const client = WlClient::from(wl_client);
+    return client ? client->client_session : nullptr;
 }
 
 auto mf::get_session(wl_resource* surface) -> std::shared_ptr<ms::Session>
 {
+    // TODO: evaluate if this is actually what we want. Sometime's a surface's client's session is not the most
+    // applicable session for the surface. See WlClient::client_session for details.
     return get_session(wl_resource_get_client(surface));
 }
 

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -585,14 +585,14 @@ mf::WaylandConnector::WaylandConnector(
 
     WlClient::setup_new_client_handler(display.get(), shell, session_authorizer, [this](WlClient& client)
         {
-            int const fd = wl_client_get_fd(client.raw_client);
+            int const fd = wl_client_get_fd(client.raw_client());
             auto const handler_iter = connect_handlers.find(fd);
 
             if (handler_iter != std::end(connect_handlers))
             {
                 auto const callback = handler_iter->second;
                 connect_handlers.erase(handler_iter);
-                callback(client.client_session);
+                callback(client.client_session());
             }
         });
 
@@ -765,7 +765,7 @@ bool mf::WaylandConnector::wl_display_global_filter_func(wl_client const* client
 auto mir::frontend::get_session(wl_client* wl_client) -> std::shared_ptr<scene::Session>
 {
     auto const client = WlClient::from(wl_client);
-    return client ? client->client_session : nullptr;
+    return client ? client->client_session() : nullptr;
 }
 
 auto mf::get_session(wl_resource* surface) -> std::shared_ptr<ms::Session>

--- a/src/server/frontend_wayland/wl_client.cpp
+++ b/src/server/frontend_wayland/wl_client.cpp
@@ -151,14 +151,14 @@ auto mf::WlClient::from(wl_client* client) -> WlClient*
     return ctx ? ctx->client.get() : nullptr;
 }
 
-mf::WlClient::WlClient(wl_client* raw_client, std::shared_ptr<ms::Session> const& client_session, msh::Shell* shell)
-    : raw_client{raw_client},
-      client_session{client_session},
-      shell{shell}
+mf::WlClient::WlClient(wl_client* client, std::shared_ptr<ms::Session> const& session, msh::Shell* shell)
+    : shell{shell},
+      client{client},
+      session{session}
 {
 }
 
 mf::WlClient::~WlClient()
 {
-    shell->close_session(client_session);
+    shell->close_session(session);
 }

--- a/src/server/frontend_wayland/wl_client.cpp
+++ b/src/server/frontend_wayland/wl_client.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "wl_client.h"
+
+#include "null_event_sink.h"
+#include "mir/frontend/session_authorizer.h"
+#include "mir/frontend/session_credentials.h"
+#include "mir/shell/shell.h"
+#include "mir/scene/session.h"
+
+#include <wayland-server-core.h>
+
+namespace mf = mir::frontend;
+namespace ms = mir::scene;
+namespace msh = mir::shell;
+
+struct mf::WlClient::ConstructionCtx
+{
+    ConstructionCtx(
+        std::shared_ptr<msh::Shell> const& shell,
+        std::shared_ptr<mf::SessionAuthorizer> const& session_authorizer,
+        std::function<void(WlClient&)>&& client_created_callback)
+        : shell{shell},
+          session_authorizer{session_authorizer},
+          client_created_callback{std::make_unique<std::function<void(WlClient&)>>(std::move(client_created_callback))}
+    {
+    }
+
+    wl_listener client_construction_listener;
+    wl_listener display_destruction_listener;
+    std::shared_ptr<msh::Shell> const shell;
+    std::shared_ptr<mf::SessionAuthorizer> const session_authorizer;
+    /// Needs to be a pointer so std::is_standard_layout passes
+    std::unique_ptr<std::function<void(WlClient&)>> const client_created_callback;
+};
+
+struct mf::WlClient::ClientCtx
+{
+    ClientCtx(wl_client* raw_client, std::shared_ptr<ms::Session> const& client_session, msh::Shell* shell)
+        : client{std::unique_ptr<WlClient>{new WlClient{raw_client, client_session, shell}}}
+    {
+    }
+
+    static auto from(wl_listener* listener) -> ClientCtx*
+    {
+        ClientCtx* ctx;
+        ctx = wl_container_of(listener, ctx, destroy_listener);
+        return ctx;
+    }
+
+    std::unique_ptr<WlClient> const client;
+    wl_listener destroy_listener;
+};
+
+static_assert(
+    std::is_standard_layout<mf::WlClient::ClientCtx>::value,
+    "ClientCtx must be standard layout for wl_container_of to be defined behaviour");
+
+static_assert(
+    std::is_standard_layout<mf::WlClient::ConstructionCtx>::value,
+    "ConstructionCtx must be standard layout for wl_container_of to be "
+    "defined behaviour.");
+
+namespace
+{
+void cleanup_construction_ctx(wl_listener* listener, void*)
+{
+    mf::WlClient::ConstructionCtx* construction_context;
+    construction_context = wl_container_of(listener, construction_context, display_destruction_listener);
+    delete construction_context;
+}
+
+void cleanup_client_ctx(wl_listener* listener, void* /*data*/)
+{
+    auto const ctx = mf::WlClient::ClientCtx::from(listener);
+    // This ensures that further calls to wl_client_get_destroy_listener(client, &cleanup_client_ctx) - and hence
+    // WlClient::from(client) - return nullptr.
+    wl_list_remove(&ctx->destroy_listener.link);
+    delete ctx;
+}
+
+void handle_client_created(wl_listener* listener, void* data)
+{
+    auto client = reinterpret_cast<wl_client*>(data);
+
+    mf::WlClient::ConstructionCtx* construction_context;
+    construction_context = wl_container_of(listener, construction_context, client_construction_listener);
+
+    pid_t client_pid;
+    uid_t client_uid;
+    gid_t client_gid;
+    wl_client_get_credentials(client, &client_pid, &client_uid, &client_gid);
+
+    if (!construction_context->session_authorizer->connection_is_allowed({client_pid, client_uid, client_gid}))
+    {
+        wl_client_destroy(client);
+        return;
+    }
+
+    auto session = construction_context->shell->open_session(
+        client_pid,
+        "",
+        std::make_shared<mf::NullEventSink>());
+
+    auto client_context = new mf::WlClient::ClientCtx{client, session, construction_context->shell.get()};
+    client_context->destroy_listener.notify = &cleanup_client_ctx;
+    wl_client_add_destroy_listener(client, &client_context->destroy_listener);
+
+    (*construction_context->client_created_callback)(*client_context->client.get());
+}
+}
+
+void mf::WlClient::setup_new_client_handler(
+    wl_display* display,
+    std::shared_ptr<shell::Shell> const& shell,
+    std::shared_ptr<SessionAuthorizer> const& session_authorizer,
+    std::function<void(WlClient&)>&& client_created_callback)
+{
+    auto context = new ConstructionCtx{shell, session_authorizer, std::move(client_created_callback)};
+
+    context->client_construction_listener.notify = &handle_client_created;
+    wl_display_add_client_created_listener(display, &context->client_construction_listener);
+
+    // This handles deleting the ConstructionCtx we just created when the display is destoryed
+    context->display_destruction_listener.notify = &cleanup_construction_ctx;
+    wl_display_add_destroy_listener(display, &context->display_destruction_listener);
+}
+
+auto mf::WlClient::from(wl_client* client) -> WlClient*
+{
+    auto listener = wl_client_get_destroy_listener(client, &cleanup_client_ctx);
+    auto ctx = ClientCtx::from(listener);
+    return ctx ? ctx->client.get() : nullptr;
+}
+
+mf::WlClient::WlClient(wl_client* raw_client, std::shared_ptr<ms::Session> const& client_session, msh::Shell* shell)
+    : raw_client{raw_client},
+      client_session{client_session},
+      shell{shell}
+{
+}
+
+mf::WlClient::~WlClient()
+{
+    shell->close_session(client_session);
+}

--- a/src/server/frontend_wayland/wl_client.h
+++ b/src/server/frontend_wayland/wl_client.h
@@ -44,9 +44,6 @@ class SessionAuthorizer;
 class WlClient
 {
 public:
-    struct ConstructionCtx;
-    struct ClientCtx;
-
     /// Initializes a ConstructionCtx that will create a WlClient for each wl_client created on the display. Should only
     /// be called once per display. Destruction of the ConstructionCtx is handled automatically.
     static void setup_new_client_handler(
@@ -56,6 +53,9 @@ public:
         std::function<void(WlClient&)>&& client_created_callback);
 
     static auto from(wl_client* client) -> WlClient*;
+
+    WlClient(wl_client* raw_client, std::shared_ptr<scene::Session> const& client_session, shell::Shell* shell);
+    ~WlClient();
 
     /// The underlying Wayland client
     wl_client* const raw_client;
@@ -68,11 +68,7 @@ public:
     /// individual apps.
     std::shared_ptr<scene::Session> const client_session;
 
-    ~WlClient();
-
 private:
-    WlClient(wl_client* raw_client, std::shared_ptr<scene::Session> const& client_session, shell::Shell* shell);
-
     /// This shell is owned by the ClientSessionConstructor, which outlives all clients.
     shell::Shell* const shell;
 };

--- a/src/server/frontend_wayland/wl_client.h
+++ b/src/server/frontend_wayland/wl_client.h
@@ -54,11 +54,11 @@ public:
 
     static auto from(wl_client* client) -> WlClient*;
 
-    WlClient(wl_client* raw_client, std::shared_ptr<scene::Session> const& client_session, shell::Shell* shell);
+    WlClient(wl_client* client, std::shared_ptr<scene::Session> const& session, shell::Shell* shell);
     ~WlClient();
 
     /// The underlying Wayland client
-    wl_client* const raw_client;
+    auto raw_client() const -> wl_client* { return client; }
 
     /// The Mir session associated with this client. Be careful when using this that it's actually the session you want.
     /// All clients have a session but the surfaces they create may get associated with additional sessions.
@@ -66,11 +66,13 @@ public:
     /// For example all surfaces from a single XWayland server are attached to a single WlClient with a single cleint
     /// session, but their scene::Surfaces are associated with multiple sessions created in the XWayland frontend for
     /// individual apps.
-    std::shared_ptr<scene::Session> const client_session;
+    auto client_session() const -> std::shared_ptr<scene::Session> { return session; }
 
 private:
     /// This shell is owned by the ClientSessionConstructor, which outlives all clients.
     shell::Shell* const shell;
+    wl_client* const client;
+    std::shared_ptr<scene::Session> const session;
 };
 }
 }

--- a/src/server/frontend_wayland/wl_client.h
+++ b/src/server/frontend_wayland/wl_client.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_FRONTEND_WL_CLIENT_H_
+#define MIR_FRONTEND_WL_CLIENT_H_
+
+struct wl_client;
+struct wl_listener;
+struct wl_display;
+
+#include <memory>
+#include <functional>
+
+namespace mir
+{
+namespace shell
+{
+class Shell;
+}
+namespace scene
+{
+class Session;
+}
+
+namespace frontend
+{
+class SessionAuthorizer;
+
+class WlClient
+{
+public:
+    struct ConstructionCtx;
+    struct ClientCtx;
+
+    /// Initializes a ConstructionCtx that will create a WlClient for each wl_client created on the display. Should only
+    /// be called once per display. Destruction of the ConstructionCtx is handled automatically.
+    static void setup_new_client_handler(
+        wl_display* display,
+        std::shared_ptr<shell::Shell> const& shell,
+        std::shared_ptr<SessionAuthorizer> const& session_authorizer,
+        std::function<void(WlClient&)>&& client_created_callback);
+
+    static auto from(wl_client* client) -> WlClient*;
+
+    /// The underlying Wayland client
+    wl_client* const raw_client;
+
+    /// The Mir session associated with this client. Be careful when using this that it's actually the session you want.
+    /// All clients have a session but the surfaces they create may get associated with additional sessions.
+    ///
+    /// For example all surfaces from a single XWayland server are attached to a single WlClient with a single cleint
+    /// session, but their scene::Surfaces are associated with multiple sessions created in the XWayland frontend for
+    /// individual apps.
+    std::shared_ptr<scene::Session> const client_session;
+
+    ~WlClient();
+
+private:
+    WlClient(wl_client* raw_client, std::shared_ptr<scene::Session> const& client_session, shell::Shell* shell);
+
+    /// This shell is owned by the ClientSessionConstructor, which outlives all clients.
+    shell::Shell* const shell;
+};
+}
+}
+
+#endif // MIR_FRONTEND_WL_CLIENT_H_

--- a/src/server/frontend_wayland/wl_client.h
+++ b/src/server/frontend_wayland/wl_client.h
@@ -54,7 +54,6 @@ public:
 
     static auto from(wl_client* client) -> WlClient*;
 
-    WlClient(wl_client* client, std::shared_ptr<scene::Session> const& session, shell::Shell* shell);
     ~WlClient();
 
     /// The underlying Wayland client
@@ -69,6 +68,10 @@ public:
     auto client_session() const -> std::shared_ptr<scene::Session> { return session; }
 
 private:
+    WlClient(wl_client* client, std::shared_ptr<scene::Session> const& session, shell::Shell* shell);
+
+    static void handle_client_created(wl_listener* listener, void* data);
+
     /// This shell is owned by the ClientSessionConstructor, which outlives all clients.
     shell::Shell* const shell;
     wl_client* const client;


### PR DESCRIPTION
This breaks `ClientPrivate` in `wayland_connector.cpp` into its own files. The immediate benefits are simplifying `wayland_connector.cpp` and improving and documenting the logic around creating clients. 

The main motivation for doing this now is to help with #1896. Outputs for the XWayland client will sometimes need to report different dimensions than outputs for Wayland clients. I could try to pipe the output manager and XDG output manager through to XWayland, add a map of clients, etc etc but the probably easier and IMO cleaner solution is to add a property to clients which XWayland sets the the outputs use. Creating a client class is the prerequisite for adding a property to a client.