### PR TITLE
Improve Wayland object destruction path

### DIFF
--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -514,11 +514,6 @@ public:
         return planes_;
     }
 private:
-    void destroy() override
-    {
-        destroy_wayland_object();
-    }
-
     EGLDisplay const dpy;
     std::shared_ptr<mg::EGLExtensions> const egl_extensions;
     BufferGLDescription const& desc;
@@ -595,11 +590,6 @@ private:
     EGLDisplay dpy;
     std::shared_ptr<mg::EGLExtensions> egl_extensions;
     std::shared_ptr<mg::DmaBufFormatDescriptors const> const formats;
-
-    void destroy() override
-    {
-        destroy_wayland_object();
-    }
 
     void add(
         mir::Fd fd,
@@ -1065,11 +1055,6 @@ public:
         }
     }
 private:
-    void destroy() override
-    {
-        destroy_wayland_object();
-    }
-
     void create_params(struct wl_resource* params_id) override
     {
         new LinuxDmaBufParams{params_id, dpy, egl_extensions, formats};

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -514,7 +514,7 @@ mf::ForeignToplevelManagerV1::~ForeignToplevelManagerV1()
 void mf::ForeignToplevelManagerV1::stop()
 {
     send_finished_event();
-    wl_resource_destroy(resource); // Will result in this being deleted
+    destroy_and_delete();
 }
 
 // ForeignToplevelHandleV1

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -177,7 +177,6 @@ private:
     void activate(struct wl_resource* seat) override;
     void close() override;
     void set_rectangle(struct wl_resource* surface, int32_t x, int32_t y, int32_t width, int32_t height) override;
-    void destroy() override;
     void set_fullscreen(std::experimental::optional<struct wl_resource*> const& output) override;
     void unset_fullscreen() override;
     ///@}
@@ -515,7 +514,7 @@ mf::ForeignToplevelManagerV1::~ForeignToplevelManagerV1()
 void mf::ForeignToplevelManagerV1::stop()
 {
     send_finished_event();
-    destroy_wayland_object();
+    wl_resource_destroy(resource); // Will result in this being deleted
 }
 
 // ForeignToplevelHandleV1
@@ -678,11 +677,6 @@ void mf::ForeignToplevelHandleV1::set_rectangle(
 {
     // This would be used for the destination of a window minimization animation
     // Nothing must be done with this info. It is not a protocol violation to ignore it
-}
-
-void mf::ForeignToplevelHandleV1::destroy()
-{
-    destroy_wayland_object();
 }
 
 void mf::ForeignToplevelHandleV1::set_fullscreen(std::experimental::optional<struct wl_resource*> const& /*output*/)

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -80,7 +80,6 @@ private:
         std::experimental::optional<wl_resource*> const& output,
         uint32_t layer,
         std::string const& namespace_) override;
-    void destroy() override;
 
     mf::LayerShellV1* const shell;
 };
@@ -179,7 +178,6 @@ private:
     void set_keyboard_interactivity(uint32_t keyboard_interactivity) override;
     void get_popup(wl_resource* popup) override;
     void ack_configure(uint32_t serial) override;
-    void destroy() override;
     void set_layer(uint32_t layer) override;
 
     // from WindowWlSurfaceRole
@@ -268,11 +266,6 @@ void mf::LayerShellV1::Instance::get_layer_surface(
         output_id,
         *shell,
         layer_shell_layer_to_mir_depth_layer(layer));
-}
-
-void mf::LayerShellV1::Instance::destroy()
-{
-    destroy_wayland_object();
 }
 
 // LayerSurfaceV1
@@ -579,11 +572,6 @@ void mf::LayerSurfaceV1::ack_configure(uint32_t serial)
     // We don't want to make the client acking one configure result in us sending another
 
     inform_window_role_of_pending_placement();
-}
-
-void mf::LayerSurfaceV1::destroy()
-{
-    destroy_wayland_object();
 }
 
 void mf::LayerSurfaceV1::set_layer(uint32_t layer)

--- a/src/server/frontend_wayland/pointer_constraints_unstable_v1.cpp
+++ b/src/server/frontend_wayland/pointer_constraints_unstable_v1.cpp
@@ -58,8 +58,6 @@ private:
     Executor& wayland_executor;
     std::shared_ptr<shell::Shell> const shell;
 
-    void destroy() override;
-
     void lock_pointer(
         wl_resource* id,
         wl_resource* surface,
@@ -85,6 +83,7 @@ public:
         std::shared_ptr<scene::Surface> const& scene_surface,
         std::experimental::optional<wl_resource*> const& region,
         PointerConstraintsV1::Lifetime lifetime);
+    ~LockedPointerV1();
 
 private:
     std::shared_ptr<shell::Shell> const shell;
@@ -94,7 +93,6 @@ private:
 
     std::shared_ptr<MyWaylandSurfaceObserver> const my_surface_observer;
 
-    void destroy() override;
     void set_cursor_position_hint(double /*surface_x*/, double /*surface_y*/) override;
     void set_region(const std::experimental::optional<wl_resource*>& /*region*/) override;
 };
@@ -109,6 +107,7 @@ public:
         std::shared_ptr<scene::Surface> const& scene_surface,
         std::experimental::optional<wl_resource*> const& region,
         PointerConstraintsV1::Lifetime lifetime);
+    ~ConfinedPointerV1();
 
 private:
     std::shared_ptr<shell::Shell> const shell;
@@ -118,7 +117,6 @@ private:
 
     std::shared_ptr<SurfaceObserver> const my_surface_observer;
 
-    void destroy() override;
     void set_region(const std::experimental::optional<wl_resource*>& /*region*/) override;
 };
 
@@ -251,11 +249,6 @@ mir::frontend::PointerConstraintsV1::PointerConstraintsV1(wl_resource* resource,
 {
 }
 
-void mir::frontend::PointerConstraintsV1::destroy()
-{
-    destroy_wayland_object();
-}
-
 void mir::frontend::PointerConstraintsV1::lock_pointer(
     wl_resource* id,
     wl_resource* surface,
@@ -337,7 +330,7 @@ mir::frontend::LockedPointerV1::LockedPointerV1(
         send_locked_event();
 }
 
-void mir::frontend::LockedPointerV1::destroy()
+mir::frontend::LockedPointerV1::~LockedPointerV1()
 {
     mark_destroyed();
     if (auto const scene_surface = weak_scene_surface.lock())
@@ -347,7 +340,6 @@ void mir::frontend::LockedPointerV1::destroy()
         mods.confine_pointer = MirPointerConfinementState::mir_pointer_unconfined;
         shell->modify_surface(scene_surface->session().lock(), scene_surface, mods);
     }
-    destroy_wayland_object();
 }
 
 void mir::frontend::LockedPointerV1::set_cursor_position_hint(double /*surface_x*/, double /*surface_y*/)
@@ -404,7 +396,7 @@ mir::frontend::ConfinedPointerV1::ConfinedPointerV1(
         send_confined_event();
 }
 
-void mir::frontend::ConfinedPointerV1::destroy()
+mir::frontend::ConfinedPointerV1::~ConfinedPointerV1()
 {
     mark_destroyed();
     if (auto const scene_surface = weak_scene_surface.lock())
@@ -414,7 +406,6 @@ void mir::frontend::ConfinedPointerV1::destroy()
         mods.confine_pointer = MirPointerConfinementState::mir_pointer_unconfined;
         shell->modify_surface(scene_surface->session().lock(), scene_surface, mods);
     }
-    destroy_wayland_object();
 }
 
 void mir::frontend::ConfinedPointerV1::set_region(const std::experimental::optional<wl_resource*>& /*region*/)

--- a/src/server/frontend_wayland/relative_pointer_unstable_v1.cpp
+++ b/src/server/frontend_wayland/relative_pointer_unstable_v1.cpp
@@ -44,8 +44,6 @@ public:
 private:
     std::shared_ptr<shell::Shell> const shell;
 
-    void destroy() override;
-
     void get_relative_pointer(wl_resource* id, wl_resource* pointer) override;
 };
 
@@ -56,7 +54,6 @@ public:
 
 private:
     wayland::Weak<WlPointer> const pointer;
-    void destroy() override;
 };
 }
 }
