### PR TITLE
InputDeviceRegistry: return device handle when adding device

### DIFF
--- a/include/platform/mir/input/input_device_registry.h
+++ b/include/platform/mir/input/input_device_registry.h
@@ -35,7 +35,7 @@ public:
     InputDeviceRegistry() = default;
     virtual ~InputDeviceRegistry() = default;
 
-    virtual auto add_device(std::shared_ptr<InputDevice> const& device) -> std::shared_ptr<Device> = 0;
+    virtual auto add_device(std::shared_ptr<InputDevice> const& device) -> std::weak_ptr<Device> = 0;
     virtual void remove_device(std::shared_ptr<InputDevice> const& device) = 0;
 protected:
     InputDeviceRegistry(InputDeviceRegistry const&) = delete;

--- a/include/platform/mir/input/input_device_registry.h
+++ b/include/platform/mir/input/input_device_registry.h
@@ -26,6 +26,7 @@ namespace mir
 {
 namespace input
 {
+class Device;
 class InputDevice;
 
 class InputDeviceRegistry
@@ -34,7 +35,7 @@ public:
     InputDeviceRegistry() = default;
     virtual ~InputDeviceRegistry() = default;
 
-    virtual void add_device(std::shared_ptr<InputDevice> const& device) = 0;
+    virtual auto add_device(std::shared_ptr<InputDevice> const& device) -> std::shared_ptr<Device> = 0;
     virtual void remove_device(std::shared_ptr<InputDevice> const& device) = 0;
 protected:
     InputDeviceRegistry(InputDeviceRegistry const&) = delete;

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -196,7 +196,7 @@ mi::DefaultInputDeviceHub::DefaultInputDeviceHub(
     input_dispatchable->add_watch(device_queue);
 }
 
-void mi::DefaultInputDeviceHub::add_device(std::shared_ptr<InputDevice> const& device)
+auto mi::DefaultInputDeviceHub::add_device(std::shared_ptr<InputDevice> const& device) -> std::shared_ptr<Device>
 {
     if (!device)
         BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid input device"));
@@ -213,7 +213,7 @@ void mi::DefaultInputDeviceHub::add_device(std::shared_ptr<InputDevice> const& d
     if (it == end(devices))
     {
         auto queue = std::make_shared<dispatch::ActionQueue>();
-        auto handle = restore_or_create_device(lock, *device, queue);
+        auto const handle = restore_or_create_device(lock, *device, queue);
         // send input device info to observer loop..
         devices.push_back(std::make_unique<RegisteredDevice>(
             device, handle->id(), queue, cookie_authority, handle));
@@ -223,6 +223,7 @@ void mi::DefaultInputDeviceHub::add_device(std::shared_ptr<InputDevice> const& d
 
         seat->add_device(*handle);
         dev->start(seat, input_dispatchable);
+        return handle;
     }
     else
     {

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -196,7 +196,7 @@ mi::DefaultInputDeviceHub::DefaultInputDeviceHub(
     input_dispatchable->add_watch(device_queue);
 }
 
-auto mi::DefaultInputDeviceHub::add_device(std::shared_ptr<InputDevice> const& device) -> std::shared_ptr<Device>
+auto mi::DefaultInputDeviceHub::add_device(std::shared_ptr<InputDevice> const& device) -> std::weak_ptr<Device>
 {
     if (!device)
         BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid input device"));

--- a/src/server/input/default_input_device_hub.h
+++ b/src/server/input/default_input_device_hub.h
@@ -90,7 +90,7 @@ public:
                           std::shared_ptr<ServerStatusListener> const& server_status_listener);
 
     // InputDeviceRegistry - calls from mi::Platform
-    void add_device(std::shared_ptr<InputDevice> const& device) override;
+    auto add_device(std::shared_ptr<InputDevice> const& device) -> std::shared_ptr<Device> override;
     void remove_device(std::shared_ptr<InputDevice> const& device) override;
 
     // InputDeviceHub - calls from server components / shell

--- a/src/server/input/default_input_device_hub.h
+++ b/src/server/input/default_input_device_hub.h
@@ -90,7 +90,7 @@ public:
                           std::shared_ptr<ServerStatusListener> const& server_status_listener);
 
     // InputDeviceRegistry - calls from mi::Platform
-    auto add_device(std::shared_ptr<InputDevice> const& device) -> std::shared_ptr<Device> override;
+    auto add_device(std::shared_ptr<InputDevice> const& device) -> std::weak_ptr<Device> override;
     void remove_device(std::shared_ptr<InputDevice> const& device) override;
 
     // InputDeviceHub - calls from server components / shell

--- a/tests/include/mir/test/doubles/mock_input_device_registry.h
+++ b/tests/include/mir/test/doubles/mock_input_device_registry.h
@@ -31,7 +31,7 @@ namespace doubles
 {
 struct MockInputDeviceRegistry : input::InputDeviceRegistry
 {
-    MOCK_METHOD1(add_device,void (std::shared_ptr<input::InputDevice> const&));
+    MOCK_METHOD1(add_device, std::shared_ptr<input::Device>(std::shared_ptr<input::InputDevice> const&));
     MOCK_METHOD1(remove_device, void(std::shared_ptr<input::InputDevice> const&));
 
 };

--- a/tests/include/mir/test/doubles/mock_input_device_registry.h
+++ b/tests/include/mir/test/doubles/mock_input_device_registry.h
@@ -31,7 +31,7 @@ namespace doubles
 {
 struct MockInputDeviceRegistry : input::InputDeviceRegistry
 {
-    MOCK_METHOD1(add_device, std::shared_ptr<input::Device>(std::shared_ptr<input::InputDevice> const&));
+    MOCK_METHOD1(add_device, std::weak_ptr<input::Device>(std::shared_ptr<input::InputDevice> const&));
     MOCK_METHOD1(remove_device, void(std::shared_ptr<input::InputDevice> const&));
 
 };

--- a/tests/unit-tests/input/evdev/test_evdev_input_platform.cpp
+++ b/tests/unit-tests/input/evdev/test_evdev_input_platform.cpp
@@ -54,7 +54,7 @@ namespace
 
 struct MockInputDeviceRegistry : public mi::InputDeviceRegistry
 {
-    MOCK_METHOD1(add_device, void(std::shared_ptr<mi::InputDevice> const&));
+    MOCK_METHOD1(add_device, std::shared_ptr<mi::Device>(std::shared_ptr<mi::InputDevice> const&));
     MOCK_METHOD1(remove_device, void(std::shared_ptr<mi::InputDevice> const&));
 };
 

--- a/tests/unit-tests/input/evdev/test_evdev_input_platform.cpp
+++ b/tests/unit-tests/input/evdev/test_evdev_input_platform.cpp
@@ -54,7 +54,7 @@ namespace
 
 struct MockInputDeviceRegistry : public mi::InputDeviceRegistry
 {
-    MOCK_METHOD1(add_device, std::shared_ptr<mi::Device>(std::shared_ptr<mi::InputDevice> const&));
+    MOCK_METHOD1(add_device, std::weak_ptr<mi::Device>(std::shared_ptr<mi::InputDevice> const&));
     MOCK_METHOD1(remove_device, void(std::shared_ptr<mi::InputDevice> const&));
 };
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -59,7 +59,7 @@ namespace
 class StubInputDeviceRegistry : public mi::InputDeviceRegistry
 {
 public:
-    auto add_device(std::shared_ptr<mi::InputDevice> const&) -> std::shared_ptr<mi::Device> override { return {}; }
+    auto add_device(std::shared_ptr<mi::InputDevice> const&) -> std::weak_ptr<mi::Device> override { return {}; }
     void remove_device(std::shared_ptr<mi::InputDevice> const&) override {}
 };
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -59,7 +59,7 @@ namespace
 class StubInputDeviceRegistry : public mi::InputDeviceRegistry
 {
 public:
-    void add_device(std::shared_ptr<mi::InputDevice> const&) override {}
+    auto add_device(std::shared_ptr<mi::InputDevice> const&) -> std::shared_ptr<mi::Device> override { return {}; }
     void remove_device(std::shared_ptr<mi::InputDevice> const&) override {}
 };
 

--- a/tests/unit-tests/input/test_x11_platform.cpp
+++ b/tests/unit-tests/input/test_x11_platform.cpp
@@ -76,6 +76,7 @@ struct X11PlatformTest : ::testing::Test
                                           dev->start(&mock_pointer_sink, &builder);
                                       else if (contains(info.capabilities, mi::DeviceCapability::keyboard))
                                           dev->start(&mock_keyboard_sink, &builder);
+                                      return nullptr;
                                   })
                           );
     }

--- a/tests/unit-tests/input/test_x11_platform.cpp
+++ b/tests/unit-tests/input/test_x11_platform.cpp
@@ -68,7 +68,7 @@ struct X11PlatformTest : ::testing::Test
     void capture_devices()
     {
         ON_CALL(mock_registry, add_device(_))
-            .WillByDefault(Invoke([this](auto const& dev)
+            .WillByDefault(Invoke([this](auto const& dev) -> std::weak_ptr<mi::Device>
                                   {
                                       devices.push_back(dev);
                                       auto const info = dev->get_device_info();
@@ -76,7 +76,7 @@ struct X11PlatformTest : ::testing::Test
                                           dev->start(&mock_pointer_sink, &builder);
                                       else if (contains(info.capabilities, mi::DeviceCapability::keyboard))
                                           dev->start(&mock_keyboard_sink, &builder);
-                                      return nullptr;
+                                      return {};
                                   })
                           );
     }


### PR DESCRIPTION
This will allow the thing that created a device to set it's config (specifically, allow for keymaps to be set). Part of #2111.