### PR TITLE
X11 platform: make things const

### DIFF
--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -92,9 +92,8 @@ public:
     XGLContext(::Display* const x_dpy,
                std::shared_ptr<mg::GLConfig> const& gl_config,
                EGLContext const shared_ctx)
-        : egl{*gl_config}
+        : egl{*gl_config, x_dpy, shared_ctx}
     {
-        egl.setup(x_dpy, shared_ctx);
     }
 
     ~XGLContext() = default;
@@ -110,7 +109,7 @@ public:
     }
 
 private:
-    mgx::helpers::EGLHelper egl;
+    mgx::helpers::EGLHelper const egl;
 };
 }
 
@@ -239,7 +238,7 @@ mgx::Display::Display(::Display* x_dpy,
                       std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
                       std::shared_ptr<GLConfig> const& gl_config,
                       std::shared_ptr<DisplayReport> const& report)
-    : shared_egl{*gl_config},
+    : shared_egl{*gl_config, x_dpy},
       x_dpy{x_dpy},
       gl_config{gl_config},
       pixel_width{get_pixel_width(x_dpy)},
@@ -247,8 +246,6 @@ mgx::Display::Display(::Display* x_dpy,
       report{report},
       last_frame{std::make_shared<AtomicFrame>()}
 {
-    shared_egl.setup(x_dpy);
-
     geom::Point top_left{0, 0};
 
     for (auto const& requested_size : requested_sizes)

--- a/src/platforms/x11/graphics/display.h
+++ b/src/platforms/x11/graphics/display.h
@@ -122,13 +122,13 @@ private:
     };
 
     std::vector<std::unique_ptr<OutputInfo>> outputs;
-    helpers::EGLHelper shared_egl;
+    helpers::EGLHelper const shared_egl;
     ::Display* const x_dpy;
     std::shared_ptr<GLConfig> const gl_config;
-    float pixel_width;
-    float pixel_height;
+    float const pixel_width;
+    float const pixel_height;
     std::shared_ptr<DisplayReport> const report;
-    std::shared_ptr<AtomicFrame> last_frame;
+    std::shared_ptr<AtomicFrame> const last_frame;
 };
 
 }

