### PR TITLE
XWayland incremental data transfers

### DIFF
--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -606,6 +606,7 @@ auto mf::XCBConnection::xcb_type_atom(XCBType type) const -> xcb_atom_t
         case XCBType::UTF8_STRING:  return UTF8_STRING;
         case XCBType::WM_STATE:     return WM_STATE;
         case XCBType::WM_PROTOCOLS: return WM_PROTOCOLS;
+        case XCBType::INCR:         return INCR;
     }
 
     BOOST_THROW_EXCEPTION(std::runtime_error(

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -49,6 +49,7 @@ enum class XCBType
     UTF8_STRING,
     WM_STATE,
     WM_PROTOCOLS,
+    INCR,
 };
 
 template<XCBType T> struct NativeXCBType                { typedef void type;};
@@ -60,6 +61,9 @@ template<> struct NativeXCBType<XCBType::STRING>        { typedef char type; };
 template<> struct NativeXCBType<XCBType::UTF8_STRING>   { typedef char type; };
 template<> struct NativeXCBType<XCBType::WM_STATE>      { typedef uint32_t type; };
 template<> struct NativeXCBType<XCBType::WM_PROTOCOLS>  { typedef uint32_t type; };
+// https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#incr_properties:
+// "The contents of the INCR property will be an integer"
+template<> struct NativeXCBType<XCBType::INCR>          { typedef int32_t type; };
 
 class XCBConnection
 {

--- a/src/server/frontend_xwayland/xwayland_clipboard_provider.cpp
+++ b/src/server/frontend_xwayland/xwayland_clipboard_provider.cpp
@@ -80,13 +80,14 @@ void send_selection_notify(
         XCB_EVENT_MASK_NO_EVENT,
         reinterpret_cast<const char*>(&selection_notify));
 }
+}
 
