### PR TITLE
X11 platform: handle key state changes when window is not focused

### DIFF
--- a/src/platforms/x11/input/input_platform.cpp
+++ b/src/platforms/x11/input/input_platform.cpp
@@ -71,7 +71,7 @@ auto const scroll_factor = 10;
 
 auto init_xkb_extension(mir::X::X11Resources* x11_resources) -> xcb_query_extension_reply_t const*
 {
-    auto const xkb_extension = xcb_get_extension_data(x11_resources->conn->connection(), &xcb_xkb_id);
+    auto const xkb_extension = x11_resources->conn->get_extension_data(&xcb_xkb_id);
     if (!xkb_extension || !xkb_extension->present)
     {
         mir::log_warning("XKB X11 extension not available, keyboard will not work");

--- a/src/platforms/x11/input/input_platform.cpp
+++ b/src/platforms/x11/input/input_platform.cpp
@@ -524,7 +524,7 @@ void mix::XInputPlatform::process_xkb_event(xcb_generic_event_t* event)
     case XCB_XKB_STATE_NOTIFY:
     {
         auto const state_ev = reinterpret_cast<xcb_xkb_state_notify_event_t*>(event);
-        auto const changed = xkb_state_update_mask(
+        xkb_state_update_mask(
             key_state,
             state_ev->baseMods,
             state_ev->latchedMods,
@@ -532,7 +532,20 @@ void mix::XInputPlatform::process_xkb_event(xcb_generic_event_t* event)
             state_ev->baseGroup,
             state_ev->latchedGroup,
             state_ev->lockedGroup);
-        (void)changed;
+        // This only works for modifiers, but unlike the normal events it tracks presses and releases when the window
+        // is not focused
+        switch (state_ev->eventType)
+        {
+        case XCB_KEY_PRESS:
+            key_pressed(state_ev->keycode, state_ev->time);
+            break;
+
+        case XCB_KEY_RELEASE:
+            key_released(state_ev->keycode, state_ev->time);
+            break;
+
+        default:;
+        }
     }   break;
 
     default:;

--- a/src/platforms/x11/input/input_platform.h
+++ b/src/platforms/x11/input/input_platform.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <functional>
 #include <vector>
+#include <set>
 #include <xcb/xcb.h>
 
 struct xkb_context;
@@ -65,6 +66,8 @@ public:
 private:
     void process_input_events();
     void process_input_event(xcb_generic_event_t* event);
+    void key_pressed(xcb_keycode_t key, xcb_timestamp_t timestamp);
+    void key_released(xcb_keycode_t key, xcb_timestamp_t timestamp);
     /// Defer work until all pending events are processed. Should only be called while processing events.
     void defer(std::function<void()>&& work);
     std::shared_ptr<mir::X::X11Resources> const x11_resources;
@@ -75,6 +78,8 @@ private:
     xkb_context* const xkb_ctx;
     xkb_keymap* const keymap;
     xkb_state* const key_state;
+    xcb_timestamp_t last_timestamp{0};
+    std::set<xcb_keycode_t> pressed_keys;
     bool kbd_grabbed;
     bool ptr_grabbed;
     std::vector<std::function<void()>> deferred;

--- a/src/platforms/x11/input/input_platform.h
+++ b/src/platforms/x11/input/input_platform.h
@@ -82,6 +82,7 @@ private:
     xkb_state* const key_state;
     xcb_timestamp_t last_timestamp{0};
     std::set<xcb_keycode_t> pressed_keys;
+    std::set<xcb_keycode_t> modifiers;
     bool kbd_grabbed;
     bool ptr_grabbed;
     std::vector<std::function<void()>> deferred;

--- a/src/platforms/x11/input/input_platform.h
+++ b/src/platforms/x11/input/input_platform.h
@@ -66,6 +66,7 @@ public:
 private:
     void process_input_events();
     void process_input_event(xcb_generic_event_t* event);
+    void process_xkb_event(xcb_generic_event_t* event);
     void key_pressed(xcb_keycode_t key, xcb_timestamp_t timestamp);
     void key_released(xcb_keycode_t key, xcb_timestamp_t timestamp);
     /// Defer work until all pending events are processed. Should only be called while processing events.
@@ -75,6 +76,7 @@ private:
     std::shared_ptr<input::InputDeviceRegistry> const registry;
     std::shared_ptr<XInputDevice> const core_keyboard;
     std::shared_ptr<XInputDevice> const core_pointer;
+    xcb_query_extension_reply_t const* const xkb_extension;
     xkb_context* const xkb_ctx;
     xkb_keymap* const keymap;
     xkb_state* const key_state;

--- a/src/platforms/x11/x11_resources.cpp
+++ b/src/platforms/x11/x11_resources.cpp
@@ -68,6 +68,11 @@ public:
         return atom;
     }
 
+    auto get_extension_data(xcb_extension_t *ext) const -> xcb_query_extension_reply_t const* override
+    {
+        return xcb_get_extension_data(conn, ext);
+    }
+
     auto generate_id() const -> uint32_t override
     {
         return xcb_generate_id(conn);

--- a/src/platforms/x11/x11_resources.h
+++ b/src/platforms/x11/x11_resources.h
@@ -54,6 +54,7 @@ public:
     virtual auto screen() const -> xcb_screen_t* = 0;
     /// Synchronous for now, since that makes everything simpler
     virtual auto intern_atom(std::string const& name) const -> xcb_atom_t = 0;
+    virtual auto get_extension_data(xcb_extension_t *ext) const -> xcb_query_extension_reply_t const* = 0;
     virtual auto generate_id() const -> uint32_t = 0;
     virtual void create_window(
         xcb_window_t window,

--- a/tests/include/mir/test/doubles/mock_x11_resources.h
+++ b/tests/include/mir/test/doubles/mock_x11_resources.h
@@ -44,6 +44,7 @@ public:
     MOCK_CONST_METHOD0(poll_for_event, xcb_generic_event_t*());
     MOCK_CONST_METHOD0(screen, xcb_screen_t*());
     MOCK_CONST_METHOD1(intern_atom, xcb_atom_t(std::string const& name));
+    MOCK_CONST_METHOD1(get_extension_data, xcb_query_extension_reply_t const*(xcb_extension_t *ext));
     MOCK_CONST_METHOD0(generate_id, uint32_t());
     MOCK_CONST_METHOD5(create_window, void(
         xcb_window_t window,

--- a/tests/mir_test_doubles/mock_xkb.cpp
+++ b/tests/mir_test_doubles/mock_xkb.cpp
@@ -21,11 +21,52 @@
 
 #include <cstring>
 
+// xcb/xkb.h has a struct member named "explicit", which C++ does not like
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
+#define explicit explicit_
+#include <xcb/xkb.h>
+#undef explicit
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
 namespace mtd=mir::test::doubles;
 
 namespace
 {
 mtd::MockXkb* global_mock = nullptr;
+}
+
+struct xcb_extension_t {};
+xcb_extension_t xcb_xkb_id;
+
+xcb_xkb_use_extension_cookie_t
+xcb_xkb_use_extension(xcb_connection_t*, uint16_t, uint16_t)
+{
+    return {0};
+}
+
+xcb_xkb_use_extension_reply_t *
+xcb_xkb_use_extension_reply(xcb_connection_t*, xcb_xkb_use_extension_cookie_t, xcb_generic_error_t**)
+{
+    return nullptr;
+}
+
+xcb_void_cookie_t
+xcb_xkb_select_events(
+    xcb_connection_t*,
+    xcb_xkb_device_spec_t,
+    uint16_t,
+    uint16_t,
+    uint16_t,
+    uint16_t,
+    uint16_t,
+    const void*)
+{
+    return {0};
 }
 
 mtd::MockXkb::MockXkb()


### PR DESCRIPTION
Fixes #2029. There are a couple pieces to this.
1. Use the XKB extension to track the modifier state. This gives us more correct symcodes (which we send on to Mir but don't seem to care much about) as well as the ability to know the state of the modifiers when the window is focused. 
2. Cache pressed keys. For a number of reasons key ups and key downs may not be perfectly paired up (XKB events duplicating normal events in some cases, keys that are pressed when the window is unfocused and released when the window is focused, etc). The `pressed_keys` set allows us to make sure the events we send on to Mir are more coherent.
3. Synthesize key up events for all non-modifiers when the window looses focus. This keeps us from getting endlessly repeating keys. Modifiers are any key that an XKB event has related to in the past (because these are the keys for which we *will* see changes made when the window isn't focused).

This ended up being probably more code than was worth it, but it's done now.