### PR TITLE
adding PromptSessionListener & PromptSessionManager

### DIFF
--- a/debian/libmiroil1.symbols
+++ b/debian/libmiroil1.symbols
@@ -50,11 +50,11 @@ libmiroil.so.1 libmiroil1 #MINVER#
  (c++)"miroil::PromptSessionManager::PromptSessionManager(miroil::PromptSessionManager const&)@MIROIL_1.0" 2.3.2
  (c++)"miroil::PromptSessionManager::PromptSessionManager(miroil::PromptSessionManager&&)@MIROIL_1.0" 2.3.2
  (c++)"miroil::PromptSessionManager::PromptSessionManager(std::shared_ptr<mir::scene::PromptSessionManager> const&)@MIROIL_1.0" 2.3.2
- (c++)"miroil::PromptSessionManager::applicationFor(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::application_for(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_1.0" 2.3.2
  (c++)"miroil::PromptSessionManager::operator==(miroil::PromptSessionManager const&)@MIROIL_1.0" 2.3.2
- (c++)"miroil::PromptSessionManager::resumePromptSession(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_1.0" 2.3.2
- (c++)"miroil::PromptSessionManager::stopPromptSession(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_1.0" 2.3.2
- (c++)"miroil::PromptSessionManager::suspendPromptSession(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::resume_prompt_session(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::stop_prompt_session(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::suspend_prompt_session(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_1.0" 2.3.2
  (c++)"miroil::PromptSessionManager::~PromptSessionManager()@MIROIL_1.0" 2.3.2
  (c++)"typeinfo for miroil::PromptSessionListener@MIROIL_1.0" 2.3.2
  (c++)"vtable for miroil::PromptSessionListener@MIROIL_1.0" 2.3.2

--- a/debian/libmiroil1.symbols
+++ b/debian/libmiroil1.symbols
@@ -46,3 +46,15 @@ libmiroil.so.1 libmiroil1 #MINVER#
  (c++)"miroil::InputDevice::InputDevice(miroil::InputDevice&&)@MIROIL_1.0" 2.3.2
  (c++)"miroil::InputDevice::operator=(miroil::InputDevice const&)@MIROIL_1.0" 2.3.2
  (c++)"miroil::InputDevice::operator=(miroil::InputDevice&&)@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionListener::~PromptSessionListener()@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::PromptSessionManager(miroil::PromptSessionManager const&)@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::PromptSessionManager(miroil::PromptSessionManager&&)@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::PromptSessionManager(std::shared_ptr<mir::scene::PromptSessionManager> const&)@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::applicationFor(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::operator==(miroil::PromptSessionManager const&)@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::resumePromptSession(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::stopPromptSession(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::suspendPromptSession(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_1.0" 2.3.2
+ (c++)"miroil::PromptSessionManager::~PromptSessionManager()@MIROIL_1.0" 2.3.2
+ (c++)"typeinfo for miroil::PromptSessionListener@MIROIL_1.0" 2.3.2
+ (c++)"vtable for miroil::PromptSessionListener@MIROIL_1.0" 2.3.2

--- a/include/miroil/miroil/prompt_session_listener.h
+++ b/include/miroil/miroil/prompt_session_listener.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2016-2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIROIL_PROMPT_SESSION_LISTENER_H
+#define MIROIL_PROMPT_SESSION_LISTENER_H
+#include <memory>
+
+namespace mir { namespace scene { class PromptSession; } }
+namespace mir { namespace scene { class Session; } }
+
+namespace miroil {
+    
+class PromptSessionListener
+{
+public:
+    virtual ~PromptSessionListener();
+    
+    PromptSessionListener& operator=(PromptSessionListener const&) = delete;    
+
+    virtual void starting(std::shared_ptr<mir::scene::PromptSession> const& prompt_session) = 0;
+    virtual void stopping(std::shared_ptr<mir::scene::PromptSession> const& prompt_session) = 0;
+    virtual void suspending(std::shared_ptr<mir::scene::PromptSession> const& prompt_session) = 0;
+    virtual void resuming(std::shared_ptr<mir::scene::PromptSession> const& prompt_session) = 0;
+    virtual void prompt_provider_added(mir::scene::PromptSession const& prompt_session,
+                               std::shared_ptr<mir::scene::Session> const& prompt_provider) = 0;
+    virtual void prompt_provider_removed(mir::scene::PromptSession const& prompt_session,
+                                 std::shared_ptr<mir::scene::Session> const& prompt_provider) = 0;
+                                 
+protected:
+    PromptSessionListener() = default;
+    PromptSessionListener(PromptSessionListener const&) = delete;
+};
+
+}
+
+#endif // MIROIL_PROMPT_SESSION_LISTENER_H

