### PR TITLE
Add Alpine Linux CI

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -19,60 +19,42 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
-    # Only run if we have access to secrets.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-
     steps:
     - id: set-matrix
       name: Determine BuildAndTest matrix
       run: |
         set -euo pipefail
 
-        if [ "${{ github.event_name }}" == "push" -a "${{ github.ref }}" == "refs/heads/master" ]; then
-          cat <<EOF | jq -c . | awk '{ print "::set-output name=matrix::" $0 }'
-        {
-          "spread-task": [
-            "google:ubuntu-20.04-64:spread/build/ubuntu:asan",
-            "google:ubuntu-20.04-64:spread/build/ubuntu:tsan",
-            "google:ubuntu-20.04-64:spread/build/ubuntu:ubsan",
-            "google:ubuntu-20.04-64:spread/build/ubuntu:asan_clang",
-            "google:ubuntu-20.04-64:spread/build/ubuntu:tsan_clang",
-            "google:ubuntu-20.04-64:spread/build/ubuntu:ubsan_clang"
-          ],
-          "allow-fail": [false]
-        }
-        EOF
+        if ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}; then
+          TASKS='"google:ubuntu-20.04-64:spread/build/ubuntu:asan"
+                 "google:ubuntu-20.04-64:spread/build/ubuntu:tsan"
+                 "google:ubuntu-20.04-64:spread/build/ubuntu:ubsan"
+                 "google:ubuntu-20.04-64:spread/build/ubuntu:asan_clang"
+                 "google:ubuntu-20.04-64:spread/build/ubuntu:tsan_clang"
+                 "google:ubuntu-20.04-64:spread/build/ubuntu:ubsan_clang"'
         else
-          cat <<EOF | jq -c . | awk '{ print "::set-output name=matrix::" $0 }'
-        {
-          "spread-task": [
-            "google:ubuntu-20.04-64:spread/build/sbuild:debian_sid",
-            "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_groovy",
-            "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu",
-            "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_arm64",
-            "google:ubuntu-20.04-64:spread/build/ubuntu:rpi",
-            "google:ubuntu-20.04-64:spread/build/ubuntu:clang",
-            "google:fedora-32-64:spread/build/fedora:amd64",
-            "google:fedora-33-64:spread/build/fedora:amd64"
-          ],
-          "allow-fail": [false],
-          "include": [
-            {
-              "spread-task": "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_devel",
-              "allow-fail": true
-            },
-            {
-              "spread-task": "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_proposed",
-              "allow-fail": true
-            },
-            {
-              "spread-task": "fedora-rawhide-64:spread/build/fedora:amd64",
-              "allow-fail": true
-            }
-          ]
-        }
-        EOF
+          TASKS='"lxd:alpine-3.14:spread/build/alpine:amd64"
+                 "lxd:alpine-edge:spread/build/alpine:amd64"'
+
+          # Only run if we have access to secrets.
+          if ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}; then
+            TASKS+='"google:ubuntu-20.04-64:spread/build/sbuild:debian_sid"
+                    "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_groovy"
+                    "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu"
+                    "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_arm64"
+                    "google:ubuntu-20.04-64:spread/build/ubuntu:rpi"
+                    "google:ubuntu-20.04-64:spread/build/ubuntu:clang"
+                    "google:fedora-32-64:spread/build/fedora:amd64"
+                    "google:fedora-33-64:spread/build/fedora:amd64"'
+            FAILING_TASKS='"google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_devel"
+                           "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_proposed"
+                           "google:fedora-rawhide-64:spread/build/fedora:amd64"'
+          fi
         fi
+
+        ( echo ${TASKS:-} | jq -s '{ "spread-task": ., "allow-fail": [false] }';
+          echo ${FAILING_TASKS:-} | jq '{ "spread-task": ., "allow-fail": true }' | jq -s '{ "include": . }' ) \
+        | jq -cs add | awk '{ print "::set-output name=matrix::" $0 }'
 
   BuildAndTest:
     needs: GetMatrix
