### PR TITLE
Refactor X11Resources to prepare for X11 platform improvements

### DIFF
--- a/src/platforms/x11/X11_resources.cpp
+++ b/src/platforms/x11/X11_resources.cpp
@@ -40,6 +40,8 @@ int mx::mir_x11_error_handler(Display* dpy, XErrorEvent* eev)
 
 auto mx::X11Resources::get_conn() -> std::shared_ptr<::Display>
 {
+    std::lock_guard<std::mutex> lock{mutex};
+
     if (auto conn = connection.lock())
         return conn;
 
@@ -63,17 +65,20 @@ void mx::X11Resources::set_output_config_for_win(
     Window win,
     std::weak_ptr<graphics::DisplayConfigurationOutput const> configuration)
 {
+    std::lock_guard<std::mutex> lock{mutex};
     output_configs[win] = configuration;
 }
 
 void mx::X11Resources::clear_output_config_for_win(Window win)
 {
+    std::lock_guard<std::mutex> lock{mutex};
     output_configs.erase(win);
 }
 
 auto mx::X11Resources::get_output_config_for_win(Window win)
     -> std::experimental::optional<graphics::DisplayConfigurationOutput const* const>
 {
+    std::lock_guard<std::mutex> lock{mutex};
     auto iter = output_configs.find(win);
     std::shared_ptr<graphics::DisplayConfigurationOutput const> configuration;
     if (iter != output_configs.end() && (configuration = iter->second.lock()))

--- a/src/platforms/x11/X11_resources.h
+++ b/src/platforms/x11/X11_resources.h
@@ -20,8 +20,9 @@
 #define MIR_X11_RESOURCES_H_
 
 #include <X11/Xlib.h>
-#include <experimental/optional>
+#include <optional>
 #include <unordered_map>
+#include <functional>
 #include <mutex>
 
 namespace mir
@@ -39,20 +40,31 @@ int mir_x11_error_handler(Display* dpy, XErrorEvent* eev);
 class X11Resources
 {
 public:
+    class VirtualOutput
+    {
+    public:
+        VirtualOutput() = default;
+        virtual ~VirtualOutput() = default;
+        VirtualOutput(VirtualOutput const&) = delete;
+        VirtualOutput& operator=(VirtualOutput const&) = delete;
+
+        virtual auto configuration() const -> graphics::DisplayConfigurationOutput const& = 0;
+    };
+
     auto get_conn() -> std::shared_ptr<::Display>;
-    void set_output_config_for_win(
-        Window win,
-        std::weak_ptr<graphics::DisplayConfigurationOutput const> configuration);
-    void clear_output_config_for_win(Window win);
-    auto get_output_config_for_win(Window win)
-        -> std::experimental::optional<graphics::DisplayConfigurationOutput const* const>;
+
+    void set_set_output_for_window(Window win, VirtualOutput* output);
+    void clear_output_for_window(Window win);
+
+    /// X11Resources's mutex stays locked while the provided function runs
+    void with_output_for_window(Window win, std::function<void(std::optional<VirtualOutput const*> output)> fn);
 
     static X11Resources instance;
 
 private:
     std::mutex mutex;
     std::weak_ptr<::Display> connection;
-    std::unordered_map<Window, std::weak_ptr<graphics::DisplayConfigurationOutput const>> output_configs;
+    std::unordered_map<Window, VirtualOutput*> outputs;
 };
 
 }

--- a/src/platforms/x11/X11_resources.h
+++ b/src/platforms/x11/X11_resources.h
@@ -22,6 +22,7 @@
 #include <X11/Xlib.h>
 #include <experimental/optional>
 #include <unordered_map>
+#include <mutex>
 
 namespace mir
 {
@@ -49,6 +50,7 @@ public:
     static X11Resources instance;
 
 private:
+    std::mutex mutex;
     std::weak_ptr<::Display> connection;
     std::unordered_map<Window, std::weak_ptr<graphics::DisplayConfigurationOutput const>> output_configs;
 };

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -30,7 +30,6 @@
 #include "display.h"
 #include "platform.h"
 #include "display_buffer.h"
-#include "../X11_resources.h"
 
 #include <boost/throw_exception.hpp>
 
@@ -276,8 +275,8 @@ mgx::Display::Display(::Display* x_dpy,
             last_frame,
             report,
             *gl_config);
-        outputs.push_back(std::make_unique<OutputInfo>(move(window), move(display_buffer), configuration));
         top_left.x += as_delta(configuration->extents().size.width);
+        outputs.push_back(std::make_unique<OutputInfo>(move(window), move(display_buffer), move(configuration)));
     }
 
     shared_egl.make_current();
@@ -305,7 +304,7 @@ std::unique_ptr<mg::DisplayConfiguration> mgx::Display::configuration() const
     std::vector<DisplayConfigurationOutput> output_configurations;
     for (auto const& output : outputs)
     {
-        output_configurations.push_back(*output->configuration);
+        output_configurations.push_back(*output->config);
     }
     return std::make_unique<mgx::DisplayConfiguration>(output_configurations);
 }
