### PR TITLE
Respect `--enable-key-repeat` with Wayland

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -485,24 +485,21 @@ void mf::WaylandExtensions::run_builders(wl_display*, std::function<void(std::fu
 }
 
 mf::WaylandConnector::WaylandConnector(
-    std::shared_ptr<msh::Shell> const& shell,
-    std::shared_ptr<MirDisplay> const& display_config,
-    std::shared_ptr<mi::InputDeviceHub> const& input_hub,
-    std::shared_ptr<mi::Seat> const& seat,
-    std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
-    std::shared_ptr<mf::SessionAuthorizer> const& session_authorizer,
-    std::shared_ptr<SurfaceStack> const& surface_stack,
-    std::shared_ptr<ms::Clipboard> const& clipboard,
-    bool arw_socket,
-    std::unique_ptr<WaylandExtensions> extensions_,
-    WaylandProtocolExtensionFilter const& extension_filter)
+    std::shared_ptr<shell::Shell> const& shell, std::shared_ptr<MirDisplay> const& display_config,
+    std::shared_ptr<input::InputDeviceHub> const& input_hub, std::shared_ptr<input::Seat> const& seat,
+    std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
+    std::shared_ptr<SessionAuthorizer> const& session_authorizer,
+    std::shared_ptr<SurfaceStack> const& surface_stack, std::shared_ptr<scene::Clipboard> const& clipboard,
+    bool arw_socket, std::unique_ptr<WaylandExtensions> extensions_,
+    WaylandProtocolExtensionFilter const& extension_filter, bool enable_key_repeat)
     : display{wl_display_create(), &cleanup_display},
       pause_signal{eventfd(0, EFD_CLOEXEC | EFD_SEMAPHORE)},
       executor{std::make_shared<WaylandExecutor>(wl_display_get_event_loop(display.get()))},
       allocator{allocator_for_display(allocator, display.get(), executor)},
       shell{shell},
       extensions{std::move(extensions_)},