@@ -84,11 +81,6 @@ mir::frontend::RelativePointerManagerV1::RelativePointerManagerV1(wl_resource* r
 {
 }
 
-void mir::frontend::RelativePointerManagerV1::destroy()
-{
-    destroy_wayland_object();
-}
-
 void mir::frontend::RelativePointerManagerV1::get_relative_pointer(wl_resource* id, wl_resource* pointer)
 {
     new RelativePointerV1{id, dynamic_cast<WlPointer*>(wayland::Pointer::from(pointer))};
@@ -99,10 +91,4 @@ mir::frontend::RelativePointerV1::RelativePointerV1(wl_resource* id, WlPointer* 
     pointer{pointer}
 {
     pointer->set_relative_pointer(this);
-}
-
-
-void mir::frontend::RelativePointerV1::destroy()
-{
-    destroy_wayland_object();
 }

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -203,9 +203,13 @@ public:
     ~WlShellSurface() = default;
 
 protected:
-    void destroy() override
+    void surface_destroyed() override
     {
-        wl_resource_destroy(resource);
+        // The spec is a little contradictory:
+        // wl_surface: When a client wants to destroy a wl_surface, they must destroy this 'role object' before the wl_surface
+        // wl_shell_surface: On the server side the object is automatically destroyed when the related wl_surface is destroyed
+        // Without a destroy request, it seems the latter must be correct, so that is what we implement
+        destroy_wayland_object();
     }
 
     void set_toplevel() override

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -209,7 +209,7 @@ protected:
         // wl_surface: When a client wants to destroy a wl_surface, they must destroy this 'role object' before the wl_surface
         // wl_shell_surface: On the server side the object is automatically destroyed when the related wl_surface is destroyed
         // Without a destroy request, it seems the latter must be correct, so that is what we implement
-        destroy_wayland_object();
+        destroy_and_delete();
     }
 
     void set_toplevel() override

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -441,6 +441,14 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
     pending_explicit_height = std::experimental::nullopt;
 }
 
+void mf::WindowWlSurfaceRole::surface_destroyed()
+{
+    // "When a client wants to destroy a wl_surface, they must destroy this 'role object' wl_surface"
+    // NOTE: the wl_shell_surface specification seems contradictory, so this method is overridden in it's implementation
+    BOOST_THROW_EXCEPTION(std::runtime_error{
+        "wl_surface@" + std::to_string(wl_resource_get_id(surface->resource)) + " destroyed before associated role"});
+}
+
 mir::shell::SurfaceSpecification& mf::WindowWlSurfaceRole::spec()
 {
     if (!pending_changes)

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -70,9 +70,9 @@ mf::WindowWlSurfaceRole::WindowWlSurfaceRole(
     std::shared_ptr<msh::Shell> const& shell,
     OutputManager* output_manager)
     : surface{surface},
-      client{client},
+      weak_client{WlClient::from(client)},
       shell{shell},
-      session{get_session(client)},
+      session{weak_client.value().client_session()},
       output_manager{output_manager},
       observer{std::make_shared<WaylandSurfaceObserver>(wayland_executor, seat, surface, this)},
       params{std::make_unique<scene::SurfaceCreationParameters>(
@@ -264,7 +264,7 @@ void mf::WindowWlSurfaceRole::set_fullscreen(std::experimental::optional<struct 
         shell::SurfaceSpecification mods;
         mods.state = scene_surface->state_tracker().with(mir_window_state_fullscreen).active_state();
         auto const output_id = output ?
-            output_manager->output_id_for(client, output.value()) :
+            output_manager->output_id_for(weak_client.value().raw_client(), output.value()) :
             std::experimental::nullopt;
         if (output_id)
             mods.output_id = output_id.value();
@@ -274,7 +274,7 @@ void mf::WindowWlSurfaceRole::set_fullscreen(std::experimental::optional<struct 
     {
         params->state = mir_window_state_fullscreen;
         auto const output_id = output ?
-            output_manager->output_id_for(client, output.value()) :
+            output_manager->output_id_for(weak_client.value().raw_client(), output.value()) :
             std::experimental::nullopt;
         if (output_id)
             params->output_id = output_id.value();
@@ -443,10 +443,20 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
 
 void mf::WindowWlSurfaceRole::surface_destroyed()
 {
-    // "When a client wants to destroy a wl_surface, they must destroy this 'role object' wl_surface"
-    // NOTE: the wl_shell_surface specification seems contradictory, so this method is overridden in it's implementation
-    BOOST_THROW_EXCEPTION(std::runtime_error{
-        "wl_surface@" + std::to_string(wl_resource_get_id(surface->resource)) + " destroyed before associated role"});
+    if (weak_client)
+    {
+        // "When a client wants to destroy a wl_surface, they must destroy this 'role object' wl_surface"
+        // NOTE: the wl_shell_surface specification seems contradictory, so this method is overridden in it's implementation
+        BOOST_THROW_EXCEPTION(std::runtime_error{
+            "wl_surface@" + std::to_string(wl_resource_get_id(surface->resource)) +
+            " destroyed before associated role"});
+    }
+    else
+    {
+        // If the client has been destroyed, everything is getting cleaned up in an arbitrary order. Delete this so our
+        // derived class doesn't end up using the now-defunct surface.
+        delete this;
+    }
 }
 
 mir::shell::SurfaceSpecification& mf::WindowWlSurfaceRole::spec()
@@ -490,7 +500,9 @@ void mf::WindowWlSurfaceRole::create_scene_surface()
             auto const output = output_manager->output_for(conf.id);
             if (output)
             {
-                output.value()->for_each_output_resource_bound_by(client, [&](wl_resource* resource)
+                output.value()->for_each_output_resource_bound_by(
+                    weak_client.value().raw_client(),
+                    [&](wl_resource* resource)
                     {
                         surface->send_enter_event(resource);
                     });

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -20,6 +20,7 @@
 #define MIR_FRONTEND_WINDOW_WL_SURFACE_ROLE_H
 
 #include "wl_surface_role.h"
+#include "wl_client.h"
 
 #include "mir/wayland/wayland_base.h"
 #include "mir/geometry/displacement.h"
@@ -123,7 +124,7 @@ protected:
 
 private:
     WlSurface* const surface;
-    wl_client* client;
+    wayland::Weak<WlClient> const weak_client;
     std::shared_ptr<shell::Shell> const shell;
     std::shared_ptr<scene::Session> const session;
     OutputManager* output_manager;

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -119,6 +119,7 @@ protected:
     auto latest_timestamp() const -> std::chrono::nanoseconds;
 
     void commit(WlSurfaceState const& state) override;
+    void surface_destroyed() override;
 
 private:
     WlSurface* const surface;

--- a/src/server/frontend_wayland/wl_client.cpp
+++ b/src/server/frontend_wayland/wl_client.cpp
@@ -115,6 +115,10 @@ void mf::WlClient::setup_new_client_handler(
 
 auto mf::WlClient::from(wl_client* client) -> WlClient*
 {
+    if (!client)
+    {
+        return nullptr;
+    }
     auto listener = wl_client_get_destroy_listener(client, &cleanup_client_ctx);
     auto ctx = ClientCtx::from(listener);
     return ctx ? ctx->client.get() : nullptr;

--- a/src/server/frontend_wayland/wl_client.h
+++ b/src/server/frontend_wayland/wl_client.h
@@ -26,6 +26,8 @@ struct wl_display;
 #include <memory>
 #include <functional>
 
+#include "mir/wayland/wayland_base.h"
+
 namespace mir
 {
 namespace shell
@@ -41,7 +43,7 @@ namespace frontend
 {
 class SessionAuthorizer;
 
-class WlClient
+class WlClient : public wayland::LifetimeTracker
 {
 public:
     /// Initializes a ConstructionCtx that will create a WlClient for each wl_client created on the display. Should only

--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -55,8 +55,6 @@ public:
 
     void receive(std::string const& mime_type, mir::Fd fd) override;
 
-    void destroy() override;
-
     void finish() override
     {
     }
@@ -87,11 +85,6 @@ mf::WlDataDevice::Offer::Offer(WlDataDevice* device, std::shared_ptr<scene::Clip
 void mf::WlDataDevice::Offer::receive(std::string const& mime_type, mir::Fd fd)
 {
     source->initiate_send(mime_type, fd);
-}
-
-void mf::WlDataDevice::Offer::destroy()
-{
-    destroy_wayland_object();
 }
 
 mf::WlDataDevice::WlDataDevice(
@@ -128,11 +121,6 @@ void mf::WlDataDevice::set_selection(std::experimental::optional<struct wl_resou
     {
         clipboard.clear_paste_source();
     }
-}
-
-void mf::WlDataDevice::release()
-{
-    destroy_wayland_object();
 }
 
 void mf::WlDataDevice::focus_on(wl_client* focus)

--- a/src/server/frontend_wayland/wl_data_device.h
+++ b/src/server/frontend_wayland/wl_data_device.h
@@ -52,7 +52,6 @@ public:
         (void)source, (void)origin, (void)icon, (void)serial;
     }
     void set_selection(std::experimental::optional<struct wl_resource*> const& source, uint32_t serial) override;
-    void release() override;
     /// @}
 
 private:

--- a/src/server/frontend_wayland/wl_data_source.cpp
+++ b/src/server/frontend_wayland/wl_data_source.cpp
@@ -121,11 +121,6 @@ void mf::WlDataSource::offer(std::string const& mime_type)
     mime_types.push_back(mime_type);
 }
 
-void mf::WlDataSource::destroy()
-{
-    destroy_wayland_object();
-}
-
 void mf::WlDataSource::paste_source_set(std::shared_ptr<scene::ClipboardSource> const& source)
 {
     if (source && source == paste_source.lock())

--- a/src/server/frontend_wayland/wl_data_source.h
+++ b/src/server/frontend_wayland/wl_data_source.h
@@ -48,7 +48,6 @@ public:
     /// Wayland requests
     /// @{
     void offer(std::string const& mime_type) override;
-    void destroy() override;
     void set_actions(uint32_t dnd_actions) override
     {
         (void)dnd_actions;

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -263,11 +263,6 @@ void mf::WlKeyboard::update_modifier_state()
     }
 }
 
-void mf::WlKeyboard::release()
-{
-    wl_resource_destroy(resource);
-}
-
 void mir::frontend::WlKeyboard::resync_keyboard()
 {
     update_keyboard_state(acquire_current_keyboard_state());

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -79,8 +79,6 @@ private:
     uint32_t mods_latched{0};
     uint32_t mods_locked{0};
     uint32_t group{0};
-
-    void release() override;
 };
 }
 }

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -382,11 +382,6 @@ void mf::WlPointer::set_cursor(
     (void)serial;
 }
 
-void mf::WlPointer::release()
-{
-    destroy_wayland_object();
-}
-
 WlSurfaceCursor::WlSurfaceCursor(mf::WlSurface* surface, geom::Displacement hotspot)
     : surface{surface},
       stream{surface->stream},

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -82,7 +82,6 @@ private:
         std::experimental::optional<wl_resource*> const& surface,
         int32_t hotspot_x,
         int32_t hotspot_y) override;
-    void release() override;
     ///@}
 
     wayland::Weak<WlSurface> surface_under_cursor;

--- a/src/server/frontend_wayland/wl_region.cpp
+++ b/src/server/frontend_wayland/wl_region.cpp
@@ -43,11 +43,6 @@ mf::WlRegion* mf::WlRegion::from(wl_resource* resource)
     return static_cast<WlRegion*>(static_cast<wayland::Region*>(raw));
 }
 
-void mf::WlRegion::destroy()
-{
-    wl_resource_destroy(resource);
-}
-
 void mf::WlRegion::add(int32_t x, int32_t y, int32_t width, int32_t height)
 {
     rects.push_back(geom::Rectangle{{x, y}, {width, height}});

--- a/src/server/frontend_wayland/wl_region.h
+++ b/src/server/frontend_wayland/wl_region.h
@@ -42,7 +42,6 @@ public:
     static WlRegion* from(wl_resource* resource);
 
 private:
-    void destroy() override;
     void add(int32_t x, int32_t y, int32_t width, int32_t height) override;
     void subtract(int32_t x, int32_t y, int32_t width, int32_t height) override;
 

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -146,7 +146,6 @@ private:
     void get_pointer(wl_resource* new_pointer) override;
     void get_keyboard(wl_resource* new_keyboard) override;
     void get_touch(wl_resource* new_touch) override;
-    void release() override;
 };
 
 mf::WlSeat::WlSeat(
@@ -287,11 +286,6 @@ void mf::WlSeat::Instance::get_touch(wl_resource* new_touch)
         {
             listeners->unregister_listener(client, listener);
         });
-}
-
-void mf::WlSeat::Instance::release()
-{
-    destroy_wayland_object();
 }
 
 auto mf::WlSeat::current_focused_client() const -> wl_client*

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -37,7 +37,6 @@ public:
     WlSubcompositorInstance(wl_resource* new_resource);
 
 private:
-    void destroy() override;
     void get_subsurface(wl_resource* new_subsurface, wl_resource* surface, wl_resource* parent) override;
 };
 }
@@ -56,11 +55,6 @@ void mf::WlSubcompositor::bind(wl_resource* new_wl_subcompositor)
 mf::WlSubcompositorInstance::WlSubcompositorInstance(wl_resource* new_resource)
     : wayland::Subcompositor(new_resource, Version<1>())
 {
-}
-
-void mf::WlSubcompositorInstance::destroy()
-{
-    destroy_wayland_object();
 }
 
 void mf::WlSubcompositorInstance::get_subsurface(
@@ -163,11 +157,6 @@ void mf::WlSubsurface::set_sync()
 void mf::WlSubsurface::set_desync()
 {
     synchronized_ = false;
-}
-
-void mf::WlSubsurface::destroy()
-{
-    destroy_wayland_object();
 }
 
 void mf::WlSubsurface::refresh_surface_data_now()

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -209,3 +209,11 @@ void mf::WlSubsurface::commit(WlSurfaceState const& state)
         cached_state = std::experimental::nullopt;
     }
 }
+
+void mf::WlSubsurface::surface_destroyed()
+{
+    // "When a client wants to destroy a wl_surface, they must destroy this 'role object' before the wl_surface."
+    BOOST_THROW_EXCEPTION(std::runtime_error{
+        "wl_surface@" + std::to_string(wl_resource_get_id(surface->resource)) +
+        " destroyed before it's associated wl_subsurface@" + std::to_string(wl_resource_get_id(resource))});
+}

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -77,6 +77,7 @@ private:
 
     void refresh_surface_data_now() override;
     virtual void commit(WlSurfaceState const& state) override;
+    void surface_destroyed() override;
 
     WlSurface* const surface;
     /// This class is responsible for removing itself from the parent's children list when needed

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -74,8 +74,6 @@ private:
     void set_sync() override;
     void set_desync() override;
 
-    void destroy() override; // overrides function in both WlSurfaceRole and wayland::Subsurface
-
     void refresh_surface_data_now() override;
     virtual void commit(WlSurfaceState const& state) override;
     void surface_destroyed() override;

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -23,6 +23,7 @@
 #include "wayland_wrapper.h"
 #include "wl_surface_role.h"
 #include "wl_surface.h"
+#include "wl_client.h"
 
 #include <vector>
 #include <memory>
@@ -82,6 +83,7 @@ private:
     WlSurface* const surface;
     /// This class is responsible for removing itself from the parent's children list when needed
     wayland::Weak<WlSurface> const parent;
+    wayland::Weak<WlClient> const weak_client;
     bool synchronized_;
     std::experimental::optional<WlSurfaceState> cached_state;
 };

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -235,7 +235,6 @@ void mf::WlSurface::send_frame_callbacks()
             auto const timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now().time_since_epoch());
             frame->send_done_event(timestamp_ms.count());
-            frame->destroy_wayland_object();
         }
     }
     frame_callbacks.clear();

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -103,7 +103,7 @@ mf::WlSurface::WlSurface(
 
 mf::WlSurface::~WlSurface()
 {
-    role->destroy();
+    role->surface_destroyed();
     session->destroy_buffer_stream(stream);
 }
 
@@ -493,4 +493,4 @@ auto mf::NullWlSurfaceRole::scene_surface() const -> std::experimental::optional
 }
 void mf::NullWlSurfaceRole::refresh_surface_data_now() {}
 void mf::NullWlSurfaceRole::commit(WlSurfaceState const& state) { surface->commit(state); }
-void mf::NullWlSurfaceRole::destroy() {}
+void mf::NullWlSurfaceRole::surface_destroyed() {}

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -49,8 +49,7 @@ namespace mw = mir::wayland;
 namespace msh = mir::shell;
 
 mf::WlSurfaceState::Callback::Callback(wl_resource* new_resource)
-    : mw::Callback{new_resource, Version<1>()},
-      destroyed{deleted_flag_for_resource(resource)}
+    : mw::Callback{new_resource, Version<1>()}
 {
 }
 
@@ -230,11 +229,12 @@ void mf::WlSurface::send_frame_callbacks()
 {
     for (auto const& frame : frame_callbacks)
     {
-        if (!*frame->destroyed)
+        if (frame)
         {
             auto const timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now().time_since_epoch());
-            frame->send_done_event(timestamp_ms.count());
+            frame.value().send_done_event(timestamp_ms.count());
+            frame.value().destroy_and_delete();
         }
     }
     frame_callbacks.clear();
@@ -270,7 +270,8 @@ void mf::WlSurface::damage_buffer(int32_t x, int32_t y, int32_t width, int32_t h
 
 void mf::WlSurface::frame(wl_resource* new_callback)
 {
-    pending.frame_callbacks.push_back(std::make_shared<WlSurfaceState::Callback>(new_callback));
+    auto callback = new WlSurfaceState::Callback{new_callback};
+    pending.frame_callbacks.push_back(wayland::make_weak(callback));
 }
 
 void mf::WlSurface::set_opaque_region(std::experimental::optional<wl_resource*> const& region)

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -240,11 +240,6 @@ void mf::WlSurface::send_frame_callbacks()
     frame_callbacks.clear();
 }
 
-void mf::WlSurface::destroy()
-{
-    destroy_wayland_object();
-}
-
 void mf::WlSurface::attach(std::experimental::optional<wl_resource*> const& buffer, int32_t x, int32_t y)
 {
     if (x != 0 || y != 0)

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -159,7 +159,6 @@ private:
 
     void send_frame_callbacks();
 
-    void destroy() override;
     void attach(std::experimental::optional<wl_resource*> const& buffer, int32_t x, int32_t y) override;
     void damage(int32_t x, int32_t y, int32_t width, int32_t height) override;
     void frame(wl_resource* callback) override;

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -100,7 +100,7 @@ public:
     auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
     void refresh_surface_data_now() override;
     void commit(WlSurfaceState const& state) override;
-    void destroy() override;
+    void surface_destroyed() override;
 
 private:
     WlSurface* const surface;

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -65,7 +65,6 @@ struct WlSurfaceState
     {
     public:
         Callback(wl_resource* new_resource);
-        std::shared_ptr<bool> destroyed;
     };
 
     // if you add variables, don't forget to update this
@@ -83,7 +82,7 @@ struct WlSurfaceState
     std::experimental::optional<int> scale;
     std::experimental::optional<geometry::Displacement> offset;
     std::experimental::optional<std::experimental::optional<std::vector<geometry::Rectangle>>> input_shape;
-    std::vector<std::shared_ptr<Callback>> frame_callbacks;
+    std::vector<wayland::Weak<Callback>> frame_callbacks;
 
 private:
     // only set to true if invalidate_surface_data() is called
@@ -154,7 +153,7 @@ private:
     WlSurfaceState pending;
     geometry::Displacement offset_;
     std::experimental::optional<geometry::Size> buffer_size_;
-    std::vector<std::shared_ptr<WlSurfaceState::Callback>> frame_callbacks;
+    std::vector<wayland::Weak<WlSurfaceState::Callback>> frame_callbacks;
     std::experimental::optional<std::vector<mir::geometry::Rectangle>> input_shape;
 
     void send_frame_callbacks();

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -45,7 +45,7 @@ public:
     virtual auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> = 0;
     virtual void refresh_surface_data_now() = 0;
     virtual void commit(WlSurfaceState const& state) = 0;
-    virtual void destroy() = 0;
+    virtual void surface_destroyed() = 0;
     virtual ~WlSurfaceRole() = default;
 };
 }

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -183,8 +183,3 @@ void mf::WlTouch::maybe_frame()
         needs_frame = false;
     }
 }
-
-void mf::WlTouch::release()
-{
-    destroy_wayland_object();
-}

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -71,8 +71,6 @@ private:
         std::pair<float, float> const& root_position);
     void up(uint32_t serial, std::chrono::milliseconds const& ms, int32_t touch_id);
     void maybe_frame();
-
-    void release() override;
 };
 
 }

--- a/src/server/frontend_wayland/xdg_output_v1.cpp
+++ b/src/server/frontend_wayland/xdg_output_v1.cpp
@@ -48,7 +48,6 @@ private:
         Instance(wl_resource* new_resource, OutputManager* manager);
 
     private:
-        void destroy() override;
         void get_xdg_output(wl_resource* new_output, wl_resource* output) override;
 
         OutputManager* const output_manager;
@@ -97,11 +96,6 @@ mf::XdgOutputManagerV1::Instance::Instance(wl_resource* new_resource, OutputMana
     : XdgOutputManagerV1{new_resource, Version<3>()},
       output_manager{manager}
 {
-}
-
-void mf::XdgOutputManagerV1::Instance::destroy()
-{
-    destroy_wayland_object();
 }
 
 void mf::XdgOutputManagerV1::Instance::get_xdg_output(wl_resource* new_output, wl_resource* output)
@@ -194,9 +188,4 @@ mf::XdgOutputV1::XdgOutputV1(
          */
         send_done_event();
     }
-}
-
-void mf::XdgOutputV1::destroy()
-{
-    destroy_wayland_object();
 }

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -49,7 +49,6 @@ public:
     XdgSurfaceStable(wl_resource* new_resource, WlSurface* surface, XdgShellStable const& xdg_shell);
     ~XdgSurfaceStable() = default;
 
-    void destroy() override;
     void get_toplevel(wl_resource* new_toplevel) override;
     void get_popup(
         wl_resource* new_popup,
@@ -83,7 +82,6 @@ public:
         XdgSurfaceStable* xdg_surface,
         WlSurface* surface);
 
-    void destroy() override;
     void set_parent(std::experimental::optional<struct wl_resource*> const& parent) override;
     void set_title(std::string const& title) override;
     void set_app_id(std::string const& app_id) override;
@@ -118,7 +116,6 @@ public:
     XdgPositionerStable(wl_resource* new_resource);
 
 private:
-    void destroy() override;
     void set_size(int32_t width, int32_t height) override;
     void set_anchor_rect(int32_t x, int32_t y, int32_t width, int32_t height) override;
     void set_anchor(uint32_t anchor) override;
@@ -137,7 +134,6 @@ public:
     Instance(wl_resource* new_resource, mf::XdgShellStable* shell);
 
 private:
-    void destroy() override;
     void create_positioner(wl_resource* new_positioner) override;
     void get_xdg_surface(wl_resource* new_xdg_surface, wl_resource* surface) override;
     void pong(uint32_t serial) override;
