### PR TITLE
WLCS WaylandExecutor: don't do work under lock

### DIFF
--- a/tests/acceptance-tests/wayland/test_wlcs_display_server.cpp
+++ b/tests/acceptance-tests/wayland/test_wlcs_display_server.cpp
@@ -280,7 +280,6 @@ private:
                 err);
         }
 
-        std::unique_lock<std::recursive_mutex> lock{executor->mutex};
         while (auto work = executor->get_work())
         {
             try


### PR DESCRIPTION
Using a recursive mutex and doing `work()` under lock was causing the deadlock observed in #1881. I'm unsure of if that exposed a bug that was already there, or if changes there created a new bug, but either way it's dependent on the wayland executor jobs being run under lock.

I don't think there's any reason to do that or to use a recursive mutex. The "real" Wayland executor doesn't execute arbitrary work under lock (as far as I can tell), so the WLCS one shouldn't need to either.