### PR TITLE
Continue building debs for Ubuntu 21.04

### DIFF
--- a/.github/workflows/ppa-upload.yml
+++ b/.github/workflows/ppa-upload.yml
@@ -16,6 +16,7 @@ jobs:
         release:
         - "20.04"
         - "20.10"
+        - "21.04"
         - "devel"
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
The Launchpad PPAs for mir no longer provide up-to-date builds of mir for Ubuntu 21.04 (see https://launchpad.net/~mir-team/+archive/ubuntu/dev/+packages ) - this change in behaviour coincides with the opening of the impish archive in launchpad which causes 'devel' to refer to impish rather than hirsute. This pull request should hopefully restore the availability of debs for hirsute.