### PR TITLE
tests/wlcs: XFail XdgToplevelStableTest.touch_can_not_steal_pointer_based_move

### DIFF
--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -88,6 +88,8 @@ set(EXPECTED_FAILURES
 
   AllSurfaceTypes/TouchTest.sends_touch_up_on_surface_destroy/4 # Fixed by https://github.com/MirServer/wlcs/pull/199
   AllSurfaceTypes/TouchTest.sends_touch_up_on_surface_destroy/5 # Fixed by https://github.com/MirServer/wlcs/pull/199
+
+  XdgToplevelStableTest.touch_can_not_steal_pointer_based_move # https://github.com/MirServer/mir/issues/1792
 )
 
 if (MIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN)


### PR DESCRIPTION
This is issue #1792