### PR TITLE
Async XWayland copy paste

### DIFF
--- a/src/server/frontend_xwayland/xwayland_clipboard_provider.cpp
+++ b/src/server/frontend_xwayland/xwayland_clipboard_provider.cpp
@@ -21,6 +21,7 @@
 
 #include "xwayland_log.h"
 #include "mir/scene/clipboard.h"
+#include "mir/dispatch/multiplexing_dispatchable.h"
 
 #include <xcb/xfixes.h>
 #include <string.h>
@@ -29,6 +30,7 @@
 
 namespace mf = mir::frontend;
 namespace ms = mir::scene;
+namespace md = mir::dispatch;
 
 namespace
 {
@@ -105,8 +107,10 @@ private:
 
 mf::XWaylandClipboardProvider::XWaylandClipboardProvider(
     XCBConnection& connection,
+    std::shared_ptr<md::MultiplexingDispatchable> const& dispatcher,
     std::shared_ptr<scene::Clipboard> const& clipboard)
     : connection{connection},
+      dispatcher{dispatcher},
       clipboard{clipboard},
       clipboard_observer{std::make_shared<ClipboardObserver>(this)},
       selection_window{create_selection_window(connection)}

--- a/src/server/frontend_xwayland/xwayland_clipboard_provider.h
+++ b/src/server/frontend_xwayland/xwayland_clipboard_provider.h
@@ -41,7 +41,7 @@ class XWaylandClipboardProvider
 {
 public:
     XWaylandClipboardProvider(
-        XCBConnection& connection,
+        std::shared_ptr<XCBConnection> const& connection,
         std::shared_ptr<dispatch::MultiplexingDispatchable> const& dispatcher,
         std::shared_ptr<scene::Clipboard> const& clipboard);
     ~XWaylandClipboardProvider();
@@ -90,7 +90,7 @@ private:
     /// Called by the observer, indicates the paste source has been set by someone (could be us or Wayland)
     void paste_source_set(std::shared_ptr<scene::ClipboardSource> const& source);
 
-    XCBConnection& connection;
+    std::shared_ptr<XCBConnection> const connection;
     std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
     std::shared_ptr<scene::Clipboard> const clipboard;
     std::shared_ptr<ClipboardObserver> const clipboard_observer;

--- a/src/server/frontend_xwayland/xwayland_clipboard_provider.h
+++ b/src/server/frontend_xwayland/xwayland_clipboard_provider.h
@@ -30,6 +30,10 @@ namespace scene
 class Clipboard;
 class ClipboardSource;
 }
+namespace dispatch
+{
+class MultiplexingDispatchable;
+}
 namespace frontend
 {
 /// Exposes non-X11 selections to X11 clients
@@ -38,6 +42,7 @@ class XWaylandClipboardProvider
 public:
     XWaylandClipboardProvider(
         XCBConnection& connection,
+        std::shared_ptr<dispatch::MultiplexingDispatchable> const& dispatcher,
         std::shared_ptr<scene::Clipboard> const& clipboard);
     ~XWaylandClipboardProvider();
 
@@ -86,6 +91,7 @@ private:
     void paste_source_set(std::shared_ptr<scene::ClipboardSource> const& source);
 
     XCBConnection& connection;
+    std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
     std::shared_ptr<scene::Clipboard> const clipboard;
     std::shared_ptr<ClipboardObserver> const clipboard_observer;
     xcb_window_t const selection_window;

--- a/src/server/frontend_xwayland/xwayland_clipboard_provider.h
+++ b/src/server/frontend_xwayland/xwayland_clipboard_provider.h
@@ -79,14 +79,6 @@ private:
         xcb_atom_t target,
         std::string const& mime_type);
 
-    /// Notify the client that the property is ready
-    void send_selection_notify(
-        xcb_timestamp_t time,
-        xcb_window_t requestor,
-        xcb_atom_t property,
-        xcb_atom_t selection,
-        xcb_atom_t target);
-
     /// Called by the observer, indicates the paste source has been set by someone (could be us or Wayland)
     void paste_source_set(std::shared_ptr<scene::ClipboardSource> const& source);
 

--- a/src/server/frontend_xwayland/xwayland_clipboard_source.cpp
+++ b/src/server/frontend_xwayland/xwayland_clipboard_source.cpp
@@ -306,6 +306,8 @@ void mf::XWaylandClipboardSource::selection_notify_event(xcb_selection_notify_ev
                 if (reply->type == connection.INCR)
                 {
                     log_error("Incremental copies from X11 are not supported");
+                    std::lock_guard<std::mutex> lock{mutex};
+                    in_progress_send.reset();
                 }
                 else
                 {

--- a/src/server/frontend_xwayland/xwayland_clipboard_source.cpp
+++ b/src/server/frontend_xwayland/xwayland_clipboard_source.cpp
@@ -60,30 +60,6 @@ auto create_receiving_window(mf::XCBConnection const& connection) -> xcb_window_
     return receiving_window;
 }
 
-class WriteError : public std::runtime_error
-{
-public:
-    WriteError() : runtime_error{strerror(errno)}
-    {
-    }
-};
-
-/// Like write(), but calls write() until the whole buffer has been written
-void write_repeatedly(mir::Fd const& fd, uint8_t const* buffer, size_t size)
-{
-    auto remaining = size;
-    while (remaining > 0)
-    {
-        auto len = write(fd, buffer, remaining);
-        if (len < 0)
-        {
-            throw WriteError();
-        }
-        buffer += len;
-        remaining -= len;
-    }
-}
-
 auto map2vec(std::map<std::string, xcb_atom_t> const& map) -> std::vector<std::string>
 {
     std::vector<std::string> result;
@@ -142,6 +118,76 @@ private:
     XWaylandClipboardSource* owner; ///< Can be null
 };
 
+class mf::XWaylandClipboardSource::DataSender : public md::Dispatchable
+{
+public:
+    DataSender(mir::Fd const& destination_fd)
+        : destination_fd{destination_fd}
+    {
+    }
+
+    /// Returns if the previous buffer was empty. If return value is true, this needs to be added to the dispatcher.
+    auto add_data(std::vector<uint8_t>&& new_data) -> bool {
+        std::lock_guard<std::mutex> lock{mutex};
+        if (data.empty())
+        {
+            data = std::move(new_data);
+            return true;
+        }
+        else
+        {
+            data.insert(data.end(), new_data.begin(), new_data.end());
+            return false;
+        }
+    }
+
+private:
+    auto watch_fd() const -> mir::Fd override
+    {
+        return destination_fd;
+    }
+
+    auto dispatch(md::FdEvents events) -> bool override
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+
+        if (events & md::FdEvent::error)
+        {
+            mir::log_error("failed to send X11 clipboard data: fd error");
+            return false;
+        }
+
+        if (events & md::FdEvent::remote_closed)
+        {
+            mir::log_error("failed to send X11 clipboard data: fd closed");
+            return false;
+        }
+
+        if (events & md::FdEvent::writable)
+        {
+            auto const len = write(destination_fd, &data[0], data.size());
+            if (len < 0)
+            {
+                mir::log_error("failed to send X11 clipboard data: %s", strerror(errno));
+                return false;
+            }
+            data.erase(data.begin(), data.begin() + len);
+        }
+
+        return !data.empty();
+    }
+
+    auto relevant_events() const -> md::FdEvents override
+    {
+        return md::FdEvent::writable;
+    }
+
+    mir::Fd const destination_fd;
+
+    std::mutex mutex;
+    std::vector<uint8_t> data;
+};
+
 mf::XWaylandClipboardSource::XWaylandClipboardSource(
     XCBConnection& connection,
     std::shared_ptr<md::MultiplexingDispatchable> const& dispatcher,
@@ -187,12 +233,12 @@ mf::XWaylandClipboardSource::~XWaylandClipboardSource()
 void mf::XWaylandClipboardSource::initiate_send(xcb_atom_t target_type, Fd const& receiver_fd)
 {
     std::unique_lock<std::mutex> lock{mutex};
-    if (pending_send_fd)
+    if (in_progress_send)
     {
         log_error("can not send clipboard data from X11 because another send is currently in progress");
         return;
     }
-    pending_send_fd = receiver_fd;
+    in_progress_send = std::make_shared<DataSender>(receiver_fd);
     lock.unlock();
 
     if (verbose_xwayland_logging_enabled())
@@ -263,16 +309,17 @@ void mf::XWaylandClipboardSource::selection_notify_event(xcb_selection_notify_ev
                 }
                 else
                 {
-                    send_data_to_fd(
-                        static_cast<uint8_t*>(xcb_get_property_value(reply)),
-                        xcb_get_property_value_length(reply));
+                    auto const data_ptr = static_cast<uint8_t*>(xcb_get_property_value(reply));
+                    auto const data_size = xcb_get_property_value_length(reply);
+                    std::vector<uint8_t> data{data_ptr, data_ptr + data_size};
+                    add_data_to_in_progress_send(std::move(data), true);
                 }
             },
             [&](const std::string& error_message)
             {
                 log_error("Error getting selection property: %s", error_message.c_str());
                 std::lock_guard<std::mutex> lock{mutex};
-                pending_send_fd.reset();
+                in_progress_send.reset();
             }});
 
         completion();
