### PR TITLE
Add stream operator for miral::Window

### DIFF
--- a/debian/libmiral4.symbols
+++ b/debian/libmiral4.symbols
@@ -395,3 +395,4 @@ libmiral.so.4 libmiral4 #MINVER#
  MIRAL_3.2@MIRAL_3.2 3.2.0
  (c++)"miral::Output::logical_group_id()@MIRAL_3.2" 3.2.0
  (c++)"miral::Output::logical_group_id() const@MIRAL_3.2" 3.2.0
+ (c++)"miral::operator<<(std::basic_ostream<char, std::char_traits<char> >&, miral::Window const&)@MIRAL_3.3" 3.3.0

--- a/include/miral/miral/window.h
+++ b/include/miral/miral/window.h
@@ -79,7 +79,7 @@ bool operator==(Window const& lhs, Window const& rhs);
 bool operator==(std::shared_ptr<mir::scene::Surface> const& lhs, Window const& rhs);
 bool operator==(Window const& lhs, std::shared_ptr<mir::scene::Surface> const& rhs);
 bool operator<(Window const& lhs, Window const& rhs);
-auto operator<<(std::ostream& stream, const miral::Window& window) -> std::ostream&;
+auto operator<<(std::ostream& stream, miral::Window const& window) -> std::ostream&;
 
 inline bool operator!=(Window const& lhs, Window const& rhs) { return !(lhs == rhs); }
 inline bool operator!=(std::shared_ptr<mir::scene::Surface> const& lhs, Window const& rhs) { return !(lhs == rhs); }

--- a/include/miral/miral/window.h
+++ b/include/miral/miral/window.h
@@ -25,6 +25,7 @@
 #include <mir/geometry/size.h>
 
 #include <memory>
+#include <iosfwd>
 
 namespace mir
 {
@@ -78,6 +79,7 @@ bool operator==(Window const& lhs, Window const& rhs);
 bool operator==(std::shared_ptr<mir::scene::Surface> const& lhs, Window const& rhs);
 bool operator==(Window const& lhs, std::shared_ptr<mir::scene::Surface> const& rhs);
 bool operator<(Window const& lhs, Window const& rhs);
+auto operator<<(std::ostream& stream, const miral::Window& window) -> std::ostream&;
 
 inline bool operator!=(Window const& lhs, Window const& rhs) { return !(lhs == rhs); }
 inline bool operator!=(std::shared_ptr<mir::scene::Surface> const& lhs, Window const& rhs) { return !(lhs == rhs); }

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -446,10 +446,3 @@ global:
     miral::Output::logical_group_id*;
   };
 } MIRAL_3.1;
-
-MIRAL_3.3 {
-global:
-  extern "C++" {
-    miral::operator<<(std::basic_ostream<char, std::char_traits<char> >&, miral::Window const&);
-  };
-} MIRAL_3.2;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -446,3 +446,10 @@ global:
     miral::Output::logical_group_id*;
   };
 } MIRAL_3.1;
+
+MIRAL_3.3 {
+global:
+  extern "C++" {
+    miral::operator<<(std::basic_ostream<char, std::char_traits<char> >&, miral::Window const&);
+  };
+} MIRAL_3.2;

--- a/src/miral/window.cpp
+++ b/src/miral/window.cpp
@@ -126,7 +126,7 @@ bool miral::operator<(Window const& lhs, Window const& rhs)
     return lhs.self.owner_before(rhs.self);
 }
 
-auto miral::operator<<(std::ostream& stream, const miral::Window& window) -> std::ostream&
+auto miral::operator<<(std::ostream& stream, miral::Window const& window) -> std::ostream&
 {
     std::shared_ptr<mir::scene::Surface> surface{window};
     if (surface)

--- a/src/miral/window.cpp
+++ b/src/miral/window.cpp
@@ -125,3 +125,16 @@ bool miral::operator<(Window const& lhs, Window const& rhs)
 {
     return lhs.self.owner_before(rhs.self);
 }
+
+auto miral::operator<<(std::ostream& stream, const miral::Window& window) -> std::ostream&
+{
+    std::shared_ptr<mir::scene::Surface> surface{window};
+    if (surface)
+    {
+        return stream << surface->name();
+    }
+    else
+    {
+        return stream << "(null window)";
+    }
+}

--- a/tests/miral/select_active_window.cpp
+++ b/tests/miral/select_active_window.cpp
@@ -62,17 +62,6 @@ struct SelectActiveWindow : mt::TestWindowManagerTools
 };
 }
 
-namespace std
-{
-auto operator<<(std::ostream& out, miral::Window const& window) -> std::ostream&
-{
-    if (std::shared_ptr<mir::scene::Surface> surface = window)
-        return out << surface->name();
-    else
-        return out << "(nul)";
-}
-}
-
 // lp:1626659
 // "If the surface has a child dialog, the deepest descendant
 // dialog should receive input focus."
@@ -92,8 +81,7 @@ TEST_F(SelectActiveWindow, given_a_child_dialog_when_selecting_the_parent_the_di
     auto dialog = create_window(creation_parameters);
 
     auto actual = basic_window_manager.select_active_window(parent);
-    EXPECT_THAT(actual, Eq(dialog))
-        << "actual=" << actual << ", expected=" << dialog;
+    EXPECT_THAT(actual, Eq(dialog));
 }
 
 TEST_F(SelectActiveWindow, given_a_hidden_child_dialog_when_selecting_the_parent_the_parent_receives_focus)
@@ -116,6 +104,5 @@ TEST_F(SelectActiveWindow, given_a_hidden_child_dialog_when_selecting_the_parent
     basic_window_manager.modify_window(basic_window_manager.info_for(dialog), mods);
 
     auto actual = basic_window_manager.select_active_window(parent);
-    EXPECT_THAT(actual, Eq(parent))
-                << "actual=" << actual << ", expected=" << parent;
+    EXPECT_THAT(actual, Eq(parent));
 }


### PR DESCRIPTION
This makes window's correctly appear in test failures, and may have other uses. https://github.com/google/googletest/issues/1149 explains why the stream operators really need to be declared in the same place as the class. I tried a number of other ways, and this is the only one I found to be successful.