### PR TITLE
udev: Handle the first entry of an udev iterator being invalid

### DIFF
--- a/src/include/platform/mir/udev/wrapper.h
+++ b/src/include/platform/mir/udev/wrapper.h
@@ -113,7 +113,7 @@ public:
         iterator ();
         iterator (std::shared_ptr<Context> const& ctx, udev_list_entry* entry);
 
-        void increment();
+        void increment(udev_list_entry* start_from);
 
         std::shared_ptr<Context> ctx;
         udev_list_entry* entry;


### PR DESCRIPTION
If a udev device is removed between the time we scan and the time
we try and iterate through it then the `device_from_syspath` call
will fail with a `std::runtime_error`.

We catch that on `++iterator` and `iterator++` but *not* if the
very first udev device has disappeared; in that case we crash
with an unhandled exception.

Extend the `increment()` handling to also handle the inital case,
and then use it to handle the case where the first udev device
has disappeared.