@@ -172,11 +168,6 @@ mf::XdgShellStable::Instance::Instance(wl_resource* new_resource, mf::XdgShellSt
 {
 }
 
-void mf::XdgShellStable::Instance::destroy()
-{
-    destroy_wayland_object();
-}
-
 void mf::XdgShellStable::Instance::create_positioner(wl_resource* new_positioner)
 {
     new XdgPositionerStable{new_positioner};
@@ -206,11 +197,6 @@ mf::XdgSurfaceStable::XdgSurfaceStable(wl_resource* new_resource, WlSurface* sur
       surface{surface},
       xdg_shell{xdg_shell}
 {
-}
-
-void mf::XdgSurfaceStable::destroy()
-{
-    destroy_wayland_object();
 }
 
 void mf::XdgSurfaceStable::get_toplevel(wl_resource* new_toplevel)
@@ -355,11 +341,6 @@ void mf::XdgPopupStable::grab(struct wl_resource* seat, uint32_t serial)
     set_type(mir_window_type_menu);
 }
 
-void mf::XdgPopupStable::destroy()
-{
-    destroy_wayland_object();
-}
-
 void mf::XdgPopupStable::handle_resize(const std::experimental::optional<geometry::Point>& new_top_left_,
                                        const geometry::Size& new_size)
 {
@@ -417,11 +398,6 @@ mf::XdgToplevelStable::XdgToplevelStable(wl_resource* new_resource, XdgSurfaceSt
     send_configure_event(0, 0, &states);
     wl_array_release(&states);
     xdg_surface->send_configure();
-}
-
-void mf::XdgToplevelStable::destroy()
-{
-    destroy_wayland_object();
 }
 
 void mf::XdgToplevelStable::set_parent(std::experimental::optional<struct wl_resource*> const& parent)
@@ -617,11 +593,6 @@ mf::XdgPositionerStable::XdgPositionerStable(wl_resource* new_resource)
     // specifying gravity is not required by the xdg shell protocol, but is by Mir window managers
     surface_placement_gravity = mir_placement_gravity_center;
     aux_rect_placement_gravity = mir_placement_gravity_center;
-}
-
-void mf::XdgPositionerStable::destroy()
-{
-    destroy_wayland_object();
 }
 
 void mf::XdgPositionerStable::set_size(int32_t width, int32_t height)

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -73,7 +73,6 @@ public:
     void set_aux_rect_offset_now(geometry::Displacement const& new_aux_rect_offset);
 
     void grab(struct wl_resource* seat, uint32_t serial) override;
-    void destroy() override;
 
     void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override {};

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -47,7 +47,6 @@ public:
     XdgSurfaceV6(wl_resource* new_resource, WlSurface* surface, XdgShellV6 const& xdg_shell);
     ~XdgSurfaceV6() = default;
 
-    void destroy() override;
     void get_toplevel(wl_resource* new_toplevel) override;
     void get_popup(wl_resource* new_popup, wl_resource* parent_surface, wl_resource* positioner) override;
     void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) override;
@@ -81,7 +80,6 @@ public:
         WlSurface* surface);
 
     void grab(struct wl_resource* seat, uint32_t serial) override;
-    void destroy() override;
 
     void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override {};
@@ -103,7 +101,6 @@ class XdgToplevelV6 : mw::XdgToplevelV6, public WindowWlSurfaceRole
 public:
     XdgToplevelV6(wl_resource* new_resource, XdgSurfaceV6* xdg_surface, WlSurface* surface);
 
-    void destroy() override;
     void set_parent(std::experimental::optional<struct wl_resource*> const& parent) override;
     void set_title(std::string const& title) override;
     void set_app_id(std::string const& app_id) override;
@@ -138,7 +135,6 @@ public:
     XdgPositionerV6(wl_resource* new_resource);
 
 private:
-    void destroy() override;
     void set_size(int32_t width, int32_t height) override;
     void set_anchor_rect(int32_t x, int32_t y, int32_t width, int32_t height) override;
     void set_anchor(uint32_t anchor) override;
@@ -157,7 +153,6 @@ public:
     Instance(wl_resource* new_resource, mf::XdgShellV6* shell);
 
 private:
-    void destroy() override;
     void create_positioner(wl_resource* new_positioner) override;
     void get_xdg_surface(wl_resource* new_xdg_surface, wl_resource* surface) override;
     void pong(uint32_t serial) override;
@@ -169,11 +164,6 @@ mf::XdgShellV6::Instance::Instance(wl_resource* new_resource, mf::XdgShellV6* sh
     : mw::XdgShellV6{new_resource, Version<1>()},
       shell{shell}
 {
-}
-
-void mf::XdgShellV6::Instance::destroy()
-{
-    destroy_wayland_object();
 }
 
 void mf::XdgShellV6::Instance::create_positioner(wl_resource* new_positioner)
@@ -227,11 +217,6 @@ mf::XdgSurfaceV6::XdgSurfaceV6(wl_resource* new_resource, WlSurface* surface,
       surface{surface},
       xdg_shell{xdg_shell}
 {
-}
-
-void mf::XdgSurfaceV6::destroy()
-{
-    wl_resource_destroy(resource);
 }
 
 void mf::XdgSurfaceV6::get_toplevel(wl_resource* new_toplevel)
@@ -325,11 +310,6 @@ void mf::XdgPopupV6::grab(struct wl_resource* seat, uint32_t serial)
     set_type(mir_window_type_menu);
 }
 
-void mf::XdgPopupV6::destroy()
-{
-    wl_resource_destroy(resource);
-}
-
 void mf::XdgPopupV6::handle_resize(const std::experimental::optional<geometry::Point>& new_top_left,
                                    const geometry::Size& new_size)
 {
@@ -373,11 +353,6 @@ mf::XdgToplevelV6::XdgToplevelV6(struct wl_resource* new_resource, XdgSurfaceV6*
     send_configure_event(0, 0, &states);
     wl_array_release(&states);
     xdg_surface->send_configure();
-}
-
-void mf::XdgToplevelV6::destroy()
-{
-    wl_resource_destroy(resource);
 }
 
 void mf::XdgToplevelV6::set_parent(std::experimental::optional<struct wl_resource*> const& parent)
@@ -572,11 +547,6 @@ mf::XdgPositionerV6::XdgPositionerV6(wl_resource* new_resource)
     // specifying gravity is not required by the xdg shell protocol, but is by Mir window managers
     surface_placement_gravity = mir_placement_gravity_center;
     aux_rect_placement_gravity = mir_placement_gravity_center;
-}
-
-void mf::XdgPositionerV6::destroy()
-{
-    wl_resource_destroy(resource);
 }
 
 void mf::XdgPositionerV6::set_size(int32_t width, int32_t height)

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -163,7 +163,7 @@ void mf::XWaylandSurfaceRole::commit(WlSurfaceState const& state)
     }
 }
 
-void mf::XWaylandSurfaceRole::destroy()
+void mf::XWaylandSurfaceRole::surface_destroyed()
 {
     if (auto const wm_surface = weak_wm_surface.lock())
     {

--- a/src/server/frontend_xwayland/xwayland_surface_role.h
+++ b/src/server/frontend_xwayland/xwayland_surface_role.h
@@ -70,7 +70,7 @@ private:
     auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
     void refresh_surface_data_now() override;
     void commit(WlSurfaceState const& state) override;
-    void destroy() override;
+    void surface_destroyed() override;
     /// @}
 };
 }

--- a/src/wayland/generated/pointer-constraints-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/pointer-constraints-unstable-v1_wrapper.cpp
@@ -48,10 +48,9 @@ struct mw::PointerConstraintsV1::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<PointerConstraintsV1*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -65,7 +64,6 @@ struct mw::PointerConstraintsV1::Thunks
 
     static void lock_pointer_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface, struct wl_resource* pointer, struct wl_resource* region, uint32_t lifetime)
     {
-        auto me = static_cast<PointerConstraintsV1*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &zwp_locked_pointer_v1_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -80,6 +78,7 @@ struct mw::PointerConstraintsV1::Thunks
         }
         try
         {
+            auto me = static_cast<PointerConstraintsV1*>(wl_resource_get_user_data(resource));
             me->lock_pointer(id_resolved, surface, pointer, region_resolved, lifetime);
         }
         catch(ProtocolError const& err)
@@ -94,7 +93,6 @@ struct mw::PointerConstraintsV1::Thunks
 
     static void confine_pointer_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface, struct wl_resource* pointer, struct wl_resource* region, uint32_t lifetime)
     {
-        auto me = static_cast<PointerConstraintsV1*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &zwp_confined_pointer_v1_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -109,6 +107,7 @@ struct mw::PointerConstraintsV1::Thunks
         }
         try
         {
+            auto me = static_cast<PointerConstraintsV1*>(wl_resource_get_user_data(resource));
             me->confine_pointer(id_resolved, surface, pointer, region_resolved, lifetime);
         }
         catch(ProtocolError const& err)
@@ -178,11 +177,6 @@ bool mw::PointerConstraintsV1::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &zwp_pointer_constraints_v1_interface_data, Thunks::request_vtable);
 }
 
-void mw::PointerConstraintsV1::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 mw::PointerConstraintsV1::Global::Global(wl_display* display, Version<1>)
     : wayland::Global{
           wl_global_create(
@@ -240,10 +234,9 @@ struct mw::LockedPointerV1::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<LockedPointerV1*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -257,11 +250,11 @@ struct mw::LockedPointerV1::Thunks
 
     static void set_cursor_position_hint_thunk(struct wl_client* client, struct wl_resource* resource, wl_fixed_t surface_x, wl_fixed_t surface_y)
     {
-        auto me = static_cast<LockedPointerV1*>(wl_resource_get_user_data(resource));
         double surface_x_resolved{wl_fixed_to_double(surface_x)};
         double surface_y_resolved{wl_fixed_to_double(surface_y)};
         try
         {
+            auto me = static_cast<LockedPointerV1*>(wl_resource_get_user_data(resource));
             me->set_cursor_position_hint(surface_x_resolved, surface_y_resolved);
         }
         catch(ProtocolError const& err)
@@ -276,7 +269,6 @@ struct mw::LockedPointerV1::Thunks
 
     static void set_region_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* region)
     {
-        auto me = static_cast<LockedPointerV1*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> region_resolved;
         if (region != nullptr)
         {
@@ -284,6 +276,7 @@ struct mw::LockedPointerV1::Thunks
         }
         try
         {
+            auto me = static_cast<LockedPointerV1*>(wl_resource_get_user_data(resource));
             me->set_region(region_resolved);
         }
         catch(ProtocolError const& err)
@@ -340,11 +333,6 @@ bool mw::LockedPointerV1::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &zwp_locked_pointer_v1_interface_data, Thunks::request_vtable);
 }
 
-void mw::LockedPointerV1::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_interface const* mw::LockedPointerV1::Thunks::set_region_types[] {
     &wl_region_interface_data};
 
@@ -379,10 +367,9 @@ struct mw::ConfinedPointerV1::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<ConfinedPointerV1*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -396,7 +383,6 @@ struct mw::ConfinedPointerV1::Thunks
 
     static void set_region_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* region)
     {
-        auto me = static_cast<ConfinedPointerV1*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> region_resolved;
         if (region != nullptr)
         {
@@ -404,6 +390,7 @@ struct mw::ConfinedPointerV1::Thunks
         }
         try
         {
+            auto me = static_cast<ConfinedPointerV1*>(wl_resource_get_user_data(resource));
             me->set_region(region_resolved);
         }
         catch(ProtocolError const& err)
@@ -458,11 +445,6 @@ void mw::ConfinedPointerV1::send_unconfined_event() const
 bool mw::ConfinedPointerV1::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &zwp_confined_pointer_v1_interface_data, Thunks::request_vtable);
