### PR TITLE
Place popups on output their anchor is on

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -2053,7 +2053,6 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
 -> mir::optional_value<Rectangle>
 {
     auto const hints = parameters.placement_hints().value();
-    auto const active_output_area = active_output();
     auto const win_gravity = parameters.window_placement_gravity().value();
 
     if (parameters.size().is_set())
@@ -2064,6 +2063,9 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
 
     Rectangle aux_rect = parameters.aux_rect().value();
     aux_rect.top_left = aux_rect.top_left + (parent.top_left-Point{});
+
+    auto const probable_display_area= display_area_for(aux_rect);
+    auto const placement_bounds = probable_display_area ? probable_display_area.value()->area : parent;
 
     std::vector<MirPlacementGravity> rect_gravities{parameters.aux_rect_placement_gravity().value()};
 
@@ -2078,7 +2080,7 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
             auto result = constrain_to(parent, anchor_for(aux_rect, rect_gravity) + offset) +
                 offset_for(size, win_gravity);
 
-            if (active_output_area.contains(Rectangle{result, size}))
+            if (placement_bounds.contains(Rectangle{result, size}))
                 return Rectangle{result, size};
 
             if (!default_result.is_set())
@@ -2090,7 +2092,7 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
             auto result = constrain_to(parent, anchor_for(aux_rect, flip_x(rect_gravity)) + flip_x(offset)) +
                 offset_for(size, flip_x(win_gravity));
 
-            if (active_output_area.contains(Rectangle{result, size}))
+            if (placement_bounds.contains(Rectangle{result, size}))
                 return Rectangle{result, size};
         }
 
@@ -2099,7 +2101,7 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
             auto result = constrain_to(parent, anchor_for(aux_rect, flip_y(rect_gravity)) + flip_y(offset)) +
                 offset_for(size, flip_y(win_gravity));
 
-            if (active_output_area.contains(Rectangle{result, size}))
+            if (placement_bounds.contains(Rectangle{result, size}))
                 return Rectangle{result, size};
         }
 
@@ -2108,7 +2110,7 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
             auto result = constrain_to(parent, anchor_for(aux_rect, flip_x(flip_y(rect_gravity))) + flip_x(flip_y(offset))) +
                 offset_for(size, flip_x(flip_y(win_gravity)));
 
-            if (active_output_area.contains(Rectangle{result, size}))
+            if (placement_bounds.contains(Rectangle{result, size}))
                 return Rectangle{result, size};
         }
     }
@@ -2120,8 +2122,8 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
 
         if (hints & mir_placement_hints_slide_x)
         {
-            auto const left_overhang  = result.x - active_output_area.top_left.x;
-            auto const right_overhang = (result + as_displacement(size)).x - active_output_area.top_right().x;
+            auto const left_overhang  = result.x - placement_bounds.top_left.x;
+            auto const right_overhang = (result + as_displacement(size)).x - placement_bounds.top_right().x;
 
             if (left_overhang < DeltaX{0})
                 result -= left_overhang;
@@ -2131,8 +2133,8 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
 
         if (hints & mir_placement_hints_slide_y)
         {
-            auto const top_overhang  = result.y - active_output_area.top_left.y;
-            auto const bot_overhang = (result + as_displacement(size)).y - active_output_area.bottom_left().y;
+            auto const top_overhang  = result.y - placement_bounds.top_left.y;
+            auto const bot_overhang = (result + as_displacement(size)).y - placement_bounds.bottom_left().y;
 
             if (top_overhang < DeltaY{0})
                 result -= top_overhang;
@@ -2140,7 +2142,7 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
                 result -= bot_overhang;
         }
 
-        if (active_output_area.contains(Rectangle{result, size}))
+        if (placement_bounds.contains(Rectangle{result, size}))
             return Rectangle{result, size};
     }
 
@@ -2151,8 +2153,8 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
 
         if (hints & mir_placement_hints_resize_x)
         {
-            auto const left_overhang  = result.x - active_output_area.top_left.x;
-            auto const right_overhang = (result + as_displacement(size)).x - active_output_area.top_right().x;
+            auto const left_overhang  = result.x - placement_bounds.top_left.x;
+            auto const right_overhang = (result + as_displacement(size)).x - placement_bounds.top_right().x;
 
             if (left_overhang < DeltaX{0})
             {
@@ -2168,8 +2170,8 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
 
         if (hints & mir_placement_hints_resize_y)
         {
-            auto const top_overhang  = result.y - active_output_area.top_left.y;
-            auto const bot_overhang = (result + as_displacement(size)).y - active_output_area.bottom_left().y;
+            auto const top_overhang  = result.y - placement_bounds.top_left.y;
+            auto const bot_overhang = (result + as_displacement(size)).y - placement_bounds.bottom_left().y;
 
             if (top_overhang < DeltaY{0})
             {
@@ -2183,7 +2185,7 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
             }
         }
 
-        if (active_output_area.contains(Rectangle{result, size}))
+        if (placement_bounds.contains(Rectangle{result, size}))
             return Rectangle{result, size};
     }
 

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -753,11 +753,11 @@ auto miral::BasicWindowManager::display_area_for(WindowInfo const& info) const -
 }
 
 auto miral::BasicWindowManager::display_area_for(Rectangle const& rect) const