@@ -363,35 +410,29 @@ void mf::XWaylandClipboardSource::create_source(xcb_timestamp_t timestamp, std::
     clipboard->set_paste_source(source);
 }
 
-void mf::XWaylandClipboardSource::send_data_to_fd(uint8_t const* data, size_t size)
+void mf::XWaylandClipboardSource::add_data_to_in_progress_send(std::vector<uint8_t>&& data, bool completes_send)
 {
-    std::unique_lock<std::mutex> lock{mutex};
-    if (!pending_send_fd)
+    std::lock_guard<std::mutex> lock{mutex};
+
+    if (!in_progress_send)
     {
         log_error("Can not send clipboard data from X11 because pending_send_fd is not set");
         return;
     }
-    auto const fd = pending_send_fd.value();
-    lock.unlock();
 
     if (verbose_xwayland_logging_enabled())
     {
-        log_info("Writing clipboard data from X11");
+        log_info("Writing %zu bytes of clipboard data from X11", data.size());
     }
 
-    try
+    if (in_progress_send->add_data(std::move(data)))
     {
-        write_repeatedly(fd, data, size);
-    }
-    catch (WriteError const& err)
-    {
-        log_error("Failed to write X11 clipboard data to fd: %s", err.what());
-        // Continue to clear the fd either way
+        dispatcher->add_watch(in_progress_send);
     }
 
-    lock.lock();
-    if (pending_send_fd && pending_send_fd.value() == fd)
+    if (completes_send)
     {
-        pending_send_fd.reset();
+        // The dispatcher will hold onto it until it's done
+        in_progress_send.reset();
     }
 }