--- a/src/platforms/x11/graphics/display_buffer.cpp
+++ b/src/platforms/x11/graphics/display_buffer.cpp
@@ -40,12 +40,11 @@ mgx::DisplayBuffer::DisplayBuffer(::Display* const x_dpy,
                                   : report{r},
                                     area{view_area},
                                     transform(1),
-                                    egl{gl_config},
+                                    egl{gl_config, x_dpy, win, shared_context},
                                     last_frame{f},
                                     output_id{output_id},
                                     eglGetSyncValues{nullptr}
 {
-    egl.setup(x_dpy, win, shared_context);
     egl.report_egl_configuration(
         [&r] (EGLDisplay disp, EGLConfig cfg)
         {

--- a/src/platforms/x11/graphics/display_buffer.h
+++ b/src/platforms/x11/graphics/display_buffer.h
@@ -78,9 +78,9 @@ private:
     std::shared_ptr<DisplayReport> const report;
     geometry::Rectangle area;
     glm::mat2 transform;
-    helpers::EGLHelper egl;
+    helpers::EGLHelper const egl;
     std::shared_ptr<AtomicFrame> const last_frame;
-    DisplayConfigurationOutputId output_id;
+    DisplayConfigurationOutputId const output_id;
 
     typedef EGLBoolean (EGLAPIENTRY EglGetSyncValuesCHROMIUM)
         (EGLDisplay dpy, EGLSurface surface, int64_t *ust,

--- a/src/platforms/x11/graphics/egl_helper.cpp
+++ b/src/platforms/x11/graphics/egl_helper.cpp
@@ -27,16 +27,8 @@ namespace mg = mir::graphics;
 namespace mgx = mg::X;
 namespace mgxh = mgx::helpers;
 
-mgxh::EGLHelper::EGLHelper(GLConfig const& gl_config)
-    : depth_buffer_bits{gl_config.depth_buffer_bits()},
-      stencil_buffer_bits{gl_config.stencil_buffer_bits()},
-      egl_display{EGL_NO_DISPLAY}, egl_config{0},
-      egl_context{EGL_NO_CONTEXT}, egl_surface{EGL_NO_SURFACE},
-      should_terminate_egl{false}
-{
-}
-
-void mgxh::EGLHelper::setup(::Display* const x_dpy)
+mgxh::EGLHelper::EGLHelper(GLConfig const& gl_config, ::Display* const x_dpy)
+    : EGLHelper{gl_config}
 {
     eglBindAPI(EGL_OPENGL_ES_API);
 
@@ -52,7 +44,8 @@ void mgxh::EGLHelper::setup(::Display* const x_dpy)
         BOOST_THROW_EXCEPTION(mg::egl_error("Failed to create EGL context"));
 }
 
-void mgxh::EGLHelper::setup(::Display* const x_dpy, EGLContext shared_context)
+mgxh::EGLHelper::EGLHelper(GLConfig const& gl_config, ::Display* const x_dpy, EGLContext shared_context)
+    : EGLHelper{gl_config}
 {
     eglBindAPI(EGL_OPENGL_ES_API);
 
@@ -68,8 +61,8 @@ void mgxh::EGLHelper::setup(::Display* const x_dpy, EGLContext shared_context)
         BOOST_THROW_EXCEPTION(mg::egl_error("Failed to create EGL context"));
 }
 
-void mgxh::EGLHelper::setup(::Display* const x_dpy, Window win,
-                            EGLContext shared_context)
+mgxh::EGLHelper::EGLHelper(GLConfig const& gl_config, ::Display* const x_dpy, Window win, EGLContext shared_context)
+    : EGLHelper{gl_config}
 {
     eglBindAPI(EGL_OPENGL_ES_API);
 
@@ -106,7 +99,7 @@ mgxh::EGLHelper::~EGLHelper() noexcept
     }
 }
 
-bool mgxh::EGLHelper::swap_buffers()
+bool mgxh::EGLHelper::swap_buffers() const
 {
     auto ret = eglSwapBuffers(egl_display, egl_surface);
     return (ret == EGL_TRUE);
@@ -123,6 +116,15 @@ bool mgxh::EGLHelper::release_current() const
 {
     auto ret = eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
     return (ret == EGL_TRUE);
+}
+
+mgxh::EGLHelper::EGLHelper(GLConfig const& gl_config)
+    : depth_buffer_bits{gl_config.depth_buffer_bits()},
+      stencil_buffer_bits{gl_config.stencil_buffer_bits()},
+      egl_display{EGL_NO_DISPLAY}, egl_config{0},
+      egl_context{EGL_NO_CONTEXT}, egl_surface{EGL_NO_SURFACE},
+      should_terminate_egl{false}
+{
 }
 
 void mgxh::EGLHelper::setup_internal(::Display* const x_dpy, bool initialize)

--- a/src/platforms/x11/graphics/egl_helper.h
+++ b/src/platforms/x11/graphics/egl_helper.h
@@ -40,18 +40,15 @@ namespace helpers
 class EGLHelper
 {
 public:
-    EGLHelper(GLConfig const& gl_config);
-    ~EGLHelper() noexcept;
-
     EGLHelper(const EGLHelper&) = delete;
     EGLHelper& operator=(const EGLHelper&) = delete;
 
-    void setup(::Display* const x_dpy);
-    void setup(::Display* const x_dpy, EGLContext shared_context);
-    void setup(::Display* const x_dpy, Window win,
-               EGLContext shared_context);
+    EGLHelper(GLConfig const& gl_config, ::Display* const x_dpy);
+    EGLHelper(GLConfig const& gl_config, ::Display* const x_dpy, EGLContext shared_context);
+    EGLHelper(GLConfig const& gl_config, ::Display* const x_dpy, Window win, EGLContext shared_context);
+    ~EGLHelper() noexcept;
 
-    bool swap_buffers();
+    bool swap_buffers() const;
     bool make_current() const;
     bool release_current() const;
 
@@ -62,6 +59,7 @@ public:
 
     void report_egl_configuration(std::function<void(EGLDisplay, EGLConfig)>) const;
 private:
+    EGLHelper(GLConfig const& gl_config);
     void setup_internal(::Display* const x_dpy, bool initialize);
 
     EGLint const depth_buffer_bits;


### PR DESCRIPTION
This changes `EGLHelper` from two stage to one stage initialization, which allows it to be const. Also makes some other things const.