-}
-
-void mw::ConfinedPointerV1::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
 }
 
 struct wl_interface const* mw::ConfinedPointerV1::Thunks::set_region_types[] {

--- a/src/wayland/generated/pointer-constraints-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/pointer-constraints-unstable-v1_wrapper.cpp
@@ -42,11 +42,6 @@ struct wl_interface const* all_null_types [] {
 
 // PointerConstraintsV1
 
-mw::PointerConstraintsV1* mw::PointerConstraintsV1::from(struct wl_resource* resource)
-{
-    return static_cast<PointerConstraintsV1*>(wl_resource_get_user_data(resource));
-}
-
 struct mw::PointerConstraintsV1::Thunks
 {
     static int const supported_version;
@@ -57,6 +52,10 @@ struct mw::PointerConstraintsV1::Thunks
         try
         {
             me->destroy();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -83,6 +82,10 @@ struct mw::PointerConstraintsV1::Thunks
         {
             me->lock_pointer(id_resolved, surface, pointer, region_resolved, lifetime);
         }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
+        }
         catch(...)
         {
             internal_error_processing_request(client, "PointerConstraintsV1::lock_pointer()");
@@ -107,6 +110,10 @@ struct mw::PointerConstraintsV1::Thunks
         try
         {
             me->confine_pointer(id_resolved, surface, pointer, region_resolved, lifetime);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -216,12 +223,16 @@ void const* mw::PointerConstraintsV1::Thunks::request_vtable[] {
     (void*)Thunks::lock_pointer_thunk,
     (void*)Thunks::confine_pointer_thunk};
 
-// LockedPointerV1
-
-mw::LockedPointerV1* mw::LockedPointerV1::from(struct wl_resource* resource)
+mw::PointerConstraintsV1* mw::PointerConstraintsV1::from(struct wl_resource* resource)
 {
-    return static_cast<LockedPointerV1*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &zwp_pointer_constraints_v1_interface_data, PointerConstraintsV1::Thunks::request_vtable))
+    {
+        return static_cast<PointerConstraintsV1*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// LockedPointerV1
 
 struct mw::LockedPointerV1::Thunks
 {
@@ -233,6 +244,10 @@ struct mw::LockedPointerV1::Thunks
         try
         {
             me->destroy();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -248,6 +263,10 @@ struct mw::LockedPointerV1::Thunks
         try
         {
             me->set_cursor_position_hint(surface_x_resolved, surface_y_resolved);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -266,6 +285,10 @@ struct mw::LockedPointerV1::Thunks
         try
         {
             me->set_region(region_resolved);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -339,12 +362,16 @@ void const* mw::LockedPointerV1::Thunks::request_vtable[] {
     (void*)Thunks::set_cursor_position_hint_thunk,
     (void*)Thunks::set_region_thunk};
 
-// ConfinedPointerV1
-
-mw::ConfinedPointerV1* mw::ConfinedPointerV1::from(struct wl_resource* resource)
+mw::LockedPointerV1* mw::LockedPointerV1::from(struct wl_resource* resource)
 {
-    return static_cast<ConfinedPointerV1*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &zwp_locked_pointer_v1_interface_data, LockedPointerV1::Thunks::request_vtable))
+    {
+        return static_cast<LockedPointerV1*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// ConfinedPointerV1
 
 struct mw::ConfinedPointerV1::Thunks
 {
@@ -356,6 +383,10 @@ struct mw::ConfinedPointerV1::Thunks
         try
         {
             me->destroy();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -374,6 +405,10 @@ struct mw::ConfinedPointerV1::Thunks
         try
         {
             me->set_region(region_resolved);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -444,6 +479,15 @@ struct wl_message const mw::ConfinedPointerV1::Thunks::event_messages[] {
 void const* mw::ConfinedPointerV1::Thunks::request_vtable[] {
     (void*)Thunks::destroy_thunk,
     (void*)Thunks::set_region_thunk};
+
+mw::ConfinedPointerV1* mw::ConfinedPointerV1::from(struct wl_resource* resource)
+{
+    if (wl_resource_instance_of(resource, &zwp_confined_pointer_v1_interface_data, ConfinedPointerV1::Thunks::request_vtable))
+    {
+        return static_cast<ConfinedPointerV1*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
+}
 
 namespace mir
 {

--- a/src/wayland/generated/pointer-constraints-unstable-v1_wrapper.h
+++ b/src/wayland/generated/pointer-constraints-unstable-v1_wrapper.h
@@ -34,8 +34,6 @@ public:
     PointerConstraintsV1(struct wl_resource* resource, Version<1>);
     virtual ~PointerConstraintsV1();
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -67,7 +65,6 @@ public:
     };
 
 private:
-    virtual void destroy() = 0;
     virtual void lock_pointer(struct wl_resource* id, struct wl_resource* surface, struct wl_resource* pointer, std::experimental::optional<struct wl_resource*> const& region, uint32_t lifetime) = 0;
     virtual void confine_pointer(struct wl_resource* id, struct wl_resource* surface, struct wl_resource* pointer, std::experimental::optional<struct wl_resource*> const& region, uint32_t lifetime) = 0;
 };
@@ -85,8 +82,6 @@ public:
     void send_locked_event() const;
     void send_unlocked_event() const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -101,7 +96,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void set_cursor_position_hint(double surface_x, double surface_y) = 0;
     virtual void set_region(std::experimental::optional<struct wl_resource*> const& region) = 0;
 };
@@ -119,8 +113,6 @@ public:
     void send_confined_event() const;
     void send_unconfined_event() const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -135,7 +127,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void set_region(std::experimental::optional<struct wl_resource*> const& region) = 0;
 };
 

--- a/src/wayland/generated/relative-pointer-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/relative-pointer-unstable-v1_wrapper.cpp
@@ -39,11 +39,6 @@ struct wl_interface const* all_null_types [] {
 
 // RelativePointerManagerV1
 
-mw::RelativePointerManagerV1* mw::RelativePointerManagerV1::from(struct wl_resource* resource)
-{
-    return static_cast<RelativePointerManagerV1*>(wl_resource_get_user_data(resource));
-}
-
 struct mw::RelativePointerManagerV1::Thunks
 {
     static int const supported_version;
@@ -54,6 +49,10 @@ struct mw::RelativePointerManagerV1::Thunks
         try
         {
             me->destroy();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -74,6 +73,10 @@ struct mw::RelativePointerManagerV1::Thunks
         try
         {
             me->get_relative_pointer(id_resolved, pointer);
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -170,12 +173,16 @@ void const* mw::RelativePointerManagerV1::Thunks::request_vtable[] {
     (void*)Thunks::destroy_thunk,
     (void*)Thunks::get_relative_pointer_thunk};
 
-// RelativePointerV1
-
-mw::RelativePointerV1* mw::RelativePointerV1::from(struct wl_resource* resource)
+mw::RelativePointerManagerV1* mw::RelativePointerManagerV1::from(struct wl_resource* resource)
 {
-    return static_cast<RelativePointerV1*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &zwp_relative_pointer_manager_v1_interface_data, RelativePointerManagerV1::Thunks::request_vtable))
+    {
+        return static_cast<RelativePointerManagerV1*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// RelativePointerV1
 
 struct mw::RelativePointerV1::Thunks
 {
@@ -187,6 +194,10 @@ struct mw::RelativePointerV1::Thunks
         try
         {
             me->destroy();
+        }
+        catch(ProtocolError const& err)
+        {
+            wl_resource_post_error(err.resource(), err.code(), "%s", err.message());
         }
         catch(...)
         {
@@ -249,6 +260,15 @@ struct wl_message const mw::RelativePointerV1::Thunks::event_messages[] {
 
 void const* mw::RelativePointerV1::Thunks::request_vtable[] {
     (void*)Thunks::destroy_thunk};
+
+mw::RelativePointerV1* mw::RelativePointerV1::from(struct wl_resource* resource)
+{
+    if (wl_resource_instance_of(resource, &zwp_relative_pointer_v1_interface_data, RelativePointerV1::Thunks::request_vtable))
+    {
+        return static_cast<RelativePointerV1*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
+}
 
 namespace mir
 {

--- a/src/wayland/generated/relative-pointer-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/relative-pointer-unstable-v1_wrapper.cpp
@@ -45,10 +45,9 @@ struct mw::RelativePointerManagerV1::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<RelativePointerManagerV1*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -62,7 +61,6 @@ struct mw::RelativePointerManagerV1::Thunks
 
     static void get_relative_pointer_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* pointer)
     {
-        auto me = static_cast<RelativePointerManagerV1*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &zwp_relative_pointer_v1_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -72,6 +70,7 @@ struct mw::RelativePointerManagerV1::Thunks
         }
         try
         {
+            auto me = static_cast<RelativePointerManagerV1*>(wl_resource_get_user_data(resource));
             me->get_relative_pointer(id_resolved, pointer);
         }
         catch(ProtocolError const& err)
@@ -140,11 +139,6 @@ bool mw::RelativePointerManagerV1::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &zwp_relative_pointer_manager_v1_interface_data, Thunks::request_vtable);
 }
 
-void mw::RelativePointerManagerV1::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 mw::RelativePointerManagerV1::Global::Global(wl_display* display, Version<1>)
     : wayland::Global{
           wl_global_create(
@@ -190,10 +184,9 @@ struct mw::RelativePointerV1::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<RelativePointerV1*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -245,11 +238,6 @@ void mw::RelativePointerV1::send_relative_motion_event(uint32_t utime_hi, uint32
 bool mw::RelativePointerV1::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &zwp_relative_pointer_v1_interface_data, Thunks::request_vtable);
-}
-
-void mw::RelativePointerV1::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
 }
 
 struct wl_message const mw::RelativePointerV1::Thunks::request_messages[] {

--- a/src/wayland/generated/relative-pointer-unstable-v1_wrapper.h
+++ b/src/wayland/generated/relative-pointer-unstable-v1_wrapper.h
@@ -33,8 +33,6 @@ public:
     RelativePointerManagerV1(struct wl_resource* resource, Version<1>);
     virtual ~RelativePointerManagerV1();
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -55,7 +53,6 @@ public:
     };
 
 private:
-    virtual void destroy() = 0;
     virtual void get_relative_pointer(struct wl_resource* id, struct wl_resource* pointer) = 0;
 };
 
@@ -71,8 +68,6 @@ public:
 
     void send_relative_motion_event(uint32_t utime_hi, uint32_t utime_lo, double dx, double dy, double dx_unaccel, double dy_unaccel) const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -86,7 +81,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
 };
 
 }

--- a/src/wayland/generated/wayland_wrapper.cpp
+++ b/src/wayland/generated/wayland_wrapper.cpp
@@ -97,8 +97,9 @@ bool mw::Callback::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_callback_interface_data, Thunks::request_vtable);
 }
 
-void mw::Callback::destroy_wayland_object() const
+void mw::Callback::destroy_and_delete() const
 {
+    // Will result in this object being deleted
     wl_resource_destroy(resource);
 }
 
@@ -125,7 +126,6 @@ struct mw::Compositor::Thunks
 
     static void create_surface_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
-        auto me = static_cast<Compositor*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &wl_surface_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -135,6 +135,7 @@ struct mw::Compositor::Thunks
         }
         try
         {
+            auto me = static_cast<Compositor*>(wl_resource_get_user_data(resource));
             me->create_surface(id_resolved);
         }
         catch(ProtocolError const& err)
@@ -149,7 +150,6 @@ struct mw::Compositor::Thunks
 
     static void create_region_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
-        auto me = static_cast<Compositor*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &wl_region_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -159,6 +159,7 @@ struct mw::Compositor::Thunks
         }
         try
         {
+            auto me = static_cast<Compositor*>(wl_resource_get_user_data(resource));
             me->create_region(id_resolved);
         }
         catch(ProtocolError const& err)
@@ -228,8 +229,9 @@ bool mw::Compositor::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_compositor_interface_data, Thunks::request_vtable);
 }
 
-void mw::Compositor::destroy_wayland_object() const
+void mw::Compositor::destroy_and_delete() const
 {
+    // Will result in this object being deleted
     wl_resource_destroy(resource);
 }
 
@@ -280,7 +282,6 @@ struct mw::ShmPool::Thunks
 
     static void create_buffer_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, int32_t offset, int32_t width, int32_t height, int32_t stride, uint32_t format)
     {
-        auto me = static_cast<ShmPool*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &wl_buffer_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -290,6 +291,7 @@ struct mw::ShmPool::Thunks
         }
         try
         {
+            auto me = static_cast<ShmPool*>(wl_resource_get_user_data(resource));
             me->create_buffer(id_resolved, offset, width, height, stride, format);
         }
         catch(ProtocolError const& err)
@@ -304,10 +306,9 @@ struct mw::ShmPool::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<ShmPool*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -321,9 +322,9 @@ struct mw::ShmPool::Thunks
 
     static void resize_thunk(struct wl_client* client, struct wl_resource* resource, int32_t size)
     {
-        auto me = static_cast<ShmPool*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ShmPool*>(wl_resource_get_user_data(resource));
             me->resize(size);
         }
         catch(ProtocolError const& err)
@@ -369,11 +370,6 @@ bool mw::ShmPool::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_shm_pool_interface_data, Thunks::request_vtable);
 }
 
-void mw::ShmPool::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_interface const* mw::ShmPool::Thunks::create_buffer_types[] {
     &wl_buffer_interface_data,
     nullptr,
@@ -409,7 +405,6 @@ struct mw::Shm::Thunks
 
     static void create_pool_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, int32_t fd, int32_t size)
     {
-        auto me = static_cast<Shm*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &wl_shm_pool_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -420,6 +415,7 @@ struct mw::Shm::Thunks
         mir::Fd fd_resolved{fd};
         try
         {
+            auto me = static_cast<Shm*>(wl_resource_get_user_data(resource));
             me->create_pool(id_resolved, fd_resolved, size);
         }
         catch(ProtocolError const& err)
@@ -494,8 +490,9 @@ bool mw::Shm::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_shm_interface_data, Thunks::request_vtable);
 }
 
-void mw::Shm::destroy_wayland_object() const
+void mw::Shm::destroy_and_delete() const
 {
+    // Will result in this object being deleted
     wl_resource_destroy(resource);
 }
 
@@ -546,10 +543,9 @@ struct mw::Buffer::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Buffer*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -599,11 +595,6 @@ bool mw::Buffer::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_buffer_interface_data, Thunks::request_vtable);
 }
 
-void mw::Buffer::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_message const mw::Buffer::Thunks::request_messages[] {
     {"destroy", "", all_null_types}};
 
@@ -630,7 +621,6 @@ struct mw::DataOffer::Thunks
 
     static void accept_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial, char const* mime_type)
     {
-        auto me = static_cast<DataOffer*>(wl_resource_get_user_data(resource));
         std::experimental::optional<std::string> mime_type_resolved;
         if (mime_type != nullptr)
         {
@@ -638,6 +628,7 @@ struct mw::DataOffer::Thunks
         }
         try
         {
+            auto me = static_cast<DataOffer*>(wl_resource_get_user_data(resource));
             me->accept(serial, mime_type_resolved);
         }
         catch(ProtocolError const& err)
@@ -652,10 +643,10 @@ struct mw::DataOffer::Thunks
 
     static void receive_thunk(struct wl_client* client, struct wl_resource* resource, char const* mime_type, int32_t fd)
     {
-        auto me = static_cast<DataOffer*>(wl_resource_get_user_data(resource));
         mir::Fd fd_resolved{fd};
         try
         {
+            auto me = static_cast<DataOffer*>(wl_resource_get_user_data(resource));
             me->receive(mime_type, fd_resolved);
         }
         catch(ProtocolError const& err)
@@ -670,10 +661,9 @@ struct mw::DataOffer::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<DataOffer*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -687,9 +677,9 @@ struct mw::DataOffer::Thunks
 
     static void finish_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<DataOffer*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<DataOffer*>(wl_resource_get_user_data(resource));
             me->finish();
         }
         catch(ProtocolError const& err)
@@ -704,9 +694,9 @@ struct mw::DataOffer::Thunks
 
     static void set_actions_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t dnd_actions, uint32_t preferred_action)
     {
-        auto me = static_cast<DataOffer*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<DataOffer*>(wl_resource_get_user_data(resource));
             me->set_actions(dnd_actions, preferred_action);
         }
         catch(ProtocolError const& err)
@@ -778,11 +768,6 @@ bool mw::DataOffer::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_data_offer_interface_data, Thunks::request_vtable);
 }
 
-void mw::DataOffer::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_message const mw::DataOffer::Thunks::request_messages[] {
     {"accept", "u?s", all_null_types},
     {"receive", "sh", all_null_types},
@@ -819,9 +804,9 @@ struct mw::DataSource::Thunks
 
     static void offer_thunk(struct wl_client* client, struct wl_resource* resource, char const* mime_type)
     {
-        auto me = static_cast<DataSource*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<DataSource*>(wl_resource_get_user_data(resource));
             me->offer(mime_type);
         }
         catch(ProtocolError const& err)
@@ -836,10 +821,9 @@ struct mw::DataSource::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<DataSource*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -853,9 +837,9 @@ struct mw::DataSource::Thunks
 
     static void set_actions_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t dnd_actions)
     {
-        auto me = static_cast<DataSource*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<DataSource*>(wl_resource_get_user_data(resource));
             me->set_actions(dnd_actions);
         }
         catch(ProtocolError const& err)
@@ -953,11 +937,6 @@ bool mw::DataSource::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_data_source_interface_data, Thunks::request_vtable);
 }
 
-void mw::DataSource::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_message const mw::DataSource::Thunks::request_messages[] {
     {"offer", "s", all_null_types},
     {"destroy", "", all_null_types},
@@ -993,7 +972,6 @@ struct mw::DataDevice::Thunks
 
     static void start_drag_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* source, struct wl_resource* origin, struct wl_resource* icon, uint32_t serial)
     {
-        auto me = static_cast<DataDevice*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> source_resolved;
         if (source != nullptr)
         {
@@ -1006,6 +984,7 @@ struct mw::DataDevice::Thunks
         }
         try
         {
+            auto me = static_cast<DataDevice*>(wl_resource_get_user_data(resource));
             me->start_drag(source_resolved, origin, icon_resolved, serial);
         }
         catch(ProtocolError const& err)
@@ -1020,7 +999,6 @@ struct mw::DataDevice::Thunks
 
     static void set_selection_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* source, uint32_t serial)
     {
-        auto me = static_cast<DataDevice*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> source_resolved;
         if (source != nullptr)
         {
@@ -1028,6 +1006,7 @@ struct mw::DataDevice::Thunks
         }
         try
         {
+            auto me = static_cast<DataDevice*>(wl_resource_get_user_data(resource));
             me->set_selection(source_resolved, serial);
         }
         catch(ProtocolError const& err)
@@ -1042,10 +1021,9 @@ struct mw::DataDevice::Thunks
 
     static void release_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<DataDevice*>(wl_resource_get_user_data(resource));
         try
         {
-            me->release();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -1139,11 +1117,6 @@ bool mw::DataDevice::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_data_device_interface_data, Thunks::request_vtable);
 }
 
-void mw::DataDevice::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_interface const* mw::DataDevice::Thunks::start_drag_types[] {
     &wl_data_source_interface_data,
     &wl_surface_interface_data,
@@ -1202,7 +1175,6 @@ struct mw::DataDeviceManager::Thunks
 
     static void create_data_source_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
-        auto me = static_cast<DataDeviceManager*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &wl_data_source_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -1212,6 +1184,7 @@ struct mw::DataDeviceManager::Thunks
         }
         try
         {
+            auto me = static_cast<DataDeviceManager*>(wl_resource_get_user_data(resource));
             me->create_data_source(id_resolved);
         }
         catch(ProtocolError const& err)
@@ -1226,7 +1199,6 @@ struct mw::DataDeviceManager::Thunks
 
     static void get_data_device_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* seat)
     {
-        auto me = static_cast<DataDeviceManager*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &wl_data_device_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -1236,6 +1208,7 @@ struct mw::DataDeviceManager::Thunks
         }
         try
         {
+            auto me = static_cast<DataDeviceManager*>(wl_resource_get_user_data(resource));
             me->get_data_device(id_resolved, seat);
         }
         catch(ProtocolError const& err)
@@ -1305,8 +1278,9 @@ bool mw::DataDeviceManager::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_data_device_manager_interface_data, Thunks::request_vtable);
 }
 
-void mw::DataDeviceManager::destroy_wayland_object() const
+void mw::DataDeviceManager::destroy_and_delete() const
 {
+    // Will result in this object being deleted
     wl_resource_destroy(resource);
 }
 
@@ -1358,7 +1332,6 @@ struct mw::Shell::Thunks
 
     static void get_shell_surface_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface)
     {
-        auto me = static_cast<Shell*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &wl_shell_surface_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -1368,6 +1341,7 @@ struct mw::Shell::Thunks
         }
         try
         {
+            auto me = static_cast<Shell*>(wl_resource_get_user_data(resource));
             me->get_shell_surface(id_resolved, surface);
         }
         catch(ProtocolError const& err)
@@ -1436,8 +1410,9 @@ bool mw::Shell::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_shell_interface_data, Thunks::request_vtable);
 }
 
-void mw::Shell::destroy_wayland_object() const
+void mw::Shell::destroy_and_delete() const
 {
+    // Will result in this object being deleted
     wl_resource_destroy(resource);
 }
 
@@ -1484,9 +1459,9 @@ struct mw::ShellSurface::Thunks
 
     static void pong_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial)
     {
-        auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
             me->pong(serial);
         }
         catch(ProtocolError const& err)
@@ -1501,9 +1476,9 @@ struct mw::ShellSurface::Thunks
 
     static void move_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* seat, uint32_t serial)
     {
-        auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
             me->move(seat, serial);
         }
         catch(ProtocolError const& err)
@@ -1518,9 +1493,9 @@ struct mw::ShellSurface::Thunks
 
     static void resize_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* seat, uint32_t serial, uint32_t edges)
     {
-        auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
             me->resize(seat, serial, edges);
         }
         catch(ProtocolError const& err)
@@ -1535,9 +1510,9 @@ struct mw::ShellSurface::Thunks
 
     static void set_toplevel_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
             me->set_toplevel();
         }
         catch(ProtocolError const& err)
