### PR TITLE
Check for locked cursor before sending pointer movement

### DIFF
--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Canonical Ltd.
+ * Copyright © 2018-2021 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3,
@@ -273,12 +273,20 @@ void mf::WlPointer::enter_or_motion(MirPointerEvent const* event, WlSurface& roo
     }
     else if (position_on_target != current_position)
     {
-        send_motion_event(
-            timestamp_of(event),
-            position_on_target.first,
-            position_on_target.second);
-        current_position = position_on_target;
-        needs_frame = true;
+        switch (target_surface->confine_pointer_state())
+        {
+        case mir_pointer_locked_oneshot:
+        case mir_pointer_locked_persistent:
+            break;
+
+        default:
+            send_motion_event(
+                timestamp_of(event),
+                position_on_target.first,
+                position_on_target.second);
+            current_position = position_on_target;
+            needs_frame = true;
+        }
     }
 }
 

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Canonical Ltd.
+ * Copyright © 2018-2021 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3,
@@ -34,6 +34,7 @@
 #include "mir/compositor/buffer_stream.h"
 #include "mir/executor.h"
 #include "mir/graphics/graphic_buffer_allocator.h"
+#include "mir/scene/surface.h"
 #include "mir/shell/surface_specification.h"
 #include "mir/log.h"
 
@@ -462,6 +463,19 @@ void mf::WlSurface::set_buffer_transform(int32_t transform)
 void mf::WlSurface::set_buffer_scale(int32_t scale)
 {
     pending.scale = scale;
+}
+
+auto mf::WlSurface::confine_pointer_state() const -> MirPointerConfinementState
+{
+    if (auto const maybe_scene_surface = scene_surface())
+    {
+        if (auto const scene_surface = *maybe_scene_surface)
+        {
+            return scene_surface->confine_pointer_state();
+        }
+    }
+
+    return mir_pointer_unconfined;
 }
 
 mf::NullWlSurfaceRole::NullWlSurfaceRole(WlSurface* surface) :

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Canonical Ltd.
+ * Copyright © 2018-2021 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3,
@@ -134,6 +134,7 @@ public:
                                std::vector<mir::geometry::Rectangle>& input_shape_accumulator,
                                geometry::Displacement const& parent_offset) const;
     void commit(WlSurfaceState const& state);
+    auto confine_pointer_state() const -> MirPointerConfinementState;
 
     std::shared_ptr<scene::Session> const session;
     std::shared_ptr<compositor::BufferStream> const stream;


### PR DESCRIPTION
The changes in #1960 led to clients getting spurious pointer movement events (e.g. mir-kiosk-neverputt ends up with jitters). We shouldn't be sending those if the pointer is locked.