### PR TITLE
Do not throw exceptions in surface_destroyed()

### DIFF
--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -215,6 +215,10 @@ public:
     wl_global* const global;
 };
 
+/// Calls wl_client_post_implementation_error() if available
+[[gnu::format(printf, 2, 3)]]
+void post_implementation_error(wl_client* client, char const* fmt, ...);
+
 void internal_error_processing_request(wl_client* client, char const* method_name);
 
 }

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -203,7 +203,7 @@ public:
     ~WlShellSurface() = default;
 
 protected:
-    void surface_destroyed() override
+    void surface_destroyed() noexcept override
     {
         // The spec is a little contradictory:
         // wl_surface: When a client wants to destroy a wl_surface, they must destroy this 'role object' before the wl_surface

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -447,9 +447,14 @@ void mf::WindowWlSurfaceRole::surface_destroyed()
     {
         // "When a client wants to destroy a wl_surface, they must destroy this 'role object' wl_surface"
         // NOTE: the wl_shell_surface specification seems contradictory, so this method is overridden in it's implementation
-        BOOST_THROW_EXCEPTION(std::runtime_error{
-            "wl_surface@" + std::to_string(wl_resource_get_id(surface->resource)) +
-            " destroyed before associated role"});
+        log_warning(
+            "wl_surface@%d destroyed before associated role",
+            wl_resource_get_id(surface->resource));
+        // Post error manually instead of throwing exception because this method is called by the surface destructor
+        wayland::post_implementation_error(
+            weak_client.value().raw_client(),
+            "wl_surface@%d destroyed before associated role",
+            wl_resource_get_id(surface->resource));
     }
     else
     {

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -441,7 +441,7 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
     pending_explicit_height = std::experimental::nullopt;
 }
 
-void mf::WindowWlSurfaceRole::surface_destroyed()
+void mf::WindowWlSurfaceRole::surface_destroyed() noexcept
 {
     if (weak_client)
     {

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -120,7 +120,7 @@ protected:
     auto latest_timestamp() const -> std::chrono::nanoseconds;
 
     void commit(WlSurfaceState const& state) override;
-    void surface_destroyed() override;
+    void surface_destroyed() noexcept override;
 
 private:
     WlSurface* const surface;

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -200,7 +200,7 @@ void mf::WlSubsurface::commit(WlSurfaceState const& state)
     }
 }
 
-void mf::WlSubsurface::surface_destroyed()
+void mf::WlSubsurface::surface_destroyed() noexcept
 {
     if (weak_client)
     {

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -205,9 +205,16 @@ void mf::WlSubsurface::surface_destroyed()
     if (weak_client)
     {
         // "When a client wants to destroy a wl_surface, they must destroy this 'role object' wl_surface"
-        BOOST_THROW_EXCEPTION(std::runtime_error{
-            "wl_surface@" + std::to_string(wl_resource_get_id(surface->resource)) +
-            " destroyed before it's associated wl_subsurface@" + std::to_string(wl_resource_get_id(resource))});
+        log_warning(
+            "wl_surface@%d destroyed before it's associated wl_subsurface@%d",
+            wl_resource_get_id(surface->resource),
+            wl_resource_get_id(resource));
+        // Post error manually instead of throwing exception because this method is called by the surface destructor
+        wayland::post_implementation_error(
+            client,
+            "wl_surface@%d destroyed before it's associated wl_subsurface@%d",
+            wl_resource_get_id(surface->resource),
+            wl_resource_get_id(resource));
     }
     else
     {

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -76,7 +76,7 @@ private:
 
     void refresh_surface_data_now() override;
     virtual void commit(WlSurfaceState const& state) override;
-    void surface_destroyed() override;
+    void surface_destroyed() noexcept override;
 
     WlSurface* const surface;
     /// This class is responsible for removing itself from the parent's children list when needed

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -488,4 +488,4 @@ auto mf::NullWlSurfaceRole::scene_surface() const -> std::experimental::optional
 }
 void mf::NullWlSurfaceRole::refresh_surface_data_now() {}
 void mf::NullWlSurfaceRole::commit(WlSurfaceState const& state) { surface->commit(state); }
-void mf::NullWlSurfaceRole::surface_destroyed() {}
+void mf::NullWlSurfaceRole::surface_destroyed() noexcept {}

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -99,7 +99,7 @@ public:
     auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
     void refresh_surface_data_now() override;
     void commit(WlSurfaceState const& state) override;
-    void surface_destroyed() override;
+    void surface_destroyed() noexcept override;
 
 private:
     WlSurface* const surface;

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -45,7 +45,7 @@ public:
     virtual auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> = 0;
     virtual void refresh_surface_data_now() = 0;
     virtual void commit(WlSurfaceState const& state) = 0;
-    virtual void surface_destroyed() = 0;
+    virtual void surface_destroyed() noexcept = 0;
     virtual ~WlSurfaceRole() = default;
 };
 }

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -163,7 +163,7 @@ void mf::XWaylandSurfaceRole::commit(WlSurfaceState const& state)
     }
 }
 
-void mf::XWaylandSurfaceRole::surface_destroyed()
+void mf::XWaylandSurfaceRole::surface_destroyed() noexcept
 {
     if (auto const wm_surface = weak_wm_surface.lock())
     {

--- a/src/server/frontend_xwayland/xwayland_surface_role.h
+++ b/src/server/frontend_xwayland/xwayland_surface_role.h
@@ -70,7 +70,7 @@ private:
     auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
     void refresh_surface_data_now() override;
     void commit(WlSurfaceState const& state) override;
-    void surface_destroyed() override;
+    void surface_destroyed() noexcept override;
     /// @}
 };
 }

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -401,3 +401,10 @@ global:
     virtual?thunk?to?mir::wayland::RelativePointerV1::?RelativePointerV1*;
   };
 } MIRWAYLAND_2.1;
+
+MIRWAYLAND_2.2.2 {
+global:
+  extern "C++" {
+    mir::wayland::post_implementation_error*;
+  };
+} MIRWAYLAND_2.2.1;

--- a/src/wayland/wayland_base.cpp
+++ b/src/wayland/wayland_base.cpp
@@ -143,13 +143,23 @@ mw::Global::~Global()
     wl_global_destroy(global);
 }
 
-void mw::internal_error_processing_request(wl_client* client, char const* method_name)
+void mw::post_implementation_error(wl_client* client, char const* fmt, ...)
 {
+    va_list va;
+    va_start(va, fmt);
 #if (WAYLAND_VERSION_MAJOR > 1 || (WAYLAND_VERSION_MAJOR == 1 && WAYLAND_VERSION_MINOR > 16))
-    wl_client_post_implementation_error(client, "Mir internal error processing %s request", method_name);
+    wl_client_post_implementation_error(client, fmt, va);
 #else
+    (void)va;
+    (void)fmt;
     wl_client_post_no_memory(client);
 #endif
+    va_end(va);
+}
+
+void mw::internal_error_processing_request(wl_client* client, char const* method_name)
+{
+    post_implementation_error(client, "Mir internal error processing %s request", method_name);
     ::mir::log(
         ::mir::logging::Severity::warning,
         "frontend:Wayland",


### PR DESCRIPTION
Fixes #2055. Adds a new function to mirwayland (not an ABI break), so check to make sure I did the symbols right.