### PR TITLE
cmake: Fix running WLCS tests under ptest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,10 @@ CMAKE_DEPENDENT_OPTION(
   MIR_ENABLE_WLCS_TESTS "Also Build WLCS tests" ON
   "MIR_ENABLE_TESTS" OFF
 )
+CMAKE_DEPENDENT_OPTION(
+  MIR_RUN_WLCS_TESTS "Run WLCS tests as part of testsuite" ON
+  "MIR_ENABLE_WLCS_TESTS" OFF
+)
 
 foreach(platform IN LISTS MIR_PLATFORM)
   if (platform STREQUAL "gbm-kms")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,11 @@ CMAKE_DEPENDENT_OPTION(
   MIR_RUN_WLCS_TESTS "Run WLCS tests as part of testsuite" ON
   "MIR_ENABLE_WLCS_TESTS" OFF
 )
+CMAKE_DEPENDENT_OPTION(
+  MIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN "Expect WLCS BadBuffer tests to fail" OFF
+  "MIR_RUN_WLCS_TESTS" OFF
+)
+
 
 foreach(platform IN LISTS MIR_PLATFORM)
   if (platform STREQUAL "gbm-kms")

--- a/cmake/MirCommon.cmake
+++ b/cmake/MirCommon.cmake
@@ -193,7 +193,8 @@ function (mir_discover_external_gtests)
       set_tests_properties("${TEST_NAME}_${xfail}_fails" PROPERTIES WORKING_DIRECTORY ${TEST_WORKING_DIRECTORY})
     endif()
 
-    # Unsupported for ptest, but this should be ok
+    file(APPEND ${CMAKE_BINARY_DIR}/discover_all_tests.sh
+      "echo \"add_test\(${TEST_NAME}.${xfail}_fails ${CMAKE_BINARY_DIR}/mir_gtest/xfail_if_gtest_exists.sh ${TEST_COMMAND} ${xfail} ${TEST_ARGS_STRING})\"\n")
   endforeach ()
 endfunction()
 

--- a/cmake/MirCommon.cmake
+++ b/cmake/MirCommon.cmake
@@ -178,7 +178,7 @@ function (mir_discover_external_gtests)
   endif()
 
   file(APPEND ${CMAKE_BINARY_DIR}/discover_all_tests.sh
-    "sh ${CMAKE_SOURCE_DIR}/tools/discover_gtests.sh --test-name ${TEST_NAME} --gtest-executable \"${TEST_COMMAND}\" -- ${TEST_COMMAND} --gtest_filter=-${EXPECTED_FAILURE_STRING} ${TEST_ARGS_STRING}\n")
+    "sh ${CMAKE_SOURCE_DIR}/tools/discover_gtests.sh --test-name ${TEST_NAME} --gtest-executable \"${TEST_COMMAND} ${TEST_ARGS_STRING}\" -- ${TEST_COMMAND} ${TEST_ARGS_STRING} --gtest_filter=-${EXPECTED_FAILURE_STRING}\n")
 
   foreach (xfail IN LISTS TEST_EXPECTED_FAILURES)
     # Add a test verifying that the expected failures really do fail

--- a/cmake/MirCommon.cmake
+++ b/cmake/MirCommon.cmake
@@ -178,7 +178,7 @@ function (mir_discover_external_gtests)
   endif()
 
   file(APPEND ${CMAKE_BINARY_DIR}/discover_all_tests.sh
-    "sh ${CMAKE_SOURCE_DIR}/tools/discover_gtests.sh --test-name ${TEST_NAME} --gtest-executable \"${TEST_COMMAND} ${TEST_ARGS_STRING}\" -- ${TEST_COMMAND} ${TEST_ARGS_STRING} --gtest_filter=-${EXPECTED_FAILURE_STRING}\n")
+    "sh ${CMAKE_SOURCE_DIR}/tools/discover_gtests.sh --test-name ${TEST_NAME} --gtest-executable \"${TEST_COMMAND} ${TEST_ARGS_STRING}\" --gtest-exclude ${EXPECTED_FAILURE_STRING} -- ${TEST_COMMAND} ${TEST_ARGS_STRING} \n")
 
   foreach (xfail IN LISTS TEST_EXPECTED_FAILURES)
     # Add a test verifying that the expected failures really do fail

--- a/debian/rules
+++ b/debian/rules
@@ -36,6 +36,13 @@ ifeq ($(filter amd64 i386,$(DEB_HOST_ARCH)),)
 	COMMON_CONFIGURE_OPTIONS += -DMIR_LINK_TIME_OPTIMIZATION=OFF
 endif
 