@@ -324,11 +323,11 @@ void mgx::Display::configure(mg::DisplayConfiguration const& new_configuration)
 
         for (auto& output : outputs)
         {
-            if (output->configuration->id == conf_output.id)
+            if (output->config->id == conf_output.id)
             {
-                *output->configuration = conf_output;
-                output->display_buffer->set_view_area(output->configuration->extents());
-                output->display_buffer->set_transformation(output->configuration->transformation());
+                *output->config = conf_output;
+                output->display_buffer->set_view_area(output->config->extents());
+                output->display_buffer->set_transformation(output->config->transformation());
                 found_info = true;
                 break;
             }
@@ -394,12 +393,12 @@ mgx::Display::OutputInfo::OutputInfo(
     std::shared_ptr<DisplayConfigurationOutput> configuration)
     : window{move(window)},
       display_buffer{move(display_buffer)},
-      configuration{configuration}
+      config{move(configuration)}
 {
-    mx::X11Resources::instance.set_output_config_for_win(*this->window, this->configuration);
+    mx::X11Resources::instance.set_set_output_for_window(*this->window, this);
 }
 
 mgx::Display::OutputInfo::~OutputInfo()
 {
-    mx::X11Resources::instance.clear_output_config_for_win(*this->window);
+    mx::X11Resources::instance.clear_output_for_window(*window);
 }

--- a/src/platforms/x11/graphics/display.h
+++ b/src/platforms/x11/graphics/display.h
@@ -24,12 +24,14 @@
 #include "mir/renderer/gl/context_source.h"
 #include "mir_toolkit/common.h"
 #include "egl_helper.h"
+#include "../X11_resources.h"
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <EGL/egl.h>
 
 #include <memory>
+#include <map>
 
 namespace mir
 {
@@ -104,7 +106,7 @@ public:
     Frame last_frame_on(unsigned output_id) const override;
 
 private:
-    struct OutputInfo
+    struct OutputInfo : ::mir::X::X11Resources::VirtualOutput
     {
         OutputInfo(
             std::unique_ptr<X11Window> window,
@@ -112,9 +114,11 @@ private:
             std::shared_ptr<DisplayConfigurationOutput> configuration);
         ~OutputInfo();
 
+        auto configuration() const -> graphics::DisplayConfigurationOutput const& override { return *config; }
+
         std::unique_ptr<X11Window> window;
         std::unique_ptr<DisplayBuffer> display_buffer;
-        std::shared_ptr<DisplayConfigurationOutput> configuration;
+        std::shared_ptr<DisplayConfigurationOutput> config;
     };
 
     std::vector<std::unique_ptr<OutputInfo>> outputs;

--- a/src/platforms/x11/graphics/graphics.cpp
+++ b/src/platforms/x11/graphics/graphics.cpp
@@ -50,7 +50,8 @@ mir::UniqueModulePtr<mg::Platform> create_host_platform(
     std::shared_ptr<mir::logging::Logger> const& logger)
 {
     mir::assert_entry_point_signature<mg::CreateHostPlatform>(&create_host_platform);
-    if (!mx::X11Resources::instance.get_conn())
+    auto const conn = mx::X11Resources::instance.get_conn();
+    if (!conn)
         BOOST_THROW_EXCEPTION(std::runtime_error("Need valid x11 output"));
 
     if (options->is_set(mir::options::debug_opt))
@@ -61,7 +62,7 @@ mir::UniqueModulePtr<mg::Platform> create_host_platform(
     auto output_sizes = mgx::Platform::parse_output_sizes(options->get<std::string>(x11_displays_option_name));
 
     return mir::make_module_ptr<mgx::Platform>(
-        mx::X11Resources::instance.get_conn(),
+        conn,
         move(output_sizes),
         report
     );

--- a/src/platforms/x11/input/input_platform.cpp
+++ b/src/platforms/x11/input/input_platform.cpp
@@ -54,16 +54,21 @@ namespace
 {
 geom::Point get_pos_on_output(Window x11_window, int x, int y)
 {
-    auto output = mx::X11Resources::instance.get_output_config_for_win(x11_window);
-    if (output)
-    {
-        return output.value()->top_left + geom::Displacement{x, y};
-    }
-    else
-    {
-        mir::log_warning("X11 window %lu does not map to any known output, not applying input transformation", x11_window);
-        return geom::Point{x, y};
-    }
+    geom::Point pos{x, y};
+    mx::X11Resources::instance.with_output_for_window(x11_window, [&](std::optional<mx::X11Resources::VirtualOutput const*> output)
+        {
+            if (output)
+            {
+                pos += as_displacement(output.value()->configuration().top_left);
+            }
+            else
+            {
+                mir::log_warning(
+                    "X11 window %lu does not map to any known output, not applying input transformation",
+                    x11_window);
+            }
+        });
+    return pos;
 }
 }
 


### PR DESCRIPTION
The X11 input platform (which gets events, like window resize) needs talk to the graphics platform (which can apply output configuration changes). The previous method for doing this only shared display configs and only from the graphics platform to the input platform. This PR adds an interface to add flexibility.