### PR TITLE
Prevent exceptions propagating where they are not expected

### DIFF
--- a/src/miral/keymap.cpp
+++ b/src/miral/keymap.cpp
@@ -176,7 +176,7 @@ struct miral::Keymap::Self : mir::input::InputDeviceObserver
     catch (...)
     {
         mir::log(mir::logging::Severity::warning, MIR_LOG_COMPONENT, std::current_exception(),
-            "problem remove device (" + device->name() + ")");
+            "problem removing device (" + device->name() + ")");
     }
 
     void changes_complete() override

--- a/src/miral/keymap.cpp
+++ b/src/miral/keymap.cpp
@@ -116,11 +116,17 @@ struct miral::Keymap::Self : mir::input::InputDeviceObserver
     }
 
     void device_added(std::shared_ptr<mir::input::Device> const& device) override
+    try
     {
         std::lock_guard<decltype(mutex)> lock{mutex};
 
         if (mir::contains(device->capabilities(), mir::input::DeviceCapability::keyboard))
             add_keyboard(device);
+    }
+    catch (...)
+    {
+        mir::log(mir::logging::Severity::warning, MIR_LOG_COMPONENT, std::current_exception(),
+                 "problem adding device (" + device->name() + ")");
     }
 
     void device_changed(std::shared_ptr<mir::input::Device> const& device) override
@@ -160,11 +166,17 @@ struct miral::Keymap::Self : mir::input::InputDeviceObserver
     }
 
     void device_removed(std::shared_ptr<mir::input::Device> const& device) override
+    try
     {
         std::lock_guard<decltype(mutex)> lock{mutex};
 
         if (mir::contains(device->capabilities(), mir::input::DeviceCapability::keyboard))
             keyboards.erase(std::find(begin(keyboards), end(keyboards), device));
+    }
+    catch (...)
+    {
+        mir::log(mir::logging::Severity::warning, MIR_LOG_COMPONENT, std::current_exception(),
+            "problem remove device (" + device->name() + ")");
     }
 
     void changes_complete() override


### PR DESCRIPTION
This mitigates #2098, but a real fix would also detect and report setting an invalid keymap.