### PR TITLE
Don't give keyboard focus to popups

### DIFF
--- a/src/include/server/mir/shell/abstract_shell.h
+++ b/src/include/server/mir/shell/abstract_shell.h
@@ -170,6 +170,7 @@ private:
     std::weak_ptr<scene::Session> focus_session;
     std::weak_ptr<scene::Surface> notified_focus_surface;
     std::shared_ptr<scene::SurfaceObserver> focus_surface_observer;
+    std::vector<std::weak_ptr<scene::Surface>> popups_of_focused_surface;
 
     void notify_focus_locked(
         std::unique_lock<std::mutex> const& lock,

--- a/src/miral/minimal_window_manager.cpp
+++ b/src/miral/minimal_window_manager.cpp
@@ -56,6 +56,41 @@ auto touch_center(MirTouchEvent const* event) -> mir::geometry::Point
 
     return {total_x/count, total_y/count};
 }
+
+auto is_ancestor(
+    miral::WindowManagerTools const& tools,
+    miral::Window const& maybe_parent,
+    miral::Window const& maybe_child) -> bool
+{
+    if (maybe_parent == maybe_child)
+    {
+        return false;
+    }
+    auto window = maybe_child;
+    while ((window = tools.info_for(window).parent()))
+    {
+        if (window == maybe_parent)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// Returns true if selecting the new window consums the current input event
+auto selecting_window_consumes_event(
+    miral::WindowManagerTools const& tools,
+    miral::Window const& selected_window) -> bool
+{
+    auto const active = tools.active_window();
+    // Return true if a menu window is currently active and a parent is being selected.
+    // If we don't consume the event in this case popup menus appear after being dismissed.
+    // (see https://github.com/MirServer/mir/issues/1818)
+    return (
+        active &&
+        tools.info_for(active).type() == mir_window_type_menu &&
+        is_ancestor(tools, selected_window, active));
+}
 }
 
 struct miral::MinimalWindowManager::Impl
@@ -361,6 +396,7 @@ bool miral::MinimalWindowManager::Impl::handle_pointer_event(MirPointerEvent con
     {
         if (auto const window = tools.window_at(new_cursor))
         {
+            consumes_event = selecting_window_consumes_event(tools, window);
             tools.select_active_window(window);
         }
     }
@@ -440,6 +476,7 @@ bool miral::MinimalWindowManager::Impl::handle_touch_event(MirTouchEvent const* 
     {
         if (auto const window = tools.window_at(new_touch))
         {
+            consumes_event = selecting_window_consumes_event(tools, window);
             tools.select_active_window(window);
         }
     }

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -402,10 +402,24 @@ void msh::AbstractShell::set_focus_to(
     std::shared_ptr<ms::Session> const& focus_session,
     std::shared_ptr<ms::Surface> const& focus_surface)
 {
+    // Don't give keyboard focus to popups
+    auto surface = focus_surface;
+    while (surface)
+    {
+        auto const type = surface->type();
+        if (type != mir_window_type_gloss &&
+            type != mir_window_type_tip &&
+            type != mir_window_type_menu)
+        {
+            break;
+        }
+        surface = surface->parent();
+    }
+
     std::unique_lock<std::mutex> lock(focus_mutex);
 
-    notify_focus_locked(lock, focus_session, focus_surface);
-    update_focus_locked(lock, focus_session, focus_surface);
+    notify_focus_locked(lock, focus_session, surface);
+    update_focus_locked(lock, focus_session, surface);
 }
 
 void msh::AbstractShell::notify_focus_locked(

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -402,6 +402,8 @@ void msh::AbstractShell::set_focus_to(
     std::shared_ptr<ms::Session> const& focus_session,
     std::shared_ptr<ms::Surface> const& focus_surface)
 {
+    std::vector<std::shared_ptr<ms::Surface>> new_popups;
+
     // Don't give keyboard focus to popups
     auto surface = focus_surface;
     while (surface)
@@ -413,10 +415,30 @@ void msh::AbstractShell::set_focus_to(
         {
             break;
         }
+        new_popups.push_back(surface);
         surface = surface->parent();
     }
 
     std::unique_lock<std::mutex> lock(focus_mutex);
+
+    for (auto const& old_popup_weak : popups_of_focused_surface)
+    {
+        if (auto const old_popup = old_popup_weak.lock())
+        {
+            if (find(begin(new_popups), end(new_popups), old_popup) == end(new_popups))
+            {
+                // If the popup isn't in the set of new popups, hide it
+                old_popup->request_client_surface_close();
+                old_popup->hide();
+            }
+        }
+    }
+
+    popups_of_focused_surface.clear();
+    for (auto const& new_popup : new_popups)
+    {
+        popups_of_focused_surface.push_back(new_popup);
+    }
 
     notify_focus_locked(lock, focus_session, surface);
     update_focus_locked(lock, focus_session, surface);
@@ -453,13 +475,6 @@ void msh::AbstractShell::notify_focus_locked(
             if (find(begin(new_focus_tree), end(new_focus_tree), item) == end(new_focus_tree))
             {
                 item->set_focus_state(mir_window_focus_state_unfocused);
-
-                // When a menu loses focus we should close and unmap it
-                if (item->type() == mir_window_type_menu)
-                {
-                    item->request_client_surface_close();
-                    item->hide();
-                }
             }
         }
 


### PR DESCRIPTION
The spec is not super clear to me on where keyboard focus should go with regards to popups, but other compositors including Weston do **not** give keyboard focus to popups. GTK handles both fine, but Qt has issues in edge cases when popups get input focus (#1941). Draft because it does not yet play nice with the proposed popup WLCS in https://github.com/MirServer/wlcs/pull/190 (specifically, it doesn't dismiss popups when new surfaces are created). I'm also not sure if this is the correct place to put this code.

Fixes #1941, Fixes #1818. Better alternative to #1942