@@ -1552,9 +1527,9 @@ struct mw::ShellSurface::Thunks
 
     static void set_transient_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* parent, int32_t x, int32_t y, uint32_t flags)
     {
-        auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
             me->set_transient(parent, x, y, flags);
         }
         catch(ProtocolError const& err)
@@ -1569,7 +1544,6 @@ struct mw::ShellSurface::Thunks
 
     static void set_fullscreen_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t method, uint32_t framerate, struct wl_resource* output)
     {
-        auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> output_resolved;
         if (output != nullptr)
         {
@@ -1577,6 +1551,7 @@ struct mw::ShellSurface::Thunks
         }
         try
         {
+            auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
             me->set_fullscreen(method, framerate, output_resolved);
         }
         catch(ProtocolError const& err)
@@ -1591,9 +1566,9 @@ struct mw::ShellSurface::Thunks
 
     static void set_popup_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* seat, uint32_t serial, struct wl_resource* parent, int32_t x, int32_t y, uint32_t flags)
     {
-        auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
             me->set_popup(seat, serial, parent, x, y, flags);
         }
         catch(ProtocolError const& err)
@@ -1608,7 +1583,6 @@ struct mw::ShellSurface::Thunks
 
     static void set_maximized_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* output)
     {
-        auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> output_resolved;
         if (output != nullptr)
         {
@@ -1616,6 +1590,7 @@ struct mw::ShellSurface::Thunks
         }
         try
         {
+            auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
             me->set_maximized(output_resolved);
         }
         catch(ProtocolError const& err)
@@ -1630,9 +1605,9 @@ struct mw::ShellSurface::Thunks
 
     static void set_title_thunk(struct wl_client* client, struct wl_resource* resource, char const* title)
     {
-        auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
             me->set_title(title);
         }
         catch(ProtocolError const& err)
@@ -1647,9 +1622,9 @@ struct mw::ShellSurface::Thunks
 
     static void set_class_thunk(struct wl_client* client, struct wl_resource* resource, char const* class_)
     {
-        auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ShellSurface*>(wl_resource_get_user_data(resource));
             me->set_class(class_);
         }
         catch(ProtocolError const& err)
@@ -1716,8 +1691,9 @@ bool mw::ShellSurface::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_shell_surface_interface_data, Thunks::request_vtable);
 }
 
-void mw::ShellSurface::destroy_wayland_object() const
+void mw::ShellSurface::destroy_and_delete() const
 {
+    // Will result in this object being deleted
     wl_resource_destroy(resource);
 }
 
@@ -1798,10 +1774,9 @@ struct mw::Surface::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -1815,7 +1790,6 @@ struct mw::Surface::Thunks
 
     static void attach_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* buffer, int32_t x, int32_t y)
     {
-        auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> buffer_resolved;
         if (buffer != nullptr)
         {
@@ -1823,6 +1797,7 @@ struct mw::Surface::Thunks
         }
         try
         {
+            auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
             me->attach(buffer_resolved, x, y);
         }
         catch(ProtocolError const& err)
@@ -1837,9 +1812,9 @@ struct mw::Surface::Thunks
 
     static void damage_thunk(struct wl_client* client, struct wl_resource* resource, int32_t x, int32_t y, int32_t width, int32_t height)
     {
-        auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
             me->damage(x, y, width, height);
         }
         catch(ProtocolError const& err)
@@ -1854,7 +1829,6 @@ struct mw::Surface::Thunks
 
     static void frame_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t callback)
     {
-        auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
         wl_resource* callback_resolved{
             wl_resource_create(client, &wl_callback_interface_data, wl_resource_get_version(resource), callback)};
         if (callback_resolved == nullptr)
@@ -1864,6 +1838,7 @@ struct mw::Surface::Thunks
         }
         try
         {
+            auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
             me->frame(callback_resolved);
         }
         catch(ProtocolError const& err)
@@ -1878,7 +1853,6 @@ struct mw::Surface::Thunks
 
     static void set_opaque_region_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* region)
     {
-        auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> region_resolved;
         if (region != nullptr)
         {
@@ -1886,6 +1860,7 @@ struct mw::Surface::Thunks
         }
         try
         {
+            auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
             me->set_opaque_region(region_resolved);
         }
         catch(ProtocolError const& err)
@@ -1900,7 +1875,6 @@ struct mw::Surface::Thunks
 
     static void set_input_region_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* region)
     {
-        auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> region_resolved;
         if (region != nullptr)
         {
@@ -1908,6 +1882,7 @@ struct mw::Surface::Thunks
         }
         try
         {
+            auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
             me->set_input_region(region_resolved);
         }
         catch(ProtocolError const& err)
@@ -1922,9 +1897,9 @@ struct mw::Surface::Thunks
 
     static void commit_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
             me->commit();
         }
         catch(ProtocolError const& err)
@@ -1939,9 +1914,9 @@ struct mw::Surface::Thunks
 
     static void set_buffer_transform_thunk(struct wl_client* client, struct wl_resource* resource, int32_t transform)
     {
-        auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
             me->set_buffer_transform(transform);
         }
         catch(ProtocolError const& err)
@@ -1956,9 +1931,9 @@ struct mw::Surface::Thunks
 
     static void set_buffer_scale_thunk(struct wl_client* client, struct wl_resource* resource, int32_t scale)
     {
-        auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
             me->set_buffer_scale(scale);
         }
         catch(ProtocolError const& err)
@@ -1973,9 +1948,9 @@ struct mw::Surface::Thunks
 
     static void damage_buffer_thunk(struct wl_client* client, struct wl_resource* resource, int32_t x, int32_t y, int32_t width, int32_t height)
     {
-        auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<Surface*>(wl_resource_get_user_data(resource));
             me->damage_buffer(x, y, width, height);
         }
         catch(ProtocolError const& err)
@@ -2035,11 +2010,6 @@ void mw::Surface::send_leave_event(struct wl_resource* output) const
 bool mw::Surface::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &wl_surface_interface_data, Thunks::request_vtable);
-}
-
-void mw::Surface::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
 }
 
 struct wl_interface const* mw::Surface::Thunks::attach_types[] {
@@ -2107,7 +2077,6 @@ struct mw::Seat::Thunks
 
     static void get_pointer_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
-        auto me = static_cast<Seat*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &wl_pointer_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -2117,6 +2086,7 @@ struct mw::Seat::Thunks
         }
         try
         {
+            auto me = static_cast<Seat*>(wl_resource_get_user_data(resource));
             me->get_pointer(id_resolved);
         }
         catch(ProtocolError const& err)
@@ -2131,7 +2101,6 @@ struct mw::Seat::Thunks
 
     static void get_keyboard_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
-        auto me = static_cast<Seat*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &wl_keyboard_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -2141,6 +2110,7 @@ struct mw::Seat::Thunks
         }
         try
         {
+            auto me = static_cast<Seat*>(wl_resource_get_user_data(resource));
             me->get_keyboard(id_resolved);
         }
         catch(ProtocolError const& err)
@@ -2155,7 +2125,6 @@ struct mw::Seat::Thunks
 
     static void get_touch_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
-        auto me = static_cast<Seat*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &wl_touch_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -2165,6 +2134,7 @@ struct mw::Seat::Thunks
         }
         try
         {
+            auto me = static_cast<Seat*>(wl_resource_get_user_data(resource));
             me->get_touch(id_resolved);
         }
         catch(ProtocolError const& err)
@@ -2179,10 +2149,9 @@ struct mw::Seat::Thunks
 
     static void release_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Seat*>(wl_resource_get_user_data(resource));
         try
         {
-            me->release();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -2269,11 +2238,6 @@ bool mw::Seat::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_seat_interface_data, Thunks::request_vtable);
 }
 
-void mw::Seat::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 mw::Seat::Global::Global(wl_display* display, Version<6>)
     : wayland::Global{
           wl_global_create(
@@ -2332,7 +2296,6 @@ struct mw::Pointer::Thunks
 
     static void set_cursor_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial, struct wl_resource* surface, int32_t hotspot_x, int32_t hotspot_y)
     {
-        auto me = static_cast<Pointer*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> surface_resolved;
         if (surface != nullptr)
         {
@@ -2340,6 +2303,7 @@ struct mw::Pointer::Thunks
         }
         try
         {
+            auto me = static_cast<Pointer*>(wl_resource_get_user_data(resource));
             me->set_cursor(serial, surface_resolved, hotspot_x, hotspot_y);
         }
         catch(ProtocolError const& err)
@@ -2354,10 +2318,9 @@ struct mw::Pointer::Thunks
 
     static void release_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Pointer*>(wl_resource_get_user_data(resource));
         try
         {
-            me->release();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -2475,11 +2438,6 @@ bool mw::Pointer::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_pointer_interface_data, Thunks::request_vtable);
 }
 
-void mw::Pointer::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_interface const* mw::Pointer::Thunks::set_cursor_types[] {
     nullptr,
     &wl_surface_interface_data,
@@ -2532,10 +2490,9 @@ struct mw::Keyboard::Thunks
 
     static void release_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Keyboard*>(wl_resource_get_user_data(resource));
         try
         {
-            me->release();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -2618,11 +2575,6 @@ bool mw::Keyboard::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_keyboard_interface_data, Thunks::request_vtable);
 }
 
-void mw::Keyboard::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_interface const* mw::Keyboard::Thunks::enter_types[] {
     nullptr,
     &wl_surface_interface_data,
@@ -2663,10 +2615,9 @@ struct mw::Touch::Thunks
 
     static void release_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Touch*>(wl_resource_get_user_data(resource));
         try
         {
-            me->release();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -2764,11 +2715,6 @@ bool mw::Touch::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_touch_interface_data, Thunks::request_vtable);
 }
 
-void mw::Touch::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_interface const* mw::Touch::Thunks::down_types[] {
     nullptr,
     nullptr,
@@ -2809,10 +2755,9 @@ struct mw::Output::Thunks
 
     static void release_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Output*>(wl_resource_get_user_data(resource));
         try
         {
-            me->release();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -2913,11 +2858,6 @@ bool mw::Output::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_output_interface_data, Thunks::request_vtable);
 }
 
-void mw::Output::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 mw::Output::Global::Global(wl_display* display, Version<3>)
     : wayland::Global{
           wl_global_create(
@@ -2973,10 +2913,9 @@ struct mw::Region::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Region*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -2990,9 +2929,9 @@ struct mw::Region::Thunks
 
     static void add_thunk(struct wl_client* client, struct wl_resource* resource, int32_t x, int32_t y, int32_t width, int32_t height)
     {
-        auto me = static_cast<Region*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<Region*>(wl_resource_get_user_data(resource));
             me->add(x, y, width, height);
         }
         catch(ProtocolError const& err)
@@ -3007,9 +2946,9 @@ struct mw::Region::Thunks
 
     static void subtract_thunk(struct wl_client* client, struct wl_resource* resource, int32_t x, int32_t y, int32_t width, int32_t height)
     {
-        auto me = static_cast<Region*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<Region*>(wl_resource_get_user_data(resource));
             me->subtract(x, y, width, height);
         }
         catch(ProtocolError const& err)
@@ -3054,11 +2993,6 @@ bool mw::Region::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_region_interface_data, Thunks::request_vtable);
 }
 
-void mw::Region::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_message const mw::Region::Thunks::request_messages[] {
     {"destroy", "", all_null_types},
     {"add", "iiii", all_null_types},
@@ -3086,10 +3020,9 @@ struct mw::Subcompositor::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Subcompositor*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -3103,7 +3036,6 @@ struct mw::Subcompositor::Thunks
 
     static void get_subsurface_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface, struct wl_resource* parent)
     {
-        auto me = static_cast<Subcompositor*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &wl_subsurface_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -3113,6 +3045,7 @@ struct mw::Subcompositor::Thunks
         }
         try
         {
+            auto me = static_cast<Subcompositor*>(wl_resource_get_user_data(resource));
             me->get_subsurface(id_resolved, surface, parent);
         }
         catch(ProtocolError const& err)
@@ -3181,11 +3114,6 @@ bool mw::Subcompositor::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &wl_subcompositor_interface_data, Thunks::request_vtable);
 }
 
-void mw::Subcompositor::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 mw::Subcompositor::Global::Global(wl_display* display, Version<1>)
     : wayland::Global{
           wl_global_create(
@@ -3232,10 +3160,9 @@ struct mw::Subsurface::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -3249,9 +3176,9 @@ struct mw::Subsurface::Thunks
 
     static void set_position_thunk(struct wl_client* client, struct wl_resource* resource, int32_t x, int32_t y)
     {
-        auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
             me->set_position(x, y);
         }
         catch(ProtocolError const& err)
@@ -3266,9 +3193,9 @@ struct mw::Subsurface::Thunks
 
     static void place_above_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* sibling)
     {
-        auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
             me->place_above(sibling);
         }
         catch(ProtocolError const& err)
@@ -3283,9 +3210,9 @@ struct mw::Subsurface::Thunks
 
     static void place_below_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* sibling)
     {
-        auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
             me->place_below(sibling);
         }
         catch(ProtocolError const& err)
@@ -3300,9 +3227,9 @@ struct mw::Subsurface::Thunks
 
     static void set_sync_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
             me->set_sync();
         }
         catch(ProtocolError const& err)
@@ -3317,9 +3244,9 @@ struct mw::Subsurface::Thunks
 
     static void set_desync_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<Subsurface*>(wl_resource_get_user_data(resource));
             me->set_desync();
         }
         catch(ProtocolError const& err)
@@ -3364,11 +3291,6 @@ mw::Subsurface::~Subsurface()
 bool mw::Subsurface::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &wl_subsurface_interface_data, Thunks::request_vtable);
-}
-
-void mw::Subsurface::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
 }
 
 struct wl_interface const* mw::Subsurface::Thunks::place_above_types[] {

--- a/src/wayland/generated/wayland_wrapper.h
+++ b/src/wayland/generated/wayland_wrapper.h
@@ -53,7 +53,7 @@ public:
 
     void send_done_event(uint32_t callback_data) const;
 
-    void destroy_wayland_object() const;
+    void destroy_and_delete() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -80,7 +80,7 @@ public:
     Compositor(struct wl_resource* resource, Version<4>);
     virtual ~Compositor();
 
-    void destroy_wayland_object() const;
+    void destroy_and_delete() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -116,8 +116,6 @@ public:
     ShmPool(struct wl_resource* resource, Version<1>);
     virtual ~ShmPool();
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -127,7 +125,6 @@ public:
 
 private:
     virtual void create_buffer(struct wl_resource* id, int32_t offset, int32_t width, int32_t height, int32_t stride, uint32_t format) = 0;
-    virtual void destroy() = 0;
     virtual void resize(int32_t size) = 0;
 };
 
@@ -143,7 +140,7 @@ public:
 
     void send_format_event(uint32_t format) const;
 
-    void destroy_wayland_object() const;
+    void destroy_and_delete() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -254,8 +251,6 @@ public:
 
     void send_release_event() const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -269,7 +264,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
 };
 
 class DataOffer : public Resource
@@ -287,8 +281,6 @@ public:
     void send_source_actions_event(uint32_t source_actions) const;
     bool version_supports_action();
     void send_action_event(uint32_t dnd_action) const;
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -315,7 +307,6 @@ public:
 private:
     virtual void accept(uint32_t serial, std::experimental::optional<std::string> const& mime_type) = 0;
     virtual void receive(std::string const& mime_type, mir::Fd fd) = 0;
-    virtual void destroy() = 0;
     virtual void finish() = 0;
     virtual void set_actions(uint32_t dnd_actions, uint32_t preferred_action) = 0;
 };
@@ -339,8 +330,6 @@ public:
     void send_dnd_finished_event() const;
     bool version_supports_action();
     void send_action_event(uint32_t dnd_action) const;
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -367,7 +356,6 @@ public:
 
 private:
     virtual void offer(std::string const& mime_type) = 0;
-    virtual void destroy() = 0;
     virtual void set_actions(uint32_t dnd_actions) = 0;
 };
 
@@ -387,8 +375,6 @@ public:
     void send_motion_event(uint32_t time, double x, double y) const;
     void send_drop_event() const;
     void send_selection_event(std::experimental::optional<struct wl_resource*> const& id) const;
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -415,7 +401,6 @@ public:
 private:
     virtual void start_drag(std::experimental::optional<struct wl_resource*> const& source, struct wl_resource* origin, std::experimental::optional<struct wl_resource*> const& icon, uint32_t serial) = 0;
     virtual void set_selection(std::experimental::optional<struct wl_resource*> const& source, uint32_t serial) = 0;
