### PR TITLE
Fix a log error message

### DIFF
--- a/src/miral/internal_client.cpp
+++ b/src/miral/internal_client.cpp
@@ -131,10 +131,10 @@ void WlInternalClientRunner<Base>::run(mir::Server& server)
                     wl_display_roundtrip(display);
                 }
             }
-            catch (std::exception const& e)
+            catch (std::exception const&)
             {
                 mir::log(mir::logging::Severity::informational, MIR_LOG_COMPONENT,
-                         std::make_exception_ptr(e), e.what());
+                         std::current_exception(), "internal client failed to connect to server");
             }
         }};
 }

--- a/src/platforms/eglstream-kms/server/egl_output.cpp
+++ b/src/platforms/eglstream-kms/server/egl_output.cpp
@@ -166,11 +166,11 @@ mgek::EGLOutput::~EGLOutput()
     {
         restore_saved_crtc();
     }
-    catch(std::exception const& e)
+    catch(std::exception const&)
     {
         log(logging::Severity::error,
             MIR_LOG_COMPONENT_FALLBACK,
-            std::make_exception_ptr(e),
+            std::current_exception(),
             "Failed to restore saved crtc");
     }
 }

--- a/src/platforms/evdev/platform.cpp
+++ b/src/platforms/evdev/platform.cpp
@@ -366,10 +366,10 @@ void mie::Platform::start()
                     break;
                 }
             }
-            catch (std::exception const& e)
+            catch (std::exception const&)
             {
                 auto const message = "Failed to handle UDev " + event_type + " event for " + device.syspath();
-                log(logging::Severity::warning, MIR_LOG_COMPONENT, std::make_exception_ptr(e), message);
+                log(logging::Severity::warning, MIR_LOG_COMPONENT, std::current_exception(), message);
             }
         });
 

--- a/src/server/input/vt_filter.cpp
+++ b/src/server/input/vt_filter.cpp
@@ -50,12 +50,12 @@ bool mir::input::VTFilter::handle(MirEvent const& event)
         {
             switcher->switch_to(
                 vtno,
-                [](std::exception const& err)
+                [](std::exception const&)
                 {
                     mir::log(
                         mir::logging::Severity::error,
                         "VT switch key handler",
-                        std::make_exception_ptr(err),
+                        std::current_exception(),
                         "Failed to switch to requested VT");
                 });
         };


### PR DESCRIPTION
We were slicing the exception being reported by copying to the runtime type.

Before:
```
...Dynamic exception type: std::exception
std::exception::what: std::exception
```

After:
```
... /home/alan/CLionProjects/mir/src/platform/udev/udev_wrapper.cpp(60): Throw in function {anonymous}::DeviceImpl::DeviceImpl(udev_device*)
Dynamic exception type: boost::wrapexcept<std::runtime_error>
std::exception::what: Udev device does not exist
```