--- a/src/server/frontend_xwayland/xwayland_clipboard_source.cpp
+++ b/src/server/frontend_xwayland/xwayland_clipboard_source.cpp
@@ -20,6 +20,7 @@
 
 #include "xwayland_log.h"
 #include "mir/scene/clipboard.h"
+#include "mir/dispatch/multiplexing_dispatchable.h"
 
 #include <xcb/xfixes.h>
 #include <string.h>
@@ -29,6 +30,7 @@
 
 namespace mf = mir::frontend;
 namespace ms = mir::scene;
+namespace md = mir::dispatch;
 
 namespace
 {
@@ -142,8 +144,10 @@ private:
 
 mf::XWaylandClipboardSource::XWaylandClipboardSource(
     XCBConnection& connection,
+    std::shared_ptr<md::MultiplexingDispatchable> const& dispatcher,
     std::shared_ptr<scene::Clipboard> const& clipboard)
     : connection{connection},
+      dispatcher{dispatcher},
       clipboard{clipboard},
       receiving_window{create_receiving_window(connection)}
 {

--- a/src/server/frontend_xwayland/xwayland_clipboard_source.h
+++ b/src/server/frontend_xwayland/xwayland_clipboard_source.h
@@ -30,6 +30,10 @@ namespace scene
 class Clipboard;
 class ClipboardSource;
 }
+namespace dispatch
+{
+class MultiplexingDispatchable;
+}
 namespace frontend
 {
 /// Exposes X11 selections to non-X11 clients
@@ -38,6 +42,7 @@ class XWaylandClipboardSource
 public:
     XWaylandClipboardSource(
         XCBConnection& connection,
+        std::shared_ptr<dispatch::MultiplexingDispatchable> const& dispatcher,
         std::shared_ptr<scene::Clipboard> const& clipboard);
     ~XWaylandClipboardSource();
 
@@ -69,6 +74,7 @@ private:
     void send_data_to_fd(uint8_t const* data, size_t size);
 
     XCBConnection& connection;
+    std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
     std::shared_ptr<scene::Clipboard> const clipboard;
     xcb_window_t const receiving_window;
 

--- a/src/server/frontend_xwayland/xwayland_clipboard_source.h
+++ b/src/server/frontend_xwayland/xwayland_clipboard_source.h
@@ -62,6 +62,7 @@ public:
 
 private:
     class ClipboardSource;
+    class DataSender;
 
     XWaylandClipboardSource(XWaylandClipboardSource const&) = delete;
     XWaylandClipboardSource& operator=(XWaylandClipboardSource const&) = delete;
@@ -71,7 +72,7 @@ private:
     void create_source(xcb_timestamp_t timestamp, std::vector<xcb_atom_t> const& targets);
 
     /// Sends the given data to the current destination fd and then closes and removes the fd
-    void send_data_to_fd(uint8_t const* data, size_t size);
+    void add_data_to_in_progress_send(std::vector<uint8_t>&& data, bool completes_send);
 
     XCBConnection& connection;
     std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
@@ -82,7 +83,7 @@ private:
     xcb_window_t current_clipbaord_owner{XCB_WINDOW_NONE};
     xcb_timestamp_t clipboard_ownership_timestamp{0};
     std::shared_ptr<ClipboardSource> clipboard_source;
-    std::optional<Fd> pending_send_fd;
+    std::shared_ptr<DataSender> in_progress_send;
 };
 }
 }

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -138,6 +138,7 @@ mf::XWaylandWM::XWaylandWM(
     std::shared_ptr<WaylandConnector> wayland_connector,
     wl_client* wayland_client,
     Fd const& fd,
+    std::shared_ptr<dispatch::MultiplexingDispatchable> const& dispatcher,
     float assumed_surface_scale)
     : connection{std::make_shared<XCBConnection>(fd)},
       xfixes{init_xfixes(*connection)},