-    virtual void release() = 0;
 };
 
 class DataDeviceManager : public Resource
@@ -428,7 +413,7 @@ public:
     DataDeviceManager(struct wl_resource* resource, Version<3>);
     virtual ~DataDeviceManager();
 
-    void destroy_wayland_object() const;
+    void destroy_and_delete() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -472,7 +457,7 @@ public:
     Shell(struct wl_resource* resource, Version<1>);
     virtual ~Shell();
 
-    void destroy_wayland_object() const;
+    void destroy_and_delete() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -516,7 +501,7 @@ public:
     void send_configure_event(uint32_t edges, int32_t width, int32_t height) const;
     void send_popup_done_event() const;
 
-    void destroy_wayland_object() const;
+    void destroy_and_delete() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -584,8 +569,6 @@ public:
     void send_enter_event(struct wl_resource* output) const;
     void send_leave_event(struct wl_resource* output) const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -606,7 +589,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void attach(std::experimental::optional<struct wl_resource*> const& buffer, int32_t x, int32_t y) = 0;
     virtual void damage(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
     virtual void frame(struct wl_resource* callback) = 0;
@@ -631,8 +613,6 @@ public:
     void send_capabilities_event(uint32_t capabilities) const;
     bool version_supports_name();
     void send_name_event(std::string const& name) const;
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -670,7 +650,6 @@ private:
     virtual void get_pointer(struct wl_resource* id) = 0;
     virtual void get_keyboard(struct wl_resource* id) = 0;
     virtual void get_touch(struct wl_resource* id) = 0;
-    virtual void release() = 0;
 };
 
 class Pointer : public Resource
@@ -696,8 +675,6 @@ public:
     void send_axis_stop_event(uint32_t time, uint32_t axis) const;
     bool version_supports_axis_discrete();
     void send_axis_discrete_event(uint32_t axis, int32_t discrete) const;
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -746,7 +723,6 @@ public:
 
 private:
     virtual void set_cursor(uint32_t serial, std::experimental::optional<struct wl_resource*> const& surface, int32_t hotspot_x, int32_t hotspot_y) = 0;
-    virtual void release() = 0;
 };
 
 class Keyboard : public Resource
@@ -766,8 +742,6 @@ public:
     void send_modifiers_event(uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group) const;
     bool version_supports_repeat_info();
     void send_repeat_info_event(int32_t rate, int32_t delay) const;
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -799,7 +773,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void release() = 0;
 };
 
 class Touch : public Resource
@@ -822,8 +795,6 @@ public:
     bool version_supports_orientation();
     void send_orientation_event(int32_t id, double orientation) const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -843,7 +814,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void release() = 0;
 };
 
 class Output : public Resource
@@ -862,8 +832,6 @@ public:
     void send_done_event() const;
     bool version_supports_scale();
     void send_scale_event(int32_t factor) const;
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -921,7 +889,6 @@ public:
     };
 
 private:
-    virtual void release() = 0;
 };
 
 class Region : public Resource
@@ -934,8 +901,6 @@ public:
     Region(struct wl_resource* resource, Version<1>);
     virtual ~Region();
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -944,7 +909,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void add(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
     virtual void subtract(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
 };
@@ -958,8 +922,6 @@ public:
 
     Subcompositor(struct wl_resource* resource, Version<1>);
     virtual ~Subcompositor();
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -986,7 +948,6 @@ public:
     };
 
 private:
-    virtual void destroy() = 0;
     virtual void get_subsurface(struct wl_resource* id, struct wl_resource* surface, struct wl_resource* parent) = 0;
 };
 
@@ -999,8 +960,6 @@ public:
 
     Subsurface(struct wl_resource* resource, Version<1>);
     virtual ~Subsurface();
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -1015,7 +974,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void set_position(int32_t x, int32_t y) = 0;
     virtual void place_above(struct wl_resource* sibling) = 0;
     virtual void place_below(struct wl_resource* sibling) = 0;

--- a/src/wayland/generated/wlr-foreign-toplevel-management-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-foreign-toplevel-management-unstable-v1_wrapper.cpp
@@ -47,9 +47,9 @@ struct mw::ForeignToplevelManagerV1::Thunks
 
     static void stop_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<ForeignToplevelManagerV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ForeignToplevelManagerV1*>(wl_resource_get_user_data(resource));
             me->stop();
         }
         catch(ProtocolError const& err)
@@ -129,8 +129,9 @@ bool mw::ForeignToplevelManagerV1::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &zwlr_foreign_toplevel_manager_v1_interface_data, Thunks::request_vtable);
 }
 
-void mw::ForeignToplevelManagerV1::destroy_wayland_object() const
+void mw::ForeignToplevelManagerV1::destroy_and_delete() const
 {
+    // Will result in this object being deleted
     wl_resource_destroy(resource);
 }
 
@@ -180,9 +181,9 @@ struct mw::ForeignToplevelHandleV1::Thunks
 
     static void set_maximized_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
             me->set_maximized();
         }
         catch(ProtocolError const& err)
@@ -197,9 +198,9 @@ struct mw::ForeignToplevelHandleV1::Thunks
 
     static void unset_maximized_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
             me->unset_maximized();
         }
         catch(ProtocolError const& err)
@@ -214,9 +215,9 @@ struct mw::ForeignToplevelHandleV1::Thunks
 
     static void set_minimized_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
             me->set_minimized();
         }
         catch(ProtocolError const& err)
@@ -231,9 +232,9 @@ struct mw::ForeignToplevelHandleV1::Thunks
 
     static void unset_minimized_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
             me->unset_minimized();
         }
         catch(ProtocolError const& err)
@@ -248,9 +249,9 @@ struct mw::ForeignToplevelHandleV1::Thunks
 
     static void activate_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* seat)
     {
-        auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
             me->activate(seat);
         }
         catch(ProtocolError const& err)
@@ -265,9 +266,9 @@ struct mw::ForeignToplevelHandleV1::Thunks
 
     static void close_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
             me->close();
         }
         catch(ProtocolError const& err)
@@ -282,9 +283,9 @@ struct mw::ForeignToplevelHandleV1::Thunks
 
     static void set_rectangle_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* surface, int32_t x, int32_t y, int32_t width, int32_t height)
     {
-        auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
             me->set_rectangle(surface, x, y, width, height);
         }
         catch(ProtocolError const& err)
@@ -299,10 +300,9 @@ struct mw::ForeignToplevelHandleV1::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -316,7 +316,6 @@ struct mw::ForeignToplevelHandleV1::Thunks
 
     static void set_fullscreen_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* output)
     {
-        auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> output_resolved;
         if (output != nullptr)
         {
@@ -324,6 +323,7 @@ struct mw::ForeignToplevelHandleV1::Thunks
         }
         try
         {
+            auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
             me->set_fullscreen(output_resolved);
         }
         catch(ProtocolError const& err)
@@ -338,9 +338,9 @@ struct mw::ForeignToplevelHandleV1::Thunks
 
     static void unset_fullscreen_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<ForeignToplevelHandleV1*>(wl_resource_get_user_data(resource));
             me->unset_fullscreen();
         }
         catch(ProtocolError const& err)
@@ -426,11 +426,6 @@ void mw::ForeignToplevelHandleV1::send_closed_event() const
 bool mw::ForeignToplevelHandleV1::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &zwlr_foreign_toplevel_handle_v1_interface_data, Thunks::request_vtable);
-}
-
-void mw::ForeignToplevelHandleV1::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
 }
 
 struct wl_interface const* mw::ForeignToplevelHandleV1::Thunks::activate_types[] {

--- a/src/wayland/generated/wlr-foreign-toplevel-management-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-foreign-toplevel-management-unstable-v1_wrapper.h
@@ -36,7 +36,7 @@ public:
     void send_toplevel_event(struct wl_resource* toplevel) const;
     void send_finished_event() const;
 
-    void destroy_wayland_object() const;
+    void destroy_and_delete() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -85,8 +85,6 @@ public:
     void send_done_event() const;
     void send_closed_event() const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -126,7 +124,6 @@ private:
     virtual void activate(struct wl_resource* seat) = 0;
     virtual void close() = 0;
     virtual void set_rectangle(struct wl_resource* surface, int32_t x, int32_t y, int32_t width, int32_t height) = 0;
-    virtual void destroy() = 0;
     virtual void set_fullscreen(std::experimental::optional<struct wl_resource*> const& output) = 0;
     virtual void unset_fullscreen() = 0;
 };

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
@@ -47,7 +47,6 @@ struct mw::LayerShellV1::Thunks
 
     static void get_layer_surface_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface, struct wl_resource* output, uint32_t layer, char const* namespace_)
     {
-        auto me = static_cast<LayerShellV1*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &zwlr_layer_surface_v1_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -62,6 +61,7 @@ struct mw::LayerShellV1::Thunks
         }
         try
         {
+            auto me = static_cast<LayerShellV1*>(wl_resource_get_user_data(resource));
             me->get_layer_surface(id_resolved, surface, output_resolved, layer, namespace_);
         }
         catch(ProtocolError const& err)
@@ -76,10 +76,9 @@ struct mw::LayerShellV1::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<LayerShellV1*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -147,11 +146,6 @@ bool mw::LayerShellV1::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &zwlr_layer_shell_v1_interface_data, Thunks::request_vtable);
 }
 
-void mw::LayerShellV1::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 mw::LayerShellV1::Global::Global(wl_display* display, Version<3>)
     : wayland::Global{
           wl_global_create(
@@ -200,9 +194,9 @@ struct mw::LayerSurfaceV1::Thunks
 
     static void set_size_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t width, uint32_t height)
     {
-        auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
             me->set_size(width, height);
         }
         catch(ProtocolError const& err)
@@ -217,9 +211,9 @@ struct mw::LayerSurfaceV1::Thunks
 
     static void set_anchor_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t anchor)
     {
-        auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
             me->set_anchor(anchor);
         }
         catch(ProtocolError const& err)
@@ -234,9 +228,9 @@ struct mw::LayerSurfaceV1::Thunks
 
     static void set_exclusive_zone_thunk(struct wl_client* client, struct wl_resource* resource, int32_t zone)
     {
-        auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
             me->set_exclusive_zone(zone);
         }
         catch(ProtocolError const& err)
@@ -251,9 +245,9 @@ struct mw::LayerSurfaceV1::Thunks
 
     static void set_margin_thunk(struct wl_client* client, struct wl_resource* resource, int32_t top, int32_t right, int32_t bottom, int32_t left)
     {
-        auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
             me->set_margin(top, right, bottom, left);
         }
         catch(ProtocolError const& err)
@@ -268,9 +262,9 @@ struct mw::LayerSurfaceV1::Thunks
 
     static void set_keyboard_interactivity_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t keyboard_interactivity)
     {
-        auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
             me->set_keyboard_interactivity(keyboard_interactivity);
         }
         catch(ProtocolError const& err)
@@ -285,9 +279,9 @@ struct mw::LayerSurfaceV1::Thunks
 
     static void get_popup_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* popup)
     {
-        auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
             me->get_popup(popup);
         }
         catch(ProtocolError const& err)
@@ -302,9 +296,9 @@ struct mw::LayerSurfaceV1::Thunks
 
     static void ack_configure_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial)
     {
-        auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
             me->ack_configure(serial);
         }
         catch(ProtocolError const& err)
@@ -319,10 +313,9 @@ struct mw::LayerSurfaceV1::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -336,9 +329,9 @@ struct mw::LayerSurfaceV1::Thunks
 
     static void set_layer_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t layer)
     {
-        auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<LayerSurfaceV1*>(wl_resource_get_user_data(resource));
             me->set_layer(layer);
         }
         catch(ProtocolError const& err)
@@ -393,11 +386,6 @@ void mw::LayerSurfaceV1::send_closed_event() const
 bool mw::LayerSurfaceV1::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &zwlr_layer_surface_v1_interface_data, Thunks::request_vtable);
-}
-
-void mw::LayerSurfaceV1::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
 }
 
 struct wl_interface const* mw::LayerSurfaceV1::Thunks::get_popup_types[] {

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
@@ -33,8 +33,6 @@ public:
     LayerShellV1(struct wl_resource* resource, Version<3>);
     virtual ~LayerShellV1();
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -71,7 +69,6 @@ public:
 
 private:
     virtual void get_layer_surface(struct wl_resource* id, struct wl_resource* surface, std::experimental::optional<struct wl_resource*> const& output, uint32_t layer, std::string const& namespace_) = 0;
-    virtual void destroy() = 0;
 };
 
 class LayerSurfaceV1 : public Resource
@@ -86,8 +83,6 @@ public:
 
     void send_configure_event(uint32_t serial, uint32_t width, uint32_t height) const;
     void send_closed_event() const;
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -125,7 +120,6 @@ private:
     virtual void set_keyboard_interactivity(uint32_t keyboard_interactivity) = 0;
     virtual void get_popup(struct wl_resource* popup) = 0;
     virtual void ack_configure(uint32_t serial) = 0;
-    virtual void destroy() = 0;
     virtual void set_layer(uint32_t layer) = 0;
 };
 

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.cpp
@@ -45,10 +45,9 @@ struct mw::XdgOutputManagerV1::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgOutputManagerV1*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -62,7 +61,6 @@ struct mw::XdgOutputManagerV1::Thunks
 
     static void get_xdg_output_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* output)
     {
-        auto me = static_cast<XdgOutputManagerV1*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &zxdg_output_v1_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -72,6 +70,7 @@ struct mw::XdgOutputManagerV1::Thunks
         }
         try
         {
+            auto me = static_cast<XdgOutputManagerV1*>(wl_resource_get_user_data(resource));
             me->get_xdg_output(id_resolved, output);
         }
         catch(ProtocolError const& err)
@@ -140,11 +139,6 @@ bool mw::XdgOutputManagerV1::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &zxdg_output_manager_v1_interface_data, Thunks::request_vtable);
 }
 
-void mw::XdgOutputManagerV1::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 mw::XdgOutputManagerV1::Global::Global(wl_display* display, Version<3>)
     : wayland::Global{
           wl_global_create(
@@ -190,10 +184,9 @@ struct mw::XdgOutputV1::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgOutputV1*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -273,11 +266,6 @@ void mw::XdgOutputV1::send_description_event(std::string const& description) con
 bool mw::XdgOutputV1::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &zxdg_output_v1_interface_data, Thunks::request_vtable);
-}
-
-void mw::XdgOutputV1::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
 }
 
 struct wl_message const mw::XdgOutputV1::Thunks::request_messages[] {

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
@@ -33,8 +33,6 @@ public:
     XdgOutputManagerV1(struct wl_resource* resource, Version<3>);
     virtual ~XdgOutputManagerV1();
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -55,7 +53,6 @@ public:
     };
 
 private:
-    virtual void destroy() = 0;
     virtual void get_xdg_output(struct wl_resource* id, struct wl_resource* output) = 0;
 };
 
@@ -77,8 +74,6 @@ public:
     bool version_supports_description();
     void send_description_event(std::string const& description) const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -96,7 +91,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
 };
 
 }

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
@@ -50,10 +50,9 @@ struct mw::XdgShellV6::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgShellV6*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -67,7 +66,6 @@ struct mw::XdgShellV6::Thunks
 
     static void create_positioner_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
-        auto me = static_cast<XdgShellV6*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &zxdg_positioner_v6_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -77,6 +75,7 @@ struct mw::XdgShellV6::Thunks
         }
         try
         {
+            auto me = static_cast<XdgShellV6*>(wl_resource_get_user_data(resource));
             me->create_positioner(id_resolved);
         }
         catch(ProtocolError const& err)
@@ -91,7 +90,6 @@ struct mw::XdgShellV6::Thunks
 
     static void get_xdg_surface_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface)
     {
-        auto me = static_cast<XdgShellV6*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &zxdg_surface_v6_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -101,6 +99,7 @@ struct mw::XdgShellV6::Thunks
         }
         try
         {
+            auto me = static_cast<XdgShellV6*>(wl_resource_get_user_data(resource));
             me->get_xdg_surface(id_resolved, surface);
         }
         catch(ProtocolError const& err)