-class SelectionSender : public md::Dispatchable
+class mf::XWaylandClipboardProvider::SelectionSender : public md::Dispatchable
 {
 public:
     SelectionSender(
         std::shared_ptr<mf::XCBConnection> const& connection,
-        mir::Fd&& source_fd,
+        Fd&& source_fd,
         xcb_timestamp_t time,
         xcb_window_t requester,
         xcb_atom_t selection,
@@ -107,7 +108,7 @@ public:
 
 private:
 
-    auto watch_fd() const -> mir::Fd override
+    auto watch_fd() const -> Fd override
     {
         return source_fd;
     }
@@ -187,7 +188,6 @@ private:
     size_t data_size; ///< how much of the buffer is being used
     std::unique_ptr<uint8_t[]> const buffer;
 };
-}
 
 class mf::XWaylandClipboardProvider::ClipboardObserver : public scene::ClipboardObserver
 {

--- a/src/server/frontend_xwayland/xwayland_clipboard_provider.cpp
+++ b/src/server/frontend_xwayland/xwayland_clipboard_provider.cpp
@@ -338,9 +338,11 @@ void mf::XWaylandClipboardProvider::send_data(
         return;
     }
 
-    Fd out_fd{fds[0]}, in_fd{fds[1]};
+    Fd out_fd{fds[0]};
 
     {
+        Fd in_fd{fds[1]};
+
         std::lock_guard<std::mutex> lock{mutex};
         if (!current_source)
         {
@@ -348,8 +350,7 @@ void mf::XWaylandClipboardProvider::send_data(
             send_selection_notify(*connection, time, requester, XCB_ATOM_NONE, connection->CLIPBOARD, target);
             return;
         }
-        current_source->initiate_send(mime_type, in_fd);
-        in_fd = {}; // release ownership of the fd here
+        current_source->initiate_send(mime_type, std::move(in_fd));
     }
 
     dispatcher->add_watch(std::make_shared<SelectionSender>(

--- a/src/server/frontend_xwayland/xwayland_clipboard_provider.h
+++ b/src/server/frontend_xwayland/xwayland_clipboard_provider.h
@@ -21,6 +21,8 @@
 
 #include "xcb_connection.h"
 
+#include <map>
+
 struct xcb_xfixes_selection_notify_event_t;
 
 namespace mir
@@ -50,12 +52,23 @@ public:
     /// @{
     void selection_request_event(xcb_selection_request_event_t* event);
     void xfixes_selection_notify_event(xcb_xfixes_selection_notify_event_t* event);
+    void property_deleted_event(xcb_window_t window, xcb_atom_t property);
     /// @}
-
 
 private:
     class SelectionSender;
     class ClipboardObserver;
+
+    struct ThreadsafeSelf
+    {
+        ThreadsafeSelf(XWaylandClipboardProvider* ptr)
+            : ptr{ptr}
+        {
+        }
+
+        std::mutex mutex;
+        XWaylandClipboardProvider* ptr; ///< nulled out when provider is destroyed
+    };
 
     XWaylandClipboardProvider(XWaylandClipboardProvider const&) = delete;
     XWaylandClipboardProvider& operator=(XWaylandClipboardProvider const&) = delete;
@@ -83,6 +96,10 @@ private:
     /// Called by the observer, indicates the paste source has been set by someone (could be us or Wayland)
     void paste_source_set(std::shared_ptr<scene::ClipboardSource> const& source);
 
+    /// Called by the sender, indicates sending should resume when the sender's property is deleted
+    void defer_incremental_send(std::shared_ptr<SelectionSender> sender, xcb_window_t window, xcb_atom_t property);
+
+    std::shared_ptr<ThreadsafeSelf> const threadsafe_self;
     std::shared_ptr<XCBConnection> const connection;
     std::shared_ptr<dispatch::MultiplexingDispatchable> const dispatcher;
     std::shared_ptr<scene::Clipboard> const clipboard;
@@ -95,6 +112,9 @@ private:
     xcb_timestamp_t clipboard_ownership_timestamp{XCB_TIME_CURRENT_TIME};
     /// The source X11 clients can paste from. Should never be a source from this XWayland connection. Can be null
     std::shared_ptr<scene::ClipboardSource> current_source;
+    /// Maps window/property pairs to SelectionSender's that are waiting for those properties to be deleted in order to
+    /// continue an incremental send.
+    std::map<std::pair<xcb_window_t, xcb_atom_t>, std::shared_ptr<SelectionSender>> pending_incremental_sends;
 };
 }
 }

--- a/src/server/frontend_xwayland/xwayland_clipboard_provider.h
+++ b/src/server/frontend_xwayland/xwayland_clipboard_provider.h
@@ -54,6 +54,7 @@ public:
 
 
 private:
+    class SelectionSender;
     class ClipboardObserver;
 
     XWaylandClipboardProvider(XWaylandClipboardProvider const&) = delete;

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -662,6 +662,12 @@ void mf::XWaylandWM::handle_property_notify(xcb_property_notify_event_t *event)
     {
         surface.value()->property_notify(event->atom);
     }
+
+    // Inform the clipboard provider, in case this is part of an incremental data send
+    if (event->state == XCB_PROPERTY_DELETE)
+    {
+        clipboard_provider->property_deleted_event(event->window, event->atom);
+    }
 }
 
 void mf::XWaylandWM::handle_create_notify(xcb_create_notify_event_t *event)

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -668,6 +668,12 @@ void mf::XWaylandWM::handle_property_notify(xcb_property_notify_event_t *event)
     {
         clipboard_provider->property_deleted_event(event->window, event->atom);
     }
+
+    // Inform the clipboard source, in case it's new data for an incremental send
+    if (event->state == XCB_PROPERTY_NEW_VALUE && connection->is_ours(event->window))
+    {
+        clipboard_source->property_notify_event(event->window, event->atom);
+    }
 }
 
 void mf::XWaylandWM::handle_create_notify(xcb_create_notify_event_t *event)


### PR DESCRIPTION
This enables large copy-pastes between X11 and Wayland.

The X11 protocol this implements can be found [here](https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#incr_properties). Basically, first the property is set to type `INCR`, once the receiver deletes that chunks of data start being sent (a new one after the previous is deleted). The last chunk has a length of zero, and then the receiver knows it's done.

How large a data transfer is needed to make this PR relevant? Unclear. For Wayland -> X11 we have it hard-coded to 64kb (same as Weston). Somewhere I read the real cutoff was 256kb. X11 Kate seems to allow copying out much bigger buffers without incremental transfers. In any case, There is no longer a limit with this PR.