+# We can't guarantee non-Ubuntu builds will build against WLCS packages we
+# control, so disable it on non-Ubuntu builds
+ifeq ($(filter Ubuntu,$(DEB_VENDOR)),)
+	COMMON_CONFIGURE_OPTIONS += -DMIR_ENABLE_WLCS_TESTS=OFF
+endif
+
+
 $(info COMMON_CONFIGURE_OPTIONS: ${COMMON_CONFIGURE_OPTIONS})
 
 AVAILABLE_PLATFORMS=gbm-kms\;x11\;wayland\;eglstream-kms

--- a/debian/rules
+++ b/debian/rules
@@ -39,7 +39,7 @@ endif
 # We can't guarantee non-Ubuntu builds will build against WLCS packages we
 # control, so disable it on non-Ubuntu builds
 ifeq ($(filter Ubuntu,$(DEB_VENDOR)),)
-	COMMON_CONFIGURE_OPTIONS += -DMIR_ENABLE_WLCS_TESTS=OFF
+	COMMON_CONFIGURE_OPTIONS += -DMIR_RUN_WLCS_TESTS=OFF
 endif
 
 

--- a/spread/build/sbuild/task.yaml
+++ b/spread/build/sbuild/task.yaml
@@ -68,4 +68,9 @@ execute: |
 
     echo "export XDG_RUNTIME_DIR=/tmp" >> debian/opts.mk
 
+    # Running the tests under QEMU fails to entirely correctly support libwayland's SIGSEGV handler
+    if [ ${DEB_HOST_ARCH} == "arm64" ]; then
+      echo "OVERRIDE_CONFIGURE_OPTIONS += -DMIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN=ON" >> debian/opts.mk
+    fi
+
     sbuild "${SBUILD_OPTS[@]}"

--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -14,6 +14,10 @@ execute: |
 
     apt-get update
 
+    # Add Mir dev PPA for any out-of-archive packages needed
+    # (Currently: a newer version of WLCS)
+    add-apt-repository ppa:mir-team/dev
+
     # to get dpkg-architecture and mk-build-deps
     apt-get install \
       --yes \

--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -101,5 +101,8 @@ execute: |
     # change the build type
     echo "OVERRIDE_CONFIGURE_OPTIONS += -DCMAKE_BUILD_TYPE=${BUILD_TYPE}" >> debian/opts.mk
 
+    # Quirk for the GitHub actions CI environment
+    echo "OVERRIDE_CONFIGURE_OPTIONS += -DMIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN=ON" >> debian/opts.mk
+
     # build and run tests
     debian/rules build

--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -35,12 +35,59 @@ mir_discover_external_gtests(
     ClientSurfaceEventsTest.frame_timestamp_increases
     ClientSurfaceEventsTest.surface_gets_enter_event
     ClientSurfaceEventsTest.surface_gets_leave_event
-    SubsurfaceTest.place_below_simple
     SubsurfaceTest.place_above_simple
+    SubsurfaceTest.place_below_simple
+    TouchInputSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
+    TouchInputSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
+    TouchInputSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
+    TouchInputSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
+    TouchInputSubsurfaces/SubsurfaceTest.place_above_simple/0
+    TouchInputSubsurfaces/SubsurfaceTest.place_below_simple/0
+    TouchInputSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
+    TouchInputSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
+    TouchInputSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
+    TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_out_from_under_input_device/0
+    TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_under_input_device_once/0
+    TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_under_input_device_twice/0
+    TouchInputSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
+    WlShellSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
+    WlShellSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
+    WlShellSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
+    WlShellSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
+    WlShellSubsurfaces/SubsurfaceTest.place_above_simple/0
+    WlShellSubsurfaces/SubsurfaceTest.place_below_simple/0
+    WlShellSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
+    WlShellSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
+    WlShellSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
+    WlShellSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
+    XdgShellStableSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
+    XdgShellStableSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
+    XdgShellStableSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
+    XdgShellStableSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
+    XdgShellStableSubsurfaces/SubsurfaceTest.place_above_simple/0
+    XdgShellStableSubsurfaces/SubsurfaceTest.place_below_simple/0
+    XdgShellStableSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
+    XdgShellStableSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
+    XdgShellStableSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
+    XdgShellStableSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
+    XdgShellV6Subsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
+    XdgShellV6Subsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
+    XdgShellV6Subsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
+    XdgShellV6Subsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
+    XdgShellV6Subsurfaces/SubsurfaceTest.place_above_simple/0
+    XdgShellV6Subsurfaces/SubsurfaceTest.place_below_simple/0
+    XdgShellV6Subsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
+    XdgShellV6Subsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
+    XdgShellV6Subsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
+    XdgShellV6Subsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
     XdgSurfaceStableTest.attaching_buffer_to_unconfigured_xdg_surface_is_an_error
-    XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_committed_buffer_is_an_error
     XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_attached_buffer_is_an_error
+    XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_committed_buffer_is_an_error
     XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_existing_role_is_an_error
+    XdgToplevelStableTest.pointer_leaves_surface_during_interactive_move
+    XdgToplevelStableTest.pointer_leaves_surface_during_interactive_resize
+    XdgToplevelV6Test.pointer_leaves_surface_during_interactive_move
+    XdgToplevelV6Test.pointer_leaves_surface_during_interactive_resize
 )
 
 install(TARGETS miral_wlcs_integration LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/mir)