--> std::experimental::optional<std::shared_ptr<DisplayArea>>
+-> std::optional<std::shared_ptr<DisplayArea>>
 {
     int max_overlap_area = 0;
     int min_distance = INT_MAX;
-    std::experimental::optional<std::shared_ptr<DisplayArea>> best_area;
+    std::optional<std::shared_ptr<DisplayArea>> best_area;
     for (auto& area : display_areas)
     {
         auto const intersection = rect.intersection_with(area->area).size;

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -2064,7 +2064,7 @@ auto miral::BasicWindowManager::place_relative(mir::geometry::Rectangle const& p
     Rectangle aux_rect = parameters.aux_rect().value();
     aux_rect.top_left = aux_rect.top_left + (parent.top_left-Point{});
 
-    auto const probable_display_area= display_area_for(aux_rect);
+    auto const probable_display_area = display_area_for(aux_rect);
     auto const placement_bounds = probable_display_area ? probable_display_area.value()->area : parent;
 
     std::vector<MirPlacementGravity> rect_gravities{parameters.aux_rect_placement_gravity().value()};

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -37,7 +37,7 @@
 
 #include <boost/bimap.hpp>
 #include <boost/bimap/multiset_of.hpp>
-#include <experimental/optional>
+#include <optional>
 
 #include <map>
 #include <mutex>
@@ -221,13 +221,13 @@ private:
         /// The subset of the area where normal applications are generally placed (excludes, for example, panels)
         Zone application_zone;
         /// The last zone given to the policy, or nullopt if the policy hasn't been notified of this area's creation yet
-        std::experimental::optional<Zone> zone_policy_knows_about;
+        std::optional<Zone> zone_policy_knows_about;
         /// Often a single output
         /// can be empty or (in the case of logical output groups) contain multiple outputs
         /// if all outputs are removed the next call to update_application_zones() will drop this DisplayArea
         std::vector<Output> contained_outputs;
         /// Only set if this display area represents a logical group of multiple outputs
-        std::experimental::optional<int> logical_output_group_id;
+        std::optional<int> logical_output_group_id;
         std::set<Window> attached_windows; ///< Maximized/anchored/etc windows attached to this area
     };
 
@@ -310,7 +310,7 @@ private:
     auto active_display_area() const -> std::shared_ptr<DisplayArea>;
     auto display_area_for_output_id(int output_id) const -> std::shared_ptr<DisplayArea>; ///< returns null if not found
     auto display_area_for(WindowInfo const& info) const -> std::shared_ptr<DisplayArea>;
-    auto display_area_for(Rectangle const& rect) const -> std::experimental::optional<std::shared_ptr<DisplayArea>>;
+    auto display_area_for(Rectangle const& rect) const -> std::optional<std::shared_ptr<DisplayArea>>;
     /// Returns the application zone area after shrinking it for the exclusive zone if needed
     static auto apply_exclusive_rect_to_application_zone(
         mir::geometry::Rectangle const& original_zone,

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -310,6 +310,7 @@ private:
     auto active_display_area() const -> std::shared_ptr<DisplayArea>;
     auto display_area_for_output_id(int output_id) const -> std::shared_ptr<DisplayArea>; ///< returns null if not found
     auto display_area_for(WindowInfo const& info) const -> std::shared_ptr<DisplayArea>;
+    auto display_area_for(Rectangle const& rect) const -> std::experimental::optional<std::shared_ptr<DisplayArea>>;
     /// Returns the application zone area after shrinking it for the exclusive zone if needed
     static auto apply_exclusive_rect_to_application_zone(
         mir::geometry::Rectangle const& original_zone,


### PR DESCRIPTION
Only when the parent window spans outputs does this change the behaviour.

In these cases, child window is constrained to the output that contains the anchor rectangle, not the one that contains the parent rectangle. This seems right to me.

Fixes: #1408 