### PR TITLE
Use less out-of-date cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,6 @@ add_compile_definitions(LOG_NDEBUG=1)
 enable_testing()
 find_package(PkgConfig)
 
-include_directories(include/core)
 include_directories(include/common)
 
 # Check for boost

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,6 @@ find_package(PkgConfig)
 
 include_directories(include/core)
 include_directories(include/common)
-include_directories(include/cookie)
 
 # Check for boost
 find_package(Boost 1.48.0 COMPONENTS date_time system program_options filesystem iostreams REQUIRED)

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -15,7 +15,7 @@ set(symbol_map ${CMAKE_SOURCE_DIR}/src/client/symbols.map)
 add_compile_definitions(MIR_LOG_COMPONENT_FALLBACK="mirclient")
 
 set(MIR_CLIENT_SOURCES)
-set(MIR_CLIENT_REFERENCES mircommon)
+set(MIR_CLIENT_REFERENCES mircommon mircore)
 
 add_subdirectory(events)
 add_subdirectory(input)
@@ -28,6 +28,8 @@ add_library(mirclientobjects OBJECT
   mir_cursor_api.cpp
   ${MIR_CLIENT_SOURCES}
 )
+
+target_link_libraries(mirclientobjects mircore)
 
 add_library(mirclient SHARED $<TARGET_OBJECTS:mirclientobjects> $<TARGET_OBJECTS:mirsharedinput>)
 

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -29,7 +29,10 @@ add_library(mirclientobjects OBJECT
   ${MIR_CLIENT_SOURCES}
 )
 
-target_link_libraries(mirclientobjects mircore)
+target_link_libraries(mirclientobjects
+  LINK_PUBLIC
+    mircore
+)
 
 add_library(mirclient SHARED $<TARGET_OBJECTS:mirclientobjects> $<TARGET_OBJECTS:mirsharedinput>)
 

--- a/src/client/input/CMakeLists.txt
+++ b/src/client/input/CMakeLists.txt
@@ -20,7 +20,11 @@ add_library(mirsharedinput OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/xkb_mapper.cpp
 )
 
-target_link_libraries(mirsharedinput mircookie mircore)
+target_link_libraries(mirsharedinput
+  LINK_PUBLIC
+    mircore
+    mircookie
+)
 
 list(APPEND MIR_CLIENT_REFERENCES ${XKBCOMMON_LIBRARIES})
 

--- a/src/client/input/CMakeLists.txt
+++ b/src/client/input/CMakeLists.txt
@@ -20,6 +20,8 @@ add_library(mirsharedinput OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/xkb_mapper.cpp
 )
 
+target_link_libraries(mirsharedinput mircookie)
+
 list(APPEND MIR_CLIENT_REFERENCES ${XKBCOMMON_LIBRARIES})
 
 set(MIR_CLIENT_SOURCES ${MIR_CLIENT_SOURCES} PARENT_SCOPE)

--- a/src/client/input/CMakeLists.txt
+++ b/src/client/input/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(mirsharedinput OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/xkb_mapper.cpp
 )
 
-target_link_libraries(mirsharedinput mircookie)
+target_link_libraries(mirsharedinput mircookie mircore)
 
 list(APPEND MIR_CLIENT_REFERENCES ${XKBCOMMON_LIBRARIES})
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -49,8 +49,9 @@ add_library(mircommon SHARED
 )
 
 target_link_libraries(mircommon
-  mircore
-  ${MIR_COMMON_REFERENCES}
+  LINK_PUBLIC
+    mircore
+    ${MIR_COMMON_REFERENCES}
 )
 
 

--- a/src/common/events/CMakeLists.txt
+++ b/src/common/events/CMakeLists.txt
@@ -36,6 +36,10 @@ add_library(
   ${EVENT_SOURCES}
 )
 
