### PR TITLE
Bump wlr_layer_shell_unstable_v1 version from 3 to 4

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -2216,18 +2216,20 @@ void miral::BasicWindowManager::validate_modification_request(WindowSpecificatio
         case mir_window_type_utility:
         case mir_window_type_dialog:
         case mir_window_type_satellite:
+        case mir_window_type_decoration:
             switch (target_type)
             {
             case mir_window_type_normal:
             case mir_window_type_utility:
             case mir_window_type_dialog:
             case mir_window_type_satellite:
+            case mir_window_type_decoration:
                 break;
 
             default:
                 BOOST_THROW_EXCEPTION(std::runtime_error("Invalid surface type change"));
             }
-	    // Falls through.
+            break;
 
         case mir_window_type_menu:
             switch (target_type)
@@ -2239,13 +2241,12 @@ void miral::BasicWindowManager::validate_modification_request(WindowSpecificatio
             default:
                 BOOST_THROW_EXCEPTION(std::runtime_error("Invalid surface type change"));
             }
-	    // Falls through.
+            break;
 
         case mir_window_type_gloss:
         case mir_window_type_freestyle:
         case mir_window_type_inputmethod:
         case mir_window_type_tip:
-        case mir_window_type_decoration:
             if (target_type != original_type)
                 BOOST_THROW_EXCEPTION(std::runtime_error("Invalid surface type change"));
             break;

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -68,7 +68,7 @@ class LayerShellV1::Instance : wayland::LayerShellV1
 {
 public:
     Instance(wl_resource* new_resource, mf::LayerShellV1* shell)
-        : LayerShellV1{new_resource, Version<3>()},
+        : LayerShellV1{new_resource, Version<4>()},
           shell{shell}
     {
     }
@@ -214,7 +214,7 @@ mf::LayerShellV1::LayerShellV1(
     std::shared_ptr<msh::Shell> shell,
     WlSeat& seat,
     OutputManager* output_manager)
-    : Global(display, Version<3>()),
+    : Global(display, Version<4>()),
       wayland_executor{wayland_executor},
       shell{shell},
       seat{seat},
@@ -276,7 +276,7 @@ mf::LayerSurfaceV1::LayerSurfaceV1(
     std::experimental::optional<graphics::DisplayConfigurationOutputId> output_id,
     LayerShellV1 const& layer_shell,
     MirDepthLayer layer)
-    : mw::LayerSurfaceV1(new_resource, Version<3>()),
+    : mw::LayerSurfaceV1(new_resource, Version<4>()),
       WindowWlSurfaceRole(
           layer_shell.wayland_executor,
           &layer_shell.seat,

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -288,6 +288,7 @@ mf::LayerSurfaceV1::LayerSurfaceV1(
     // TODO: Error if surface has buffer attached or committed
     shell::SurfaceSpecification spec;
     spec.state = mir_window_state_attached;
+    spec.type = mir_window_type_decoration; // default keybaord interactivity is none
     spec.depth_layer = layer;
     if (output_id)
         spec.output_id = output_id.value();
@@ -517,7 +518,27 @@ void mf::LayerSurfaceV1::set_margin(int32_t top, int32_t right, int32_t bottom, 
 
 void mf::LayerSurfaceV1::set_keyboard_interactivity(uint32_t keyboard_interactivity)
 {
-    (void)keyboard_interactivity;
+    msh::SurfaceSpecification spec;
+    switch (keyboard_interactivity)
+    {
+    case KeyboardInteractivity::none:
+        spec.type = mir_window_type_decoration;
+        break;
+
+    // TODO: implement exclusive keyboard interactivity correctly
+    case KeyboardInteractivity::exclusive:
+    case KeyboardInteractivity::on_demand:
+        spec.type = mir_window_type_normal;
+        break;
+
+    default:
+        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+            resource,
+            Error::invalid_keyboard_interactivity,
+            "Invalid keyboard interactivity %d",
+            keyboard_interactivity));
+    }
+    apply_spec(spec);
 }
 
 void mf::LayerSurfaceV1::get_popup(struct wl_resource* popup)

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
@@ -123,9 +123,9 @@ struct mw::LayerShellV1::Thunks
     static void const* request_vtable[];
 };
 
-int const mw::LayerShellV1::Thunks::supported_version = 3;
+int const mw::LayerShellV1::Thunks::supported_version = 4;
 
-mw::LayerShellV1::LayerShellV1(struct wl_resource* resource, Version<3>)
+mw::LayerShellV1::LayerShellV1(struct wl_resource* resource, Version<4>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {
@@ -146,7 +146,7 @@ bool mw::LayerShellV1::is_instance(wl_resource* resource)
     return wl_resource_instance_of(resource, &zwlr_layer_shell_v1_interface_data, Thunks::request_vtable);
 }
 
-mw::LayerShellV1::Global::Global(wl_display* display, Version<3>)
+mw::LayerShellV1::Global::Global(wl_display* display, Version<4>)
     : wayland::Global{
           wl_global_create(
               display,
@@ -355,9 +355,9 @@ struct mw::LayerSurfaceV1::Thunks
     static void const* request_vtable[];
 };
 
-int const mw::LayerSurfaceV1::Thunks::supported_version = 3;
+int const mw::LayerSurfaceV1::Thunks::supported_version = 4;
 
-mw::LayerSurfaceV1::LayerSurfaceV1(struct wl_resource* resource, Version<3>)
+mw::LayerSurfaceV1::LayerSurfaceV1(struct wl_resource* resource, Version<4>)
     : client{wl_resource_get_client(resource)},
       resource{resource}
 {

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
@@ -30,7 +30,7 @@ public:
 
     static LayerShellV1* from(struct wl_resource*);
 
-    LayerShellV1(struct wl_resource* resource, Version<3>);
+    LayerShellV1(struct wl_resource* resource, Version<4>);
     virtual ~LayerShellV1();
 
     struct wl_client* const client;
@@ -58,7 +58,7 @@ public:
     class Global : public wayland::Global
     {
     public:
-        Global(wl_display* display, Version<3>);
+        Global(wl_display* display, Version<4>);
 
         auto interface_name() const -> char const* override;
 
@@ -78,7 +78,7 @@ public:
 
     static LayerSurfaceV1* from(struct wl_resource*);
 
-    LayerSurfaceV1(struct wl_resource* resource, Version<3>);
+    LayerSurfaceV1(struct wl_resource* resource, Version<4>);
     virtual ~LayerSurfaceV1();
 
     void send_configure_event(uint32_t serial, uint32_t width, uint32_t height) const;
@@ -87,11 +87,19 @@ public:
     struct wl_client* const client;
     struct wl_resource* const resource;
 
+    struct KeyboardInteractivity
+    {
+        static uint32_t const none = 0;
+        static uint32_t const exclusive = 1;
+        static uint32_t const on_demand = 2;
+    };
+
     struct Error
     {
         static uint32_t const invalid_surface_state = 0;
         static uint32_t const invalid_size = 1;
         static uint32_t const invalid_anchor = 2;
+        static uint32_t const invalid_keyboard_interactivity = 3;
     };
 
     struct Anchor

--- a/src/wayland/protocol/wlr-layer-shell-unstable-v1.xml
+++ b/src/wayland/protocol/wlr-layer-shell-unstable-v1.xml
@@ -25,7 +25,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zwlr_layer_shell_v1" version="3">
+  <interface name="zwlr_layer_shell_v1" version="4">
     <description summary="create surfaces that are layers of the desktop">
       Clients can use this interface to assign the surface_layer role to
       wl_surfaces. Such surfaces are assigned to a "layer" of the output and
@@ -46,6 +46,12 @@
         or committed is a client error, and any attempts by a client to attach
         or manipulate a buffer prior to the first layer_surface.configure call
         must also be treated as errors.
+
+        After creating a layer_surface object and setting it up, the client
+        must perform an initial commit without any buffer attached.
+        The compositor will reply with a layer_surface.configure event.
+        The client must acknowledge it and is then allowed to attach a buffer
+        to map the surface.
 
         You may pass NULL for output to allow the compositor to decide which
         output to use. Generally this will be the one that the user most
@@ -94,7 +100,7 @@
     </request>
   </interface>
 
-  <interface name="zwlr_layer_surface_v1" version="3">
+  <interface name="zwlr_layer_surface_v1" version="4">
     <description summary="layer metadata interface">
       An interface that may be implemented by a wl_surface, for surfaces that
       are designed to be rendered as a layer of a stacked desktop-like
@@ -103,6 +109,14 @@
       Layer surface state (layer, size, anchor, exclusive zone,
       margin, interactivity) is double-buffered, and will be applied at the
       time wl_surface.commit of the corresponding wl_surface is called.
+
+      Attaching a null buffer to a layer surface unmaps it.
+
+      Unmapping a layer_surface means that the surface cannot be shown by the
+      compositor until it is explicitly mapped again. The layer_surface
+      returns to the state it had right after layer_shell.get_layer_surface.
+      The client can re-map the surface by performing a commit without any
+      buffer attached, waiting for a configure event and handling it as usual.
     </description>
 
     <request name="set_size">
@@ -189,21 +203,85 @@
       <arg name="left" type="int"/>
     </request>
 
+    <enum name="keyboard_interactivity">
+      <description summary="types of keyboard interaction possible for a layer shell surface">
+        Types of keyboard interaction possible for layer shell surfaces. The
+        rationale for this is twofold: (1) some applications are not interested
+        in keyboard events and not allowing them to be focused can improve the
+        desktop experience; (2) some applications will want to take exclusive
+        keyboard focus.
+      </description>
+
+      <entry name="none" value="0">
+        <description summary="no keyboard focus is possible">
+          This value indicates that this surface is not interested in keyboard
+          events and the compositor should never assign it the keyboard focus.
+
+          This is the default value, set for newly created layer shell surfaces.
+
+          This is useful for e.g. desktop widgets that display information or
+          only have interaction with non-keyboard input devices.
+        </description>
+      </entry>
+      <entry name="exclusive" value="1">
+        <description summary="request exclusive keyboard focus">
+          Request exclusive keyboard focus if this surface is above the shell surface layer.
+
+          For the top and overlay layers, the seat will always give
+          exclusive keyboard focus to the top-most layer which has keyboard
+          interactivity set to exclusive. If this layer contains multiple
+          surfaces with keyboard interactivity set to exclusive, the compositor
+          determines the one receiving keyboard events in an implementation-
+          defined manner. In this case, no guarantee is made when this surface
+          will receive keyboard focus (if ever).
+
+          For the bottom and background layers, the compositor is allowed to use
+          normal focus semantics.
+
+          This setting is mainly intended for applications that need to ensure
+          they receive all keyboard events, such as a lock screen or a password
+          prompt.
+        </description>
+      </entry>
+      <entry name="on_demand" value="2" since="4">
+        <description summary="request regular keyboard focus semantics">
+          This requests the compositor to allow this surface to be focused and
+          unfocused by the user in an implementation-defined manner. The user
+          should be able to unfocus this surface even regardless of the layer
+          it is on.
+
+          Typically, the compositor will want to use its normal mechanism to
+          manage keyboard focus between layer shell surfaces with this setting
+          and regular toplevels on the desktop layer (e.g. click to focus).
+          Nevertheless, it is possible for a compositor to require a special
+          interaction to focus or unfocus layer shell surfaces (e.g. requiring
+          a click even if focus follows the mouse normally, or providing a
+          keybinding to switch focus between layers).
+
+          This setting is mainly intended for desktop shell components (e.g.
+          panels) that allow keyboard interaction. Using this option can allow
+          implementing a desktop shell that can be fully usable without the
+          mouse.
+        </description>
+      </entry>
+    </enum>
+
     <request name="set_keyboard_interactivity">
       <description summary="requests keyboard events">
-        Set to 1 to request that the seat send keyboard events to this layer
-        surface. For layers below the shell surface layer, the seat will use
-        normal focus semantics. For layers above the shell surface layers, the
-        seat will always give exclusive keyboard focus to the top-most layer
-        which has keyboard interactivity set to true.
+        Set how keyboard events are delivered to this surface. By default,
+        layer shell surfaces do not receive keyboard events; this request can
+        be used to change this.
+
+        This setting is inherited by child surfaces set by the get_popup
+        request.
 
         Layer surfaces receive pointer, touch, and tablet events normally. If
         you do not want to receive them, set the input region on your surface
         to an empty region.
 
-        Events is double-buffered, see wl_surface.commit.
+        Keyboard interactivity is double-buffered, see wl_surface.commit.
       </description>
-      <arg name="keyboard_interactivity" type="uint"/>
+      <arg name="keyboard_interactivity" type="uint" enum="keyboard_interactivity"/>
     </request>
 
     <request name="get_popup">
@@ -288,6 +366,7 @@
       <entry name="invalid_surface_state" value="0" summary="provided surface state is invalid"/>
       <entry name="invalid_size" value="1" summary="size is invalid"/>
       <entry name="invalid_anchor" value="2" summary="anchor bitfield is invalid"/>
+      <entry name="invalid_keyboard_interactivity" value="3" summary="keyboard interactivity is invalid"/>
     </enum>
 
     <enum name="anchor" bitfield="true">


### PR DESCRIPTION
Just a version bump. The only real behavior change is in keyboard interactivity, and not implementing that is preexisting (see #2066)