### PR TITLE
XWayland: improve popup window types and positioning

### DIFF
--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -1316,14 +1316,6 @@ void mf::XWaylandSurface::apply_cached_transient_for_and_type(std::lock_guard<st
             }
         }
     }
-    else
-    {
-        // Type should not have parent, if it does we should use a different type
-        if (parent)
-        {
-            type = mir_window_type_gloss;
-        }
-    }
 
     effective_parent = parent;
 

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -230,11 +230,11 @@ auto property_handler(
 }
 
 template<typename T>
-auto optional_from(bool return_value, T&& value) -> std::optional<T>
+auto make_optional_if(bool condition, T&& value) -> std::optional<T>
 {
-    if (return_value)
+    if (condition)
     {
-        return std::optional<T>(value);
+        return std::optional<T>(std::move(value));
     }
     else
     {
@@ -524,10 +524,10 @@ void mf::XWaylandSurface::configure_request(xcb_configure_request_event_t* event
         lock.unlock();
 
         inform_client_of_geometry(
-            optional_from(event->value_mask & XCB_CONFIG_WINDOW_X, geom::X{event->x}),
-            optional_from(event->value_mask & XCB_CONFIG_WINDOW_Y, geom::Y{event->y}),
-            optional_from(event->value_mask & XCB_CONFIG_WINDOW_WIDTH, geom::Width{event->width}),
-            optional_from(event->value_mask & XCB_CONFIG_WINDOW_HEIGHT, geom::Height{event->height}));
+            make_optional_if(event->value_mask & XCB_CONFIG_WINDOW_X, geom::X{event->x}),
+            make_optional_if(event->value_mask & XCB_CONFIG_WINDOW_Y, geom::Y{event->y}),
+            make_optional_if(event->value_mask & XCB_CONFIG_WINDOW_WIDTH, geom::Width{event->width}),
+            make_optional_if(event->value_mask & XCB_CONFIG_WINDOW_HEIGHT, geom::Height{event->height}));
 
         connection->flush();
     }

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -1103,6 +1103,10 @@ void mf::XWaylandSurface::apply_any_mods_to_scene_surface()
             spec.value()->parent.value().lock() == scene_surface->parent())
             spec.value()->parent.consume();
 
+        if (spec.value()->type.is_set() &&
+            spec.value()->type.value() == scene_surface->type())
+            spec.value()->type.consume();
+
         if (!spec.value()->is_empty())
         {
             scale_surface_spec(*spec.value());

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -540,6 +540,10 @@ void mf::XWaylandSurface::configure_notify(xcb_configure_notify_event_t* event)
                 event->x, event->y,
                 event->width, event->height);
         }
+        else
+        {
+            cached.geometry = geometry;
+        }
     }
     else
     {

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -968,7 +968,7 @@ auto mf::XWaylandSurface::scene_surface() const -> std::optional<std::shared_ptr
         return std::nullopt;
 }
 
-auto mf::XWaylandSurface::pending_spec(std::lock_guard<std::mutex> const&) -> msh::SurfaceSpecification&
+auto mf::XWaylandSurface::pending_spec(ProofOfMutexLock const&) -> msh::SurfaceSpecification&
 {
     if (!nullable_pending_spec)
         nullable_pending_spec = std::make_unique<msh::SurfaceSpecification>();
@@ -976,7 +976,7 @@ auto mf::XWaylandSurface::pending_spec(std::lock_guard<std::mutex> const&) -> ms
 }
 
 auto mf::XWaylandSurface::consume_pending_spec(
-    std::lock_guard<std::mutex> const&) -> std::optional<std::unique_ptr<msh::SurfaceSpecification>>
+    ProofOfMutexLock const&) -> std::optional<std::unique_ptr<msh::SurfaceSpecification>>
 {
     if (nullable_pending_spec)
         return move(nullable_pending_spec);
@@ -1120,7 +1120,7 @@ void mf::XWaylandSurface::request_scene_surface_state(MirWindowState new_state)
     }
 }
 
