### PR TITLE
Do not move on_consumed callback in buffer allocators

### DIFF
--- a/src/platforms/gbm-kms/server/buffer_allocator.cpp
+++ b/src/platforms/gbm-kms/server/buffer_allocator.cpp
@@ -375,8 +375,8 @@ std::shared_ptr<mg::Buffer> mgg::BufferAllocator::buffer_from_resource(
     if (auto dmabuf = dmabuf_extension->buffer_from_resource(
         buffer,
         ctx,
-        std::move(on_consumed),
-        std::move(on_release),
+        std::function<void()>{on_consumed},
+        std::function<void()>{on_release},
         wayland_executor))
     {
         return dmabuf;

--- a/src/platforms/wayland/buffer_allocator.cpp
+++ b/src/platforms/wayland/buffer_allocator.cpp
@@ -182,8 +182,8 @@ auto mgw::BufferAllocator::buffer_from_resource(
     if (auto dmabuf = dmabuf_extension->buffer_from_resource(
         buffer,
         ctx,
-        std::move(on_consumed),
-        std::move(on_release),
+        std::function<void()>{on_consumed},
+        std::function<void()>{on_release},
         wayland_executor))
     {
         return dmabuf;

--- a/src/platforms/x11/graphics/buffer_allocator.cpp
+++ b/src/platforms/x11/graphics/buffer_allocator.cpp
@@ -218,8 +218,8 @@ std::shared_ptr<mg::Buffer> mgx::BufferAllocator::buffer_from_resource(
     if (auto dmabuf = dmabuf_extension->buffer_from_resource(
         buffer,
         ctx,
-        std::move(on_consumed),
-        std::move(on_release),
+        std::function<void()>{on_consumed},
+        std::function<void()>{on_release},
         wayland_executor))
     {
         return dmabuf;


### PR DESCRIPTION
My understanding of rvalue references is still a little shaky so maybe I'm wrong, but this looks like a bug to me. In each case we're moving an rvalue reference, only to then potentially use it later. I have not observed any symptoms.