### PR TITLE
[snap] fix snap version string

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Install Snapcraft
       uses: samuelmeuli/action-snapcraft@v1
       with:
-        channel: edge
+        channel: candidate
         snapcraft_token: ${{ secrets.SNAPCRAFT_TOKEN }}
 
     - name: Check out code

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -102,5 +102,5 @@ parts:
     - libyaml-cpp0.6
     override-pull: |
       snapcraftctl pull
-      snapcraftctl set-version $( git describe )
-      snapcraftctl set-grade $( [[ $( git describe ) =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo stable || echo devel )
+      snapcraftctl set-version $( git describe | awk -F- '{ gsub(/^v/, "", $1); printf $1; if ($2) { printf "+dev" $2 "-" $3 } }' )
+      snapcraftctl set-grade $( [[ $( git describe ) =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo stable || echo devel )


### PR DESCRIPTION
---
Rather than:
```plain
$ snapcraft revisions mir-core20 | head
Rev.    Uploaded              Arches    Version                 Channels
26      2021-04-30T16:25:52Z  amd64     v2.3.3-220-g1b943e361d  latest/edge/pr2015*
# ...

$ snapcraft revisions mir-kiosk | grep head
Rev.    Uploaded              Arches    Version                   Channels
# ...
6808    2021-05-02T09:18:52Z  amd64     v2.3.3-snap123            latest/edge/mir-pr2017*
6807    2021-05-02T07:26:17Z  armhf     2.3.3+dev198-snap122      latest/edge
# ...
```

Be consistent with deb-based:
```plain
$ snapcraft revisions mir-core20 | head
Rev.    Uploaded              Arches    Version                   Channels
31      2021-05-02T09:51:19Z  amd64     2.3.3+dev239-g670e7226de  latest/edge/pr2016*
# ...

$ snapcraft revisions mir-kiosk | head                 
Rev.    Uploaded              Arches    Version                   Channels
6813    2021-05-02T10:05:28Z  arm64     2.3.3+dev234-snap122      latest/edge*
6811    2021-05-02T09:58:47Z  amd64     2.3.3+dev239-snap123      latest/edge/mir-pr2016*
# ...
```