### PR TITLE
Example WaylandShm: don't allow incorrectly sized buffers

### DIFF
--- a/examples/example-server-lib/decoration_provider.cpp
+++ b/examples/example-server-lib/decoration_provider.cpp
@@ -344,7 +344,7 @@ void DecorationProviderClient::draw_background(BackgroundInfo& ctx) const
 
     printer.printhelp(ctx);
 
-    ctx.attach_buffer(*buffer, ctx.output->scale());
+    ctx.attach_buffer(buffer->use(), ctx.output->scale());
     ctx.commit();
     roundtrip();
 }

--- a/examples/example-server-lib/wayland_app.cpp
+++ b/examples/example-server-lib/wayland_app.cpp
@@ -21,6 +21,22 @@
 #include <cstring>
 #include <algorithm>
 
+wl_callback_listener const WaylandCallback::callback_listener {
+    []/* done */(void* data, wl_callback*, uint32_t)
+    {
+        auto const cb = static_cast<WaylandCallback*>(data);
+        cb->func();
+        delete cb;
+    },
+};
+
+void WaylandCallback::create(wl_callback* callback, std::function<void()>&& func)
+{
+    auto const cb = new WaylandCallback({callback, wl_callback_destroy}, std::move(func));
+    wl_callback_add_listener(callback, &callback_listener, cb);
+    // Will destroy itself when called
+}
+
 wl_output_listener const WaylandOutput::output_listener = {
     handle_geometry,
     handle_mode,

--- a/examples/example-server-lib/wayland_app.h
+++ b/examples/example-server-lib/wayland_app.h
@@ -51,6 +51,25 @@ private:
     std::unique_ptr<T, void(*)(T*)> proxy;
 };
 
