### PR TITLE
Adding DisplayConfigurationPolicy back as a parameter

### DIFF
--- a/debian/libmiroil1.symbols
+++ b/debian/libmiroil1.symbols
@@ -21,6 +21,5 @@ libmiroil.so.1 libmiroil1 #MINVER#
  (c++)"miroil::PersistDisplayConfig::~PersistDisplayConfig()@MIROIL_1.0" 2.2.0
  (c++)"typeinfo for miroil::DisplayConfigurationPolicy@MIROIL_1.0" 2.2.0
  (c++)"vtable for miroil::DisplayConfigurationPolicy@MIROIL_1.0" 2.2.0
- MIROIL_2.2@MIROIL_2.2 2.2.0
  (c++)"miroil::PersistDisplayConfig::PersistDisplayConfig(std::shared_ptr<miroil::DisplayConfigurationStorage> const&, std::function<std::shared_ptr<miroil::DisplayConfigurationPolicy> (std::shared_ptr<mir::graphics::DisplayConfigurationPolicy> const&)> const&)@MIROIL_1.0" 2.2.0
  (c++)"miroil::dispatch_input_event(miral::Window const&, MirInputEvent const*)@MIROIL_1.0" 2.2.0

--- a/debian/libmiroil1.symbols
+++ b/debian/libmiroil1.symbols
@@ -21,3 +21,6 @@ libmiroil.so.1 libmiroil1 #MINVER#
  (c++)"miroil::PersistDisplayConfig::~PersistDisplayConfig()@MIROIL_1.0" 2.2.0
  (c++)"typeinfo for miroil::DisplayConfigurationPolicy@MIROIL_1.0" 2.2.0
  (c++)"vtable for miroil::DisplayConfigurationPolicy@MIROIL_1.0" 2.2.0
+ MIROIL_2.2@MIROIL_2.2 2.2.0
+ (c++)"miroil::PersistDisplayConfig::PersistDisplayConfig(std::shared_ptr<miroil::DisplayConfigurationStorage> const&, std::function<std::shared_ptr<miroil::DisplayConfigurationPolicy> (std::shared_ptr<mir::graphics::DisplayConfigurationPolicy> const&)> const&)@MIROIL_1.0" 2.2.0
+ (c++)"miroil::dispatch_input_event(miral::Window const&, MirInputEvent const*)@MIROIL_1.0" 2.2.0

--- a/include/miroil/miroil/eventdispatch.h
+++ b/include/miroil/miroil/eventdispatch.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIROIL_EVENTDISPATCH_H
+#define MIROIL_EVENTDISPATCH_H
+
+namespace miral { class Window; }
+
+struct MirInputEvent;
+
+namespace miroil
+{
+void dispatchInputEvent(const miral::Window& window, const MirInputEvent* event);
+}
+
+#endif //MIROIL_EVENTDISPATCH_H

--- a/include/miroil/miroil/eventdispatch.h
+++ b/include/miroil/miroil/eventdispatch.h
@@ -23,7 +23,7 @@ struct MirInputEvent;
 
 namespace miroil
 {
-void dispatchInputEvent(const miral::Window& window, const MirInputEvent* event);
+void dispatch_input_event(const miral::Window& window, const MirInputEvent* event);
 }
 
 #endif //MIROIL_EVENTDISPATCH_H

--- a/include/miroil/miroil/persist_display_config.h
+++ b/include/miroil/miroil/persist_display_config.h
@@ -38,7 +38,7 @@ public:
     auto operator=(PersistDisplayConfig const&) -> PersistDisplayConfig&;
 
     // TODO factor this out better
-    using DisplayConfigurationPolicyWrapper = std::function<std::shared_ptr<DisplayConfigurationPolicy>()>;
+    using DisplayConfigurationPolicyWrapper = std::function<std::shared_ptr<DisplayConfigurationPolicy>(std::shared_ptr<mir::graphics::DisplayConfigurationPolicy> const& wrapped)>;
 
     PersistDisplayConfig(std::shared_ptr<DisplayConfigurationStorage> const& storage,
                          DisplayConfigurationPolicyWrapper const& custom_wrapper);

