### PR TITLE
Fix mirplatform.pc include dirs

### DIFF
--- a/src/platform/mirplatform.pc.in
+++ b/src/platform/mirplatform.pc.in
@@ -7,4 +7,4 @@ Description: Mir platform library
 Version: @MIR_VERSION@
 Requires: mircommon, mircore
 Libs: -L${libdir} -lmirplatform
-Cflags: -I${includedir}/mirplatform -I${includedir}/mircommon
+Cflags: -I${includedir}/mirplatform

--- a/src/platform/mirplatform.pc.in
+++ b/src/platform/mirplatform.pc.in
@@ -7,4 +7,4 @@ Description: Mir platform library
 Version: @MIR_VERSION@
 Requires: mircommon, mircore
 Libs: -L${libdir} -lmirplatform
-Cflags: -I${includedir}/platform -I${includedir}/common
+Cflags: -I${includedir}/mirplatform -I${includedir}/mircommon


### PR DESCRIPTION
This fixes mirplatform.pc include dirs, correct dirs is mirplatform and mircommon.

Error got introduced in https://github.com/MirServer/mir/commit/270fea2994eb9fd5e086fe95013811772386fea8