-      extension_filter{extension_filter}
+      extension_filter{extension_filter},
+      enable_key_repeat{enable_key_repeat}
 {
     if (pause_signal == mir::Fd::invalid)
     {
@@ -537,14 +534,14 @@ mf::WaylandConnector::WaylandConnector(
      * crash with a different order. Yay!
      *
      * So far I've only found ones which expect wl_compositor before anything else,
-     * so stick that first.
+     * so stick that first
      */
     compositor_global = std::make_unique<mf::WlCompositor>(
         display.get(),
         executor,
         this->allocator);
     subcompositor_global = std::make_unique<mf::WlSubcompositor>(display.get());
-    seat_global = std::make_unique<mf::WlSeat>(display.get(), input_hub, seat);
+    seat_global = std::make_unique<mf::WlSeat>(display.get(), input_hub, seat, enable_key_repeat);
     output_manager = std::make_unique<mf::OutputManager>(
         display.get(),
         display_config,

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -485,21 +485,25 @@ void mf::WaylandExtensions::run_builders(wl_display*, std::function<void(std::fu
 }
 
 mf::WaylandConnector::WaylandConnector(
-    std::shared_ptr<shell::Shell> const& shell, std::shared_ptr<MirDisplay> const& display_config,
-    std::shared_ptr<input::InputDeviceHub> const& input_hub, std::shared_ptr<input::Seat> const& seat,
-    std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
-    std::shared_ptr<SessionAuthorizer> const& session_authorizer,
-    std::shared_ptr<SurfaceStack> const& surface_stack, std::shared_ptr<scene::Clipboard> const& clipboard,
-    bool arw_socket, std::unique_ptr<WaylandExtensions> extensions_,
-    WaylandProtocolExtensionFilter const& extension_filter, bool enable_key_repeat)
+    std::shared_ptr<msh::Shell> const& shell,
+    std::shared_ptr<MirDisplay> const& display_config,
+    std::shared_ptr<mi::InputDeviceHub> const& input_hub,
+    std::shared_ptr<mi::Seat> const& seat,
+    std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
+    std::shared_ptr<mf::SessionAuthorizer> const& session_authorizer,
+    std::shared_ptr<SurfaceStack> const& surface_stack,
+    std::shared_ptr<ms::Clipboard> const& clipboard,
+    bool arw_socket,
+    std::unique_ptr<WaylandExtensions> extensions_,
+    WaylandProtocolExtensionFilter const& extension_filter,
+    bool enable_key_repeat)
     : display{wl_display_create(), &cleanup_display},
       pause_signal{eventfd(0, EFD_CLOEXEC | EFD_SEMAPHORE)},
       executor{std::make_shared<WaylandExecutor>(wl_display_get_event_loop(display.get()))},
       allocator{allocator_for_display(allocator, display.get(), executor)},
       shell{shell},
       extensions{std::move(extensions_)},
-      extension_filter{extension_filter},
-      enable_key_repeat{enable_key_repeat}
+      extension_filter{extension_filter}
 {
     if (pause_signal == mir::Fd::invalid)
     {
@@ -534,7 +538,7 @@ mf::WaylandConnector::WaylandConnector(
      * crash with a different order. Yay!
      *
      * So far I've only found ones which expect wl_compositor before anything else,
-     * so stick that first
+     * so stick that first.
      */
     compositor_global = std::make_unique<mf::WlCompositor>(
         display.get(),

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -161,7 +161,6 @@ private:
     std::string wayland_display;
 
     WaylandProtocolExtensionFilter const extension_filter;
-    bool const enable_key_repeat;
 
     // Only accessed on event loop
     std::unordered_map<int, std::function<void(std::shared_ptr<scene::Session> const& session)>> mutable connect_handlers;

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -118,7 +118,8 @@ public:
         std::shared_ptr<scene::Clipboard> const& clipboard,
         bool arw_socket,
         std::unique_ptr<WaylandExtensions> extensions,
-        WaylandProtocolExtensionFilter const& extension_filter);
+        WaylandProtocolExtensionFilter const& extension_filter,
+        bool enable_key_repeat);
 
     ~WaylandConnector() override;
 
@@ -160,6 +161,7 @@ private:
     std::string wayland_display;
 
     WaylandProtocolExtensionFilter const extension_filter;
+    bool const enable_key_repeat;
 
     // Only accessed on event loop
     std::unordered_map<int, std::function<void(std::shared_ptr<scene::Session> const& session)>> mutable connect_handlers;

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -247,6 +247,8 @@ std::shared_ptr<mf::Connector>
                 the_frontend_display_changer(),
                 the_display_configuration_observer_registrar());
 
+            auto const enable_repeat = options->get<bool>(options::enable_key_repeat_opt);
+
             return std::make_shared<mf::WaylandConnector>(
                 the_shell(),
                 display_config,
@@ -261,7 +263,8 @@ std::shared_ptr<mf::Connector>
                     wayland_extensions,
                     options->is_set(mo::x11_display_opt),
                     wayland_extension_hooks),
-                wayland_extension_filter);
+                wayland_extension_filter,
+                enable_repeat);
         });
 }
 

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -41,7 +41,8 @@ namespace mi = mir::input;
 mf::WlKeyboard::WlKeyboard(
     wl_resource* new_resource,
     mir::input::Keymap const& initial_keymap,
-    std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state)
+    std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state,
+    bool enable_key_repeat)
     : Keyboard(new_resource, Version<6>()),
       keymap{nullptr, &xkb_keymap_unref},
       state{nullptr, &xkb_state_unref},
@@ -63,7 +64,7 @@ mf::WlKeyboard::WlKeyboard(
     // 25 rate and 600 delay are the default in Weston and Sway
     // At some point we will want to make this configurable
     if (version_supports_repeat_info())
-        send_repeat_info_event(25, 600);
+        send_repeat_info_event(enable_key_repeat? 25 : 0, 600);
 }
 
 mf::WlKeyboard::~WlKeyboard()

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -52,7 +52,8 @@ public:
     WlKeyboard(
         wl_resource* new_resource,
         mir::input::Keymap const& initial_keymap,
-        std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state);
+        std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state,
+        bool enable_key_repeat);
 
     ~WlKeyboard();
 

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -54,7 +54,8 @@ public:
     WlSeat(
         wl_display* display,
         std::shared_ptr<mir::input::InputDeviceHub> const& input_hub,
-        std::shared_ptr<mir::input::Seat> const& seat);
+        std::shared_ptr<mir::input::Seat> const& seat,
+        bool enable_key_repeat);
 
     ~WlSeat();
 
@@ -112,6 +113,7 @@ private:
 
     std::shared_ptr<input::InputDeviceHub> const input_hub;
     std::shared_ptr<input::Seat> const seat;
+    bool const enable_key_repeat;
 
     void bind(wl_resource* new_wl_seat) override;
 };


### PR DESCRIPTION
Uses the existing configuration option to configure clients to disable key repeat.

Mitigates: #1471