### PR TITLE
Add error message for window manager inconsistancy

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -2712,6 +2712,7 @@ void miral::BasicWindowManager::update_application_zones_and_attached_windows()
                     break;
 
                 default:
+                    log_error("Window in attached_windows is not attached or maximized");
                     break;
                 }
             }


### PR DESCRIPTION
This way the `place_attached_to_zone()` can `fatal_error()` if it's preconditions aren't met (meaning there's an obvious logic error), but we get a non-fatal error when the state is wrong (indicating there is an error, but an easier one to slip into the code).