+target_link_libraries(mirevents
+    mircore
+)
+
 include_directories(
     ${PROJECT_SOURCE_DIR}/include/client
     ${PROJECT_SOURCE_DIR}/src/include/cookie

--- a/src/common/events/CMakeLists.txt
+++ b/src/common/events/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(
 )
 
 target_link_libraries(mirevents
+  LINK_PUBLIC
     mircore
 )
 

--- a/src/cookie/CMakeLists.txt
+++ b/src/cookie/CMakeLists.txt
@@ -6,12 +6,6 @@ configure_file(
   @ONLY
 )
 
-include_directories(
-  ${PROJECT_SOURCE_DIR}/src/include/cookie
-  ${PROJECT_SOURCE_DIR}/include/cookie
-  ${NETTLE_INCLUDE_DIRS}
-)
-
 set(MIRCOOKIE_ABI 2)
 set(symbol_map ${CMAKE_SOURCE_DIR}/src/cookie/symbols.map)
 
@@ -19,6 +13,14 @@ add_library(mircookie SHARED
   authority.cpp
   const_memcmp.cpp
   hmac_cookie.cpp
+)
+
+target_include_directories(mircookie
+  PUBLIC
+    ${PROJECT_SOURCE_DIR}/include/cookie
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/include/cookie
+    ${NETTLE_INCLUDE_DIRS}
 )
 
 set_target_properties(mircookie

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -36,10 +36,9 @@ target_include_directories(mircore
 )
 
 
-target_link_libraries(
-  mircore
-
-  ${Boost_SYSTEM_LIBRARY}
+target_link_libraries(mircore
+  LINK_PRIVATE
+    ${Boost_SYSTEM_LIBRARY}
 )
 
 set(symbol_map ${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -30,6 +30,12 @@ add_library(mircore SHARED
     ${PROJECT_SOURCE_DIR}/include/core/mir_toolkit/mir_version_number.h
 )
 
+target_include_directories(mircore
+  PUBLIC
+    ${PROJECT_SOURCE_DIR}/include/core
+)
+
+
 target_link_libraries(
   mircore
 

--- a/src/gl/CMakeLists.txt
+++ b/src/gl/CMakeLists.txt
@@ -9,3 +9,8 @@ ADD_LIBRARY(
 
   tessellation_helpers.cpp
 )
+
+
+target_link_libraries(mirgl
+    mircore
+)

--- a/src/gl/CMakeLists.txt
+++ b/src/gl/CMakeLists.txt
@@ -12,5 +12,6 @@ ADD_LIBRARY(
 
 
 target_link_libraries(mirgl
+  LINK_PUBLIC
     mircore
 )

--- a/src/platform/options/CMakeLists.txt
+++ b/src/platform/options/CMakeLists.txt
@@ -10,4 +10,7 @@ add_library(miroptions OBJECT
   ${CHOICE_SOURCES}
 )
 
-target_link_libraries(miroptions mircore)
+target_link_libraries(miroptions
+  LINK_PUBLIC
+    mircore
+)

--- a/src/platform/options/CMakeLists.txt
+++ b/src/platform/options/CMakeLists.txt
@@ -9,3 +9,5 @@ add_library(miroptions OBJECT
 
   ${CHOICE_SOURCES}
 )
+
+target_link_libraries(miroptions mircore)

--- a/src/platforms/common/server/CMakeLists.txt
+++ b/src/platforms/common/server/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(server_platform_common STATIC
 
 target_link_libraries(
   server_platform_common
+  mircore
 
   ${KMS_UTILS_STATIC_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}

--- a/src/platforms/common/server/CMakeLists.txt
+++ b/src/platforms/common/server/CMakeLists.txt
@@ -17,12 +17,11 @@ add_library(server_platform_common STATIC
   buffer_from_wl_shm.cpp
 )
 
-target_link_libraries(
-  server_platform_common
-  mircore
-
-  ${KMS_UTILS_STATIC_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY}
-  ${WAYLAND_SERVER_LDFLAGS} ${WAYLAND_SERVER_LIBRARIES}
-  ${GL_LDFLAGS} ${GL_LIBRARIES}
+target_link_libraries(server_platform_common
+  LINK_PUBLIC
+    mircore
+    ${KMS_UTILS_STATIC_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${WAYLAND_SERVER_LDFLAGS} ${WAYLAND_SERVER_LIBRARIES}
+    ${GL_LDFLAGS} ${GL_LIBRARIES}
 )

--- a/src/platforms/eglstream-kms/server/CMakeLists.txt
+++ b/src/platforms/eglstream-kms/server/CMakeLists.txt
@@ -31,6 +31,10 @@ add_library(mirplatformgraphicseglstreamkmsobjects OBJECT
   threaded_drm_event_handler.cpp
 )
 
+target_link_libraries(mirplatformgraphicseglstreamkmsobjects
+  mircore
+)
+
 add_library(mirplatformgraphicseglstreamkms MODULE
   $<TARGET_OBJECTS:mirplatformgraphicseglstreamkmsobjects>
 )

--- a/src/platforms/eglstream-kms/server/CMakeLists.txt
+++ b/src/platforms/eglstream-kms/server/CMakeLists.txt
@@ -32,7 +32,8 @@ add_library(mirplatformgraphicseglstreamkmsobjects OBJECT
 )
 
 target_link_libraries(mirplatformgraphicseglstreamkmsobjects
-  mircore
+  LINK_PUBLIC
+    mircore
 )
 
 add_library(mirplatformgraphicseglstreamkms MODULE

--- a/src/platforms/evdev/CMakeLists.txt
+++ b/src/platforms/evdev/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(mirevdevutilsobjects OBJECT
 )
 
 target_link_libraries(mirevdevutilsobjects
+  LINK_PUBLIC
     mircore
 )
 
@@ -31,6 +32,7 @@ add_library(mirplatforminputevdevobjects OBJECT
         fd_store.cpp fd_store.h)
 
 target_link_libraries(mirplatforminputevdevobjects
+  LINK_PUBLIC
     mircore
 )
 

--- a/src/platforms/evdev/CMakeLists.txt
+++ b/src/platforms/evdev/CMakeLists.txt
@@ -19,12 +19,20 @@ add_library(mirevdevutilsobjects OBJECT
     button_utils.cpp
 )
 
+target_link_libraries(mirevdevutilsobjects
+    mircore
+)
+
 add_library(mirplatforminputevdevobjects OBJECT
     libinput_device.cpp
     libinput_device_ptr.cpp
     libinput_ptr.cpp
     platform.cpp
         fd_store.cpp fd_store.h)
+
+target_link_libraries(mirplatforminputevdevobjects
+    mircore
+)
 
 add_library(mirplatforminputevdev MODULE
   platform_factory.cpp

--- a/src/platforms/gbm-kms/common/CMakeLists.txt
+++ b/src/platforms/gbm-kms/common/CMakeLists.txt
@@ -8,3 +8,5 @@ add_library(
   mirsharedgbm-static STATIC
   gbm_format_conversions.cpp
 )
+
+target_link_libraries(mirsharedgbm-static mircore)

--- a/src/platforms/gbm-kms/common/CMakeLists.txt
+++ b/src/platforms/gbm-kms/common/CMakeLists.txt
@@ -9,4 +9,7 @@ add_library(
   gbm_format_conversions.cpp
 )
 
-target_link_libraries(mirsharedgbm-static mircore)
+target_link_libraries(mirsharedgbm-static
+  LINK_PUBLIC
+    mircore
+)

--- a/src/platforms/rpi-dispmanx/CMakeLists.txt
+++ b/src/platforms/rpi-dispmanx/CMakeLists.txt
@@ -14,6 +14,11 @@ add_library(mirplatformgraphicsrpidispmanxobjects OBJECT
   helpers.cpp
 )
 
+target_link_libraries(mirplatformgraphicsrpidispmanxobjects
+  LINK_PUBLIC
+    mircore
+)
+
 target_include_directories(
   mirplatformgraphicsrpidispmanxobjects
     PRIVATE

--- a/src/platforms/wayland/CMakeLists.txt
+++ b/src/platforms/wayland/CMakeLists.txt
@@ -49,6 +49,10 @@ add_library(mirplatformwayland-input STATIC
   input_device.cpp      input_device.h
 )
 
+target_link_libraries(mirplatformwayland-input
+  mircore
+)
+
 target_include_directories(mirplatformwayland-input
 PUBLIC
     ${server_common_include_dirs}

--- a/src/platforms/wayland/CMakeLists.txt
+++ b/src/platforms/wayland/CMakeLists.txt
@@ -50,7 +50,8 @@ add_library(mirplatformwayland-input STATIC
 )
 
 target_link_libraries(mirplatformwayland-input
-  mircore
+  LINK_PUBLIC
+    mircore
 )
 
 target_include_directories(mirplatformwayland-input

--- a/src/platforms/x11/graphics/CMakeLists.txt
+++ b/src/platforms/x11/graphics/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(
   graphics.cpp
 )
 
+target_link_libraries(mirplatformgraphicsx11objects-symbols mircore)
+
 target_link_libraries(
   mirplatformgraphicsx11objects
 

--- a/src/platforms/x11/graphics/CMakeLists.txt
+++ b/src/platforms/x11/graphics/CMakeLists.txt
@@ -28,7 +28,10 @@ add_library(
   graphics.cpp
 )
 
-target_link_libraries(mirplatformgraphicsx11objects-symbols mircore)
+target_link_libraries(mirplatformgraphicsx11objects-symbols
+  LINK_PUBLIC
+    mircore
+)
 
 target_link_libraries(
   mirplatformgraphicsx11objects

--- a/src/platforms/x11/input/CMakeLists.txt
+++ b/src/platforms/x11/input/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(
   input_device.cpp
 )
 
+target_link_libraries(mirplatforminputx11objects mircore)
+
 add_library(
   mirplatforminputx11objects-symbols OBJECT
 

--- a/src/platforms/x11/input/CMakeLists.txt
+++ b/src/platforms/x11/input/CMakeLists.txt
@@ -10,7 +10,10 @@ add_library(
   input_device.cpp
 )
 
-target_link_libraries(mirplatforminputx11objects mircore)
+target_link_libraries(mirplatforminputx11objects
+  LINK_PUBLIC
+    mircore
+)
 
 add_library(
   mirplatforminputx11objects-symbols OBJECT

--- a/src/renderers/gl/CMakeLists.txt
+++ b/src/renderers/gl/CMakeLists.txt
@@ -31,3 +31,5 @@ ADD_LIBRARY(
   renderer.cpp
   renderer_factory.cpp
 )
+
+target_link_libraries(mirrenderergl mircore)

--- a/src/renderers/gl/CMakeLists.txt
+++ b/src/renderers/gl/CMakeLists.txt
@@ -32,4 +32,8 @@ ADD_LIBRARY(
   renderer_factory.cpp
 )
 
-target_link_libraries(mirrenderergl mircore)
+target_link_libraries(mirrenderergl
+  LINK_PUBLIC
+    mircore
+)
+

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -69,7 +69,11 @@ add_library(mirserverobjects OBJECT
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/synchronised.h
 )
 
-target_link_libraries(mirserverobjects mircookie mircore)
+target_link_libraries(mirserverobjects
+  LINK_PUBLIC
+    mircookie
+    mircore
+)
 
 set_property(
     SOURCE glib_main_loop.cpp glib_main_loop_sources.cpp default_server_configuration.cpp

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -16,7 +16,6 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/src/include/platform
   ${PROJECT_SOURCE_DIR}/src/include/client
   ${PROJECT_SOURCE_DIR}/src/include/server
-  ${PROJECT_SOURCE_DIR}/include/cookie
   ${PROJECT_SOURCE_DIR}/src/include/cookie
   ${GLIB_INCLUDE_DIRS}
   ${GIO_INCLUDE_DIRS}
@@ -69,6 +68,8 @@ add_library(mirserverobjects OBJECT
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/glib_main_loop_sources.h
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/synchronised.h
 )
+
+target_link_libraries(mirserverobjects mircookie)
 
 set_property(
     SOURCE glib_main_loop.cpp glib_main_loop_sources.cpp default_server_configuration.cpp

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -69,7 +69,7 @@ add_library(mirserverobjects OBJECT
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/synchronised.h
 )
 
-target_link_libraries(mirserverobjects mircookie)
+target_link_libraries(mirserverobjects mircookie mircore)
 
 set_property(
     SOURCE glib_main_loop.cpp glib_main_loop_sources.cpp default_server_configuration.cpp

--- a/src/server/compositor/CMakeLists.txt
+++ b/src/server/compositor/CMakeLists.txt
@@ -25,3 +25,4 @@ ADD_LIBRARY(
   ${MIR_COMPOSITOR_SRCS}
 )
 
+target_link_libraries(mircompositor mircore)

--- a/src/server/compositor/CMakeLists.txt
+++ b/src/server/compositor/CMakeLists.txt
@@ -25,4 +25,8 @@ ADD_LIBRARY(
   ${MIR_COMPOSITOR_SRCS}
 )
 
-target_link_libraries(mircompositor mircore)
+target_link_libraries(mircompositor
+  LINK_PUBLIC
+    mircore
+)
+

--- a/src/server/console/CMakeLists.txt
+++ b/src/server/console/CMakeLists.txt
@@ -23,7 +23,10 @@ set_source_files_properties(
     "${CMAKE_C_FLAGS} -Wno-pedantic -Wno-unused-parameter -Wno-unused-function"
 )
 
-target_link_libraries(mirconsole mircore)
+target_link_libraries(mirconsole
+  LINK_PUBLIC
+    mircore
+)
 
 set_property(
     SOURCE logind_console_services.cpp default_configuration.cpp

--- a/src/server/console/CMakeLists.txt
+++ b/src/server/console/CMakeLists.txt
@@ -23,6 +23,8 @@ set_source_files_properties(
     "${CMAKE_C_FLAGS} -Wno-pedantic -Wno-unused-parameter -Wno-unused-function"
 )
 
+target_link_libraries(mirconsole mircore)
+
 set_property(
     SOURCE logind_console_services.cpp default_configuration.cpp
     PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)

--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -80,3 +80,5 @@ add_library(mirfrontend-wayland OBJECT
 
   ${WAYLAND_SOURCES}
 )
+
+target_link_libraries(mirfrontend-wayland mircore)

--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -81,4 +81,8 @@ add_library(mirfrontend-wayland OBJECT
   ${WAYLAND_SOURCES}
 )
 
-target_link_libraries(mirfrontend-wayland mircore)
+target_link_libraries(mirfrontend-wayland
+  LINK_PUBLIC
+    mircore
+)
+

--- a/src/server/frontend_xwayland/CMakeLists.txt
+++ b/src/server/frontend_xwayland/CMakeLists.txt
@@ -31,3 +31,5 @@ add_library(mirfrontend-xwayland OBJECT
 
   ${XWAYLAND_SOURCES}
 )
+
+target_link_libraries(mirfrontend-xwayland mircore)

--- a/src/server/frontend_xwayland/CMakeLists.txt
+++ b/src/server/frontend_xwayland/CMakeLists.txt
@@ -32,4 +32,8 @@ add_library(mirfrontend-xwayland OBJECT
   ${XWAYLAND_SOURCES}
 )
 
-target_link_libraries(mirfrontend-xwayland mircore)
+target_link_libraries(mirfrontend-xwayland
+  LINK_PUBLIC
+    mircore
+)
+

--- a/src/server/graphics/CMakeLists.txt
+++ b/src/server/graphics/CMakeLists.txt
@@ -17,3 +17,5 @@ add_library(
   platform_probe.cpp
   platform_probe.h
 )
+
+target_link_libraries(mirgraphics mircore)

--- a/src/server/graphics/CMakeLists.txt
+++ b/src/server/graphics/CMakeLists.txt
@@ -18,4 +18,7 @@ add_library(
   platform_probe.h
 )
 
-target_link_libraries(mirgraphics mircore)
+target_link_libraries(mirgraphics
+  LINK_PUBLIC
+    mircore
+)

--- a/src/server/input/CMakeLists.txt
+++ b/src/server/input/CMakeLists.txt
@@ -39,3 +39,5 @@ add_library(
 
   ${INPUT_SOURCES}
 )
+
+target_link_libraries(mirinput mircookie)

--- a/src/server/input/CMakeLists.txt
+++ b/src/server/input/CMakeLists.txt
@@ -40,4 +40,8 @@ add_library(
   ${INPUT_SOURCES}
 )
 
-target_link_libraries(mirinput mircookie mircore)
+target_link_libraries(mirinput
+  LINK_PUBLIC
+    mircookie
+    mircore
+)

--- a/src/server/input/CMakeLists.txt
+++ b/src/server/input/CMakeLists.txt
@@ -40,4 +40,4 @@ add_library(
   ${INPUT_SOURCES}
 )
 
-target_link_libraries(mirinput mircookie)
+target_link_libraries(mirinput mircookie mircore)

--- a/src/server/report/CMakeLists.txt
+++ b/src/server/report/CMakeLists.txt
@@ -8,3 +8,5 @@ add_library(
     reports.cpp
     reports.h
 )
+
+target_link_libraries(mirreport mircore)

--- a/src/server/report/CMakeLists.txt
+++ b/src/server/report/CMakeLists.txt
@@ -9,4 +9,7 @@ add_library(
     reports.h
 )
 
-target_link_libraries(mirreport mircore)
+target_link_libraries(mirreport
+  LINK_PUBLIC
+    mircore
+)

--- a/src/server/report/logging/CMakeLists.txt
+++ b/src/server/report/logging/CMakeLists.txt
@@ -18,3 +18,4 @@ add_library(
   ${LOGGING_SOURCES}
 )
 
+target_link_libraries(mirlogging mircore)

--- a/src/server/report/logging/CMakeLists.txt
+++ b/src/server/report/logging/CMakeLists.txt
@@ -18,4 +18,7 @@ add_library(
   ${LOGGING_SOURCES}
 )
 
-target_link_libraries(mirlogging mircore)
+target_link_libraries(mirlogging
+  LINK_PUBLIC
+    mircore
+)

--- a/src/server/report/lttng/CMakeLists.txt
+++ b/src/server/report/lttng/CMakeLists.txt
@@ -46,6 +46,8 @@ add_library(
   ${LTTNG_SOURCES}
 )
 
+target_link_libraries(mirlttng mircore)
+
 add_library(mirserverlttng SHARED tracepoints.c)
 
 target_link_libraries(

--- a/src/server/report/lttng/CMakeLists.txt
+++ b/src/server/report/lttng/CMakeLists.txt
@@ -46,7 +46,10 @@ add_library(
   ${LTTNG_SOURCES}
 )
 
-target_link_libraries(mirlttng mircore)
+target_link_libraries(mirlttng
+  LINK_PUBLIC
+    mircore
+)
 
 add_library(mirserverlttng SHARED tracepoints.c)
 

--- a/src/server/report/null/CMakeLists.txt
+++ b/src/server/report/null/CMakeLists.txt
@@ -10,3 +10,5 @@ add_library(
     shell_report.cpp
     shell_report.h
 )
+
+target_link_libraries(mirnullreport mircore)

--- a/src/server/report/null/CMakeLists.txt
+++ b/src/server/report/null/CMakeLists.txt
@@ -11,4 +11,7 @@ add_library(
     shell_report.h
 )
 
-target_link_libraries(mirnullreport mircore)
+target_link_libraries(mirnullreport
+  LINK_PUBLIC
+    mircore
+)

--- a/src/server/scene/CMakeLists.txt
+++ b/src/server/scene/CMakeLists.txt
@@ -34,3 +34,5 @@ ADD_LIBRARY(
   surface_state_tracker.cpp
   ${CMAKE_SOURCE_DIR}/src/include/server/mir/scene/surface_observer.h
 )
+
+target_link_libraries(mirscene mircore)

--- a/src/server/scene/CMakeLists.txt
+++ b/src/server/scene/CMakeLists.txt
@@ -35,4 +35,7 @@ ADD_LIBRARY(
   ${CMAKE_SOURCE_DIR}/src/include/server/mir/scene/surface_observer.h
 )
 
-target_link_libraries(mirscene mircore)
+target_link_libraries(mirscene
+  LINK_PUBLIC
+    mircore
+)

--- a/src/server/shell/CMakeLists.txt
+++ b/src/server/shell/CMakeLists.txt
@@ -24,3 +24,6 @@ add_library(
 
   ${SHELL_SOURCES}
 )
+
+target_link_libraries(mirshell mircore)
+

--- a/src/server/shell/CMakeLists.txt
+++ b/src/server/shell/CMakeLists.txt
@@ -25,5 +25,8 @@ add_library(
   ${SHELL_SOURCES}
 )
 
-target_link_libraries(mirshell mircore)
+target_link_libraries(mirshell
+  LINK_PUBLIC
+    mircore
+)
 

--- a/src/server/shell/decoration/CMakeLists.txt
+++ b/src/server/shell/decoration/CMakeLists.txt
@@ -17,3 +17,5 @@ add_library(
 
   ${DECORATION_SOURCES}
 )
+
+target_link_libraries(mirshelldecoration mircore)

--- a/src/server/shell/decoration/CMakeLists.txt
+++ b/src/server/shell/decoration/CMakeLists.txt
@@ -18,4 +18,7 @@ add_library(
   ${DECORATION_SOURCES}
 )
 
-target_link_libraries(mirshelldecoration mircore)
+target_link_libraries(mirshelldecoration
+  LINK_PUBLIC
+    mircore
+)

--- a/tests/integration-tests/CMakeLists.txt
+++ b/tests/integration-tests/CMakeLists.txt
@@ -3,7 +3,6 @@ include(CMakeDependentOption)
 include_directories(
   ${CMAKE_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${PROJECT_SOURCE_DIR}/include/cookie
   ${PROJECT_SOURCE_DIR}/src/include/platform
   ${PROJECT_SOURCE_DIR}/src/include/cookie
   ${PROJECT_SOURCE_DIR}/src/include/common

--- a/tests/mir_test/CMakeLists.txt
+++ b/tests/mir_test/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(mir-public-test OBJECT
   spin_wait.cpp
 )
 
+target_link_libraries(mir-public-test mircore)
+
 add_library(mir-test-static STATIC
   fake_clock.cpp
   fd_utils.cpp
@@ -22,6 +24,8 @@ add_library(mir-test-static STATIC
   wait_object.cpp
   $<TARGET_OBJECTS:mir-public-test>
 )
+
+target_link_libraries(mir-test-static mircore)
 
 if (NOT HAVE_PTHREAD_GETNAME_NP)
     set_source_files_properties (current_thread_name.cpp PROPERTIES COMPILE_DEFINITIONS MIR_DONT_USE_PTHREAD_GETNAME_NP

--- a/tests/mir_test/CMakeLists.txt
+++ b/tests/mir_test/CMakeLists.txt
@@ -15,7 +15,10 @@ add_library(mir-public-test OBJECT
   spin_wait.cpp
 )
 
-target_link_libraries(mir-public-test mircore)
+target_link_libraries(mir-public-test
+  LINK_PUBLIC
+    mircore
+)
 
 add_library(mir-test-static STATIC
   fake_clock.cpp
@@ -25,7 +28,10 @@ add_library(mir-test-static STATIC
   $<TARGET_OBJECTS:mir-public-test>
 )
 
-target_link_libraries(mir-test-static mircore)
+target_link_libraries(mir-test-static
+  LINK_PUBLIC
+    mircore
+)
 
 if (NOT HAVE_PTHREAD_GETNAME_NP)
     set_source_files_properties (current_thread_name.cpp PROPERTIES COMPILE_DEFINITIONS MIR_DONT_USE_PTHREAD_GETNAME_NP

--- a/tests/mir_test_doubles/CMakeLists.txt
+++ b/tests/mir_test_doubles/CMakeLists.txt
@@ -74,6 +74,8 @@ add_library(mir-public-test-doubles OBJECT
   fake_display.cpp ${CMAKE_SOURCE_DIR}/include/test/mir/test/doubles/fake_display.h
 )
 
+target_link_libraries(mir-public-test-doubles mircore)
+
 add_library(mir-test-doubles-static STATIC
   $<TARGET_OBJECTS:mir-public-test-doubles>
   ${TEST_UTILS_SRCS}
@@ -96,6 +98,8 @@ target_link_libraries(mir-test-doubles-static
 add_library(mir-public-test-doubles-platform OBJECT
   ${MIR_TEST_DOUBLES_PLATFORM_SRCS}
 )
+
+target_link_libraries(mir-public-test-doubles-platform mircore)
 
 add_library(
   mir-test-doubles-platform-static STATIC

--- a/tests/mir_test_doubles/CMakeLists.txt
+++ b/tests/mir_test_doubles/CMakeLists.txt
@@ -74,7 +74,10 @@ add_library(mir-public-test-doubles OBJECT
   fake_display.cpp ${CMAKE_SOURCE_DIR}/include/test/mir/test/doubles/fake_display.h
 )
 
-target_link_libraries(mir-public-test-doubles mircore)
+target_link_libraries(mir-public-test-doubles
+  LINK_PUBLIC
+    mircore
+)
 
 add_library(mir-test-doubles-static STATIC
   $<TARGET_OBJECTS:mir-public-test-doubles>
@@ -99,7 +102,10 @@ add_library(mir-public-test-doubles-platform OBJECT
   ${MIR_TEST_DOUBLES_PLATFORM_SRCS}
 )
 
-target_link_libraries(mir-public-test-doubles-platform mircore)
+target_link_libraries(mir-public-test-doubles-platform
+  LINK_PUBLIC
+    mircore
+)
 
 add_library(
   mir-test-doubles-platform-static STATIC

--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -50,7 +50,10 @@ add_library(mir-public-test-framework OBJECT
   test_display_server.cpp  ${PROJECT_SOURCE_DIR}/include/test/miral/test_display_server.h
 )
 
-target_link_libraries(mir-public-test-framework mircore)
+target_link_libraries(mir-public-test-framework
+  LINK_PUBLIC
+    mircore
+)
 
 set_property(
     SOURCE udev_environment.cpp
@@ -65,10 +68,16 @@ add_library(mir-protected-test-framework OBJECT
   input_testing_server_options.cpp
 )
 
-target_link_libraries(mir-protected-test-framework mircore)
+target_link_libraries(mir-protected-test-framework
+  LINK_PUBLIC
+    mircore
+)
 
 add_library(mir-libinput-test-framework OBJECT libinput_environment.cpp)
-target_link_libraries(mir-libinput-test-framework mircore)
+target_link_libraries(mir-libinput-test-framework
+  LINK_PUBLIC
+    mircore
+)
 
 add_library(mir-umock-test-framework OBJECT udev_environment.cpp)
 
@@ -102,7 +111,10 @@ add_library(
   stub_input_platform.cpp
   )
 
-target_link_libraries(mir-test-input-framework mircore)
+target_link_libraries(mir-test-input-framework
+  LINK_PUBLIC
+    mircore
+)
 
 add_library(
   mirplatforminputstub MODULE

--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -50,6 +50,8 @@ add_library(mir-public-test-framework OBJECT
   test_display_server.cpp  ${PROJECT_SOURCE_DIR}/include/test/miral/test_display_server.h
 )
 
+target_link_libraries(mir-public-test-framework mircore)
+
 set_property(
     SOURCE udev_environment.cpp
     PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
@@ -63,7 +65,11 @@ add_library(mir-protected-test-framework OBJECT
   input_testing_server_options.cpp
 )
 
+target_link_libraries(mir-protected-test-framework mircore)
+
 add_library(mir-libinput-test-framework OBJECT libinput_environment.cpp)
+target_link_libraries(mir-libinput-test-framework mircore)
+
 add_library(mir-umock-test-framework OBJECT udev_environment.cpp)
 
 
@@ -95,6 +101,8 @@ add_library(
   fake_input_device_impl.cpp
   stub_input_platform.cpp
   )
+
+target_link_libraries(mir-test-input-framework mircore)
 
 add_library(
   mirplatforminputstub MODULE

--- a/tests/umock-acceptance-tests/CMakeLists.txt
+++ b/tests/umock-acceptance-tests/CMakeLists.txt
@@ -3,7 +3,6 @@ include(CMakeDependentOption)
 include_directories(
   ${CMAKE_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/tests/include/
-  ${CMAKE_SOURCE_DIR}/include/cookie
   ${UMOCKDEV_INCLUDE_DIRS}
 )
 

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -26,7 +26,6 @@ include_directories(
   ${GBM_INCLUDE_DIRS}
   ${UMOCKDEV_INCLUDE_DIRS}
 
-  ${PROJECT_SOURCE_DIR}/include/cookie
   ${PROJECT_SOURCE_DIR}/include/renderers/sw
   ${PROJECT_SOURCE_DIR}/src/include/cookie
   ${PROJECT_SOURCE_DIR}/src/include/platform


### PR DESCRIPTION
There's a lot of archaic cmake around the project, and this chips away a piece.

Rather than setting public include directories in dependent targets they can be automated using `target_include_directories(... PUBLIC ...)`.

This makes a start with mircore and mircookie.