@@ -115,9 +114,9 @@ struct mw::XdgShellV6::Thunks
 
     static void pong_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial)
     {
-        auto me = static_cast<XdgShellV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgShellV6*>(wl_resource_get_user_data(resource));
             me->pong(serial);
         }
         catch(ProtocolError const& err)
@@ -193,11 +192,6 @@ bool mw::XdgShellV6::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &zxdg_shell_v6_interface_data, Thunks::request_vtable);
 }
 
-void mw::XdgShellV6::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 mw::XdgShellV6::Global::Global(wl_display* display, Version<1>)
     : wayland::Global{
           wl_global_create(
@@ -253,10 +247,9 @@ struct mw::XdgPositionerV6::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -270,9 +263,9 @@ struct mw::XdgPositionerV6::Thunks
 
     static void set_size_thunk(struct wl_client* client, struct wl_resource* resource, int32_t width, int32_t height)
     {
-        auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
             me->set_size(width, height);
         }
         catch(ProtocolError const& err)
@@ -287,9 +280,9 @@ struct mw::XdgPositionerV6::Thunks
 
     static void set_anchor_rect_thunk(struct wl_client* client, struct wl_resource* resource, int32_t x, int32_t y, int32_t width, int32_t height)
     {
-        auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
             me->set_anchor_rect(x, y, width, height);
         }
         catch(ProtocolError const& err)
@@ -304,9 +297,9 @@ struct mw::XdgPositionerV6::Thunks
 
     static void set_anchor_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t anchor)
     {
-        auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
             me->set_anchor(anchor);
         }
         catch(ProtocolError const& err)
@@ -321,9 +314,9 @@ struct mw::XdgPositionerV6::Thunks
 
     static void set_gravity_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t gravity)
     {
-        auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
             me->set_gravity(gravity);
         }
         catch(ProtocolError const& err)
@@ -338,9 +331,9 @@ struct mw::XdgPositionerV6::Thunks
 
     static void set_constraint_adjustment_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t constraint_adjustment)
     {
-        auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
             me->set_constraint_adjustment(constraint_adjustment);
         }
         catch(ProtocolError const& err)
@@ -355,9 +348,9 @@ struct mw::XdgPositionerV6::Thunks
 
     static void set_offset_thunk(struct wl_client* client, struct wl_resource* resource, int32_t x, int32_t y)
     {
-        auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPositionerV6*>(wl_resource_get_user_data(resource));
             me->set_offset(x, y);
         }
         catch(ProtocolError const& err)
@@ -402,11 +395,6 @@ bool mw::XdgPositionerV6::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &zxdg_positioner_v6_interface_data, Thunks::request_vtable);
 }
 
-void mw::XdgPositionerV6::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_message const mw::XdgPositionerV6::Thunks::request_messages[] {
     {"destroy", "", all_null_types},
     {"set_size", "ii", all_null_types},
@@ -442,10 +430,9 @@ struct mw::XdgSurfaceV6::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -459,7 +446,6 @@ struct mw::XdgSurfaceV6::Thunks
 
     static void get_toplevel_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
-        auto me = static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &zxdg_toplevel_v6_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -469,6 +455,7 @@ struct mw::XdgSurfaceV6::Thunks
         }
         try
         {
+            auto me = static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
             me->get_toplevel(id_resolved);
         }
         catch(ProtocolError const& err)
@@ -483,7 +470,6 @@ struct mw::XdgSurfaceV6::Thunks
 
     static void get_popup_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* parent, struct wl_resource* positioner)
     {
-        auto me = static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &zxdg_popup_v6_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -493,6 +479,7 @@ struct mw::XdgSurfaceV6::Thunks
         }
         try
         {
+            auto me = static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
             me->get_popup(id_resolved, parent, positioner);
         }
         catch(ProtocolError const& err)
@@ -507,9 +494,9 @@ struct mw::XdgSurfaceV6::Thunks
 
     static void set_window_geometry_thunk(struct wl_client* client, struct wl_resource* resource, int32_t x, int32_t y, int32_t width, int32_t height)
     {
-        auto me = static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
             me->set_window_geometry(x, y, width, height);
         }
         catch(ProtocolError const& err)
@@ -524,9 +511,9 @@ struct mw::XdgSurfaceV6::Thunks
 
     static void ack_configure_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial)
     {
-        auto me = static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgSurfaceV6*>(wl_resource_get_user_data(resource));
             me->ack_configure(serial);
         }
         catch(ProtocolError const& err)
@@ -579,11 +566,6 @@ bool mw::XdgSurfaceV6::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &zxdg_surface_v6_interface_data, Thunks::request_vtable);
 }
 
-void mw::XdgSurfaceV6::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_interface const* mw::XdgSurfaceV6::Thunks::get_toplevel_types[] {
     &zxdg_toplevel_v6_interface_data};
 
@@ -626,10 +608,9 @@ struct mw::XdgToplevelV6::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -643,7 +624,6 @@ struct mw::XdgToplevelV6::Thunks
 
     static void set_parent_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* parent)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> parent_resolved;
         if (parent != nullptr)
         {
@@ -651,6 +631,7 @@ struct mw::XdgToplevelV6::Thunks
         }
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->set_parent(parent_resolved);
         }
         catch(ProtocolError const& err)
@@ -665,9 +646,9 @@ struct mw::XdgToplevelV6::Thunks
 
     static void set_title_thunk(struct wl_client* client, struct wl_resource* resource, char const* title)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->set_title(title);
         }
         catch(ProtocolError const& err)
@@ -682,9 +663,9 @@ struct mw::XdgToplevelV6::Thunks
 
     static void set_app_id_thunk(struct wl_client* client, struct wl_resource* resource, char const* app_id)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->set_app_id(app_id);
         }
         catch(ProtocolError const& err)
@@ -699,9 +680,9 @@ struct mw::XdgToplevelV6::Thunks
 
     static void show_window_menu_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->show_window_menu(seat, serial, x, y);
         }
         catch(ProtocolError const& err)
@@ -716,9 +697,9 @@ struct mw::XdgToplevelV6::Thunks
 
     static void move_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* seat, uint32_t serial)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->move(seat, serial);
         }
         catch(ProtocolError const& err)
@@ -733,9 +714,9 @@ struct mw::XdgToplevelV6::Thunks
 
     static void resize_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* seat, uint32_t serial, uint32_t edges)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->resize(seat, serial, edges);
         }
         catch(ProtocolError const& err)
@@ -750,9 +731,9 @@ struct mw::XdgToplevelV6::Thunks
 
     static void set_max_size_thunk(struct wl_client* client, struct wl_resource* resource, int32_t width, int32_t height)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->set_max_size(width, height);
         }
         catch(ProtocolError const& err)
@@ -767,9 +748,9 @@ struct mw::XdgToplevelV6::Thunks
 
     static void set_min_size_thunk(struct wl_client* client, struct wl_resource* resource, int32_t width, int32_t height)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->set_min_size(width, height);
         }
         catch(ProtocolError const& err)
@@ -784,9 +765,9 @@ struct mw::XdgToplevelV6::Thunks
 
     static void set_maximized_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->set_maximized();
         }
         catch(ProtocolError const& err)
@@ -801,9 +782,9 @@ struct mw::XdgToplevelV6::Thunks
 
     static void unset_maximized_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->unset_maximized();
         }
         catch(ProtocolError const& err)
@@ -818,7 +799,6 @@ struct mw::XdgToplevelV6::Thunks
 
     static void set_fullscreen_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* output)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> output_resolved;
         if (output != nullptr)
         {
@@ -826,6 +806,7 @@ struct mw::XdgToplevelV6::Thunks
         }
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->set_fullscreen(output_resolved);
         }
         catch(ProtocolError const& err)
@@ -840,9 +821,9 @@ struct mw::XdgToplevelV6::Thunks
 
     static void unset_fullscreen_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->unset_fullscreen();
         }
         catch(ProtocolError const& err)
@@ -857,9 +838,9 @@ struct mw::XdgToplevelV6::Thunks
 
     static void set_minimized_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevelV6*>(wl_resource_get_user_data(resource));
             me->set_minimized();
         }
         catch(ProtocolError const& err)
@@ -918,11 +899,6 @@ void mw::XdgToplevelV6::send_close_event() const
 bool mw::XdgToplevelV6::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &zxdg_toplevel_v6_interface_data, Thunks::request_vtable);
-}
-
-void mw::XdgToplevelV6::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
 }
 
 struct wl_interface const* mw::XdgToplevelV6::Thunks::set_parent_types[] {
@@ -999,10 +975,9 @@ struct mw::XdgPopupV6::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgPopupV6*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -1016,9 +991,9 @@ struct mw::XdgPopupV6::Thunks
 
     static void grab_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* seat, uint32_t serial)
     {
-        auto me = static_cast<XdgPopupV6*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPopupV6*>(wl_resource_get_user_data(resource));
             me->grab(seat, serial);
         }
         catch(ProtocolError const& err)
@@ -1073,11 +1048,6 @@ void mw::XdgPopupV6::send_popup_done_event() const
 bool mw::XdgPopupV6::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &zxdg_popup_v6_interface_data, Thunks::request_vtable);
-}
-
-void mw::XdgPopupV6::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
 }
 
 struct wl_interface const* mw::XdgPopupV6::Thunks::grab_types[] {

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -38,8 +38,6 @@ public:
 
     void send_ping_event(uint32_t serial) const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -75,7 +73,6 @@ public:
     };
 
 private:
-    virtual void destroy() = 0;
     virtual void create_positioner(struct wl_resource* id) = 0;
     virtual void get_xdg_surface(struct wl_resource* id, struct wl_resource* surface) = 0;
     virtual void pong(uint32_t serial) = 0;
@@ -90,8 +87,6 @@ public:
 
     XdgPositionerV6(struct wl_resource* resource, Version<1>);
     virtual ~XdgPositionerV6();
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -135,7 +130,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void set_size(int32_t width, int32_t height) = 0;
     virtual void set_anchor_rect(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
     virtual void set_anchor(uint32_t anchor) = 0;
@@ -155,8 +149,6 @@ public:
     virtual ~XdgSurfaceV6();
 
     void send_configure_event(uint32_t serial) const;
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -178,7 +170,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void get_toplevel(struct wl_resource* id) = 0;
     virtual void get_popup(struct wl_resource* id, struct wl_resource* parent, struct wl_resource* positioner) = 0;
     virtual void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
@@ -197,8 +188,6 @@ public:
 
     void send_configure_event(int32_t width, int32_t height, struct wl_array* states) const;
     void send_close_event() const;
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -235,7 +224,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void set_parent(std::experimental::optional<struct wl_resource*> const& parent) = 0;
     virtual void set_title(std::string const& title) = 0;
     virtual void set_app_id(std::string const& app_id) = 0;
@@ -264,8 +252,6 @@ public:
     void send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const;
     void send_popup_done_event() const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -285,7 +271,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void grab(struct wl_resource* seat, uint32_t serial) = 0;
 };
 

--- a/src/wayland/generated/xdg-shell_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell_wrapper.cpp
@@ -50,10 +50,9 @@ struct mw::XdgWmBase::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgWmBase*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -67,7 +66,6 @@ struct mw::XdgWmBase::Thunks
 
     static void create_positioner_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
-        auto me = static_cast<XdgWmBase*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &xdg_positioner_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -77,6 +75,7 @@ struct mw::XdgWmBase::Thunks
         }
         try
         {
+            auto me = static_cast<XdgWmBase*>(wl_resource_get_user_data(resource));
             me->create_positioner(id_resolved);
         }
         catch(ProtocolError const& err)
@@ -91,7 +90,6 @@ struct mw::XdgWmBase::Thunks
 
     static void get_xdg_surface_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* surface)
     {
-        auto me = static_cast<XdgWmBase*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &xdg_surface_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -101,6 +99,7 @@ struct mw::XdgWmBase::Thunks
         }
         try
         {
+            auto me = static_cast<XdgWmBase*>(wl_resource_get_user_data(resource));
             me->get_xdg_surface(id_resolved, surface);
         }
         catch(ProtocolError const& err)
@@ -115,9 +114,9 @@ struct mw::XdgWmBase::Thunks
 
     static void pong_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial)
     {
-        auto me = static_cast<XdgWmBase*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgWmBase*>(wl_resource_get_user_data(resource));
             me->pong(serial);
         }
         catch(ProtocolError const& err)
@@ -193,11 +192,6 @@ bool mw::XdgWmBase::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &xdg_wm_base_interface_data, Thunks::request_vtable);
 }
 
-void mw::XdgWmBase::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 mw::XdgWmBase::Global::Global(wl_display* display, Version<1>)
     : wayland::Global{
           wl_global_create(
@@ -253,10 +247,9 @@ struct mw::XdgPositioner::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -270,9 +263,9 @@ struct mw::XdgPositioner::Thunks
 
     static void set_size_thunk(struct wl_client* client, struct wl_resource* resource, int32_t width, int32_t height)
     {
-        auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
             me->set_size(width, height);
         }
         catch(ProtocolError const& err)
@@ -287,9 +280,9 @@ struct mw::XdgPositioner::Thunks
 
     static void set_anchor_rect_thunk(struct wl_client* client, struct wl_resource* resource, int32_t x, int32_t y, int32_t width, int32_t height)
     {
-        auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
             me->set_anchor_rect(x, y, width, height);
         }
         catch(ProtocolError const& err)
@@ -304,9 +297,9 @@ struct mw::XdgPositioner::Thunks
 
     static void set_anchor_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t anchor)
     {
-        auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
             me->set_anchor(anchor);
         }
         catch(ProtocolError const& err)
@@ -321,9 +314,9 @@ struct mw::XdgPositioner::Thunks
 
     static void set_gravity_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t gravity)
     {
-        auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
             me->set_gravity(gravity);
         }
         catch(ProtocolError const& err)
@@ -338,9 +331,9 @@ struct mw::XdgPositioner::Thunks
 
     static void set_constraint_adjustment_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t constraint_adjustment)
     {
-        auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
             me->set_constraint_adjustment(constraint_adjustment);
         }
         catch(ProtocolError const& err)
@@ -355,9 +348,9 @@ struct mw::XdgPositioner::Thunks
 
     static void set_offset_thunk(struct wl_client* client, struct wl_resource* resource, int32_t x, int32_t y)
     {
-        auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPositioner*>(wl_resource_get_user_data(resource));
             me->set_offset(x, y);
         }
         catch(ProtocolError const& err)
@@ -402,11 +395,6 @@ bool mw::XdgPositioner::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &xdg_positioner_interface_data, Thunks::request_vtable);
 }
 
-void mw::XdgPositioner::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_message const mw::XdgPositioner::Thunks::request_messages[] {
     {"destroy", "", all_null_types},
     {"set_size", "ii", all_null_types},
@@ -442,10 +430,9 @@ struct mw::XdgSurface::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgSurface*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -459,7 +446,6 @@ struct mw::XdgSurface::Thunks
 
     static void get_toplevel_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id)
     {
-        auto me = static_cast<XdgSurface*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &xdg_toplevel_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -469,6 +455,7 @@ struct mw::XdgSurface::Thunks
         }
         try
         {
+            auto me = static_cast<XdgSurface*>(wl_resource_get_user_data(resource));
             me->get_toplevel(id_resolved);
         }
         catch(ProtocolError const& err)
@@ -483,7 +470,6 @@ struct mw::XdgSurface::Thunks
 
     static void get_popup_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t id, struct wl_resource* parent, struct wl_resource* positioner)
     {
-        auto me = static_cast<XdgSurface*>(wl_resource_get_user_data(resource));
         wl_resource* id_resolved{
             wl_resource_create(client, &xdg_popup_interface_data, wl_resource_get_version(resource), id)};
         if (id_resolved == nullptr)
@@ -498,6 +484,7 @@ struct mw::XdgSurface::Thunks
         }
         try
         {
+            auto me = static_cast<XdgSurface*>(wl_resource_get_user_data(resource));
             me->get_popup(id_resolved, parent_resolved, positioner);
         }
         catch(ProtocolError const& err)
@@ -512,9 +499,9 @@ struct mw::XdgSurface::Thunks
 
     static void set_window_geometry_thunk(struct wl_client* client, struct wl_resource* resource, int32_t x, int32_t y, int32_t width, int32_t height)
     {
-        auto me = static_cast<XdgSurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgSurface*>(wl_resource_get_user_data(resource));
             me->set_window_geometry(x, y, width, height);
         }
         catch(ProtocolError const& err)
