### PR TITLE
Fix potential deadlock in BasicSurface::visible()

### DIFF
--- a/src/server/compositor/stream.cpp
+++ b/src/server/compositor/stream.cpp
@@ -55,10 +55,10 @@ void mc::Stream::submit_buffer(std::shared_ptr<mg::Buffer> const& buffer)
 
     {
         std::lock_guard<decltype(mutex)> lk(mutex);
-        first_frame_posted = true;
         pf = buffer->pixel_format();
         latest_buffer_size = buffer->size();
         schedule->schedule(buffer);
+        first_frame_posted = true;
     }
     {
         std::lock_guard<decltype(callback_mutex)> lock{callback_mutex};
@@ -156,7 +156,7 @@ void mc::Stream::drop_old_buffers()
 
 bool mc::Stream::has_submitted_buffer() const
 {
-    std::lock_guard<decltype(mutex)> lk(mutex);
+    // Don't need to lock mutex because first_frame_posted is atomic
     return first_frame_posted;
 }
 

--- a/src/server/compositor/stream.h
+++ b/src/server/compositor/stream.h
@@ -68,7 +68,7 @@ private:
     geometry::Size latest_buffer_size;
     float scale_{1.0f};
     MirPixelFormat pf;
-    bool first_frame_posted;
+    std::atomic<bool> first_frame_posted;
 
     std::mutex callback_mutex;
     std::function<void(geometry::Size const&)> frame_callback;


### PR DESCRIPTION
Should fix #1337 (though I don't know how to test that). The only potential issue is that now while the first buffer is being submitted, `has_submitted_buffer()` returns `false` whereas it used to block and the return `true`. By my understanding any code that cares about this would have been a race anyway, and it's unclear that either is behavior is more correct than the other. I haven't observed any changes in behavior.