@@ -146,8 +147,8 @@ mf::XWaylandWM::XWaylandWM(
       wm_shell{std::static_pointer_cast<XWaylandWMShell>(wayland_connector->get_extension("x11-support"))},
       wayland_executor{*wm_shell->wayland_executor},
       cursors{std::make_unique<XWaylandCursors>(connection)},
-      clipboard_source{std::make_unique<XWaylandClipboardSource>(*connection, wm_shell->clipboard)},
-      clipboard_provider{std::make_unique<XWaylandClipboardProvider>(*connection, wm_shell->clipboard)},
+      clipboard_source{std::make_unique<XWaylandClipboardSource>(*connection, dispatcher, wm_shell->clipboard)},
+      clipboard_provider{std::make_unique<XWaylandClipboardProvider>(*connection, dispatcher, wm_shell->clipboard)},
       wm_window{create_wm_window(*connection)},
       scene_observer{std::make_shared<XWaylandSceneObserver>(this)},
       client_manager{std::make_shared<XWaylandClientManager>(wm_shell->shell)},

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -148,7 +148,7 @@ mf::XWaylandWM::XWaylandWM(
       wayland_executor{*wm_shell->wayland_executor},
       cursors{std::make_unique<XWaylandCursors>(connection)},
       clipboard_source{std::make_unique<XWaylandClipboardSource>(*connection, dispatcher, wm_shell->clipboard)},
-      clipboard_provider{std::make_unique<XWaylandClipboardProvider>(*connection, dispatcher, wm_shell->clipboard)},
+      clipboard_provider{std::make_unique<XWaylandClipboardProvider>(connection, dispatcher, wm_shell->clipboard)},
       wm_window{create_wm_window(*connection)},
       scene_observer{std::make_shared<XWaylandSceneObserver>(this)},
       client_manager{std::make_shared<XWaylandClientManager>(wm_shell->shell)},

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -40,6 +40,10 @@ namespace scene
 using SurfaceSet = std::set<std::weak_ptr<Surface>, std::owner_less<std::weak_ptr<Surface>>>;
 class Surface;
 }
+namespace dispatch
+{
+class MultiplexingDispatchable;
+}
 namespace frontend
 {
 class XWaylandSurface;
@@ -62,6 +66,7 @@ public:
         std::shared_ptr<WaylandConnector> wayland_connector,
         wl_client* wayland_client,
         Fd const& fd,
+        std::shared_ptr<dispatch::MultiplexingDispatchable> const& dispatcher,
         float assumed_surface_scale);
     ~XWaylandWM();
 


### PR DESCRIPTION
Pipes the X11 event dispatcher through to the clipboard provider and source, and adds pending operations to it so they do not block.  Clipboard provider's connection needed to be changed from a ref to a `shared_ptr` so `SelectionSender` wouldn't outlive it, and this adds a bit of noise to the diff.