@@ -529,9 +516,9 @@ struct mw::XdgSurface::Thunks
 
     static void ack_configure_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial)
     {
-        auto me = static_cast<XdgSurface*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgSurface*>(wl_resource_get_user_data(resource));
             me->ack_configure(serial);
         }
         catch(ProtocolError const& err)
@@ -584,11 +571,6 @@ bool mw::XdgSurface::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &xdg_surface_interface_data, Thunks::request_vtable);
 }
 
-void mw::XdgSurface::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
-}
-
 struct wl_interface const* mw::XdgSurface::Thunks::get_toplevel_types[] {
     &xdg_toplevel_interface_data};
 
@@ -631,10 +613,9 @@ struct mw::XdgToplevel::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -648,7 +629,6 @@ struct mw::XdgToplevel::Thunks
 
     static void set_parent_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* parent)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> parent_resolved;
         if (parent != nullptr)
         {
@@ -656,6 +636,7 @@ struct mw::XdgToplevel::Thunks
         }
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->set_parent(parent_resolved);
         }
         catch(ProtocolError const& err)
@@ -670,9 +651,9 @@ struct mw::XdgToplevel::Thunks
 
     static void set_title_thunk(struct wl_client* client, struct wl_resource* resource, char const* title)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->set_title(title);
         }
         catch(ProtocolError const& err)
@@ -687,9 +668,9 @@ struct mw::XdgToplevel::Thunks
 
     static void set_app_id_thunk(struct wl_client* client, struct wl_resource* resource, char const* app_id)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->set_app_id(app_id);
         }
         catch(ProtocolError const& err)
@@ -704,9 +685,9 @@ struct mw::XdgToplevel::Thunks
 
     static void show_window_menu_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->show_window_menu(seat, serial, x, y);
         }
         catch(ProtocolError const& err)
@@ -721,9 +702,9 @@ struct mw::XdgToplevel::Thunks
 
     static void move_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* seat, uint32_t serial)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->move(seat, serial);
         }
         catch(ProtocolError const& err)
@@ -738,9 +719,9 @@ struct mw::XdgToplevel::Thunks
 
     static void resize_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* seat, uint32_t serial, uint32_t edges)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->resize(seat, serial, edges);
         }
         catch(ProtocolError const& err)
@@ -755,9 +736,9 @@ struct mw::XdgToplevel::Thunks
 
     static void set_max_size_thunk(struct wl_client* client, struct wl_resource* resource, int32_t width, int32_t height)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->set_max_size(width, height);
         }
         catch(ProtocolError const& err)
@@ -772,9 +753,9 @@ struct mw::XdgToplevel::Thunks
 
     static void set_min_size_thunk(struct wl_client* client, struct wl_resource* resource, int32_t width, int32_t height)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->set_min_size(width, height);
         }
         catch(ProtocolError const& err)
@@ -789,9 +770,9 @@ struct mw::XdgToplevel::Thunks
 
     static void set_maximized_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->set_maximized();
         }
         catch(ProtocolError const& err)
@@ -806,9 +787,9 @@ struct mw::XdgToplevel::Thunks
 
     static void unset_maximized_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->unset_maximized();
         }
         catch(ProtocolError const& err)
@@ -823,7 +804,6 @@ struct mw::XdgToplevel::Thunks
 
     static void set_fullscreen_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* output)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         std::experimental::optional<struct wl_resource*> output_resolved;
         if (output != nullptr)
         {
@@ -831,6 +811,7 @@ struct mw::XdgToplevel::Thunks
         }
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->set_fullscreen(output_resolved);
         }
         catch(ProtocolError const& err)
@@ -845,9 +826,9 @@ struct mw::XdgToplevel::Thunks
 
     static void unset_fullscreen_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->unset_fullscreen();
         }
         catch(ProtocolError const& err)
@@ -862,9 +843,9 @@ struct mw::XdgToplevel::Thunks
 
     static void set_minimized_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgToplevel*>(wl_resource_get_user_data(resource));
             me->set_minimized();
         }
         catch(ProtocolError const& err)
@@ -923,11 +904,6 @@ void mw::XdgToplevel::send_close_event() const
 bool mw::XdgToplevel::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &xdg_toplevel_interface_data, Thunks::request_vtable);
-}
-
-void mw::XdgToplevel::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
 }
 
 struct wl_interface const* mw::XdgToplevel::Thunks::set_parent_types[] {
@@ -1004,10 +980,9 @@ struct mw::XdgPopup::Thunks
 
     static void destroy_thunk(struct wl_client* client, struct wl_resource* resource)
     {
-        auto me = static_cast<XdgPopup*>(wl_resource_get_user_data(resource));
         try
         {
-            me->destroy();
+            wl_resource_destroy(resource);
         }
         catch(ProtocolError const& err)
         {
@@ -1021,9 +996,9 @@ struct mw::XdgPopup::Thunks
 
     static void grab_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* seat, uint32_t serial)
     {
-        auto me = static_cast<XdgPopup*>(wl_resource_get_user_data(resource));
         try
         {
+            auto me = static_cast<XdgPopup*>(wl_resource_get_user_data(resource));
             me->grab(seat, serial);
         }
         catch(ProtocolError const& err)
@@ -1078,11 +1053,6 @@ void mw::XdgPopup::send_popup_done_event() const
 bool mw::XdgPopup::is_instance(wl_resource* resource)
 {
     return wl_resource_instance_of(resource, &xdg_popup_interface_data, Thunks::request_vtable);
-}
-
-void mw::XdgPopup::destroy_wayland_object() const
-{
-    wl_resource_destroy(resource);
 }
 
 struct wl_interface const* mw::XdgPopup::Thunks::grab_types[] {

--- a/src/wayland/generated/xdg-shell_wrapper.h
+++ b/src/wayland/generated/xdg-shell_wrapper.h
@@ -38,8 +38,6 @@ public:
 
     void send_ping_event(uint32_t serial) const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -75,7 +73,6 @@ public:
     };
 
 private:
-    virtual void destroy() = 0;
     virtual void create_positioner(struct wl_resource* id) = 0;
     virtual void get_xdg_surface(struct wl_resource* id, struct wl_resource* surface) = 0;
     virtual void pong(uint32_t serial) = 0;
@@ -90,8 +87,6 @@ public:
 
     XdgPositioner(struct wl_resource* resource, Version<1>);
     virtual ~XdgPositioner();
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -143,7 +138,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void set_size(int32_t width, int32_t height) = 0;
     virtual void set_anchor_rect(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
     virtual void set_anchor(uint32_t anchor) = 0;
@@ -163,8 +157,6 @@ public:
     virtual ~XdgSurface();
 
     void send_configure_event(uint32_t serial) const;
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -186,7 +178,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void get_toplevel(struct wl_resource* id) = 0;
     virtual void get_popup(struct wl_resource* id, std::experimental::optional<struct wl_resource*> const& parent, struct wl_resource* positioner) = 0;
     virtual void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
@@ -205,8 +196,6 @@ public:
 
     void send_configure_event(int32_t width, int32_t height, struct wl_array* states) const;
     void send_close_event() const;
-
-    void destroy_wayland_object() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -243,7 +232,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void set_parent(std::experimental::optional<struct wl_resource*> const& parent) = 0;
     virtual void set_title(std::string const& title) = 0;
     virtual void set_app_id(std::string const& app_id) = 0;
@@ -272,8 +260,6 @@ public:
     void send_configure_event(int32_t x, int32_t y, int32_t width, int32_t height) const;
     void send_popup_done_event() const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -293,7 +279,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void destroy() = 0;
     virtual void grab(struct wl_resource* seat, uint32_t serial) = 0;
 };
 

--- a/src/wayland/generator/interface.cpp
+++ b/src/wayland/generator/interface.cpp
@@ -121,7 +121,7 @@ Emitter Interface::declaration() const
                 destructor_prototype(),
             },
             event_prototypes(),
-            {"void destroy_wayland_object() const;"},
+            (has_destroy_request ? nullptr : "void destroy_and_delete() const;"),
             member_vars(),
             enum_declarations(),
             event_opcodes(),
@@ -149,12 +149,15 @@ Emitter Interface::implementation() const
             destructor_impl(),
             event_impls(),
             is_instance_impl(),
-            Lines{
-                {"void ", nmspace, "destroy_wayland_object() const"},
-                Block{
-                    {"wl_resource_destroy(resource);"}
+            (has_destroy_request ? Emitter{nullptr} :
+                Lines{
+                    {"void ", nmspace, "destroy_and_delete() const"},
+                    Block{
+                        {"// Will result in this object being deleted"},
+                        {"wl_resource_destroy(resource);"},
+                    }
                 }
-            },
+            ),
             (global ? global.value().implementation() : nullptr),
             types_init(),
             Lines{

--- a/src/wayland/generator/interface.h
+++ b/src/wayland/generator/interface.h
@@ -87,7 +87,7 @@ private:
     std::vector<Event> const events;
     std::vector<Enum> const enums;
     std::vector<std::string> const parent_interfaces;
-    bool const has_vtable;
+    bool const has_destroy_request;
 };
 
 #endif // MIR_WAYLAND_GENERATOR_INTERFACE_H

--- a/src/wayland/generator/method.cpp
+++ b/src/wayland/generator/method.cpp
@@ -23,6 +23,7 @@
 
 Method::Method(xmlpp::Element const& node, std::string const& class_name, bool is_event)
     : name{node.get_attribute_value("name")},
+      type{node.get_attribute_value("type")},
       class_name{class_name},
       min_version{get_since_version(node)}
 {

--- a/src/wayland/generator/method.h
+++ b/src/wayland/generator/method.h
@@ -50,6 +50,7 @@ protected:
     static int get_since_version(xmlpp::Element const& node);
 
     std::string const name;
+    std::string const type;
     std::string const class_name;
     int const min_version;
     std::vector<Argument> arguments;

--- a/src/wayland/generator/request.cpp
+++ b/src/wayland/generator/request.cpp
@@ -26,7 +26,14 @@ Request::Request(xmlpp::Element const& node, std::string const& class_name)
 // TODO: Decide whether to resolve wl_resource* to wrapped types (ie: Region, Surface, etc).
 Emitter Request::virtual_mir_prototype() const
 {
-    return {"virtual void ", name, "(", mir_args(), ") = 0;"};
+    if (is_destroy())
+    {
+        return nullptr;
+    }
+    else
+    {
+        return {"virtual void ", name, "(", mir_args(), ") = 0;"};
+    }
 }
 
 // TODO: Decide whether to resolve wl_resource* to wrapped types (ie: Region, Surface, etc).
@@ -34,11 +41,17 @@ Emitter Request::thunk_impl() const
 {
     return {"static void ", name, "_thunk(", wl_args(), ")",
         Block{
-            {"auto me = static_cast<", class_name, "*>(wl_resource_get_user_data(resource));"},
             wl2mir_converters(),
             "try",
             Block{
-                {"me->", name, "(", mir_call_args(), ");"}
+                (is_destroy() ?
+                    Emitter{"wl_resource_destroy(resource);"}
+                :
+                    Lines{
+                        {"auto me = static_cast<", class_name, "*>(wl_resource_get_user_data(resource));"},
+                        {"me->", name, "(", mir_call_args(), ");"},
+                    }
+                )
             },
             "catch(ProtocolError const& err)",
             Block{
@@ -59,7 +72,7 @@ Emitter Request::vtable_initialiser() const
 
 bool Request::is_destroy() const
 {
-    return name == "destroy";
+    return type == "destructor";
 }
 
 Emitter Request::wl_args() const

--- a/src/wayland/generator/request.cpp
+++ b/src/wayland/generator/request.cpp
@@ -57,6 +57,11 @@ Emitter Request::vtable_initialiser() const
     return {name, "_thunk"};
 }
 
+bool Request::is_destroy() const
+{
+    return name == "destroy";
+}
+
 Emitter Request::wl_args() const
 {
     Emitter client_arg = "struct wl_client* client";

--- a/src/wayland/generator/request.h
+++ b/src/wayland/generator/request.h
@@ -36,6 +36,9 @@ public:
     // the bit of this objects vtable that holds this method
     Emitter vtable_initialiser() const;
 
+    // If this request destroys the object
+    bool is_destroy() const;
+
 protected:
     // arguments from libwayland to the thunk
     Emitter wl_args() const;

--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -85,6 +85,9 @@ set(EXPECTED_FAILURES
   XdgToplevelStableTest.pointer_leaves_surface_during_interactive_resize
   XdgToplevelV6Test.pointer_leaves_surface_during_interactive_move
   XdgToplevelV6Test.pointer_leaves_surface_during_interactive_resize
+
+  AllSurfaceTypes/TouchTest.sends_touch_up_on_surface_destroy/4 # Fixed by https://github.com/MirServer/wlcs/pull/199
+  AllSurfaceTypes/TouchTest.sends_touch_up_on_surface_destroy/5 # Fixed by https://github.com/MirServer/wlcs/pull/199
 )
 
 if (MIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN)

--- a/tests/miral/generated/server-decoration_wrapper.cpp
+++ b/tests/miral/generated/server-decoration_wrapper.cpp
@@ -39,11 +39,6 @@ struct wl_interface const* all_null_types [] {
 
 // ServerDecorationManager
 
-mw::ServerDecorationManager* mw::ServerDecorationManager::from(struct wl_resource* resource)
-{
-    return static_cast<ServerDecorationManager*>(wl_resource_get_user_data(resource));
-}
-
 struct mw::ServerDecorationManager::Thunks
 {
     static int const supported_version;
@@ -168,12 +163,16 @@ struct wl_message const mw::ServerDecorationManager::Thunks::event_messages[] {
 void const* mw::ServerDecorationManager::Thunks::request_vtable[] {
     (void*)Thunks::create_thunk};
 
-// ServerDecoration
-
-mw::ServerDecoration* mw::ServerDecoration::from(struct wl_resource* resource)
+mw::ServerDecorationManager* mw::ServerDecorationManager::from(struct wl_resource* resource)
 {
-    return static_cast<ServerDecoration*>(wl_resource_get_user_data(resource));
+    if (wl_resource_instance_of(resource, &org_kde_kwin_server_decoration_manager_interface_data, ServerDecorationManager::Thunks::request_vtable))
+    {
+        return static_cast<ServerDecorationManager*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
 }
+
+// ServerDecoration
 
 struct mw::ServerDecoration::Thunks
 {
@@ -266,6 +265,15 @@ struct wl_message const mw::ServerDecoration::Thunks::event_messages[] {
 void const* mw::ServerDecoration::Thunks::request_vtable[] {
     (void*)Thunks::release_thunk,
     (void*)Thunks::request_mode_thunk};
+
+mw::ServerDecoration* mw::ServerDecoration::from(struct wl_resource* resource)
+{
+    if (wl_resource_instance_of(resource, &org_kde_kwin_server_decoration_interface_data, ServerDecoration::Thunks::request_vtable))
+    {
+        return static_cast<ServerDecoration*>(wl_resource_get_user_data(resource));
+    }
+    return nullptr;
+}
 
 namespace mir
 {

--- a/tests/miral/generated/server-decoration_wrapper.h
+++ b/tests/miral/generated/server-decoration_wrapper.h
@@ -35,7 +35,7 @@ public:
 
     void send_default_mode_event(uint32_t mode) const;
 
-    void destroy_wayland_object() const;
+    void destroy_and_delete() const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -84,8 +84,6 @@ public:
 
     void send_mode_event(uint32_t mode) const;
 
-    void destroy_wayland_object() const;
-
     struct wl_client* const client;
     struct wl_resource* const resource;
 
@@ -106,7 +104,6 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void release() = 0;
     virtual void request_mode(uint32_t mode) = 0;
 };
 

--- a/tests/miral/server_example_decoration.cpp
+++ b/tests/miral/server_example_decoration.cpp
@@ -34,11 +34,6 @@ struct ServerDecoration :
         send_mode_event(decoration_mode);
     }
 
-    void release() override
-    {
-        destroy_wayland_object();
-    }
-
     void request_mode(uint32_t mode) override
     {
         if (mode != decoration_mode)


### PR DESCRIPTION
This changes the generated code to automatically destroy Wayland resources. This cleans up a ton of user functions, almost all of which were just calling `destroy_wayland_object()`. For the few that had additional logic, it's been moved to the destructor.

`destroy_wayland_object()` is now completely gone, and replaced with `destroy_and_delete()` for objects that don't have a destructor.

Fixes #1447