### PR TITLE
Add mechanism to skip "broken" wlcs tests

### DIFF
--- a/cmake/MirCommon.cmake
+++ b/cmake/MirCommon.cmake
@@ -169,10 +169,12 @@ function (mir_discover_external_gtests)
 
   # The expected failures, in a colon-delimited list for GTest
   string(REPLACE ";" ":" EXPECTED_FAILURE_STRING "${TEST_EXPECTED_FAILURES}")
+  # The expected failures, in a colon-delimited list for GTest
+  string(REPLACE ";" ":" BROKEN_TESTS "${TEST_BROKEN_TESTS}")
   # The command line arguments, as would be passed to the shell
   string(REPLACE ";" " " TEST_ARGS_STRING "${TEST_ARGS}")
 
-  add_test(NAME ${TEST_NAME} COMMAND ${TEST_COMMAND} "--gtest_filter=-${TEST_BROKEN_TESTS}:${EXPECTED_FAILURE_STRING}" ${TEST_ARGS})
+  add_test(NAME ${TEST_NAME} COMMAND ${TEST_COMMAND} "--gtest_filter=-${BROKEN_TESTS}:${EXPECTED_FAILURE_STRING}" ${TEST_ARGS})
   if (TEST_WORKING_DIRECTORY)
     set_tests_properties(${TEST_NAME} PROPERTIES WORKING_DIRECTORY ${TEST_WORKING_DIRECTORY})
   endif()

--- a/cmake/MirCommon.cmake
+++ b/cmake/MirCommon.cmake
@@ -164,7 +164,7 @@ endfunction()
 
 function (mir_discover_external_gtests)
   set(one_value_args NAME COMMAND WORKING_DIRECTORY)
-  set(multi_value_args EXPECTED_FAILURES ARGS)
+  set(multi_value_args EXPECTED_FAILURES ARGS BROKEN_TESTS)
   cmake_parse_arguments(TEST "" "${one_value_args}" "${multi_value_args}" ${ARGN})
 
   # The expected failures, in a colon-delimited list for GTest
@@ -172,7 +172,7 @@ function (mir_discover_external_gtests)
   # The command line arguments, as would be passed to the shell
   string(REPLACE ";" " " TEST_ARGS_STRING "${TEST_ARGS}")
 
-  add_test(NAME ${TEST_NAME} COMMAND ${TEST_COMMAND} "--gtest_filter=-${EXPECTED_FAILURE_STRING}" ${TEST_ARGS})
+  add_test(NAME ${TEST_NAME} COMMAND ${TEST_COMMAND} "--gtest_filter=-${TEST_BROKEN_TESTS}:${EXPECTED_FAILURE_STRING}" ${TEST_ARGS})
   if (TEST_WORKING_DIRECTORY)
     set_tests_properties(${TEST_NAME} PROPERTIES WORKING_DIRECTORY ${TEST_WORKING_DIRECTORY})
   endif()

--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -91,12 +91,17 @@ if (MIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN)
   list(APPEND EXPECTED_FAILURES BadBufferTest.test_truncated_shm_file)
 endif ()
 
+set(BROKEN_TESTS
+  ClientSurfaceEventsTest.buffer_release # Has been removed upstream
+)
+
 if (MIR_RUN_WLCS_TESTS)
   mir_discover_external_gtests(
     NAME wlcs
     COMMAND ${WLCS_BINARY}
     ARGS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/miral_wlcs_integration.so
     EXPECTED_FAILURES ${EXPECTED_FAILURES}
+    BROKEN_TESTS ${BROKEN_TESTS}
   )
 endif()
 


### PR DESCRIPTION
We already dropped a test upstream: https://github.com/MirServer/wlcs/pull/196

But until wlcs is released we need a way to skip it