### PR TITLE
Add more keymap properties


### DIFF
--- a/include/common/mir/input/keymap.h
+++ b/include/common/mir/input/keymap.h
@@ -42,6 +42,12 @@ public:
     virtual auto matches(Keymap const& other) const -> bool = 0;
     /// The model name of the keyboard this keymap is for
     virtual auto model() const -> std::string = 0;
+    /// The layout name of the keyboard this keymap is for
+    virtual auto layout() const -> std::string = 0;
+    /// The variant_ name of the keyboard this keymap is for
+    virtual auto variant() const -> std::string = 0;
+    /// The options name of the keyboard this keymap is for
+    virtual auto options() const -> std::string = 0;
     virtual auto make_unique_xkb_keymap(xkb_context* context) const -> XKBKeymapPtr = 0;
 
 private:

--- a/include/common/mir/input/parameter_keymap.h
+++ b/include/common/mir/input/parameter_keymap.h
@@ -38,7 +38,7 @@ public:
 
     ParameterKeymap() = default;
     ParameterKeymap(std::string&& model, std::string&& layout, std::string&& variant, std::string&& options)
-        : model_{model}, layout{layout}, variant{variant}, options{options}
+        : model_{model}, layout_{layout}, variant_{variant}, options_{options}
     {
     }
 
@@ -47,19 +47,22 @@ public:
         std::string const& layout,
         std::string const& variant,
         std::string const& options)
-        : model_{model}, layout{layout}, variant{variant}, options{options}
+        : model_{model}, layout_{layout}, variant_{variant}, options_{options}
     {
     }
 
     auto matches(Keymap const& other) const -> bool override;
     auto model() const -> std::string override;
+    auto variant() const -> std::string override;
+    auto layout() const -> std::string override;
+    auto options() const -> std::string override;
     auto make_unique_xkb_keymap(xkb_context* context) const -> XKBKeymapPtr override;
 
 private:
     std::string model_{default_model};
-    std::string layout{default_layout};
-    std::string variant;
-    std::string options;
+    std::string layout_{default_layout};
+    std::string variant_;
+    std::string options_;
 };
 
 }

--- a/include/common/mir_toolkit/mir_input_device.h
+++ b/include/common/mir_toolkit/mir_input_device.h
@@ -237,10 +237,10 @@ void mir_keyboard_config_set_keymap_options(
     MirKeyboardConfig* conf, char const* options);
 
 /**
- * Set the variant of the keymap as a null terminated string.
+ * Set the variant_ of the keymap as a null terminated string.
  *
  * \param [in] conf     The keyboard config
- * \param [in] variant  The keymap variant
+ * \param [in] variant  The keymap variant_
  */
 void mir_keyboard_config_set_keymap_variant(
     MirKeyboardConfig* conf, char const* variant);

--- a/include/miral/miral/keymap.h
+++ b/include/miral/miral/keymap.h
@@ -36,7 +36,7 @@ public:
 
     /// Specify a keymap.
     /// Format is:
-    /// \verbatim <language>[+<variant>[+<options>]] \endverbatim
+    /// \verbatim <language>[+<variant_>[+<options>]] \endverbatim
     /// Options is a comma separated list.
     /// e.g. "uk" or "us+dvorak"
     explicit Keymap(std::string const& keymap);

--- a/include/test/mir/test/doubles/stub_keymap.h
+++ b/include/test/mir/test/doubles/stub_keymap.h
@@ -32,6 +32,9 @@ struct StubKeymap : public mir::input::Keymap
 {
     auto matches(Keymap const& other) const -> bool override { return &other == this; }
     auto model() const -> std::string override { return "stub_keymap_model"; }
+    auto variant() const -> std::string override { return "stub_keymap_variant"; }
+    auto layout() const -> std::string override { return "stub_keymap_layout"; }
+    auto options() const -> std::string override { return "stub_keymap_options"; }
     auto make_unique_xkb_keymap(xkb_context*) const -> mir::input::XKBKeymapPtr override
     {
         return {nullptr, [](auto){}};

--- a/src/common/input/parameter_keymap.cpp
+++ b/src/common/input/parameter_keymap.cpp
@@ -29,9 +29,9 @@ auto mi::ParameterKeymap::matches(Keymap const& other) const -> bool
     auto const params = dynamic_cast<ParameterKeymap const*>(&other);
     return params &&
         model_ == params->model_ &&
-        layout == params->layout &&
-        variant == params->variant &&
-        options == params->options;
+           layout_ == params->layout_ &&
+           variant_ == params->variant_ &&
+        options_ == params->options_;
 }
 
 auto mi::ParameterKeymap::model() const -> std::string
@@ -45,9 +45,9 @@ auto mi::ParameterKeymap::make_unique_xkb_keymap(xkb_context* context) const -> 
     {
         "evdev",
         model_.c_str(),
-        layout.c_str(),
-        variant.c_str(),
-        options.c_str()
+        layout_.c_str(),
+        variant_.c_str(),
+        options_.c_str()
     };
     auto keymap_ptr = xkb_keymap_new_from_names(context, &keymap_names, xkb_keymap_compile_flags(0));
 
@@ -55,8 +55,23 @@ auto mi::ParameterKeymap::make_unique_xkb_keymap(xkb_context* context) const -> 
     {
         auto const error =
             "Illegal keymap configuration evdev-" +
-            model_ + "-" + layout + "-" + variant + "-" + options;
+            model_ + "-" + layout_ + "-" + variant_ + "-" + options_;
         BOOST_THROW_EXCEPTION(std::invalid_argument(error.c_str()));
     }
     return {keymap_ptr, &xkb_keymap_unref};
+}
+
+auto mi::ParameterKeymap::variant() const -> std::string
+{
+    return variant_;
+}
+
+auto mi::ParameterKeymap::layout() const -> std::string
+{
+    return layout_;
+}
+
+auto mi::ParameterKeymap::options() const -> std::string
+{
+    return options_;
 }

--- a/src/miral/keymap.cpp
+++ b/src/miral/keymap.cpp
@@ -197,7 +197,7 @@ auto miral::Keymap::operator=(Keymap const& rhs) -> Keymap& = default;
 void miral::Keymap::operator()(mir::Server& server) const
 {
     if (self->layout.empty())
-        server.add_configuration_option(keymap_option, "keymap <layout>[+<variant>[+<options>]], e,g, \"gb\" or \"cz+qwerty\" or \"de++compose:caps\"", keymap_default());
+        server.add_configuration_option(keymap_option, "keymap <layout>[+<variant_>[+<options>]], e,g, \"gb\" or \"cz+qwerty\" or \"de++compose:caps\"", keymap_default());
 
     server.add_init_callback([this, &server]
         {

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -104,7 +104,7 @@ mf::WlSurface::~WlSurface()
 {
     // We can't use a function try block as we want to access `client`:
     // "Before any catch clauses of a function-try-block on a destructor are entered,
-    // all bases and non-variant members have already been destroyed."
+    // all bases and non-variant_ members have already been destroyed."
     try
     {
         // Destroy the buffer stream first, as surface_destroyed() may throw


### PR DESCRIPTION
In merging recent changes into the miroil branch I noticed that we can only retrieve the `model` attribute of the keymap. I don't see why this is correct or useful in isolation, so have added `layout`, `variant` and `options` (which are mentioned in that code).

If there is a better way for Lomiri to change the keymap let's discuss that.