--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -27,68 +27,76 @@ set_target_properties(
 
 pkg_get_variable(WLCS_BINARY wlcs test_runner)
 
+set(EXPECTED_FAILURES
+
+  ClientSurfaceEventsTest.frame_timestamp_increases
+  ClientSurfaceEventsTest.surface_gets_enter_event
+  ClientSurfaceEventsTest.surface_gets_leave_event
+  SubsurfaceTest.place_above_simple
+  SubsurfaceTest.place_below_simple
+  TouchInputSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
+  TouchInputSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
+  TouchInputSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
+  TouchInputSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
+  TouchInputSubsurfaces/SubsurfaceTest.place_above_simple/0
+  TouchInputSubsurfaces/SubsurfaceTest.place_below_simple/0
+  TouchInputSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
+  TouchInputSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
+  TouchInputSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
+  TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_out_from_under_input_device/0
+  TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_under_input_device_once/0
+  TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_under_input_device_twice/0
+  TouchInputSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
+  WlShellSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
+  WlShellSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
+  WlShellSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
+  WlShellSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
+  WlShellSubsurfaces/SubsurfaceTest.place_above_simple/0
+  WlShellSubsurfaces/SubsurfaceTest.place_below_simple/0
+  WlShellSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
+  WlShellSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
+  WlShellSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
+  WlShellSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
+  XdgShellStableSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
+  XdgShellStableSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
+  XdgShellStableSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
+  XdgShellStableSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
+  XdgShellStableSubsurfaces/SubsurfaceTest.place_above_simple/0
+  XdgShellStableSubsurfaces/SubsurfaceTest.place_below_simple/0
+  XdgShellStableSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
+  XdgShellStableSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
+  XdgShellStableSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
+  XdgShellStableSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
+  XdgShellV6Subsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
+  XdgShellV6Subsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
+  XdgShellV6Subsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
+  XdgShellV6Subsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
+  XdgShellV6Subsurfaces/SubsurfaceTest.place_above_simple/0
+  XdgShellV6Subsurfaces/SubsurfaceTest.place_below_simple/0
+  XdgShellV6Subsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
+  XdgShellV6Subsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
+  XdgShellV6Subsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
+  XdgShellV6Subsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
+  XdgSurfaceStableTest.attaching_buffer_to_unconfigured_xdg_surface_is_an_error
+  XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_attached_buffer_is_an_error
+  XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_committed_buffer_is_an_error
+  XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_existing_role_is_an_error
+  XdgToplevelStableTest.pointer_leaves_surface_during_interactive_move
+  XdgToplevelStableTest.pointer_leaves_surface_during_interactive_resize
+  XdgToplevelV6Test.pointer_leaves_surface_during_interactive_move
+  XdgToplevelV6Test.pointer_leaves_surface_during_interactive_resize
+)
+
+if (MIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN)
+  list(APPEND EXPECTED_FAILURES BadBufferTest.test_truncated_shm_file)
+endif ()
+
 if (MIR_RUN_WLCS_TESTS)
   mir_discover_external_gtests(
     NAME wlcs
     COMMAND ${WLCS_BINARY}
     ARGS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/miral_wlcs_integration.so
-    EXPECTED_FAILURES
-      ClientSurfaceEventsTest.frame_timestamp_increases
-      ClientSurfaceEventsTest.surface_gets_enter_event
-      ClientSurfaceEventsTest.surface_gets_leave_event
-      SubsurfaceTest.place_above_simple
-      SubsurfaceTest.place_below_simple
-      TouchInputSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
-      TouchInputSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
-      TouchInputSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
-      TouchInputSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
-      TouchInputSubsurfaces/SubsurfaceTest.place_above_simple/0
-      TouchInputSubsurfaces/SubsurfaceTest.place_below_simple/0
-      TouchInputSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
-      TouchInputSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
-      TouchInputSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
-      TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_out_from_under_input_device/0
-      TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_under_input_device_once/0
-      TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_under_input_device_twice/0
-      TouchInputSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
-      WlShellSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
-      WlShellSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
-      WlShellSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
-      WlShellSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
-      WlShellSubsurfaces/SubsurfaceTest.place_above_simple/0
-      WlShellSubsurfaces/SubsurfaceTest.place_below_simple/0
-      WlShellSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
-      WlShellSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
-      WlShellSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
-      WlShellSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
-      XdgShellStableSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
-      XdgShellStableSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
-      XdgShellStableSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
-      XdgShellStableSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
-      XdgShellStableSubsurfaces/SubsurfaceTest.place_above_simple/0
-      XdgShellStableSubsurfaces/SubsurfaceTest.place_below_simple/0
-      XdgShellStableSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
-      XdgShellStableSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
-      XdgShellStableSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
-      XdgShellStableSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
-      XdgShellV6Subsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
-      XdgShellV6Subsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
-      XdgShellV6Subsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
-      XdgShellV6Subsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
-      XdgShellV6Subsurfaces/SubsurfaceTest.place_above_simple/0
-      XdgShellV6Subsurfaces/SubsurfaceTest.place_below_simple/0
-      XdgShellV6Subsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
-      XdgShellV6Subsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
-      XdgShellV6Subsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
-      XdgShellV6Subsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
-      XdgSurfaceStableTest.attaching_buffer_to_unconfigured_xdg_surface_is_an_error
-      XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_attached_buffer_is_an_error
-      XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_committed_buffer_is_an_error
-      XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_existing_role_is_an_error
-      XdgToplevelStableTest.pointer_leaves_surface_during_interactive_move
-      XdgToplevelStableTest.pointer_leaves_surface_during_interactive_resize
-      XdgToplevelV6Test.pointer_leaves_surface_during_interactive_move
-      XdgToplevelV6Test.pointer_leaves_surface_during_interactive_resize
+    EXPECTED_FAILURES ${EXPECTED_FAILURES}
   )
 endif()
 

--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -27,67 +27,69 @@ set_target_properties(
 
 pkg_get_variable(WLCS_BINARY wlcs test_runner)
 
-mir_discover_external_gtests(
-  NAME wlcs
-  COMMAND ${WLCS_BINARY}
-  ARGS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/miral_wlcs_integration.so
-  EXPECTED_FAILURES
-    ClientSurfaceEventsTest.frame_timestamp_increases
-    ClientSurfaceEventsTest.surface_gets_enter_event
-    ClientSurfaceEventsTest.surface_gets_leave_event
-    SubsurfaceTest.place_above_simple
-    SubsurfaceTest.place_below_simple
-    TouchInputSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
-    TouchInputSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
-    TouchInputSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
-    TouchInputSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
-    TouchInputSubsurfaces/SubsurfaceTest.place_above_simple/0
-    TouchInputSubsurfaces/SubsurfaceTest.place_below_simple/0
-    TouchInputSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
-    TouchInputSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
-    TouchInputSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
-    TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_out_from_under_input_device/0
-    TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_under_input_device_once/0
-    TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_under_input_device_twice/0
-    TouchInputSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
-    WlShellSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
-    WlShellSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
-    WlShellSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
-    WlShellSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
-    WlShellSubsurfaces/SubsurfaceTest.place_above_simple/0
-    WlShellSubsurfaces/SubsurfaceTest.place_below_simple/0
-    WlShellSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
-    WlShellSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
-    WlShellSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
-    WlShellSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
-    XdgShellStableSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
-    XdgShellStableSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
-    XdgShellStableSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
-    XdgShellStableSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
-    XdgShellStableSubsurfaces/SubsurfaceTest.place_above_simple/0
-    XdgShellStableSubsurfaces/SubsurfaceTest.place_below_simple/0
-    XdgShellStableSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
-    XdgShellStableSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
-    XdgShellStableSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
-    XdgShellStableSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
-    XdgShellV6Subsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
-    XdgShellV6Subsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
-    XdgShellV6Subsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
-    XdgShellV6Subsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
-    XdgShellV6Subsurfaces/SubsurfaceTest.place_above_simple/0
-    XdgShellV6Subsurfaces/SubsurfaceTest.place_below_simple/0
-    XdgShellV6Subsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
-    XdgShellV6Subsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
-    XdgShellV6Subsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
-    XdgShellV6Subsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
-    XdgSurfaceStableTest.attaching_buffer_to_unconfigured_xdg_surface_is_an_error
-    XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_attached_buffer_is_an_error
-    XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_committed_buffer_is_an_error
-    XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_existing_role_is_an_error
-    XdgToplevelStableTest.pointer_leaves_surface_during_interactive_move
-    XdgToplevelStableTest.pointer_leaves_surface_during_interactive_resize
-    XdgToplevelV6Test.pointer_leaves_surface_during_interactive_move
-    XdgToplevelV6Test.pointer_leaves_surface_during_interactive_resize
-)
+if (MIR_RUN_WLCS_TESTS)
+  mir_discover_external_gtests(
+    NAME wlcs
+    COMMAND ${WLCS_BINARY}
+    ARGS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/miral_wlcs_integration.so
+    EXPECTED_FAILURES
+      ClientSurfaceEventsTest.frame_timestamp_increases
+      ClientSurfaceEventsTest.surface_gets_enter_event
+      ClientSurfaceEventsTest.surface_gets_leave_event
+      SubsurfaceTest.place_above_simple
+      SubsurfaceTest.place_below_simple
+      TouchInputSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
+      TouchInputSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
+      TouchInputSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
+      TouchInputSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
+      TouchInputSubsurfaces/SubsurfaceTest.place_above_simple/0
+      TouchInputSubsurfaces/SubsurfaceTest.place_below_simple/0
+      TouchInputSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
+      TouchInputSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
+      TouchInputSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
+      TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_out_from_under_input_device/0
+      TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_under_input_device_once/0
+      TouchInputSubsurfaces/SubsurfaceTest.subsurface_moves_under_input_device_twice/0
+      TouchInputSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
+      WlShellSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
+      WlShellSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
+      WlShellSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
+      WlShellSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
+      WlShellSubsurfaces/SubsurfaceTest.place_above_simple/0
+      WlShellSubsurfaces/SubsurfaceTest.place_below_simple/0
+      WlShellSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
+      WlShellSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
+      WlShellSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
+      WlShellSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
+      XdgShellStableSubsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
+      XdgShellStableSubsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
+      XdgShellStableSubsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
+      XdgShellStableSubsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
+      XdgShellStableSubsurfaces/SubsurfaceTest.place_above_simple/0
+      XdgShellStableSubsurfaces/SubsurfaceTest.place_below_simple/0
+      XdgShellStableSubsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
+      XdgShellStableSubsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
+      XdgShellStableSubsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
+      XdgShellStableSubsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
+      XdgShellV6Subsurfaces/SubsurfaceMultilevelTest.subsurface_moves_after_both_sync_parent_and_grandparent_commit/0
+      XdgShellV6Subsurfaces/SubsurfaceMultilevelTest.subsurface_with_desync_parent_moves_when_only_parent_committed/0
+      XdgShellV6Subsurfaces/SubsurfaceTest.desync_subsurface_moves_when_only_parent_committed/0
+      XdgShellV6Subsurfaces/SubsurfaceTest.one_subsurface_to_another_fallthrough/0
+      XdgShellV6Subsurfaces/SubsurfaceTest.place_above_simple/0
+      XdgShellV6Subsurfaces/SubsurfaceTest.place_below_simple/0
+      XdgShellV6Subsurfaces/SubsurfaceTest.pointer_input_correctly_offset_for_subsurface/0
+      XdgShellV6Subsurfaces/SubsurfaceTest.subsurface_does_not_move_when_parent_not_committed/0
+      XdgShellV6Subsurfaces/SubsurfaceTest.subsurface_extends_parent_input_region/0
+      XdgShellV6Subsurfaces/SubsurfaceTest.sync_subsurface_moves_when_only_parent_committed/0
+      XdgSurfaceStableTest.attaching_buffer_to_unconfigured_xdg_surface_is_an_error
+      XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_attached_buffer_is_an_error
+      XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_committed_buffer_is_an_error
+      XdgSurfaceStableTest.creating_xdg_surface_from_wl_surface_with_existing_role_is_an_error
+      XdgToplevelStableTest.pointer_leaves_surface_during_interactive_move
+      XdgToplevelStableTest.pointer_leaves_surface_during_interactive_resize
+      XdgToplevelV6Test.pointer_leaves_surface_during_interactive_move
+      XdgToplevelV6Test.pointer_leaves_surface_during_interactive_resize
+  )
+endif()
 
 install(TARGETS miral_wlcs_integration LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/mir)


### PR DESCRIPTION
This fixes running the WLCS tests under ptest, rather than silently(!) failing to run them and reporting success.

It also implements the ptest support for checking that the XFAIL tests actually fail.