### PR TITLE
X11 platform: fix cursor position on scaled outputs

### DIFF
--- a/include/core/mir/geometry/displacement_generic.h
+++ b/include/core/mir/geometry/displacement_generic.h
@@ -161,25 +161,25 @@ inline constexpr D operator*(D const& disp, Scalar scale)
 template<typename S, typename std::enable_if<std::is_base_of<detail::SizeBase, S>::value, bool>::type = true>
 inline constexpr typename S::DisplacementType as_displacement(S const& size)
 {
-    return typename S::DisplacementType{size.width.as_int(), size.height.as_int()};
+    return typename S::DisplacementType{size.width.as_value(), size.height.as_value()};
 }
 
 template<typename D, typename std::enable_if<std::is_base_of<detail::DisplacementBase, D>::value, bool>::type = true>
 inline constexpr typename D::SizeType as_size(D const& disp)
 {
-    return typename D::SizeType{disp.dx.as_int(), disp.dy.as_int()};
+    return typename D::SizeType{disp.dx.as_value(), disp.dy.as_value()};
 }
 
 template<typename P, typename std::enable_if<std::is_base_of<detail::PointBase, P>::value, bool>::type = true>
 inline constexpr typename P::DisplacementType as_displacement(P const& point)
 {
-    return typename P::DisplacementType{point.x.as_int(), point.y.as_int()};
+    return typename P::DisplacementType{point.x.as_value(), point.y.as_value()};
 }
 
 template<typename D, typename std::enable_if<std::is_base_of<detail::DisplacementBase, D>::value, bool>::type = true>
 inline constexpr typename D::PointType as_point(D const& disp)
 {
-    return typename D::PointType{disp.dx.as_int(), disp.dy.as_int()};
+    return typename D::PointType{disp.dx.as_value(), disp.dy.as_value()};
 }
 }
 }

--- a/include/core/mir/geometry/rectangle_generic.h
+++ b/include/core/mir/geometry/rectangle_generic.h
@@ -122,8 +122,8 @@ R intersection_of(R const& a, R const& b)
 
     if (max_left < min_right && max_top < min_bottom)
         return {{max_left, max_top},
-                {(min_right - max_left).as_int(),
-                (min_bottom - max_top).as_int()}};
+                {(min_right - max_left).as_value(),
+                (min_bottom - max_top).as_value()}};
     else
         return {};
 }

--- a/include/core/mir/geometry/size_generic.h
+++ b/include/core/mir/geometry/size_generic.h
@@ -105,13 +105,13 @@ inline constexpr S operator/(S const& size, Scalar scale)
 template<typename P, typename std::enable_if<std::is_base_of<detail::PointBase, P>::value, bool>::type = true>
 inline constexpr typename P::SizeType as_size(P const& point)
 {
-    return typename P::SizeType{point.x.as_int(), point.y.as_int()};
+    return typename P::SizeType{point.x.as_value(), point.y.as_value()};
 }
 
 template<typename S, typename std::enable_if<std::is_base_of<detail::SizeBase, S>::value, bool>::type = true>
 inline constexpr typename S::PointType as_point(S const& size)
 {
-    return typename S::PointType{size.width.as_int(), size.height.as_int()};
+    return typename S::PointType{size.width.as_value(), size.height.as_value()};
 }
 }
 }

--- a/src/platforms/x11/input/input_device.cpp
+++ b/src/platforms/x11/input/input_device.cpp
@@ -167,7 +167,11 @@ void mix::XInputDevice::update_button_state(int button)
     button_state = to_mir_button_state(button);
 }
 
-void mix::XInputDevice::pointer_press(std::chrono::nanoseconds event_time, int button, mir::geometry::Point const& pos, mir::geometry::Displacement scroll)
+void mix::XInputDevice::pointer_press(
+    std::chrono::nanoseconds event_time,
+    int button,
+    mir::geometry::PointF pos,
+    mir::geometry::DisplacementF scroll)
 {
     button_state |= to_mir_button(button);
     auto const movement = pos - pointer_pos;
@@ -177,17 +181,21 @@ void mix::XInputDevice::pointer_press(std::chrono::nanoseconds event_time, int b
             event_time,
             mir_pointer_action_button_down,
             button_state,
-            pointer_pos.x.as_int(),
-            pointer_pos.y.as_int(),
-            scroll.dx.as_int(),
-            scroll.dy.as_int(),
-            movement.dx.as_int(),
-            movement.dy.as_int()
+            pointer_pos.x.as_value(),
+            pointer_pos.y.as_value(),
+            scroll.dx.as_value(),
+            scroll.dy.as_value(),
+            movement.dx.as_value(),
+            movement.dy.as_value()
             )
         );
 }
 
-void mix::XInputDevice::pointer_release(std::chrono::nanoseconds event_time, int button, mir::geometry::Point const& pos, mir::geometry::Displacement scroll)
+void mix::XInputDevice::pointer_release(
+    std::chrono::nanoseconds event_time,
+    int button,
+    mir::geometry::PointF pos,
+    mir::geometry::DisplacementF scroll)
 {
     button_state &= ~to_mir_button(button);
     auto const movement = pos - pointer_pos;
@@ -197,18 +205,21 @@ void mix::XInputDevice::pointer_release(std::chrono::nanoseconds event_time, int
             event_time,
             mir_pointer_action_button_up,
             button_state,
-            pointer_pos.x.as_int(),
-            pointer_pos.y.as_int(),
-            scroll.dx.as_int(),
-            scroll.dy.as_int(),
-            movement.dx.as_int(),
-            movement.dy.as_int()
+            pointer_pos.x.as_value(),
+            pointer_pos.y.as_value(),
+            scroll.dx.as_value(),
+            scroll.dy.as_value(),
+            movement.dx.as_value(),
+            movement.dy.as_value()
             )
         );
 
 }
 
