### PR TITLE
[miral-terminal] wait for gnome-terminal-server to exit

### DIFF
--- a/examples/miral-shell/miral-terminal.sh
+++ b/examples/miral-shell/miral-terminal.sh
@@ -46,5 +46,6 @@ else
       done
     fi
   fi
-  exec $terminal --app-id io.mirserver.Terminal "$@"
+  $terminal --app-id io.mirserver.Terminal "$@"
+  wait # wait for $terminal_server exit
 fi


### PR DESCRIPTION
When we start gnome-terminal-server, we also need to wait for it to exit.

(Fixes: #1616)