--- a/src/miroil/CMakeLists.txt
+++ b/src/miroil/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(miroil SHARED
     mirbuffer.cpp ${miroil_include}/miroil/mirbuffer.h
     persist_display_config.cpp ${miroil_include}/miroil/persist_display_config.h
     display_configuration_policy.cpp ${miroil_include}/miroil/display_configuration_policy.h
+    eventdispatch.cpp ${miroil_include}/miroil/eventdispatch.h
     ${miroil_include}/miroil/display_configuration_storage.h
     ${miroil_include}/miroil/display_id.h
 )
@@ -36,6 +37,7 @@ target_include_directories(miroil
     ${PROJECT_SOURCE_DIR}/include/renderers/gl
     ${PROJECT_SOURCE_DIR}/include/server
     ${PROJECT_SOURCE_DIR}/include/client
+    ${PROJECT_SOURCE_DIR}/include/miral
     ${PROJECT_SOURCE_DIR}/src/include/server
 )
 
@@ -45,6 +47,7 @@ target_link_libraries(miroil
         mircommon
         mirserver
         mirclient
+        miral
 )
 
 set_target_properties(miroil

--- a/src/miroil/eventdispatch.cpp
+++ b/src/miroil/eventdispatch.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "miroil/eventdispatch.h"
+#include <miral/window.h>
+#include <mir/scene/surface.h>
+
+void miroil::dispatchInputEvent(const miral::Window& window, const MirInputEvent* event)
+{
+    auto e = reinterpret_cast<MirEvent const*>(event); // naughty
+
+    if (auto surface = std::shared_ptr<mir::scene::Surface>(window))
+        surface->consume(e);
+}

--- a/src/miroil/eventdispatch.cpp
+++ b/src/miroil/eventdispatch.cpp
@@ -20,7 +20,7 @@
 #include <miral/window.h>
 #include <mir/scene/surface.h>
 
-void miroil::dispatchInputEvent(const miral::Window& window, const MirInputEvent* event)
+void miroil::dispatch_input_event(const miral::Window& window, const MirInputEvent* event)
 {
     auto e = reinterpret_cast<MirEvent const*>(event); // naughty
 

--- a/src/miroil/persist_display_config.cpp
+++ b/src/miroil/persist_display_config.cpp
@@ -161,7 +161,7 @@ void miroil::PersistDisplayConfig::operator()(mir::Server& server)
         [this](std::shared_ptr<mg::DisplayConfigurationPolicy> const& wrapped)
         -> std::shared_ptr<mg::DisplayConfigurationPolicy>
         {
-            auto custom_wrapper = self->custom_wrapper();
+            auto custom_wrapper = self->custom_wrapper(wrapped);
             return std::make_shared<DisplayConfigurationPolicyAdapter>(self,
                                                                        std::make_shared<MiralWrappedMirDisplayConfigurationPolicy>(wrapped),
                                                                        custom_wrapper);

--- a/src/miroil/symbols.map
+++ b/src/miroil/symbols.map
@@ -18,6 +18,7 @@ global:
     miroil::PersistDisplayConfig::?PersistDisplayConfig*;
     miroil::PersistDisplayConfig::PersistDisplayConfig*;
     miroil::PersistDisplayConfig::operator*;
+    miroil::dispatchInputEvent*;
     non-virtual?thunk?to?miroil::DisplayConfigurationPolicy::?DisplayConfigurationPolicy*;
     non-virtual?thunk?to?miroil::DisplayConfigurationStorage::?DisplayConfigurationStorage*;
     typeinfo?for?miroil::DisplayConfigurationOptions;

--- a/src/miroil/symbols.map
+++ b/src/miroil/symbols.map
@@ -18,7 +18,7 @@ global:
     miroil::PersistDisplayConfig::?PersistDisplayConfig*;
     miroil::PersistDisplayConfig::PersistDisplayConfig*;
     miroil::PersistDisplayConfig::operator*;
-    miroil::dispatchInputEvent*;
+    miroil::dispatch_input_event*;
     non-virtual?thunk?to?miroil::DisplayConfigurationPolicy::?DisplayConfigurationPolicy*;
     non-virtual?thunk?to?miroil::DisplayConfigurationStorage::?DisplayConfigurationStorage*;
     typeinfo?for?miroil::DisplayConfigurationOptions;


### PR DESCRIPTION
Adding DisplayConfigurationPolicy back as a parameter to DisplayConfigurationPolicyWrapper (The qtmir version had this).

This is need by MirDisplayConfigurationPolicy in 
qtmir/src/platforms/mirserver/mirdisplayconfigurationpolicy.cpp
