### PR TITLE
Gracefully handle XWayland errors

### DIFF
--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -141,17 +141,13 @@ void mf::XWaylandConnector::spawn()
 
     try
     {
-        auto const wayland_socket_pair = XWaylandServer::make_socket_pair();
-        auto const x11_socket_pair = XWaylandServer::make_socket_pair();
         server = std::make_unique<XWaylandServer>(
             wayland_connector,
             *spawner,
             xwayland_path,
-            wayland_socket_pair,
-            x11_socket_pair.second,
             scale);
         auto const wm_dispatcher = std::make_shared<md::MultiplexingDispatchable>();
-        wm_dispatcher->add_watch(std::make_shared<md::ReadableFd>(x11_socket_pair.first, [this]()
+        wm_dispatcher->add_watch(std::make_shared<md::ReadableFd>(server->x11_wm_fd(), [this]()
             {
                 std::lock_guard<std::mutex> lock{mutex};
                 if (wm)
@@ -193,7 +189,7 @@ void mf::XWaylandConnector::spawn()
         wm = std::make_unique<XWaylandWM>(
             wayland_connector,
             server->client(),
-            x11_socket_pair.first,
+            server->x11_wm_fd(),
             wm_dispatcher,
             scale);
         mir::log_info("XWayland is running");

--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -18,7 +18,6 @@
 
 #include "xwayland_connector.h"
 
-
 #include "wayland_connector.h"
 #include "xwayland_server.h"
 #include "xwayland_spawner.h"
@@ -26,7 +25,7 @@
 #include "mir/log.h"
 #include "mir/dispatch/multiplexing_dispatchable.h"
 #include "mir/dispatch/readable_fd.h"
-#include "mir/terminate_with_current_exception.h"
+#include "mir/executor.h"
 
 #include <unistd.h>
 
@@ -34,10 +33,12 @@ namespace mf = mir::frontend;
 namespace md = mir::dispatch;
 
 mf::XWaylandConnector::XWaylandConnector(
+    std::shared_ptr<Executor> const& main_loop,
     std::shared_ptr<WaylandConnector> const& wayland_connector,
     std::string const& xwayland_path,
     float scale)
-    : wayland_connector{wayland_connector},
+    : main_loop{main_loop},
+      wayland_connector{wayland_connector},
       xwayland_path{xwayland_path},
       scale{scale}
 {

--- a/src/server/frontend_xwayland/xwayland_connector.cpp
+++ b/src/server/frontend_xwayland/xwayland_connector.cpp
@@ -143,6 +143,13 @@ void mf::XWaylandConnector::spawn()
     {
         auto const wayland_socket_pair = XWaylandServer::make_socket_pair();
         auto const x11_socket_pair = XWaylandServer::make_socket_pair();
+        server = std::make_unique<XWaylandServer>(
+            wayland_connector,
+            *spawner,
+            xwayland_path,
+            wayland_socket_pair,
+            x11_socket_pair.second,
+            scale);
         auto const wm_dispatcher = std::make_shared<md::MultiplexingDispatchable>();
         wm_dispatcher->add_watch(std::make_shared<md::ReadableFd>(x11_socket_pair.first, [this]()
             {
@@ -183,13 +190,6 @@ void mf::XWaylandConnector::spawn()
                 local_wm.reset();
                 local_server.reset();
             });
-        server = std::make_unique<XWaylandServer>(
-            wayland_connector,
-            *spawner,
-            xwayland_path,
-            wayland_socket_pair,
-            x11_socket_pair.second,
-            scale);
         wm = std::make_unique<XWaylandWM>(
             wayland_connector,
             server->client(),

--- a/src/server/frontend_xwayland/xwayland_connector.h
+++ b/src/server/frontend_xwayland/xwayland_connector.h
@@ -47,6 +47,7 @@ public:
     /// or even per-toolkit basis. GDK_SCALE is used by default for XWayland scale because many apps respect it, so it's
     /// generally as correct as anything.
     XWaylandConnector(
+        std::shared_ptr<Executor> const& main_loop,
         std::shared_ptr<WaylandConnector> const& wayland_connector,
         std::string const& xwayland_path,
         float scale);
@@ -62,6 +63,7 @@ public:
     auto socket_name() const -> optional_value<std::string> override;
 
 private:
+    std::shared_ptr<Executor> const main_loop;
     std::shared_ptr<WaylandConnector> const wayland_connector;
     std::string const xwayland_path;
     float const scale;

--- a/src/server/frontend_xwayland/xwayland_connector.h
+++ b/src/server/frontend_xwayland/xwayland_connector.h
@@ -68,10 +68,10 @@ private:
     std::string const xwayland_path;
     float const scale;
 
-    /// Creates the spawner if it doesn't already exist and is_started is true
-    void maybe_create_spawner(std::unique_lock<std::mutex>& lock);
-    /// Destroyes all objects including the spawner, leaves the given lock unlocked
-    void clean_up(std::unique_lock<std::mutex>& lock);
+    /// Creates the spawner if it doesn't already exist and is_started is true, given lock must be locked
+    void maybe_create_spawner(std::unique_lock<std::mutex> const& lock);
+    /// Destroyes all objects including the spawner, given lock must be locked
+    void clean_up(std::unique_lock<std::mutex> lock);
     /// Called the first time a client attempts to connect. Creates the server (which forks the XWayland process), wm
     /// and wm_event_thread.
     void spawn();

--- a/src/server/frontend_xwayland/xwayland_default_configuration.cpp
+++ b/src/server/frontend_xwayland/xwayland_default_configuration.cpp
@@ -18,6 +18,7 @@
 #include "mir/default_server_configuration.h"
 #include "mir/log.h"
 #include "mir/options/default_configuration.h"
+#include "mir/main_loop.h"
 #include "wayland_connector.h"
 #include "xwayland_connector.h"
 
@@ -75,6 +76,7 @@ std::shared_ptr<mf::Connector> mir::DefaultServerConfiguration::the_xwayland_con
                 }
                 auto wayland_connector = std::static_pointer_cast<mf::WaylandConnector>(the_wayland_connector());
                 return std::make_shared<mf::XWaylandConnector>(
+                    the_main_loop(),
                     wayland_connector,
                     options->get<std::string>("xwayland-path"),
                     scale);

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -42,6 +42,17 @@ using namespace std::chrono_literals;
 
 namespace
 {
+/// Returns a symmetrical pair of connected sockets
+auto make_socket_pair() -> std::pair<mir::Fd, mir::Fd>
+{
+    int pipe[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, pipe) < 0)
+    {
+        BOOST_THROW_EXCEPTION(std::system_error(errno, std::system_category(), "Creating socket pair failed"));
+    }
+    return std::make_pair(mir::Fd{pipe[0]}, mir::Fd{pipe[1]});
+}
+
 void exec_xwayland(
     mf::XWaylandSpawner const& spawner,
     std::string const& xwayland_path,
@@ -92,11 +103,11 @@ void exec_xwayland(
 auto fork_xwayland_process(
     mf::XWaylandSpawner const& spawner,
     std::string const& xwayland_path,
-    mir::Fd wayland_client_fd,
-    mir::Fd x11_wm_server_fd,
-    float scale) -> pid_t
+    float scale) -> mf::XWaylandProcessInfo
 {
     mir::log_info("Starting XWayland");
+    auto const wayland_socket_pair = make_socket_pair();
+    auto const x11_socket_pair = make_socket_pair();
     pid_t const xwayland_pid = fork();
 
     switch (xwayland_pid)
@@ -105,12 +116,15 @@ auto fork_xwayland_process(
         BOOST_THROW_EXCEPTION(std::system_error(errno, std::system_category(), "Failed to fork XWayland process"));
 
     case 0:
-        exec_xwayland(spawner, xwayland_path, wayland_client_fd, x11_wm_server_fd, scale);
+        exec_xwayland(spawner, xwayland_path, wayland_socket_pair.second, x11_socket_pair.second, scale);
         // Only reached if Xwayland was not executed
         abort();
 
     default:
-        return xwayland_pid;
+        return mf::XWaylandProcessInfo{
+            xwayland_pid,
+            wayland_socket_pair.first,
+            x11_socket_pair.first};
     }
 }
 
@@ -159,12 +173,9 @@ mf::XWaylandServer::XWaylandServer(
     std::shared_ptr<WaylandConnector> const& wayland_connector,
     XWaylandSpawner const& spawner,
     std::string const& xwayland_path,
-    std::pair<mir::Fd, mir::Fd> const& wayland_socket_pair,
-    mir::Fd const& x11_server_fd,
     float scale)
-    : xwayland_pid{fork_xwayland_process(spawner, xwayland_path, wayland_socket_pair.first, x11_server_fd, scale)},
-      wayland_server_fd{wayland_socket_pair.second},
-      wayland_client{connect_xwayland_wl_client(wayland_connector, wayland_server_fd, scale)},
+    : xwayland{fork_xwayland_process(spawner, xwayland_path, scale)},
+      wayland_client{connect_xwayland_wl_client(wayland_connector, xwayland.wayland_fd, scale)},
       running{true}
 {
 }
@@ -174,20 +185,20 @@ mf::XWaylandServer::~XWaylandServer()
     mir::log_info("Deiniting xwayland server");
 
     // Terminate any running xservers
-    if (kill(xwayland_pid, SIGTERM) == 0)
+    if (kill(xwayland.pid, SIGTERM) == 0)
     {
         std::this_thread::sleep_for(100ms);// After 100ms...
         if (is_running())
         {
             mir::log_info("Xwayland didn't close, killing it");
-            kill(xwayland_pid, SIGKILL);     // ...then kill it!
+            kill(xwayland.pid, SIGKILL);     // ...then kill it!
         }
     }
 
     // Calling is_running() one more time will ensure the process is reaped
     if (is_running())
     {
-        log_warning("Failed to kill Xwayland process with PID %d", xwayland_pid);
+        log_warning("Failed to kill Xwayland process with PID %d", xwayland.pid);
     }
 }
 
@@ -198,21 +209,11 @@ auto mf::XWaylandServer::is_running() const -> bool
     if (running)
     {
         int status; // Special waitpid() status, not the process exit status
-        if (waitpid(xwayland_pid, &status, WNOHANG) != 0)
+        if (waitpid(xwayland.pid, &status, WNOHANG) != 0)
         {
             running = false;
         }
     }
 
     return running;
-}
-
-auto mf::XWaylandServer::make_socket_pair() -> std::pair<mir::Fd, mir::Fd>
-{
-    int pipe[2];
-    if (socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, pipe) < 0)
-    {
-        BOOST_THROW_EXCEPTION(std::system_error(errno, std::system_category(), "Creating socket pair failed"));
-    }
-    return std::make_pair(mir::Fd{pipe[0]}, mir::Fd{pipe[1]});
 }

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -35,6 +35,13 @@ namespace frontend
 class WaylandConnector;
 class XWaylandSpawner;
 
+struct XWaylandProcessInfo
+{
+    pid_t const pid;
+    Fd const wayland_fd;
+    Fd const x11_fd;
+};
+
 class XWaylandServer
 {
 public:
@@ -42,23 +49,18 @@ public:
         std::shared_ptr<WaylandConnector> const& wayland_connector,
         XWaylandSpawner const& spawner,
         std::string const& xwayland_path,
-        std::pair<mir::Fd, mir::Fd> const& wayland_socket_pair,
-        mir::Fd const& x11_server_fd,
         float scale);
     ~XWaylandServer();
 
     auto client() const -> wl_client* { return wayland_client; }
+    auto x11_wm_fd() const -> Fd const& { return xwayland.x11_fd; }
     auto is_running() const -> bool;
-
-    // Returns a symmetrical pair of connected sockets
-    static auto make_socket_pair() -> std::pair<mir::Fd, mir::Fd>;
 
 private:
     XWaylandServer(XWaylandServer const&) = delete;
     XWaylandServer& operator=(XWaylandServer const&) = delete;
 
-    pid_t const xwayland_pid;
-    mir::Fd const wayland_server_fd;
+    XWaylandProcessInfo const xwayland;
     wl_client* const wayland_client{nullptr};
 
     mutable std::mutex mutex;


### PR DESCRIPTION
Our logic for launching XWayland has long been good but not great. #1969 is a symptom of this, and while looking into it I found other symptoms (notably when XWayland fails to start apps *also* hang for a similar but unrelated reason). This PR attempts to clean it up, show errors when needed and prevent deadlocks. Fixes #1969.

Notable changes:
- Pull in the main loop so `ThreadedDispatcher`s can be destroyed inside their own calls. The previous method of creating and joining a new thread was heavy, looked weird and didn't seem to even work in all cases.
- Use `std::enable_shared_from_this` with `XWaylandConnector`--this is because we need a `weak_ptr` when punting to the main loop in case the object dies.
- Move creation of socket pairs to `XWaylandServer`. This prevents them from being held in `XWaylandConnector::spawn()` after the server was forked, which was causing #1969
- Make error messages more correct (for example it previously said "killing XWayland" when it was really restarting it)