--- a/include/miroil/miroil/prompt_session_manager.h
+++ b/include/miroil/miroil/prompt_session_manager.h
@@ -38,13 +38,13 @@ public:
 
     bool operator==(PromptSessionManager const& other);
 
-    auto applicationFor(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const -> miral::Application;
-    void resumePromptSession(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const;
-    void stopPromptSession(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const;
-    void suspendPromptSession(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const;    
+    auto application_for(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const -> miral::Application;
+    void resume_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const;
+    void stop_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const;
+    void suspend_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const;    
 
 private:
-    std::shared_ptr<mir::scene::PromptSessionManager> m_promptSessionManager;
+    std::shared_ptr<mir::scene::PromptSessionManager> promptSessionManager;
 };
 }
 

--- a/include/miroil/miroil/prompt_session_manager.h
+++ b/include/miroil/miroil/prompt_session_manager.h
@@ -28,7 +28,7 @@ namespace miroil {
 class PromptSessionManager
 {
 public:
-    PromptSessionManager(std::shared_ptr<mir::scene::PromptSessionManager> const& promptSessionManager);
+    PromptSessionManager(std::shared_ptr<mir::scene::PromptSessionManager> const& prompt_session_manager);
     PromptSessionManager(PromptSessionManager const& src);
     PromptSessionManager(PromptSessionManager&& src);
     ~PromptSessionManager();
@@ -38,13 +38,13 @@ public:
 
     bool operator==(PromptSessionManager const& other);
 
-    auto application_for(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const -> miral::Application;
-    void resume_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const;
-    void stop_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const;
-    void suspend_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const;    
+    auto application_for(std::shared_ptr<mir::scene::PromptSession> const& prompt_session) const -> miral::Application;
+    void resume_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& prompt_session) const;
+    void stop_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& prompt_session) const;
+    void suspend_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& prompt_session) const;    
 
 private:
-    std::shared_ptr<mir::scene::PromptSessionManager> promptSessionManager;
+    std::shared_ptr<mir::scene::PromptSessionManager> prompt_session_manager;
 };
 }
 

--- a/include/miroil/miroil/prompt_session_manager.h
+++ b/include/miroil/miroil/prompt_session_manager.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2016-2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIROIL_PROMPT_SESSION_MANAGER_H
+#define MIROIL_PROMPT_SESSION_MANAGER_H
+
+#include <miral/application.h>
+
+#include <memory>
+
+namespace mir { namespace scene { class PromptSessionManager; class PromptSession;} }
+
+namespace miroil {
+    
+class PromptSessionManager
+{
+public:
+    PromptSessionManager(std::shared_ptr<mir::scene::PromptSessionManager> const& promptSessionManager);
+    PromptSessionManager(PromptSessionManager const& src);
+    PromptSessionManager(PromptSessionManager&& src);
+    ~PromptSessionManager();
+
+    auto operator=(PromptSessionManager const& src) -> PromptSessionManager&;
+    auto operator=(PromptSessionManager&& src) -> PromptSessionManager&;
+
+    bool operator==(PromptSessionManager const& other);
+
+    auto applicationFor(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const -> miral::Application;
+    void resumePromptSession(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const;
+    void stopPromptSession(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const;
+    void suspendPromptSession(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const;    
+
+private:
+    std::shared_ptr<mir::scene::PromptSessionManager> m_promptSessionManager;
+};
+}
+
+#endif //MIROIL_PROMPT_SESSION_MANAGER_H

--- a/src/miroil/CMakeLists.txt
+++ b/src/miroil/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(miroil SHARED
     event_builder.cpp ${miroil_include}/miroil/event_builder.h
     input_device.cpp ${miroil_include}/miroil/input_device.h
     input_device_observer.cpp ${miroil_include}/miroil/input_device_observer.h
+    prompt_session_listener.cpp ${miroil_include}/miroil/prompt_session_listener.h
+    prompt_session_manager.cpp ${miroil_include}/miroil/prompt_session_manager.h    
     ${miroil_include}/miroil/display_configuration_storage.h
     ${miroil_include}/miroil/display_id.h
 )

--- a/src/miroil/prompt_session_listener.cpp
+++ b/src/miroil/prompt_session_listener.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016-2021 Canonical, Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3, as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+ * SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <miroil/prompt_session_listener.h>
+
+miroil::PromptSessionListener::~PromptSessionListener() = default;

--- a/src/miroil/prompt_session_manager.cpp
+++ b/src/miroil/prompt_session_manager.cpp
@@ -17,8 +17,8 @@
 #include "miroil/prompt_session_manager.h"
 #include "mir/scene/prompt_session_manager.h"
 
-miroil::PromptSessionManager::PromptSessionManager(std::shared_ptr<mir::scene::PromptSessionManager> const& promptSessionManager) 
-:    promptSessionManager{promptSessionManager}
+miroil::PromptSessionManager::PromptSessionManager(std::shared_ptr<mir::scene::PromptSessionManager> const& prompt_session_manager) 
+:    prompt_session_manager{prompt_session_manager}
 {
 }
 
@@ -30,25 +30,25 @@ miroil::PromptSessionManager::~PromptSessionManager() = default;
 
 bool miroil::PromptSessionManager::operator==(PromptSessionManager const& other)
 {
-    return promptSessionManager == other.promptSessionManager;
+    return prompt_session_manager == other.prompt_session_manager;
 }
 
-miral::Application miroil::PromptSessionManager::application_for(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
+miral::Application miroil::PromptSessionManager::application_for(std::shared_ptr<mir::scene::PromptSession> const& prompt_session) const
 {
-    return promptSessionManager->application_for(promptSession);
+    return prompt_session_manager->application_for(prompt_session);
 }
 
-void miroil::PromptSessionManager::stop_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
+void miroil::PromptSessionManager::stop_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& prompt_session) const
 {
-    promptSessionManager->stop_prompt_session(promptSession);
+    prompt_session_manager->stop_prompt_session(prompt_session);
 }
 
-void miroil::PromptSessionManager::suspend_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
+void miroil::PromptSessionManager::suspend_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& prompt_session) const
 {
-    promptSessionManager->suspend_prompt_session(promptSession);
+    prompt_session_manager->suspend_prompt_session(prompt_session);
 }
 
-void miroil::PromptSessionManager::resume_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
+void miroil::PromptSessionManager::resume_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& prompt_session) const
 {
-    promptSessionManager->resume_prompt_session(promptSession);
+    prompt_session_manager->resume_prompt_session(prompt_session);
 }

--- a/src/miroil/prompt_session_manager.cpp
+++ b/src/miroil/prompt_session_manager.cpp
@@ -18,7 +18,7 @@
 #include "mir/scene/prompt_session_manager.h"
 
 miroil::PromptSessionManager::PromptSessionManager(std::shared_ptr<mir::scene::PromptSessionManager> const& promptSessionManager) 
-:    m_promptSessionManager{promptSessionManager}
+:    promptSessionManager{promptSessionManager}
 {
 }
 
@@ -30,25 +30,25 @@ miroil::PromptSessionManager::~PromptSessionManager() = default;
 
 bool miroil::PromptSessionManager::operator==(PromptSessionManager const& other)
 {
-    return m_promptSessionManager == other.m_promptSessionManager;
+    return promptSessionManager == other.promptSessionManager;
 }
 
-miral::Application miroil::PromptSessionManager::applicationFor(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
+miral::Application miroil::PromptSessionManager::application_for(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
 {
-    return m_promptSessionManager->application_for(promptSession);
+    return promptSessionManager->application_for(promptSession);
 }
 
-void miroil::PromptSessionManager::stopPromptSession(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
+void miroil::PromptSessionManager::stop_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
 {
-    m_promptSessionManager->stop_prompt_session(promptSession);
+    promptSessionManager->stop_prompt_session(promptSession);
 }
 
-void miroil::PromptSessionManager::suspendPromptSession(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
+void miroil::PromptSessionManager::suspend_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
 {
-    m_promptSessionManager->suspend_prompt_session(promptSession);
+    promptSessionManager->suspend_prompt_session(promptSession);
 }
 
-void miroil::PromptSessionManager::resumePromptSession(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
+void miroil::PromptSessionManager::resume_prompt_session(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
 {
-    m_promptSessionManager->resume_prompt_session(promptSession);
+    promptSessionManager->resume_prompt_session(promptSession);
 }

--- a/src/miroil/prompt_session_manager.cpp
+++ b/src/miroil/prompt_session_manager.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "miroil/prompt_session_manager.h"
+#include "mir/scene/prompt_session_manager.h"
+
+miroil::PromptSessionManager::PromptSessionManager(std::shared_ptr<mir::scene::PromptSessionManager> const& promptSessionManager) 
+:    m_promptSessionManager{promptSessionManager}
+{
+}
+
+miroil::PromptSessionManager::PromptSessionManager(PromptSessionManager&& src) = default;
+
+miroil::PromptSessionManager::PromptSessionManager(PromptSessionManager const& src) = default;
+
+miroil::PromptSessionManager::~PromptSessionManager() = default;
+
+bool miroil::PromptSessionManager::operator==(PromptSessionManager const& other)
+{
+    return m_promptSessionManager == other.m_promptSessionManager;
+}
+
+miral::Application miroil::PromptSessionManager::applicationFor(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
+{
+    return m_promptSessionManager->application_for(promptSession);
+}
+
+void miroil::PromptSessionManager::stopPromptSession(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
+{
+    m_promptSessionManager->stop_prompt_session(promptSession);
+}
+
+void miroil::PromptSessionManager::suspendPromptSession(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
+{
+    m_promptSessionManager->suspend_prompt_session(promptSession);
+}
+
+void miroil::PromptSessionManager::resumePromptSession(std::shared_ptr<mir::scene::PromptSession> const& promptSession) const
+{
+    m_promptSessionManager->resume_prompt_session(promptSession);
+}

--- a/src/miroil/symbols.map
+++ b/src/miroil/symbols.map
@@ -41,11 +41,11 @@ global:
     miroil::PromptSessionListener::operator*;
     miroil::PromptSessionManager::?PromptSessionManager*;
     miroil::PromptSessionManager::PromptSessionManager*;
-    miroil::PromptSessionManager::applicationFor*;
+    miroil::PromptSessionManager::application_for*;
     miroil::PromptSessionManager::operator*;
-    miroil::PromptSessionManager::resumePromptSession*;
-    miroil::PromptSessionManager::stopPromptSession*;
-    miroil::PromptSessionManager::suspendPromptSession*;
+    miroil::PromptSessionManager::resume_prompt_session*;
+    miroil::PromptSessionManager::stop_prompt_session*;
+    miroil::PromptSessionManager::suspend_prompt_session*;
     miroil::dispatch_input_event*;
     non-virtual?thunk?to?miroil::DisplayConfigurationPolicy::?DisplayConfigurationPolicy*;
     non-virtual?thunk?to?miroil::DisplayConfigurationStorage::?DisplayConfigurationStorage*;

--- a/src/miroil/symbols.map
+++ b/src/miroil/symbols.map
@@ -36,9 +36,20 @@ global:
     miroil::PersistDisplayConfig::?PersistDisplayConfig*;
     miroil::PersistDisplayConfig::PersistDisplayConfig*;
     miroil::PersistDisplayConfig::operator*;
+    miroil::PromptSessionListener::?PromptSessionListener*;
+    miroil::PromptSessionListener::PromptSessionListener*;
+    miroil::PromptSessionListener::operator*;
+    miroil::PromptSessionManager::?PromptSessionManager*;
+    miroil::PromptSessionManager::PromptSessionManager*;
+    miroil::PromptSessionManager::applicationFor*;
+    miroil::PromptSessionManager::operator*;
+    miroil::PromptSessionManager::resumePromptSession*;
+    miroil::PromptSessionManager::stopPromptSession*;
+    miroil::PromptSessionManager::suspendPromptSession*;
     miroil::dispatch_input_event*;
     non-virtual?thunk?to?miroil::DisplayConfigurationPolicy::?DisplayConfigurationPolicy*;
     non-virtual?thunk?to?miroil::DisplayConfigurationStorage::?DisplayConfigurationStorage*;
+    non-virtual?thunk?to?miroil::PromptSessionListener::?PromptSessionListener*;
     typeinfo?for?miroil::DisplayConfigurationOptions;
     typeinfo?for?miroil::DisplayConfigurationOptions::DisplayMode;
     typeinfo?for?miroil::DisplayConfigurationPolicy;
@@ -53,6 +64,8 @@ global:
     typeinfo?for?miroil::InputDevice;
     typeinfo?for?miroil::InputDeviceObserver;
     typeinfo?for?miroil::PersistDisplayConfig;
+    typeinfo?for?miroil::PromptSessionListener;
+    typeinfo?for?miroil::PromptSessionManager;
     vtable?for?miroil::DisplayConfigurationOptions;
     vtable?for?miroil::DisplayConfigurationOptions::DisplayMode;
     vtable?for?miroil::DisplayConfigurationPolicy;
@@ -67,6 +80,8 @@ global:
     vtable?for?miroil::InputDevice;
     vtable?for?miroil::InputDeviceObserver;
     vtable?for?miroil::PersistDisplayConfig;
+    vtable?for?miroil::PromptSessionListener;
+    vtable?for?miroil::PromptSessionManager;
   };
 
 local: *;


### PR DESCRIPTION
Qtmir uses mir::scene::PromptSessionManager which is no long available, so I've created a wrapper for this class. This is used many places in QtMir.

In addition qtmir listens to mir::scene::PromptSessionListener (also not available)... so I've created an abstract class for that.

This is used in:
https://github.com/ubports/qtmir/blob/xenial/src/platforms/mirserver/mirserverhooks.cpp

class PromptSessionListenerImpl

Which can't be solved in this way because it contains both internal mir stuff and qt stuff. So it has to be split into a mir part(miroil) and Qt part(Qtmir).