-auto mf::XWaylandSurface::latest_input_timestamp(std::lock_guard<std::mutex> const&) -> std::chrono::nanoseconds
+auto mf::XWaylandSurface::latest_input_timestamp(ProofOfMutexLock const&) -> std::chrono::nanoseconds
 {
     if (surface_observer)
     {
@@ -1301,7 +1301,7 @@ auto mf::XWaylandSurface::scaled_content_size_of(ms::Surface const& surface) -> 
     return surface.content_size() * scale;
 }
 
-auto mf::XWaylandSurface::plausible_parent(std::lock_guard<std::mutex> const&) -> std::shared_ptr<ms::Surface>
+auto mf::XWaylandSurface::plausible_parent(ProofOfMutexLock const&) -> std::shared_ptr<ms::Surface>
 {
     if (auto const current_effective = effective_parent.lock())
     {
@@ -1336,7 +1336,7 @@ auto mf::XWaylandSurface::plausible_parent(std::lock_guard<std::mutex> const&) -
     return {};
 }
 
-void mf::XWaylandSurface::apply_cached_transient_for_and_type(std::lock_guard<std::mutex> const& lock)
+void mf::XWaylandSurface::apply_cached_transient_for_and_type(ProofOfMutexLock const& lock)
 {
     auto parent = xcb_window_get_scene_surface(xwm, cached.transient_for);
     auto type = cached.type;

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -138,6 +138,13 @@ private:
 
     auto latest_input_timestamp(std::lock_guard<std::mutex> const&) -> std::chrono::nanoseconds;
 
+    /// Modifies the scene surface's geometry if needed, should not be called under lock
+    void modify_surface_geometry(
+        std::shared_ptr<scene::Surface> const& scene_surface,
+        uint16_t xcb_value_mask,
+        int16_t x, int16_t y,
+        int16_t width, int16_t height);
+
     /// Appplies any mods in nullable_pending_spec to the scene_surface (if any)
     void apply_any_mods_to_scene_surface();
 

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -169,19 +169,11 @@ private:
     /// Appplies any mods in nullable_pending_spec to the scene_surface (if any)
     void apply_any_mods_to_scene_surface();
 
-    /// Sets the position specified by the spec. top_left is always in global XWayland coordinates, even if parent is
-    /// not null. If parent is given, it is set as the parent and an aux rect for relative placement is calculated. if
-    /// parent is null, the location is specified in the global XWayland coordinates given. As always, you should call
-    /// scale_surface_spec() before sending this spec to Mir.
-    void surface_spec_set_position(
-        shell::SurfaceSpecification& spec,
-        scene::Surface* parent,
-        geometry::Point top_left);
-
-    /// One-stop-shop for scaling window modifications. Unlike with scaled Wayland surfaces, all the data going to and
-    /// from the client is in raw pixels, but Mir internally deals with scaled coordinates. This means before punting
-    /// our data off to Mir we need to scale it, which is what this function is for.
-    void scale_surface_spec(shell::SurfaceSpecification& mods);
+    /// Unlike with scaled Wayland surfaces, all the data going to and from the client is in raw pixels. Mir internally
+    /// deals with scaled coordinates. This means before modifying the Mir surface we need to scale the values in our
+    /// surface spec. We also need to convert from global to local coordinates if the surface has a parent. This
+    /// function handles all that.
+    void prep_surface_spec(ProofOfMutexLock const&, shell::SurfaceSpecification& mods);
 
     /// Return data from any surface scaled to XWayland coordinates
     /// @{

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -159,13 +159,6 @@ private:
 
     auto latest_input_timestamp(ProofOfMutexLock const&) -> std::chrono::nanoseconds;
 
-    /// Modifies the scene surface's geometry if needed, should not be called under lock
-    void modify_surface_geometry(
-        std::shared_ptr<scene::Surface> const& scene_surface,
-        uint16_t xcb_value_mask,
-        int16_t x, int16_t y,
-        int16_t width, int16_t height);
-
     /// Appplies any mods in nullable_pending_spec to the scene_surface (if any)
     void apply_any_mods_to_scene_surface();
 

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -131,6 +131,14 @@ private:
     /// Should NOT be called under lock
     void inform_client_of_window_state(WindowState const& state);
 
+    /// Calls connection->configure_window() with the given position and size, as well as tracking the calls made so
+    /// future configure notifies can determine if the source was us or the client
+    void inform_client_of_geometry(
+        std::optional<geometry::X> x,
+        std::optional<geometry::Y> y,
+        std::optional<geometry::Width> width,
+        std::optional<geometry::Height> height);
+
     /// Requests the scene surface be put into the given state
     /// If the request results in an actual surface state change, the observer will be notified
     /// Should NOT be called under lock
@@ -199,8 +207,9 @@ private:
 
         bool override_redirect;
 
-        geometry::Size size;
-        geometry::Point top_left; ///< Always in global coordinates
+        /// The last geometry we've configured the window with. Note that configure notifications we get do not
+        /// immediately change this, as there could be a more recent configure event we've sent still on the wire.
+        geometry::Rectangle geometry;
 
         /// The contents of the _NET_SUPPORTED property set by the client
         std::set<xcb_atom_t> supported_wm_protocols;

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -30,6 +30,7 @@
 #include <mutex>
 #include <chrono>
 #include <set>
+#include <deque>
 
 namespace mir
 {
@@ -220,6 +221,10 @@ private:
         xcb_window_t transient_for{XCB_WINDOW_NONE};
         MirWindowType type{mir_window_type_freestyle};
     } cached;
+
+    /// When we send a configure we push it to the back, when we get notified of a configure we pop it and all the ones
+    /// before it
+    std::deque<geometry::Rectangle> inflight_configures;
 
     /// Set in set_wl_surface and cleared when a scene surface is created from it
     std::optional<std::shared_ptr<XWaylandSurfaceObserver>> surface_observer;


### PR DESCRIPTION
Fixes #2037. I hope this refactor moderately improves some of the convoluted logic. Now window parent and type are set in one place, so we always have the information to set them correctly. Draft PR for now because I've seen occasional segfaults, so I think this introduces a memory issue somewhere.