### PR TITLE
Update the `--x11-scale` option

### DIFF
--- a/src/miral/x11_support.cpp
+++ b/src/miral/x11_support.cpp
@@ -42,10 +42,23 @@ void miral::X11Support::operator()(mir::Server& server) const
         mo::x11_display_opt,
         "Enable X11 support", mir::OptionType::null);
 
+
+    auto const x11_scale_default = []() -> char const* {
+        if (auto const gdk_scale = getenv("GDK_SCALE"))
+        {
+            return gdk_scale;
+        }
+        else
+        {
+            return "1.0";
+        }
+    }();
+
     server.add_configuration_option(
         mo::x11_scale_opt,
-        "The scale to assume X11 apps use. If unset uses the value of GDK_SCALE or 1. Can be fractional",
-        mir::OptionType::string);
+        "The scale to assume X11 apps use. Defaults to the value of GDK_SCALE or 1. Can be fractional. "
+        "(Consider also setting GDK_SCALE in app-env-x11 when using this)",
+        x11_scale_default);
 
     server.add_configuration_option(
         "xwayland-path",

--- a/src/server/frontend_xwayland/xwayland_default_configuration.cpp
+++ b/src/server/frontend_xwayland/xwayland_default_configuration.cpp
@@ -72,11 +72,15 @@ std::shared_ptr<mf::Connector> mir::DefaultServerConfiguration::the_xwayland_con
                 return std::make_shared<mf::XWaylandConnector>(
                     wayland_connector,
                     options->get<std::string>("xwayland-path"),
-                    boost::lexical_cast<float>((*options).get<std::string>(mo::x11_scale_opt)));
+                    boost::lexical_cast<float>(options->get<std::string>(mo::x11_scale_opt)));
             }
             catch (std::exception& x)
             {
-                mir::fatal_error("Failed to start XWaylandConnector: %s", x.what());
+                mir::fatal_error(
+                    "Failed to start XWaylandConnector: %s\n  (xwayland-path is '%s', x11-scale is '%s')",
+                    x.what(),
+                    options->get<std::string>("xwayland-path").c_str(),
+                    options->get<std::string>(mo::x11_scale_opt).c_str());
             }
         }
 

--- a/src/server/frontend_xwayland/xwayland_default_configuration.cpp
+++ b/src/server/frontend_xwayland/xwayland_default_configuration.cpp
@@ -17,13 +17,14 @@
 
 #include "mir/default_server_configuration.h"
 #include "mir/log.h"
+#include "mir/options/default_configuration.h"
 #include "wayland_connector.h"
 #include "xwayland_connector.h"
 
+#include <boost/lexical_cast.hpp>
+
 #include <string>
 #include <cstdlib>
-
-#include "mir/options/default_configuration.h"
 
 namespace mf = mir::frontend;
 namespace ms = mir::scene;
@@ -56,25 +57,6 @@ struct NullConnector : mf::Connector
         return mir::optional_value<std::string>();
     }
 };
-
-/// Get the scale from the provided options or from GDK_SCALE
-auto get_scale(mir::options::Option const& options) -> float
-{
-    if (auto const scale = atof(options.get(mo::x11_scale_opt, "").c_str()))
-    {
-        return scale;
-    }
-
-    if (auto const gdk_scale = getenv("GDK_SCALE"))
-    {
-        if (auto const scale = atof(gdk_scale))
-        {
-            return scale;
-        }
-    }
-
-    return 1.0f;
-}
 }
 
 std::shared_ptr<mf::Connector> mir::DefaultServerConfiguration::the_xwayland_connector()
@@ -90,7 +72,7 @@ std::shared_ptr<mf::Connector> mir::DefaultServerConfiguration::the_xwayland_con
                 return std::make_shared<mf::XWaylandConnector>(
                     wayland_connector,
                     options->get<std::string>("xwayland-path"),
-                    get_scale(*options));
+                    boost::lexical_cast<float>((*options).get<std::string>(mo::x11_scale_opt)));
             }
             catch (std::exception& x)
             {

--- a/src/server/frontend_xwayland/xwayland_default_configuration.cpp
+++ b/src/server/frontend_xwayland/xwayland_default_configuration.cpp
@@ -68,11 +68,16 @@ std::shared_ptr<mf::Connector> mir::DefaultServerConfiguration::the_xwayland_con
         {
             try
             {
+                auto const scale = boost::lexical_cast<float>(options->get<std::string>(mo::x11_scale_opt));
+                if (scale < 0.01f || scale > 100.0f)
+                {
+                    BOOST_THROW_EXCEPTION(std::runtime_error("scale outside of valid range"));
+                }
                 auto wayland_connector = std::static_pointer_cast<mf::WaylandConnector>(the_wayland_connector());
                 return std::make_shared<mf::XWaylandConnector>(
                     wayland_connector,
                     options->get<std::string>("xwayland-path"),
-                    boost::lexical_cast<float>(options->get<std::string>(mo::x11_scale_opt)));
+                    scale);
             }
             catch (std::exception& x)
             {

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -56,14 +56,8 @@ void exec_xwayland(
     auto const x11_wm_server = std::to_string(x11_wm_server_fd);
     auto const dsp_str = spawner.x11_display();
 
-    // This DPI doesn't seem to effect much (mostly apps care about GDK_SCALE and other environment variables), but
-    // doen't hurt to set it
-    unsigned dpi = scale * 96;
-    if (dpi > 2000 || dpi < 10)
-    {
-        mir::log_warning("Ignoring probably invalid XWayland DPI %d, using 96 instead", dpi);
-        dpi = 96;
-    }
+    // This DPI only effects some apps (most app care about GDK_SCALE and other environment variables)
+    unsigned const dpi = scale * 96;
     auto const dpi_str = std::to_string(dpi);
 
     std::vector<char const*> args =


### PR DESCRIPTION
Update the `--x11-scale` option to:

1. Suggest configuring GDK_SCALE in `--app-args-x11`
2. Use GDK_SCALE as the default setting
3. Give an error if `--x11-scale` value cannot be parsed