### PR TITLE
Make GTK's approach to hiding cursors work on Mir

### DIFF
--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -444,7 +444,8 @@ WlSurfaceCursor::WlSurfaceCursor(mf::WlSurface* surface, geom::Displacement hots
       surface_role{surface, std::move(on_commit)},
       hotspot{hotspot}
 {
-    surface->set_role(&surface_role);
+    if (surface)
+        surface->set_role(&surface_role);
 
     stream->set_frame_posted_callback(
         [this](auto)

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -354,7 +354,7 @@ private:
 
     mw::Weak<mf::WlSurface> const surface;
     std::shared_ptr<mc::BufferStream> const stream;
-    CursorSurfaceRole surface_role; // Used only to assert unique ownership
+    CursorSurfaceRole surface_role;
 
     std::weak_ptr<ms::Surface> surface_under_cursor;
     geom::Displacement hotspot;
@@ -370,7 +370,7 @@ struct WlHiddenCursor : mf::WlPointer::Cursor
     void set_hotspot(geom::Displacement const&) override {};
     auto cursor_surface() const -> std::experimental::optional<mf::WlSurface*> override { return {}; };
 private:
-    CursorSurfaceRole surface_role; // Used only to assert unique ownership
+    CursorSurfaceRole surface_role;
 };
 }
 
@@ -407,7 +407,6 @@ void mf::WlPointer::set_cursor(
 
     (void)serial;
 }
-
 
 void mf::WlPointer::on_commit(WlSurface* surface)
 {

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -74,6 +74,8 @@ private:
     void relative_motion(MirPointerEvent const* event);
     /// Sends a frame event only if needed, leaves needs_frame false
     void maybe_frame();
+    /// The cursor surface has committed
+    void on_commit(WlSurface* surface);
 
     /// Wayland request handlers
     ///@{
@@ -91,6 +93,7 @@ private:
     std::experimental::optional<std::pair<float, float>> current_position;
     std::unique_ptr<Cursor> cursor;
     wayland::Weak<wayland::RelativePointerV1> relative_pointer;
+    geometry::Displacement cursor_hotspot;
 };
 
 }


### PR DESCRIPTION
There was a logic error in `WlPointer::set_cursor()` that compared a pointer with an optional (both of which, unfortunately, convert to `bool`).

We also needed to hook into the "commit" on the corresponding surface to detect an attempt to unmap by sending a null buffer. It looks a bit messy, but fixes #2073.