### PR TITLE
Snap beta (not candidate) from mir-team/rc

### DIFF
--- a/tools/process_snaps.py
+++ b/tools/process_snaps.py
@@ -31,7 +31,7 @@ SOURCE_NAME = "mir"
 SNAPS = {
     "mir-kiosk": {
         "edge": {"ppa": "dev", "recipe": "mir-kiosk-edge"},
-        "candidate": {"ppa": "rc", "recipe": "mir-kiosk-candidate"},
+        "beta": {"ppa": "rc", "recipe": "mir-kiosk-candidate"},
     },
     "mir-kiosk-apps": {
         "edge": {"recipe": "mir-kiosk-apps"},
@@ -41,7 +41,7 @@ SNAPS = {
     },
     "mir-test-tools": {
         "edge": {"ppa": "dev", "recipe": "mir-test-tools-edge"},
-        "candidate": {"ppa": "rc", "recipe": "mir-test-tools"},
+        "beta": {"ppa": "rc", "recipe": "mir-test-tools"},
     },
     "egmde": {
         "edge": {"ppa": "dev", "recipe": "egmde-mir-master"},


### PR DESCRIPTION
This is to support a change to our workflow that allows an extra verification step.

* edge: automatically built from /dev. (Same as now)
* beta: automatically built from /rc. (As candidate is now)
* candidate: promoted by us from beta. (Typically when we copy /rc to /release)
* stable: promoted from candidate. (After CfT etc.)