### PR TITLE
[snaps] use PPA as defined for the snap/channel

### DIFF
--- a/tools/process_snaps.py
+++ b/tools/process_snaps.py
@@ -264,9 +264,8 @@ if __name__ == '__main__':
 
             logger.info("Triggering %s…", snap_recipe.description or snap_recipe.name)
 
-            snap_recipe.requestBuilds(archive=snap_recipe.auto_build_archive,
-                                      pocket=snap_recipe.auto_build_pocket,
-                                      channels=snap_recipe.auto_build_channels)
+            snap_recipe.requestBuilds(archive=ppa,
+                                      pocket=snap_recipe.auto_build_pocket)
             logger.debug("Triggered builds: %s", snap_recipe.web_link)
 
     for error in errors:


### PR DESCRIPTION
Rather than depending on the recipe's configuration.

`channels` isn't required, so can skip altogether.