### PR TITLE
Add missing include

### DIFF
--- a/src/platforms/x11/input/input_platform.h
+++ b/src/platforms/x11/input/input_platform.h
@@ -21,6 +21,7 @@
 #include "mir/input/platform.h"
 #include <memory>
 #include <functional>
+#include <optional>
 #include <vector>
 #include <set>
 #include <xcb/xcb.h>


### PR DESCRIPTION
This is now needed on Arch for some reason, guess a system header changed or something