+class WaylandCallback
+{
+public:
+    /// Takes ownership of callback
+    static void create(wl_callback* callback, std::function<void()>&& func);
+
+private:
+    WaylandCallback(WaylandObject<wl_callback> callback, std::function<void()>&& func)
+        : callback{std::move(callback)},
+          func{std::move(func)}
+    {
+    }
+
+    static wl_callback_listener const callback_listener;
+
+    WaylandObject<wl_callback> const callback;
+    std::function<void()> const func;
+};
+
 class WaylandOutput
 {
 public:

--- a/examples/example-server-lib/wayland_shm.cpp
+++ b/examples/example-server-lib/wayland_shm.cpp
@@ -30,7 +30,7 @@
 
 namespace geom = mir::geometry;
 
-struct wl_shm_pool* make_shm_pool(struct wl_shm* shm, int size, void **data)
+static wl_shm_pool* make_shm_pool(wl_shm* shm, int size, void **data)
 {
     static auto (*open_shm_file)() -> mir::Fd = []
         {

--- a/examples/example-server-lib/wayland_shm.cpp
+++ b/examples/example-server-lib/wayland_shm.cpp
@@ -30,6 +30,8 @@
 
 namespace geom = mir::geometry;
 
+namespace
+{
 static wl_shm_pool* make_shm_pool(wl_shm* shm, int size, void **data)
 {
     static auto (*open_shm_file)() -> mir::Fd = []
@@ -86,6 +88,7 @@ static wl_shm_pool* make_shm_pool(wl_shm* shm, int size, void **data)
     }
 
     return wl_shm_create_pool(shm, fd, size);
+}
 }
 
 struct WaylandShmPool

--- a/examples/example-server-lib/wayland_shm.cpp
+++ b/examples/example-server-lib/wayland_shm.cpp
@@ -119,8 +119,8 @@ WaylandShmBuffer::WaylandShmBuffer(
     wl_buffer* buffer)
     : pool{pool},
       data_{data},
-      size{size},
-      stride{stride},
+      size_{size},
+      stride_{stride},
       buffer{buffer}
 {
     wl_buffer_add_listener(buffer, &buffer_listener, this);
@@ -157,8 +157,8 @@ auto WaylandShm::get_buffer(geom::Size size, geom::Stride stride) -> std::shared
     size_t const data_size = size.height.as_int() * stride.as_int();
     if (!current_buffer ||
         current_buffer->is_in_use() ||
-        current_buffer->size != size ||
-        current_buffer->stride != stride)
+        current_buffer->size() != size ||
+        current_buffer->stride() != stride)
     {
         void* data;
         auto const pool_resource = make_shm_pool(shm, data_size, &data);

--- a/examples/example-server-lib/wayland_shm.cpp
+++ b/examples/example-server-lib/wayland_shm.cpp
@@ -135,7 +135,10 @@ WaylandShm::WaylandShm(wl_shm* shm)
 auto WaylandShm::get_buffer(geom::Size size, geom::Stride stride) -> std::shared_ptr<WaylandShmBuffer>
 {
     size_t const data_size = size.height.as_int() * stride.as_int();
-    if (!current_buffer || current_buffer->is_in_use() || data_size > current_buffer->data_size)
+    if (!current_buffer ||
+        current_buffer->is_in_use() ||
+        current_buffer->size != size ||
+        current_buffer->stride != stride)
     {
         void* data;
         WaylandObject<wl_shm_pool> pool{make_shm_pool(shm, data_size, &data), wl_shm_pool_destroy};

--- a/examples/example-server-lib/wayland_shm.h
+++ b/examples/example-server-lib/wayland_shm.h
@@ -32,7 +32,12 @@ struct wl_shm_pool* make_shm_pool(struct wl_shm* shm, int size, void **data);
 class WaylandShmBuffer
 {
 public:
-    WaylandShmBuffer(void* data, size_t data_size, wl_buffer* buffer);
+    WaylandShmBuffer(
+        void* data,
+        size_t data_size,
+        mir::geometry::Size size,
+        mir::geometry::Stride stride,
+        wl_buffer* buffer);
     ~WaylandShmBuffer();
 
     auto data() const -> void* { return data_; }
@@ -49,6 +54,8 @@ private:
 
     void* const data_;
     size_t const data_size;
+    mir::geometry::Size const size;
+    mir::geometry::Stride const stride;
     wl_buffer* const buffer;
     std::shared_ptr<WaylandShmBuffer> self_ptr; ///< gets cleared on release
 };

--- a/examples/example-server-lib/wayland_shm.h
+++ b/examples/example-server-lib/wayland_shm.h
@@ -25,10 +25,6 @@
 #include <memory>
 
 class WaylandShm;
-
-// TODO: migrate away from using this directly
-struct wl_shm_pool* make_shm_pool(struct wl_shm* shm, int size, void **data);
-
 struct WaylandShmPool;
 
 class WaylandShmBuffer : public std::enable_shared_from_this<WaylandShmBuffer>

--- a/examples/example-server-lib/wayland_shm.h
+++ b/examples/example-server-lib/wayland_shm.h
@@ -42,7 +42,11 @@ public:
     auto data() const -> void* { return data_; }
     auto size() const -> mir::geometry::Size { return size_; }
     auto stride() const -> mir::geometry::Stride { return stride_; }
+    /// Returns if this buffer is currently being used by the compositor. In-use buffers keep themselves alive.
     auto is_in_use() const -> bool { return self_ptr != nullptr; }
+    /// Marks this buffer as in-use and assumes the resulting wl_buffer is sent to the compositor. Keeps this buffer
+    /// alive until the compositor releases it (if it's not sent to the compositor or the compositor never releases it
+    /// this buffer is leaked). Should only be called if the buffer is not already in-use.
     auto use() -> wl_buffer*;
 
 private:
@@ -68,7 +72,7 @@ public:
     /// Does not take ownership of the wl_shm
     WaylandShm(wl_shm* shm);
 
-    /// The returned buffer is automatically released as long as it is sent to the compositor
+    /// Always returns a buffer of the correct size that is not in-use
     auto get_buffer(mir::geometry::Size size, mir::geometry::Stride stride) -> std::shared_ptr<WaylandShmBuffer>;
 
 private:

--- a/examples/example-server-lib/wayland_shm.h
+++ b/examples/example-server-lib/wayland_shm.h
@@ -43,12 +43,13 @@ public:
     ~WaylandShmBuffer();
 
     auto data() const -> void* { return data_; }
+    auto size() const -> mir::geometry::Size { return size_; }
+    auto stride() const -> mir::geometry::Stride { return stride_; }
+    auto is_in_use() const -> bool { return self_ptr != nullptr; }
     auto use() -> wl_buffer*;
 
 private:
     friend WaylandShm;
-
-    auto is_in_use() const -> bool { return self_ptr != nullptr; }
 
     static wl_buffer_listener const buffer_listener;
 
@@ -56,8 +57,8 @@ private:
 
     std::shared_ptr<WaylandShmPool> const pool;
     void* const data_;
-    mir::geometry::Size const size;
-    mir::geometry::Stride const stride;
+    mir::geometry::Size const size_;
+    mir::geometry::Stride const stride_;
     wl_buffer* const buffer;
     std::shared_ptr<WaylandShmBuffer> self_ptr; ///< Is set on use and cleared on release
 };

--- a/examples/example-server-lib/wayland_shm.h
+++ b/examples/example-server-lib/wayland_shm.h
@@ -29,12 +29,14 @@ class WaylandShm;
 // TODO: migrate away from using this directly
 struct wl_shm_pool* make_shm_pool(struct wl_shm* shm, int size, void **data);
 
+struct WaylandShmPool;
+
 class WaylandShmBuffer : public std::enable_shared_from_this<WaylandShmBuffer>
 {
 public:
     WaylandShmBuffer(
+        std::shared_ptr<WaylandShmPool> pool,
         void* data,
-        size_t data_size,
         mir::geometry::Size size,
         mir::geometry::Stride stride,
         wl_buffer* buffer);
@@ -52,8 +54,8 @@ private:
 
     static void handle_release(void *data, wl_buffer*);
 
+    std::shared_ptr<WaylandShmPool> const pool;
     void* const data_;
-    size_t const data_size;
     mir::geometry::Size const size;
     mir::geometry::Stride const stride;
     wl_buffer* const buffer;

--- a/examples/example-server-lib/wayland_shm.h
+++ b/examples/example-server-lib/wayland_shm.h
@@ -23,6 +23,7 @@
 
 #include <wayland-client.h>
 #include <memory>
+#include <vector>
 
 class WaylandShm;
 struct WaylandShmPool;
@@ -59,6 +60,8 @@ private:
     std::shared_ptr<WaylandShmBuffer> self_ptr; ///< Is set on use and cleared on release
 };
 
+/// A single WaylandShm does not efficiently provision multiple buffers for multiple window sizes. Please use one
+/// WaylandShm per window (if windows may have distinct sizes)
 class WaylandShm
 {
 public:
@@ -70,7 +73,8 @@ public:
 
 private:
     wl_shm* const shm;
-    std::shared_ptr<WaylandShmBuffer> current_buffer;
+    /// get_buffer() assumes all buffers in the list have the same size and stride
+    std::vector<std::shared_ptr<WaylandShmBuffer>> buffers;
 };
 
 #endif // MIRAL_WAYLAND_SHM_H

--- a/examples/example-server-lib/wayland_shm.h
+++ b/examples/example-server-lib/wayland_shm.h
@@ -29,7 +29,7 @@ class WaylandShm;
 // TODO: migrate away from using this directly
 struct wl_shm_pool* make_shm_pool(struct wl_shm* shm, int size, void **data);
 
-class WaylandShmBuffer
+class WaylandShmBuffer : public std::enable_shared_from_this<WaylandShmBuffer>
 {
 public:
     WaylandShmBuffer(
@@ -41,7 +41,7 @@ public:
     ~WaylandShmBuffer();
 
     auto data() const -> void* { return data_; }
-    operator wl_buffer*() const { return buffer; }
+    auto use() -> wl_buffer*;
 
 private:
     friend WaylandShm;
@@ -57,7 +57,7 @@ private:
     mir::geometry::Size const size;
     mir::geometry::Stride const stride;
     wl_buffer* const buffer;
-    std::shared_ptr<WaylandShmBuffer> self_ptr; ///< gets cleared on release
+    std::shared_ptr<WaylandShmBuffer> self_ptr; ///< Is set on use and cleared on release
 };
 
 class WaylandShm
@@ -67,7 +67,7 @@ public:
     WaylandShm(wl_shm* shm);
 
     /// The returned buffer is automatically released as long as it is sent to the compositor
-    auto get_buffer(mir::geometry::Size size, mir::geometry::Stride stride) -> WaylandShmBuffer*;
+    auto get_buffer(mir::geometry::Size size, mir::geometry::Stride stride) -> std::shared_ptr<WaylandShmBuffer>;
 
 private:
     wl_shm* const shm;

--- a/examples/example-server-lib/wayland_surface.cpp
+++ b/examples/example-server-lib/wayland_surface.cpp
@@ -61,6 +61,11 @@ void WaylandSurface::set_fullscreen(wl_output* output)
         output);
 }
 
+void WaylandSurface::add_frame_callback(std::function<void()>&& func)
+{
+    WaylandCallback::create(wl_surface_frame(surface_), std::move(func));
+}
+
 void WaylandSurface::handle_ping(void* data, struct wl_shell_surface*, uint32_t serial)
 {
     auto const self = static_cast<WaylandSurface*>(data);

--- a/examples/example-server-lib/wayland_surface.h
+++ b/examples/example-server-lib/wayland_surface.h
@@ -24,6 +24,8 @@
 
 #include "mir/geometry/size.h"
 
+#include <functional>
+
 class WaylandSurface
 {
 public:
@@ -34,6 +36,7 @@ public:
     void commit() const;
     /// output can be null, user needs to commit after
     void set_fullscreen(wl_output* output);
+    void add_frame_callback(std::function<void()>&& func);
 
     auto app() const -> WaylandApp const* { return app_; }
     auto surface() const -> wl_surface* { return surface_; }

--- a/examples/miral-shell/spinner/miregl.h
+++ b/examples/miral-shell/spinner/miregl.h
@@ -52,27 +52,9 @@ private:
 
     std::shared_ptr<MirEglApp> const mir_egl_app;
 
-    void* content_area = nullptr;
-    struct wl_callback* new_frame_signal = nullptr;
-    struct Buffers
-    {
-        struct wl_buffer* buffer;
-        bool available;
-    } buffers[4];
-    bool waiting_for_buffer = true;
-
     EGLSurface eglsurface;
     int width_{0};
     int height_{0};
-
-    static void shell_surface_ping(void *data, struct wl_shell_surface *wl_shell_surface, uint32_t serial);
-
-    static void shell_surface_configure(void *data,
-        struct wl_shell_surface *wl_shell_surface,
-        uint32_t edges,
-        int32_t width,
-        int32_t height);
-    static void shell_surface_popup_done(void *data, struct wl_shell_surface *wl_shell_surface);
 
 };
 


### PR DESCRIPTION
In practice this doesn't currently matter because with only one buffer, buffers are never re-used (which is I guess ok for a static background, where updates are infrequent). However, it was technically incorrect to allow buffers with different geometry than requested to be returned. This PR guarantees a new buffer is created if different geometry is requested.

EDIT: this PR now also ports `SwSplash` to the new classes, which fixes some sketchy buffer management it was doing.