@@ -89,8 +71,21 @@ jobs:
       SPREAD_PATH: "/tmp/spread"
 
     steps:
-    - name: Install Spread
-      run: sudo snap install spread
+    - name: Set up LXD
+      if: ${{ startsWith(matrix.spread-task, 'lxd:') }}
+      uses: whywaita/setup-lxd@v1
+
+    - name: Set up Spread
+      run: |
+        set -e
+        if ${{ !startsWith(matrix.spread-task, 'lxd:') }}; then
+          sudo snap install spread
+        else
+          curl -s -O https://people.canonical.com/~chrishr/spread.snap
+          sudo snap install --dangerous spread.snap
+          sudo snap connect spread:lxd lxd:lxd
+          echo "LXD_DIR=/var/snap/lxd/common/lxd" >> $GITHUB_ENV
+        fi
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,9 +313,13 @@ list(APPEND CMAKE_REQUIRED_LIBRARIES ${DRM_LIBRARIES})
 # USDT integration. The integration only involves #include-ing a
 # SystemTap header and calling a macro from it in the LTTNG macro,
 # but there aren't guarantees this won't change in future.
-add_definitions(  # Drop in favour of add_compile_definitions when we drop 16.04
-  -DLTTNG_UST_HAVE_SDT_INTEGRATION
-)
+include(CheckIncludeFile)
+CHECK_INCLUDE_FILE(sys/sdt.h HAVE_SYS_SDT_H)
+if (HAVE_SYS_SDT_H)
+  add_definitions(  # Drop in favour of add_compile_definitions when we drop 16.04
+    -DLTTNG_UST_HAVE_SDT_INTEGRATION
+  )
+endif()
 
 pkg_check_modules(GL REQUIRED glesv2)
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -5,6 +5,8 @@ kill-timeout: 45m
 backends:
     lxd:
         systems:
+            - alpine-3.14
+            - alpine-edge
             - ubuntu-20.04
             - fedora-32
             - fedora-33

--- a/spread/build/alpine/task.yaml
+++ b/spread/build/alpine/task.yaml
@@ -1,0 +1,43 @@
+summary: Build (on Alpine)
+systems: [alpine-*]
+variants: [amd64]
+
+execute: |
+    apk add \
+        boost-dev \
+        capnproto-dev \
+        cmake \
+        coreutils \
+        elogind \
+        eudev-dev \
+        freetype-dev \
+        g++ \
+        glib-dev \
+        glm-dev \
+        glog-dev \
+        grep \
+        gtest-dev \
+        libepoxy-dev \
+        libevdev-dev \
+        libinput-dev \
+        libxcursor-dev \
+        libxkbcommon-dev \
+        libxml++-2.6-dev \
+        lttng-ust-dev \
+        lttng-ust-tools \
+        make \
+        mesa-dev \
+        nettle-dev \
+        py3-dbusmock \
+        py3-pillow \
+        umockdev-dev \
+        wayland-dev \
+        yaml-cpp-dev
+
+    BUILD_DIR=$(mktemp -d)
+    cmake -H$SPREAD_PATH -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DMIR_USE_LD=ld -DMIR_ENABLE_WLCS_TESTS=OFF
+    export VERBOSE=1
+    cmake --build $BUILD_DIR -- -j`nproc`
+
+    export XDG_RUNTIME_DIR=/tmp
+    cmake --build $BUILD_DIR -- ptest


### PR DESCRIPTION
Based on #1949 , thanks for the "template"!

Commit f4d0dd5979cc36c64c76ae7f8ac7eebb7c6a7c53 can be upstreamed as-is imo.

A couple of problems:
* https://github.com/MirServer/mir/commit/e3d9b53512fdd73d81254b219af5cea71e471431
* The tests fail
* Alpine 3.13 won't really be possible (at the moment) because some of the dependencies are only in the testing repo and that repo is only available on the edge version and not on the stable version. I'll see that all dependencies will be included in the Alpine 3.14 release