### PR TITLE
Use a dark gray background instead of black by default

### DIFF
--- a/src/renderers/gl/renderer.cpp
+++ b/src/renderers/gl/renderer.cpp
@@ -351,7 +351,7 @@ mrg::Renderer::Program::Program(GLuint program_id)
 
 mrg::Renderer::Renderer(graphics::DisplayBuffer& display_buffer)
     : render_target(&display_buffer),
-      clear_color{0.0f, 0.0f, 0.0f, 0.0f},
+      clear_color{0.2f, 0.2f, 0.2f, 1.0f},
       default_program(family.add_program(vshader, default_fshader)),
       alpha_program(family.add_program(vshader, alpha_fshader)),
       program_factory{std::make_unique<ProgramFactory>()},

--- a/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
+++ b/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
@@ -220,10 +220,10 @@ TEST_F(GLRenderer, avoids_src_alpha_for_rgbx_blending)  // LP: #1423462
     renderer.render(renderable_list);
 }
 
-TEST_F(GLRenderer, clears_all_channels_zero)
+TEST_F(GLRenderer, clears_all_channels)
 {
     InSequence seq;
-    EXPECT_CALL(mock_gl, glClearColor(0.0f, 0.0f, 0.0f, 0.0f));
+    EXPECT_CALL(mock_gl, glClearColor(_, _, _, _));
     EXPECT_CALL(mock_gl, glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE));
     EXPECT_CALL(mock_gl, glClear(_));
 


### PR DESCRIPTION
Anything bright or canonical-colored might be annoying, but I see no reason a simple dark gray background would be worse than a black one. This makes it much easier to tell when a Mir server has started without the overhead of rendering a background surface.

Fixes #1971 