### PR TITLE
Geometry value type conversions

### DIFF
--- a/include/core/mir/geometry/dimensions_generic.h
+++ b/include/core/mir/geometry/dimensions_generic.h
@@ -76,10 +76,15 @@ struct Value
 
         constexpr Wrapper() : value{} {}
 
-        template<typename W, typename std::enable_if<std::is_same<typename W::TagType, Tag>::value, bool>::type = true>
-        Wrapper& operator=(W const& that)
+        Wrapper& operator=(Wrapper const& that)
         {
-            value = static_cast<T>(that.value);
+            value = that.value;
+            return *this;
+        }
+
+        constexpr Wrapper(Wrapper const& that)
+            : value{that.value}
+        {
         }
 
         template<typename W, typename std::enable_if<std::is_same<typename W::TagType, Tag>::value, bool>::type = true>

--- a/include/core/mir/geometry/displacement_generic.h
+++ b/include/core/mir/geometry/displacement_generic.h
@@ -53,6 +53,13 @@ struct Displacement : detail::DisplacementBase
     constexpr Displacement(Displacement const&) = default;
     Displacement& operator=(Displacement const&) = default;
 
+    template<typename D, typename std::enable_if<std::is_base_of<detail::DisplacementBase, D>::value, bool>::type = true>
+    explicit constexpr Displacement(D const& other)
+        : dx{T<DeltaXTag>{other.dx}},
+          dy{T<DeltaYTag>{other.dy}}
+    {
+    }
+
     template<typename DeltaXType, typename DeltaYType>
     constexpr Displacement(DeltaXType&& dx, DeltaYType&& dy) : dx{dx}, dy{dy} {}
 

--- a/include/core/mir/geometry/point_generic.h
+++ b/include/core/mir/geometry/point_generic.h
@@ -50,6 +50,13 @@ struct Point : detail::PointBase
     constexpr Point(Point const&) = default;
     Point& operator=(Point const&) = default;
 
+    template<typename P, typename std::enable_if<std::is_base_of<detail::PointBase, P>::value, bool>::type = true>
+    explicit constexpr Point(P const& other)
+        : x{T<XTag>{other.x}},
+          y{T<YTag>{other.y}}
+    {
+    }
+
     template<typename XType, typename YType>
     constexpr Point(XType&& x, YType&& y) : x(x), y(y) {}
 

--- a/include/core/mir/geometry/size_generic.h
+++ b/include/core/mir/geometry/size_generic.h
@@ -51,6 +51,13 @@ struct Size : detail::SizeBase
     constexpr Size(Size const&) noexcept = default;
     Size& operator=(Size const&) noexcept = default;
 
+    template<typename S, typename std::enable_if<std::is_base_of<detail::SizeBase, S>::value, bool>::type = true>
+    explicit constexpr Size(S const& other)
+        : width{T<WidthTag>{other.width}},
+          height{T<HeightTag>{other.height}}
+    {
+    }
+
     template<typename WidthType, typename HeightType>
     constexpr Size(WidthType&& width, HeightType&& height) noexcept : width(width), height(height) {}
 

--- a/tests/unit-tests/geometry/test-displacement.cpp
+++ b/tests/unit-tests/geometry/test-displacement.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "mir/geometry/displacement.h"
+#include "mir/geometry/displacement_f.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -81,4 +82,26 @@ TEST(geometry, displacement_point_arithmetic)
     EXPECT_EQ(expected_pd_sub2, pd_sub2);
     EXPECT_EQ(expected_pp_sub, pp_sub);
     EXPECT_EQ(expected_pp_sub2, pp_sub2);
+}
+
+TEST(geometry, displacement_can_be_converted_from_int_to_float)
+{
+    using namespace geom;
+
+    Displacement const i{1, 3};
+    DisplacementF const f{i};
+
+    EXPECT_EQ(DeltaXF(1.0), f.dx);
+    EXPECT_EQ(DeltaYF(3.0), f.dy);
+}
+
+TEST(geometry, displacement_can_be_converted_from_float_to_int)
+{
+    using namespace geom;
+
+    DisplacementF const f{1.2, 3.0};
+    Displacement const i{f};
+
+    EXPECT_EQ(DeltaX(1), i.dx);
+    EXPECT_EQ(DeltaY(3), i.dy);
 }

--- a/tests/unit-tests/geometry/test-point.cpp
+++ b/tests/unit-tests/geometry/test-point.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "mir/geometry/point.h"
+#include "mir/geometry/point_f.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -53,4 +54,26 @@ TEST(geometry, point_is_usable)
 
     EXPECT_EQ(X(x), p.x);
     EXPECT_EQ(Y(y), p.y);
+}
+
+TEST(geometry, point_can_be_converted_from_int_to_float)
+{
+    using namespace geom;
+
+    Point const i{1, 3};
+    PointF const f{i};
+
+    EXPECT_EQ(XF(1.0), f.x);
+    EXPECT_EQ(YF(3.0), f.y);
+}
+
+TEST(geometry, point_can_be_converted_from_float_to_int)
+{
+    using namespace geom;
+
+    PointF const f{1.2, 3.0};
+    Point const i{f};
+
+    EXPECT_EQ(X(1), i.x);
+    EXPECT_EQ(Y(3), i.y);
 }

--- a/tests/unit-tests/geometry/test-size.cpp
+++ b/tests/unit-tests/geometry/test-size.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "mir/geometry/size.h"
+#include "mir/geometry/size_f.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -40,4 +41,26 @@ TEST(geometry, size)
     EXPECT_EQ(Width(0), defaultValue.width);
     EXPECT_EQ(Height(0), defaultValue.height);
     EXPECT_NE(size2x4, defaultValue);
+}
+
+TEST(geometry, size_can_be_converted_from_int_to_float)
+{
+    using namespace geom;
+
+    Size const i{1, 3};
+    SizeF const f{i};
+
+    EXPECT_EQ(WidthF(1.0), f.width);
+    EXPECT_EQ(HeightF(3.0), f.height);
+}
+
+TEST(geometry, size_can_be_converted_from_float_to_int)
+{
+    using namespace geom;
+
+    SizeF const f{1.2, 3.0};
+    Size const i{f};
+
+    EXPECT_EQ(Width(1), i.width);
+    EXPECT_EQ(Height(3), i.height);
 }


### PR DESCRIPTION
This allows explicitly constructing the 2D geometry types (point, displacement and size) from the same sorts of vectors with different value types (ie you can make a `Size` from a `SizeF`). It also makes it impossible to assign wrapped values with different value types, so an explicit conversion is required.