### PR TITLE
Fix InputDeviceHub threadsafety

### DIFF
--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -104,7 +104,7 @@ void mi::ExternalInputDeviceHub::remove_observer(std::weak_ptr<InputDeviceObserv
                 std::lock_guard<std::recursive_mutex> lock{data->mutex};
                 data->observers.remove(observer);
 
-                std::lock_guard<decltype(mutex)> vc_lock{mutex};
+                std::lock_guard<decltype(mutex)> cond_var_lock{mutex};
                 removed = true;
                 cv.notify_one();
             });

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -387,7 +387,7 @@ void mi::DefaultInputDeviceHub::for_each_input_device(std::function<void(Device 
 void mi::DefaultInputDeviceHub::for_each_mutable_input_device(std::function<void(Device&)> const& callback)
 {
     std::unique_lock<std::recursive_mutex> lock{mutex};
-    // make_transaction is false if a transaction is already in-progress
+    // perform_transaction is true if no transaction is already in-progress
     bool const perform_transaction = !pending_changes;
     if (perform_transaction)
     {

--- a/src/server/input/default_input_device_hub.h
+++ b/src/server/input/default_input_device_hub.h
@@ -29,7 +29,6 @@
 #include "mir/input/input_device_info.h"
 #include "mir/input/mir_input_config.h"
 #include "mir/thread_safe_list.h"
-#include "mir/optional_value.h"
 
 #include "mir_toolkit/event.h"
 
@@ -37,6 +36,7 @@
 #include <vector>
 #include <memory>
 #include <mutex>
+#include <optional>
 
 namespace mir
 {
@@ -74,8 +74,8 @@ struct ExternalInputDeviceHub : InputDeviceHub
 
 private:
     struct Internal;
-    std::shared_ptr<Internal> data;
-    std::shared_ptr<InputDeviceHub> hub;
+    std::shared_ptr<Internal> const data;
+    std::shared_ptr<InputDeviceHub> const hub;
 };
 
 class DefaultInputDeviceHub :
@@ -99,24 +99,29 @@ public:
     void for_each_input_device(std::function<void(Device const& device)> const& callback) override;
     void for_each_mutable_input_device(std::function<void(Device& device)> const& callback) override;
 private:
-    void add_device_handle(std::shared_ptr<DefaultDevice> const& handle);
-    void remove_device_handle(MirInputDeviceId id);
+    void add_device_handle(std::lock_guard<std::mutex> const&, std::shared_ptr<DefaultDevice> const& handle);
+    void remove_device_handle(std::lock_guard<std::mutex> const&, MirInputDeviceId id);
     void device_changed(Device* dev);
-    void emit_changed_devices();
-    MirInputDeviceId create_new_device_id();
-    void store_device_config(DefaultDevice const& dev);
-    std::shared_ptr<DefaultDevice> restore_or_create_device(InputDevice& dev,
-                                                            std::shared_ptr<dispatch::ActionQueue> const& queue);
-    mir::optional_value<MirInputDevice> get_stored_device_config(std::string const& id);
+    void complete_transaction();
+    MirInputDeviceId create_new_device_id(std::lock_guard<std::mutex> const&);
+    void store_device_config(std::lock_guard<std::mutex> const&, DefaultDevice const& dev);
+    auto restore_or_create_device(
+        std::lock_guard<std::mutex> const& lock,
+        InputDevice& dev,
+        std::shared_ptr<dispatch::ActionQueue> const& queue) -> std::shared_ptr<DefaultDevice>;
+    auto get_stored_device_config(
+        std::lock_guard<std::mutex> const&,
+        std::string const& id) -> std::optional<MirInputDevice>;
 
     std::shared_ptr<Seat> const seat;
     std::shared_ptr<dispatch::MultiplexingDispatchable> const input_dispatchable;
-    std::mutex mutable handles_guard;
     std::shared_ptr<dispatch::ActionQueue> const device_queue;
     std::shared_ptr<cookie::Authority> const cookie_authority;
     std::shared_ptr<KeyMapper> const key_mapper;
     std::shared_ptr<ServerStatusListener> const server_status_listener;
+    ThreadSafeList<std::shared_ptr<InputDeviceObserver>> observers;
 
+    /// Does not guarantee it's own threadsafety, non-const methods should not be called from multiple threads at once
     struct RegisteredDevice : public InputSink
     {
     public:
@@ -145,16 +150,13 @@ private:
         std::shared_ptr<dispatch::ActionQueue> queue;
     };
 
+    std::mutex mutex;
     std::vector<std::shared_ptr<Device>> handles;
-    MirInputConfig config;
     std::vector<std::unique_ptr<RegisteredDevice>> devices;
-    ThreadSafeList<std::shared_ptr<InputDeviceObserver>> observers;
-    std::mutex changed_devices_guard;
-    std::unique_ptr<std::vector<std::shared_ptr<Device>>> changed_devices;
-
-    std::mutex stored_configurations_guard;
+    /// Nullopt when no transaction is in progress. Set to an empty vector when a transaction starts, and change
+    /// notications are sent about each device contained in the vector when the transaction is done.
+    std::optional<std::vector<std::shared_ptr<Device>>> pending_changes;
     std::vector<MirInputDevice> stored_devices;
-
     MirInputDeviceId device_id_generator;
     bool ready{false};
 };


### PR DESCRIPTION
Reading through this code, I saw what appeared to be a number of threadsafety issues. I'm not sure if these were mistakes or it was determined that nothing would be using these classes in ways that cause race conditions. Either way, doing stuff from the Wayland thread for OSK support may introduce problems, so better get everything straight first.

A potential downside is that now some observer methods are called while under lock, which is generally not advisable. I don't *think* there's any case in which we need to change input devices from an observer call. Not calling the observer under lock would be nontrivial (and slightly less performant).