### PR TITLE
Standardize on keysym/key_code names

### DIFF
--- a/examples/mir_demo_server/server_example_input_filter.cpp
+++ b/examples/mir_demo_server/server_example_input_filter.cpp
@@ -44,10 +44,10 @@ void print_key_event(MirInputEvent const* ev)
     auto event_time = mir_input_event_get_event_time(ev);
     auto kev = mir_input_event_get_keyboard_event(ev);
     auto scan_code = mir_keyboard_event_scan_code(kev);
-    auto key_code = mir_keyboard_event_key_code(kev);
+    auto keysym = mir_keyboard_event_keysym(kev);
 
     std::cout << "Handling key event (time, scancode, keycode): " << event_time << " " <<
-              scan_code << " " << key_code << std::endl;
+              scan_code << " " << keysym << std::endl;
 }
 
 void print_touch_event(MirInputEvent const* ev)

--- a/include/client/mir/events/event_builders.h
+++ b/include/client/mir/events/event_builders.h
@@ -67,7 +67,7 @@ EventUPtr make_event(frontend::SurfaceId const& surface_id, geometry::Rectangle 
 
 // Key event
 EventUPtr make_event(MirInputDeviceId device_id, std::chrono::nanoseconds timestamp,
-    std::vector<uint8_t> const& cookie, MirKeyboardAction action, xkb_keysym_t key_code,
+    std::vector<uint8_t> const& cookie, MirKeyboardAction action, xkb_keysym_t keysym,
     int scan_code, MirInputEventModifiers modifiers);
 
 void set_modifier(MirEvent& event, MirInputEventModifiers modifiers);

--- a/include/client/mir_toolkit/events/input/keyboard_event.h
+++ b/include/client/mir_toolkit/events/input/keyboard_event.h
@@ -45,13 +45,13 @@ typedef struct MirKeyboardEvent MirKeyboardEvent;
 MirKeyboardAction mir_keyboard_event_action(MirKeyboardEvent const* event);
 
 /**
- * Retrieve the xkb mapped keycode associated with the key acted on.. May
+ * Retrieve the xkb mapped keysym associated with the key acted on.. May
  * be interpreted as per <xkbcommon/xkb-keysyms.h>
  *
  *   \param [in] event The key event
  *   \return           The xkb_keysym
  */
-xkb_keysym_t mir_keyboard_event_key_code(MirKeyboardEvent const* event);
+xkb_keysym_t mir_keyboard_event_keysym(MirKeyboardEvent const* event);
 
 /**
  * Retrieve the raw hardware scan code associated with the key acted on. May

--- a/include/miral/miral/toolkit_event.h
+++ b/include/miral/miral/toolkit_event.h
@@ -146,7 +146,7 @@ MirEvent const* mir_input_event_get_event(MirInputEvent const* event);
 MirKeyboardAction mir_keyboard_event_action(MirKeyboardEvent const* event);
 
 /**
- * Retrieve the xkb mapped keycode associated with the key acted on.. May
+ * Retrieve the xkb mapped keysym associated with the key acted on.. May
  * be interpreted as per <xkbcommon/xkbcommon-keysyms.h>
  *
  *   \param [in] event The key event

--- a/include/platform/mir/input/event_builder.h
+++ b/include/platform/mir/input/event_builder.h
@@ -40,7 +40,7 @@ public:
     virtual ~EventBuilder() = default;
     using Timestamp = std::chrono::nanoseconds;
 
-    virtual EventUPtr key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t key_code, int scan_code) = 0;
+    virtual EventUPtr key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t keysym, int scan_code) = 0;
 
     virtual EventUPtr pointer_event(Timestamp timestamp, MirPointerAction action, MirPointerButtons buttons_pressed,
                                     float hscroll_value, float vscroll_value, float relative_x_value,

--- a/include/test/mir/test/event_matchers.h
+++ b/include/test/mir/test/event_matchers.h
@@ -157,7 +157,7 @@ MATCHER_P(KeyOfSymbol, keysym, "")
     if (kev == nullptr)
         return false;
 
-    if(mir_keyboard_event_key_code(kev) != static_cast<xkb_keysym_t>(keysym))
+    if(mir_keyboard_event_keysym(kev) != static_cast<xkb_keysym_t>(keysym))
         return false;
 
     return true;
@@ -196,7 +196,7 @@ MATCHER_P(MirKeyboardEventMatches, event, "")
         return false;
 
     return mir_keyboard_event_action(expected) == mir_keyboard_event_action(actual) &&
-        mir_keyboard_event_key_code(expected) == mir_keyboard_event_key_code(actual) &&
+        mir_keyboard_event_keysym(expected) == mir_keyboard_event_keysym(actual) &&
         mir_keyboard_event_scan_code(expected) == mir_keyboard_event_scan_code(actual) &&
         mir_keyboard_event_modifiers(expected) == mir_keyboard_event_modifiers(actual);
 }

--- a/src/client/event_printer.cpp
+++ b/src/client/event_printer.cpp
@@ -220,7 +220,7 @@ std::ostream& mir::operator<<(std::ostream& out, MirInputEvent const& event)
             auto key_event = mir_input_event_get_keyboard_event(&event);
             return out << "key_event(when=" << event_time << ", from=" << device_id << ", window_id=" << window_id << ", "
                 << mir_keyboard_event_action(key_event)
-                << ", code=" << mir_keyboard_event_key_code(key_event)
+                << ", code=" << mir_keyboard_event_keysym(key_event)
                 << ", scan=" << mir_keyboard_event_scan_code(key_event) << ", modifiers=" << std::hex
                 << static_cast<MirInputEventModifier>(mir_keyboard_event_modifiers(key_event)) << std::dec << ')';
         }

--- a/src/client/events/event_builders.cpp
+++ b/src/client/events/event_builders.cpp
@@ -154,7 +154,7 @@ mir::EventUPtr mev::make_event(frontend::SurfaceId const& surface_id, geometry::
 }
 
 mir::EventUPtr mev::make_event(MirInputDeviceId device_id, std::chrono::nanoseconds timestamp,
-    std::vector<uint8_t> const& cookie, MirKeyboardAction action, xkb_keysym_t key_code,
+    std::vector<uint8_t> const& cookie, MirKeyboardAction action, xkb_keysym_t keysym,
     int scan_code, MirInputEventModifiers modifiers)
 {
     auto e = new_event<MirKeyboardEvent>();
@@ -163,7 +163,7 @@ mir::EventUPtr mev::make_event(MirInputDeviceId device_id, std::chrono::nanoseco
     e->set_event_time(timestamp);
     e->set_cookie(cookie);
     e->set_action(action);
-    e->set_key_code(key_code);
+    e->set_keysym(keysym);
     e->set_scan_code(scan_code);
     e->set_modifiers(modifiers);
 

--- a/src/client/input/input_event.cpp
+++ b/src/client/input/input_event.cpp
@@ -129,9 +129,9 @@ MirKeyboardAction mir_keyboard_event_action(MirKeyboardEvent const* kev) MIR_HAN
     return kev->action();
 })
 
-xkb_keysym_t mir_keyboard_event_key_code(MirKeyboardEvent const* kev) MIR_HANDLE_EVENT_EXCEPTION(
+xkb_keysym_t mir_keyboard_event_keysym(MirKeyboardEvent const* kev) MIR_HANDLE_EVENT_EXCEPTION(
 {
-    return kev->key_code();
+    return kev->keysym();
 })
 
 int mir_keyboard_event_scan_code(MirKeyboardEvent const* kev) MIR_HANDLE_EVENT_EXCEPTION(

--- a/src/client/input/xkb_mapper.cpp
+++ b/src/client/input/xkb_mapper.cpp
@@ -337,10 +337,10 @@ bool mircv::XKBMapper::XkbMappingState::update_and_map(MirEvent& event, mircv::X
     uint32_t xkb_scan_code = to_xkb_scan_code(key_ev.scan_code());
     auto old_state = modifier_state;
     std::string key_text;
-    xkb_keysym_t key_sym;
-    key_sym = update_state(xkb_scan_code, key_ev.action(), compose_state, key_text);
+    xkb_keysym_t keysym;
+    keysym = update_state(xkb_scan_code, key_ev.action(), compose_state, key_text);
 
-    key_ev.set_key_code(key_sym);
+    key_ev.set_keysym(keysym);
     key_ev.set_text(key_text.c_str());
     // TODO we should also indicate effective/consumed modifier state to properly
     // implement short cuts with keys that are only reachable via modifier keys
@@ -351,13 +351,13 @@ bool mircv::XKBMapper::XkbMappingState::update_and_map(MirEvent& event, mircv::X
 
 xkb_keysym_t mircv::XKBMapper::XkbMappingState::update_state(uint32_t scan_code, MirKeyboardAction action, mircv::XKBMapper::ComposeState* compose_state, std::string& text)
 {
-    auto key_sym = xkb_state_key_get_one_sym(state.get(), scan_code);
+    auto keysym = xkb_state_key_get_one_sym(state.get(), scan_code);
     auto const mod_change = modifier_from_xkb_scan_code(scan_code);
 
     // Occasionally, we see XKB_KEY_Meta_L where XKB_KEY_Alt_L is correct
     if (mod_change == mir_input_event_modifier_alt_left)
     {
-        key_sym = XKB_KEY_Alt_L;
+        keysym = XKB_KEY_Alt_L;
     }
 
     if(action == mir_keyboard_action_down || action == mir_keyboard_action_repeat)
@@ -369,7 +369,7 @@ xkb_keysym_t mircv::XKBMapper::XkbMappingState::update_state(uint32_t scan_code,
     }
 
     if (compose_state)
-        key_sym = compose_state->update_state(key_sym, action, text);
+        keysym = compose_state->update_state(keysym, action, text);
 
     if (action == mir_keyboard_action_up)
     {
@@ -386,7 +386,7 @@ xkb_keysym_t mircv::XKBMapper::XkbMappingState::update_state(uint32_t scan_code,
         press_modifier(mod_change);
     }
 
-    return key_sym;
+    return keysym;
 }
 
 MirInputEventModifiers mircv::XKBMapper::XkbMappingState::modifiers() const

--- a/src/client/symbols.map
+++ b/src/client/symbols.map
@@ -40,7 +40,7 @@ MIR_CLIENT_2.5 {
   mir_input_event_has_cookie;
   mir_keyboard_event_action;
   mir_keyboard_event_input_event;
-  mir_keyboard_event_key_code;
+  mir_keyboard_event_keysym;
   mir_keyboard_event_key_text;
   mir_keyboard_event_modifiers;
   mir_keyboard_event_scan_code;

--- a/src/common/events/keyboard_event.cpp
+++ b/src/common/events/keyboard_event.cpp
@@ -39,14 +39,14 @@ void MirKeyboardEvent::set_action(MirKeyboardAction action)
     action_ = action;
 }
 
-int32_t MirKeyboardEvent::key_code() const
+int32_t MirKeyboardEvent::keysym() const
 {
-    return key_code_;
+    return keysym_;
 }
 
-void MirKeyboardEvent::set_key_code(int32_t key_code)
+void MirKeyboardEvent::set_keysym(int32_t keysym)
 {
-    key_code_ = key_code;
+    keysym_ = keysym;
 }
 
 int32_t MirKeyboardEvent::scan_code() const

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -454,3 +454,11 @@ MIR_COMMON_2.5 {
   };
 
 } MIR_COMMON_0.26;
+
+MIR_COMMON_2.6 {
+ global:
+  extern "C++" {
+    MirKeyboardEvent::keysym*;
+    MirKeyboardEvent::set_keysym*;
+  };
+} MIR_COMMON_2.5;

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -451,14 +451,7 @@ MIR_COMMON_2.5 {
     vtable?for?MirTouchEvent;
     vtable?for?MirPointerEvent;
     vtable?for?MirCloseSurfaceEvent;
-  };
-
-} MIR_COMMON_0.26;
-
-MIR_COMMON_2.6 {
- global:
-  extern "C++" {
     MirKeyboardEvent::keysym*;
     MirKeyboardEvent::set_keysym*;
   };
-} MIR_COMMON_2.5;
+} MIR_COMMON_0.26;

--- a/src/include/common/mir/events/keyboard_event.h
+++ b/src/include/common/mir/events/keyboard_event.h
@@ -32,8 +32,8 @@ struct MirKeyboardEvent : MirInputEvent
     MirKeyboardAction action() const;
     void set_action(MirKeyboardAction action);
 
-    int32_t key_code() const;
-    void set_key_code(int32_t key_code);
+    int32_t keysym() const;
+    void set_keysym(int32_t keysym);
 
     int32_t scan_code() const;
     void set_scan_code(int32_t scan_code);
@@ -43,7 +43,7 @@ struct MirKeyboardEvent : MirInputEvent
 
 private:
     MirKeyboardAction action_ = {};
-    int32_t key_code_ = 0;
+    int32_t keysym_ = 0;
     int32_t scan_code_ = 0;
     std::string text_ = {};
 };

--- a/src/miral/toolkit_event.cpp
+++ b/src/miral/toolkit_event.cpp
@@ -76,7 +76,7 @@ MirKeyboardAction mir_keyboard_event_action(MirKeyboardEvent const* event)
 
 xkb_keysym_t mir_keyboard_event_key_code(MirKeyboardEvent const* event)
 {
-    return ::mir_keyboard_event_key_code(event);
+    return ::mir_keyboard_event_keysym(event);
 }
 
 int mir_keyboard_event_scan_code(MirKeyboardEvent const* event)

--- a/src/miral/window_management_trace.cpp
+++ b/src/miral/window_management_trace.cpp
@@ -245,7 +245,7 @@ auto dump_of(MirKeyboardEvent const* event) -> std::string
 
         bout.append("from", device_id)
             .append("action", mir_keyboard_event_action(event))
-            .append("code", mir_keyboard_event_key_code(event))
+            .append("sym", mir_keyboard_event_keysym(event))
             .append("scan", mir_keyboard_event_scan_code(event));
 
         out.setf(std::ios_base::hex, std::ios_base::basefield);

--- a/src/platforms/wayland/display_input.h
+++ b/src/platforms/wayland/display_input.h
@@ -36,8 +36,8 @@ namespace wayland
 class KeyboardInput
 {
 public:
-    virtual void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) = 0;
-    virtual void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) = 0;
+    virtual void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int32_t scan_code) = 0;
+    virtual void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int32_t scan_code) = 0;
 
     KeyboardInput() = default;
     virtual ~KeyboardInput() = default;

--- a/src/platforms/wayland/input_device.cpp
+++ b/src/platforms/wayland/input_device.cpp
@@ -146,14 +146,14 @@ miw::KeyboardInputDevice::KeyboardInputDevice(std::shared_ptr<dispatch::ActionQu
 {
 }
 
-void miw::KeyboardInputDevice::key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code)
+void miw::KeyboardInputDevice::key_press(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int32_t scan_code)
 {
-    enqueue([=](EventBuilder* b) { return b->key_event(event_time, mir_keyboard_action_down, key_sym, key_code); });
+    enqueue([=](EventBuilder* b) { return b->key_event(event_time, mir_keyboard_action_down, keysym, scan_code); });
 }
 
-void miw::KeyboardInputDevice::key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code)
+void miw::KeyboardInputDevice::key_release(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int32_t scan_code)
 {
-    enqueue([=](EventBuilder* b) { return b->key_event(event_time, mir_keyboard_action_up, key_sym, key_code); });
+    enqueue([=](EventBuilder* b) { return b->key_event(event_time, mir_keyboard_action_up, keysym, scan_code); });
 }
 
 miw::PointerInputDevice::PointerInputDevice(std::shared_ptr<dispatch::ActionQueue> const& action_queue) :

--- a/src/platforms/wayland/input_device.h
+++ b/src/platforms/wayland/input_device.h
@@ -86,8 +86,8 @@ public:
     explicit KeyboardInputDevice(std::shared_ptr<dispatch::ActionQueue> const& action_queue);
 
 private:
-    void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) override;
-    void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code) override;
+    void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int32_t scan_code) override;
+    void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int32_t scan_code) override;
 };
 
 class PointerInputDevice : public GenericInputDevice, public PointerInput

--- a/src/platforms/x11/input/input_device.cpp
+++ b/src/platforms/x11/input/input_device.cpp
@@ -137,29 +137,23 @@ bool mix::XInputDevice::started() const
     return sink && builder;
 }
 
-void mix::XInputDevice::key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code)
+void mix::XInputDevice::key_press(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int scan_code)
 {
-    sink->handle_input(
-        builder->key_event(
-            event_time,
-            mir_keyboard_action_down,
-            key_sym,
-            key_code
-            )
-        );
+    sink->handle_input(builder->key_event(
+        event_time,
+        mir_keyboard_action_down,
+        keysym,
+        scan_code));
 
 }
 
-void mix::XInputDevice::key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code)
+void mix::XInputDevice::key_release(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int scan_code)
 {
-    sink->handle_input(
-        builder->key_event(
-            event_time,
-            mir_keyboard_action_up,
-            key_sym,
-            key_code
-            )
-        );
+    sink->handle_input(builder->key_event(
+        event_time,
+        mir_keyboard_action_up,
+        keysym,
+        scan_code));
 }
 
 void mix::XInputDevice::update_button_state(int button)

--- a/src/platforms/x11/input/input_device.h
+++ b/src/platforms/x11/input/input_device.h
@@ -54,8 +54,8 @@ public:
     virtual void apply_settings(TouchscreenSettings const&) override;
 
     bool started() const;
-    void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code);
-    void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t key_sym, int32_t key_code);
+    void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int scan_code);
+    void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int scan_code);
     void update_button_state(int button);
     void pointer_press(
         std::chrono::nanoseconds event_time,

--- a/src/platforms/x11/input/input_platform.cpp
+++ b/src/platforms/x11/input/input_platform.cpp
@@ -153,9 +153,9 @@ void window_resized(mir::X::X11Resources* x11_resources, xcb_window_t x11_window
         });
 }
 
-auto x11_keycode_get_scan_code(xcb_keycode_t x11_keycode) -> int
+auto xcb_keycode_get_scan_code(xcb_keycode_t xcb_keycode) -> int
 {
-    return x11_keycode - 8;
+    return xcb_keycode - 8;
 }
 }
 
@@ -394,19 +394,19 @@ void mix::XInputPlatform::process_input_event(xcb_generic_event_t* event)
         // Key repeats look like a release and an immediate press with the same timestamp. The only way to detect and
         // discard them is by peaking at the next event.
 
-        next_pending_event_callback = [this, x11_keycode = release_ev->detail, time = release_ev->time](auto next_event)
+        next_pending_event_callback = [this, xcb_keycode = release_ev->detail, time = release_ev->time](auto next_event)
             {
                 if (next_event && (next_event.value()->response_type & ~0x80) == XCB_KEY_PRESS)
                 {
                     auto const press_ev = reinterpret_cast<xcb_key_press_event_t*>(next_event.value());
-                    if (press_ev->detail == x11_keycode && press_ev->time == time)
+                    if (press_ev->detail == xcb_keycode && press_ev->time == time)
                     {
                         // This event is a key repeat, so ignore it. Also consume the next event by returning true.
                         return true;
                     }
                 }
 
-                key_released(x11_keycode, time);
+                key_released(xcb_keycode, time);
                 return false; // do not consume next event, process it normally
             };
     }   break;
@@ -569,26 +569,26 @@ void mix::XInputPlatform::process_xkb_event(xcb_generic_event_t* event)
     }
 }
 
-void mix::XInputPlatform::key_pressed(xcb_keycode_t x11_keycode, xcb_timestamp_t timestamp)
+void mix::XInputPlatform::key_pressed(xcb_keycode_t xcb_keycode, xcb_timestamp_t timestamp)
 {
-    if (pressed_keys.insert(x11_keycode).second)
+    if (pressed_keys.insert(xcb_keycode).second)
     {
         auto const event_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
             std::chrono::milliseconds{timestamp});
-        xkb_keysym_t const keysym = xkb_state_key_get_one_sym(key_state, x11_keycode);
-        auto const scan_code = x11_keycode_get_scan_code(x11_keycode);
+        xkb_keysym_t const keysym = xkb_state_key_get_one_sym(key_state, xcb_keycode);
+        auto const scan_code = xcb_keycode_get_scan_code(xcb_keycode);
         core_keyboard->key_press(event_time, keysym, scan_code);
     }
 }
 
-void mix::XInputPlatform::key_released(xcb_keycode_t x11_keycode, xcb_timestamp_t timestamp)
+void mix::XInputPlatform::key_released(xcb_keycode_t xcb_keycode, xcb_timestamp_t timestamp)
 {
-    if (pressed_keys.erase(x11_keycode))
+    if (pressed_keys.erase(xcb_keycode))
     {
         auto const event_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
             std::chrono::milliseconds{timestamp});
-        xkb_keysym_t keysym = xkb_state_key_get_one_sym(key_state, x11_keycode);
-        auto const scan_code = x11_keycode_get_scan_code(x11_keycode);
+        xkb_keysym_t keysym = xkb_state_key_get_one_sym(key_state, xcb_keycode);
+        auto const scan_code = xcb_keycode_get_scan_code(xcb_keycode);
         core_keyboard->key_release(event_time, keysym, scan_code);
     }
 }

--- a/src/server/input/default_event_builder.cpp
+++ b/src/server/input/default_event_builder.cpp
@@ -36,11 +36,11 @@ mi::DefaultEventBuilder::DefaultEventBuilder(MirInputDeviceId device_id,
 {
 }
 
-mir::EventUPtr mi::DefaultEventBuilder::key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t key_code,
+mir::EventUPtr mi::DefaultEventBuilder::key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t keysym,
                                                   int scan_code)
 {
     auto const cookie = cookie_authority->make_cookie(timestamp.count());
-    return me::make_event(device_id, timestamp, cookie->serialize(), action, key_code, scan_code, mir_input_event_modifier_none);
+    return me::make_event(device_id, timestamp, cookie->serialize(), action, keysym, scan_code, mir_input_event_modifier_none);
 }
 
 mir::EventUPtr mi::DefaultEventBuilder::pointer_event(Timestamp timestamp, MirPointerAction action,

--- a/src/server/input/default_event_builder.h
+++ b/src/server/input/default_event_builder.h
@@ -40,7 +40,7 @@ public:
                                  std::shared_ptr<cookie::Authority> const& cookie_authority,
                                  std::shared_ptr<Seat> const& seat);
 
-    EventUPtr key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t key_code, int scan_code) override;
+    EventUPtr key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t keysym, int scan_code) override;
 
     EventUPtr touch_event(Timestamp timestamp, std::vector<events::ContactState> const& contacts) override;
 

--- a/src/server/input/key_repeat_dispatcher.cpp
+++ b/src/server/input/key_repeat_dispatcher.cpp
@@ -69,8 +69,8 @@ struct DeviceRemovalFilter : mi::InputDeviceObserver
 
 auto is_meta_key(MirKeyboardEvent const* event) -> bool
 {
-    auto const key_code = mir_keyboard_event_key_code(event);
-    switch(key_code)
+    auto const keysym = mir_keyboard_event_keysym(event);
+    switch(keysym)
     {
     case XKB_KEY_Shift_R:
     case XKB_KEY_Shift_L:
@@ -83,7 +83,7 @@ auto is_meta_key(MirKeyboardEvent const* event) -> bool
     case XKB_KEY_Caps_Lock:
     case XKB_KEY_Scroll_Lock:
     case XKB_KEY_Num_Lock: return true;
-    default: return ((XKB_KEY_Shift_L <= key_code) && (key_code <= XKB_KEY_Hyper_R));
+    default: return ((XKB_KEY_Shift_L <= keysym) && (keysym <= XKB_KEY_Hyper_R));
     }
 }
 }
@@ -192,7 +192,7 @@ bool mi::KeyRepeatDispatcher::handle_key_input(MirInputDeviceId id, MirKeyboardE
         auto clone_event = [scan_code, id,
              cookie_authority=cookie_authority,
              next_dispatcher=next_dispatcher,
-             key_code = mir_keyboard_event_key_code(kev),
+             keysym = mir_keyboard_event_keysym(kev),
              modifiers = mir_keyboard_event_modifiers(kev)]()
              {
                  auto const now = std::chrono::steady_clock::now().time_since_epoch();
@@ -202,7 +202,7 @@ bool mi::KeyRepeatDispatcher::handle_key_input(MirInputDeviceId id, MirKeyboardE
                      now,
                      cookie->serialize(),
                      mir_keyboard_action_repeat,
-                     key_code,
+                     keysym,
                      scan_code,
                      modifiers);
                  next_dispatcher->dispatch(std::move(new_event));

--- a/tests/mir_test_framework/fake_input_device_impl.cpp
+++ b/tests/mir_test_framework/fake_input_device_impl.cpp
@@ -144,7 +144,7 @@ mtf::FakeInputDeviceImpl::InputDevice::InputDevice(mi::InputDeviceInfo const& in
 
 void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::KeyParameters const& key_params)
 {
-    xkb_keysym_t key_code = 0;
+    xkb_keysym_t keysym = 0;
 
     auto event_time = key_params.event_time.value_or(
         std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -153,7 +153,7 @@ void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::KeyPara
     auto input_action =
         (key_params.action == synthesis::EventAction::Down) ? mir_keyboard_action_down : mir_keyboard_action_up;
 
-    auto key_event = builder->key_event(event_time, input_action, key_code, key_params.scancode);
+    auto key_event = builder->key_event(event_time, input_action, keysym, key_params.scancode);
 
     if (!sink)
         BOOST_THROW_EXCEPTION(std::runtime_error("Device is not started."));

--- a/tests/unit-tests/input/test_event_builders.cpp
+++ b/tests/unit-tests/input/test_event_builders.cpp
@@ -41,11 +41,11 @@ struct InputEventBuilder : public Test
 TEST_F(InputEventBuilder, makes_valid_key_event)
 {
     MirKeyboardAction const action = mir_keyboard_action_down;
-    xkb_keysym_t const key_code = 34;
+    xkb_keysym_t const keysym = 34;
     int const scan_code = 17;
 
    auto ev = mev::make_event(device_id, timestamp,
-       cookie, action, key_code, scan_code, modifiers);
+       cookie, action, keysym, scan_code, modifiers);
    auto e = ev.get();
 
    EXPECT_EQ(mir_event_type_input, mir_event_get_type(e));
@@ -53,7 +53,7 @@ TEST_F(InputEventBuilder, makes_valid_key_event)
    EXPECT_EQ(mir_input_event_type_key, mir_input_event_get_type(ie));
    auto kev = mir_input_event_get_keyboard_event(ie);
    EXPECT_EQ(action, mir_keyboard_event_action(kev));
-   EXPECT_EQ(key_code, mir_keyboard_event_key_code(kev));
+   EXPECT_EQ(keysym, mir_keyboard_event_keysym(kev));
    EXPECT_EQ(scan_code, mir_keyboard_event_scan_code(kev));
    EXPECT_EQ(modifiers, mir_keyboard_event_modifiers(kev));
 }

--- a/tests/unit-tests/input/test_input_event.cpp
+++ b/tests/unit-tests/input/test_input_event.cpp
@@ -99,19 +99,19 @@ TEST(KeyInputEventProperties, up_and_down_actions_copied_from_old_style_event)
     EXPECT_EQ(mir_keyboard_action_up, mir_keyboard_event_action(new_kev));
 }
 
-TEST(KeyInputEventProperties, keycode_scancode_and_modifiers_taken_from_old_style_event)
+TEST(KeyInputEventProperties, keysym_scancode_and_modifiers_taken_from_old_style_event)
 {
-    xkb_keysym_t key_code = 171;
+    xkb_keysym_t keysym = 171;
     int scan_code = 31;
     MirInputEventModifiers modifiers = mir_input_event_modifier_shift;
 
     MirKeyboardEvent old_ev;
-    old_ev.set_key_code(key_code);
+    old_ev.set_keysym(keysym);
     old_ev.set_scan_code(scan_code);
     old_ev.set_modifiers(modifiers);
 
     auto new_kev = mir_input_event_get_keyboard_event(mir_event_get_input_event(&old_ev));
-    EXPECT_EQ(key_code, mir_keyboard_event_key_code(new_kev));
+    EXPECT_EQ(keysym, mir_keyboard_event_keysym(new_kev));
     EXPECT_EQ(scan_code, mir_keyboard_event_scan_code(new_kev));
     EXPECT_EQ(modifiers, mir_keyboard_event_modifiers(new_kev));
 }

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -391,7 +391,7 @@ TEST_F(AbstractShell, remove_display_adds_display_to_window_manager)
 TEST_F(AbstractShell, key_input_events_are_handled_by_window_manager)
 {
     MirKeyboardAction const action{mir_keyboard_action_down};
-    xkb_keysym_t const key_code{0};
+    xkb_keysym_t const keysym{0};
     int const scan_code{0};
     MirInputEventModifiers const modifiers{mir_input_event_modifier_none};
 
@@ -400,7 +400,7 @@ TEST_F(AbstractShell, key_input_events_are_handled_by_window_manager)
         event_timestamp,
         cookie,
         action,
-        key_code,
+        keysym,
         scan_code,
         modifiers);
 


### PR DESCRIPTION
Previously `key_code` was a badly overloaded name, referring to keysyms in some contexts and scan codes in other contexts. This PR standardizes the names across Mir to completely avoid the use of `key_code` (with the exception of the MirAL API, which keeps it in it's "keysym" meaning in order to remain stable).