### PR TITLE
Deprecate mir_keyboard_event_key_code()

### DIFF
--- a/debian/libmiral4.symbols
+++ b/debian/libmiral4.symbols
@@ -399,3 +399,4 @@ libmiral.so.4 libmiral4 #MINVER#
  (c++)"miral::WindowInfo::focus_mode() const@MIRAL_3.3" 3.3.0
  (c++)"miral::WindowSpecification::focus_mode() const@MIRAL_3.3" 3.3.0
  (c++)"miral::WindowSpecification::focus_mode()@MIRAL_3.3" 3.3.0
+ (c++)"miral::toolkit::mir_keyboard_event_keysym(MirKeyboardEvent const*)@MIRAL_3.3" 3.3.0

--- a/examples/miral-shell/shell_main.cpp
+++ b/examples/miral-shell/shell_main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char const* argv[])
             if (!(mods & mir_input_event_modifier_alt) || !(mods & mir_input_event_modifier_ctrl))
                 return false;
 
-            switch (mir_keyboard_event_key_code(kev))
+            switch (mir_keyboard_event_keysym(kev))
             {
             case XKB_KEY_BackSpace:
                 runner.stop();

--- a/include/miral/miral/toolkit_event.h
+++ b/include/miral/miral/toolkit_event.h
@@ -151,6 +151,7 @@ MirKeyboardAction mir_keyboard_event_action(MirKeyboardEvent const* event);
  *
  *   \param [in] event The key event
  *   \return           The xkb_keysym
+ *   \remark Since MirAL 3.3
  */
 xkb_keysym_t mir_keyboard_event_keysym(MirKeyboardEvent const* event);
 

--- a/include/miral/miral/toolkit_event.h
+++ b/include/miral/miral/toolkit_event.h
@@ -152,6 +152,11 @@ MirKeyboardAction mir_keyboard_event_action(MirKeyboardEvent const* event);
  *   \param [in] event The key event
  *   \return           The xkb_keysym
  */
+xkb_keysym_t mir_keyboard_event_keysym(MirKeyboardEvent const* event);
+
+/**
+ *   \deprecated       Returns the same thing as mir_keyboard_event_keysym(), which should be used instead.
+ */
 xkb_keysym_t mir_keyboard_event_key_code(MirKeyboardEvent const* event);
 
 /**

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -453,5 +453,6 @@ global:
     miral::PrintTo*;
     miral::WindowInfo::focus_mode*;
     miral::WindowSpecification::focus_mode*;
+    miral::toolkit::mir_keyboard_event_keysym*;
   };
 } MIRAL_3.2;

--- a/src/miral/toolkit_event.cpp
+++ b/src/miral/toolkit_event.cpp
@@ -74,6 +74,11 @@ MirKeyboardAction mir_keyboard_event_action(MirKeyboardEvent const* event)
     return ::mir_keyboard_event_action(event);
 }
 
+xkb_keysym_t mir_keyboard_event_keysym(MirKeyboardEvent const* event)
+{
+    return ::mir_keyboard_event_keysym(event);
+}
+
 xkb_keysym_t mir_keyboard_event_key_code(MirKeyboardEvent const* event)
 {
     return ::mir_keyboard_event_keysym(event);


### PR DESCRIPTION
Stacked on top of #2074