-void mix::XInputDevice::pointer_motion(std::chrono::nanoseconds event_time, mir::geometry::Point const& pos, mir::geometry::Displacement scroll)
+void mix::XInputDevice::pointer_motion(
+    std::chrono::nanoseconds event_time,
+    mir::geometry::PointF pos,
+    mir::geometry::DisplacementF scroll)
 {
     auto const movement = pos - pointer_pos;
     pointer_pos = pos;
@@ -217,12 +228,12 @@ void mix::XInputDevice::pointer_motion(std::chrono::nanoseconds event_time, mir:
             event_time,
             mir_pointer_action_motion,
             button_state,
-            pointer_pos.x.as_int(),
-            pointer_pos.y.as_int(),
-            scroll.dx.as_int(),
-            scroll.dy.as_int(),
-            movement.dx.as_int(),
-            movement.dy.as_int()
+            pointer_pos.x.as_value(),
+            pointer_pos.y.as_value(),
+            scroll.dx.as_value(),
+            scroll.dy.as_value(),
+            movement.dx.as_value(),
+            movement.dy.as_value()
             )
         );
 }

--- a/src/platforms/x11/input/input_device.h
+++ b/src/platforms/x11/input/input_device.h
@@ -22,8 +22,8 @@
 #include "mir/input/input_device.h"
 #include "mir/input/input_device_info.h"
 #include "mir_toolkit/event.h"
-#include "mir/geometry/point.h"
-#include "mir/geometry/displacement.h"
+#include "mir/geometry/point_f.h"
+#include "mir/geometry/displacement_f.h"
 #include "mir/optional_value.h"
 
 #include <chrono>
@@ -57,15 +57,26 @@ public:
     void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code);
     void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code);
     void update_button_state(int button);
-    void pointer_press(std::chrono::nanoseconds event_time, int button, mir::geometry::Point const& pos, mir::geometry::Displacement scroll);
-    void pointer_release(std::chrono::nanoseconds event_time, int button, mir::geometry::Point const& pos, mir::geometry::Displacement scroll);
-    void pointer_motion(std::chrono::nanoseconds event_time, mir::geometry::Point const& pos, mir::geometry::Displacement scroll);
+    void pointer_press(
+        std::chrono::nanoseconds event_time,
+        int button,
+        mir::geometry::PointF pos,
+        mir::geometry::DisplacementF scroll);
+    void pointer_release(
+        std::chrono::nanoseconds event_time,
+        int button,
+        mir::geometry::PointF pos,
+        mir::geometry::DisplacementF scroll);
+    void pointer_motion(
+        std::chrono::nanoseconds event_time,
+        mir::geometry::PointF pos,
+        mir::geometry::DisplacementF scroll);
 
 private:
     MirPointerButtons button_state{0};
     InputSink* sink{nullptr};
     EventBuilder* builder{nullptr};
-    geometry::Point pointer_pos;
+    geometry::PointF pointer_pos;
     InputDeviceInfo info;
 };
 

--- a/src/platforms/x11/input/input_platform.cpp
+++ b/src/platforms/x11/input/input_platform.cpp
@@ -117,16 +117,16 @@ auto init_xkb_extension(mir::X::X11Resources* x11_resources) -> xcb_query_extens
     return xkb_extension;
 }
 
-geom::Point get_pos_on_output(mir::X::X11Resources* x11_resources, xcb_window_t x11_window, int x, int y)
+auto get_pos_on_output(mir::X::X11Resources* x11_resources, xcb_window_t x11_window, float x, float y) -> geom::PointF
 {
-    geom::Point pos{x, y};
+    geom::PointF pos{x, y};
     x11_resources->with_output_for_window(
         x11_window,
         [&](std::optional<mx::X11Resources::VirtualOutput const*> output)
         {
             if (output)
             {
-                pos += as_displacement(output.value()->configuration().top_left);
+                pos += geom::DisplacementF{as_displacement(output.value()->configuration().top_left)};
             }
             else
             {

--- a/src/platforms/x11/input/input_platform.cpp
+++ b/src/platforms/x11/input/input_platform.cpp
@@ -126,7 +126,9 @@ auto get_pos_on_output(mir::X::X11Resources* x11_resources, xcb_window_t x11_win
         {
             if (output)
             {
-                pos += geom::DisplacementF{as_displacement(output.value()->configuration().top_left)};
+                float const inv_scale{1 / output.value()->configuration().scale};
+                geom::PointF const top_left{output.value()->configuration().top_left};
+                pos = top_left + as_displacement(pos) * inv_scale;
             }
             else
             {


### PR DESCRIPTION
Fixes #2034. Also introduces floating point geometry into the X11 platform, and removes the usage of `as_int()` from generic geometry calculations.