### PR TITLE
Make GTK's approach to hiding cursors work on Mir

### DIFF
--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -395,17 +395,14 @@ void mf::WlPointer::set_cursor(
     {
         auto const wl_surface = WlSurface::from(*surface);
         cursor_hotspot = {hotspot_x, hotspot_y};
-        if (cursor->cursor_surface() && wl_surface == *cursor->cursor_surface())
-        {
-            cursor->set_hotspot(cursor_hotspot);
-        }
-        else
+        if (!cursor->cursor_surface() || wl_surface != *cursor->cursor_surface())
         {
             cursor.reset(); // clean up old cursor before creating new one
             cursor = std::make_unique<WlSurfaceCursor>(wl_surface, cursor_hotspot, commit_handler);
             if (surface_under_cursor)
                 cursor->apply_to(&surface_under_cursor.value());
         }
+        // If surface is unchanged hotspot will be applied on next commit
     }
     else
     {

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -360,7 +360,7 @@ void mf::WlPointer::set_cursor(
     {
         auto const wl_surface = WlSurface::from(*surface);
         geom::Displacement const cursor_hotspot{hotspot_x, hotspot_y};
-        if (wl_surface == cursor->cursor_surface())
+        if (cursor->cursor_surface() && wl_surface == *cursor->cursor_surface())
         {
             cursor->set_hotspot(cursor_hotspot);
         }

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -323,17 +323,25 @@ namespace
 {
 struct CursorSurfaceRole : mf::NullWlSurfaceRole
 {
-    mf::WlSurface* const surface;
+    mw::Weak<mf::WlSurface> const surface;
     mf::CommitHandler* const commit_handler;
     explicit CursorSurfaceRole(mf::WlSurface* surface, mf::CommitHandler* commit_handler) :
         NullWlSurfaceRole(surface),
         surface{surface},
         commit_handler{commit_handler} {}
 
+    ~CursorSurfaceRole()
+    {
+        if (surface)
+        {
+            surface.value().clear_role();
+        }
+    }
+
     void commit(mir::frontend::WlSurfaceState const& state) override
     {
         NullWlSurfaceRole::commit(state);
-        commit_handler->on_commit(surface);
+        commit_handler->on_commit(&surface.value());
     }
 };
 

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -45,7 +45,19 @@ namespace frontend
 {
 class WlSurface;
 
-class WlPointer : public wayland::Pointer
+class CommitHandler
+{
+public:
+    virtual void on_commit(WlSurface* surface) = 0;
+
+protected:
+    CommitHandler() = default;
+    ~CommitHandler() = default;
+    CommitHandler(CommitHandler const&) = delete;
+    CommitHandler& operator=(CommitHandler const&) = delete;
+};
+
+class WlPointer : public wayland::Pointer, private CommitHandler
 {
 public:
 
@@ -74,6 +86,8 @@ private:
     void relative_motion(MirPointerEvent const* event);
     /// Sends a frame event only if needed, leaves needs_frame false
     void maybe_frame();
+    /// The cursor surface has committed
+    void on_commit(WlSurface* surface) override;
 
     /// Wayland request handlers
     ///@{
@@ -91,6 +105,7 @@ private:
     std::experimental::optional<std::pair<float, float>> current_position;
     std::unique_ptr<Cursor> cursor;
     wayland::Weak<wayland::RelativePointerV1> relative_pointer;
+    geometry::Displacement cursor_hotspot;
 };
 
 }


### PR DESCRIPTION
There was a logic error in WlPointer::set_cursor() that compared a pointer with an optional (both of which, unfortunately, convert to bool).

We also needed to hook into the "commit" on the corresponding surface to detect an attempt to unmap by sending a null buffer. It looks a bit messy, but fixes #2073.

(Alternative to #2078)