### PR TITLE
Use shared pointers to move around keymaps

### DIFF
--- a/include/common/mir/input/mir_keyboard_config.h
+++ b/include/common/mir/input/mir_keyboard_config.h
@@ -42,7 +42,7 @@ struct MirKeyboardConfig
     mir::input::Keymap const& device_keymap() const;
     mir::input::Keymap& device_keymap();
     void device_keymap(std::shared_ptr<mir::input::Keymap> keymap);
-    auto device_keymap_shared() -> std::shared_ptr<mir::input::Keymap> const&;
+    auto device_keymap_shared() const -> std::shared_ptr<mir::input::Keymap> const&;
 
     bool operator==(MirKeyboardConfig const& rhs) const;
     bool operator!=(MirKeyboardConfig const& rhs) const;

--- a/include/common/mir/input/mir_keyboard_config.h
+++ b/include/common/mir/input/mir_keyboard_config.h
@@ -39,10 +39,8 @@ struct MirKeyboardConfig
     MirKeyboardConfig(MirKeyboardConfig const& other);
     MirKeyboardConfig& operator=(MirKeyboardConfig const& other);
 
-    mir::input::Keymap const& device_keymap() const;
-    mir::input::Keymap& device_keymap();
     void device_keymap(std::shared_ptr<mir::input::Keymap> keymap);
-    auto device_keymap_shared() const -> std::shared_ptr<mir::input::Keymap> const&;
+    auto device_keymap() const -> std::shared_ptr<mir::input::Keymap> const&;
 
     bool operator==(MirKeyboardConfig const& rhs) const;
     bool operator!=(MirKeyboardConfig const& rhs) const;

--- a/src/common/input/mir_keyboard_config.cpp
+++ b/src/common/input/mir_keyboard_config.cpp
@@ -66,29 +66,19 @@ MirKeyboardConfig& MirKeyboardConfig::operator=(MirKeyboardConfig const& other)
     return *this;
 }
 
-mi::Keymap const& MirKeyboardConfig::device_keymap() const
-{
-    return *impl->device_keymap;
-}
-
-mi::Keymap& MirKeyboardConfig::device_keymap()
-{
-    return *impl->device_keymap;
-}
-
 void MirKeyboardConfig::device_keymap(std::shared_ptr<mi::Keymap> keymap)
 {
     impl->device_keymap = std::move(keymap);
 }
 
-auto MirKeyboardConfig::device_keymap_shared() const -> std::shared_ptr<mir::input::Keymap> const&
+auto MirKeyboardConfig::device_keymap() const -> std::shared_ptr<mir::input::Keymap> const&
 {
     return impl->device_keymap;
 }
 
 bool MirKeyboardConfig::operator==(MirKeyboardConfig const& rhs) const
 {
-    return device_keymap().matches(rhs.device_keymap());
+    return impl->device_keymap->matches(*rhs.device_keymap());
 }
 
 bool MirKeyboardConfig::operator!=(MirKeyboardConfig const& rhs) const
@@ -98,5 +88,5 @@ bool MirKeyboardConfig::operator!=(MirKeyboardConfig const& rhs) const
 
 std::ostream& operator<<(std::ostream& out, MirKeyboardConfig const& keyboard)
 {
-    return out << keyboard.device_keymap().model() << " config";
+    return out << keyboard.device_keymap()->model() << " config";
 }

--- a/src/common/input/mir_keyboard_config.cpp
+++ b/src/common/input/mir_keyboard_config.cpp
@@ -81,7 +81,7 @@ void MirKeyboardConfig::device_keymap(std::shared_ptr<mi::Keymap> keymap)
     impl->device_keymap = std::move(keymap);
 }
 
-auto MirKeyboardConfig::device_keymap_shared() -> std::shared_ptr<mir::input::Keymap> const&
+auto MirKeyboardConfig::device_keymap_shared() const -> std::shared_ptr<mir::input::Keymap> const&
 {
     return impl->device_keymap;
 }

--- a/src/common/input/xkb_mapper.cpp
+++ b/src/common/input/xkb_mapper.cpp
@@ -206,9 +206,9 @@ mircv::XKBMapper::XkbMappingState* mircv::XKBMapper::get_keymapping_state(MirInp
     return nullptr;
 }
 
-void mircv::XKBMapper::set_keymap_for_all_devices(Keymap const& new_keymap)
+void mircv::XKBMapper::set_keymap_for_all_devices(std::shared_ptr<Keymap> new_keymap)
 {
-    set_keymap(new_keymap.make_unique_xkb_keymap(context.get()));
+    set_keymap(new_keymap->make_unique_xkb_keymap(context.get()));
 }
 
 void mircv::XKBMapper::set_keymap(XKBKeymapPtr new_keymap)
@@ -218,9 +218,9 @@ void mircv::XKBMapper::set_keymap(XKBKeymapPtr new_keymap)
     device_mapping.clear();
 }
 
-void mircv::XKBMapper::set_keymap_for_device(MirInputDeviceId id, Keymap const& new_keymap)
+void mircv::XKBMapper::set_keymap_for_device(MirInputDeviceId id, std::shared_ptr<Keymap> new_keymap)
 {
-    set_keymap(id, new_keymap.make_unique_xkb_keymap(context.get()));
+    set_keymap(id, new_keymap->make_unique_xkb_keymap(context.get()));
 }
 
 void mircv::XKBMapper::set_keymap(MirInputDeviceId id, XKBKeymapPtr new_keymap)

--- a/src/common/input/xkb_mapper.cpp
+++ b/src/common/input/xkb_mapper.cpp
@@ -126,15 +126,6 @@ mi::XKBContextPtr mi::make_unique_context()
     return {xkb_context_new(xkb_context_flags(0)), &xkb_context_unref};
 }
 
-mi::XKBKeymapPtr mi::make_unique_keymap(xkb_context* context, char const* buffer, size_t size)
-{
-    auto keymap_ptr = xkb_keymap_new_from_buffer(context, buffer, size, XKB_KEYMAP_FORMAT_TEXT_V1, xkb_keymap_compile_flags(0));
-    if (!keymap_ptr)
-        BOOST_THROW_EXCEPTION(std::runtime_error("failed to create keymap from buffer."));
-
-    return {keymap_ptr, &xkb_keymap_unref};
-}
-
 mircv::XKBMapper::XKBMapper() :
     context{make_unique_context()},
     compose_table{make_unique_compose_table_from_locale(context, get_locale_from_environment())}
@@ -220,11 +211,6 @@ void mircv::XKBMapper::set_keymap_for_all_devices(Keymap const& new_keymap)
     set_keymap(new_keymap.make_unique_xkb_keymap(context.get()));
 }
 
-void mircv::XKBMapper::set_keymap_for_all_devices(char const* buffer, size_t len)
-{
-    set_keymap(make_unique_keymap(context.get(), buffer, len));
-}
-
 void mircv::XKBMapper::set_keymap(XKBKeymapPtr new_keymap)
 {
     std::lock_guard<std::mutex> lg(guard);
@@ -235,11 +221,6 @@ void mircv::XKBMapper::set_keymap(XKBKeymapPtr new_keymap)
 void mircv::XKBMapper::set_keymap_for_device(MirInputDeviceId id, Keymap const& new_keymap)
 {
     set_keymap(id, new_keymap.make_unique_xkb_keymap(context.get()));
-}
-
-void mircv::XKBMapper::set_keymap_for_device(MirInputDeviceId id, char const* buffer, size_t len)
-{
-    set_keymap(id, make_unique_keymap(context.get(), buffer, len));
 }
 
 void mircv::XKBMapper::set_keymap(MirInputDeviceId id, XKBKeymapPtr new_keymap)

--- a/src/include/common/mir/input/key_mapper.h
+++ b/src/include/common/mir/input/key_mapper.h
@@ -53,7 +53,7 @@ public:
     /**
      * Set a keymap for the device \a id
      */
-    virtual void set_keymap_for_device(MirInputDeviceId id, Keymap const& map) = 0;
+    virtual void set_keymap_for_device(MirInputDeviceId id, std::shared_ptr<Keymap> map) = 0;
 
     /**
      * Remove the specific keymap defined for device identified via the \a id.
@@ -65,7 +65,7 @@ public:
     /**
      * Set a default keymap for all devices.
      */
-    virtual void set_keymap_for_all_devices(Keymap const& map) = 0;
+    virtual void set_keymap_for_all_devices(std::shared_ptr<Keymap> map) = 0;
 
     /*
      * Remove all keymap configurations

--- a/src/include/common/mir/input/key_mapper.h
+++ b/src/include/common/mir/input/key_mapper.h
@@ -54,10 +54,7 @@ public:
      * Set a keymap for the device \a id
      */
     virtual void set_keymap_for_device(MirInputDeviceId id, Keymap const& map) = 0;
-    /**
-     * Set a keymap for the device \a id
-     */
-    virtual void set_keymap_for_device(MirInputDeviceId id, char const* buffer, size_t len) = 0;
+
     /**
      * Remove the specific keymap defined for device identified via the \a id.
      *
@@ -69,10 +66,7 @@ public:
      * Set a default keymap for all devices.
      */
     virtual void set_keymap_for_all_devices(Keymap const& map) = 0;
-    /**
-     * Set a default keymap for all devices.
-     */
-    virtual void set_keymap_for_all_devices(char const* buffer, size_t len) = 0;
+
     /*
      * Remove all keymap configurations
      *

--- a/src/include/common/mir/input/xkb_mapper.h
+++ b/src/include/common/mir/input/xkb_mapper.h
@@ -53,8 +53,8 @@ public:
     XKBMapper();
 
     void set_key_state(MirInputDeviceId id, std::vector<uint32_t> const& key_state) override;
-    void set_keymap_for_device(MirInputDeviceId id, Keymap const& map) override;
-    void set_keymap_for_all_devices(Keymap const& map) override;
+    void set_keymap_for_device(MirInputDeviceId id, std::shared_ptr<Keymap> map) override;
+    void set_keymap_for_all_devices(std::shared_ptr<Keymap> map) override;
     void clear_keymap_for_device(MirInputDeviceId id) override;
     void clear_all_keymaps() override;
     void map_event(MirEvent& event) override;

--- a/src/include/common/mir/input/xkb_mapper.h
+++ b/src/include/common/mir/input/xkb_mapper.h
@@ -39,7 +39,6 @@ using XKBContextPtr = std::unique_ptr<xkb_context, void(*)(xkb_context*)>;
 XKBContextPtr make_unique_context();
 
 using XKBKeymapPtr = std::unique_ptr<xkb_keymap, void(*)(xkb_keymap*)>;
-XKBKeymapPtr make_unique_keymap(xkb_context* context, char const* buffer, size_t size);
 
 using XKBStatePtr = std::unique_ptr<xkb_state, void(*)(xkb_state*)>;
 using XKBComposeTablePtr = std::unique_ptr<xkb_compose_table, void(*)(xkb_compose_table*)>;
@@ -55,9 +54,7 @@ public:
 
     void set_key_state(MirInputDeviceId id, std::vector<uint32_t> const& key_state) override;
     void set_keymap_for_device(MirInputDeviceId id, Keymap const& map) override;
-    void set_keymap_for_device(MirInputDeviceId id, char const* buffer, size_t len) override;
     void set_keymap_for_all_devices(Keymap const& map) override;
-    void set_keymap_for_all_devices(char const* buffer, size_t len) override;
     void clear_keymap_for_device(MirInputDeviceId id) override;
     void clear_all_keymaps() override;
     void map_event(MirEvent& event) override;

--- a/src/miral/keymap.cpp
+++ b/src/miral/keymap.cpp
@@ -159,7 +159,7 @@ struct miral::Keymap::Self : mir::input::InputDeviceObserver
         auto const keyboard_config = keyboard->keyboard_configuration();
         if (keyboard_config.is_set())
         {
-            model = keyboard_config.value().device_keymap().model();
+            model = keyboard_config.value().device_keymap()->model();
         }
         std::shared_ptr<mi::Keymap> keymap{std::make_shared<mi::ParameterKeymap>(model, layout, variant, options)};
         keyboard->apply_keyboard_configuration(std::move(keymap));

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -106,7 +106,7 @@ void mf::WlSeat::ConfigObserver::device_added(std::shared_ptr<input::Device> con
 {
     if (auto keyboard_config = device->keyboard_configuration())
     {
-        pending_keymap = keyboard_config.value().device_keymap_shared();
+        pending_keymap = keyboard_config.value().device_keymap();
     }
 }
 
@@ -114,7 +114,7 @@ void mf::WlSeat::ConfigObserver::device_changed(std::shared_ptr<input::Device> c
 {
     if (auto keyboard_config = device->keyboard_configuration())
     {
-        pending_keymap = keyboard_config.value().device_keymap_shared();
+        pending_keymap = keyboard_config.value().device_keymap();
     }
 }
 

--- a/src/server/input/default_device.cpp
+++ b/src/server/input/default_device.cpp
@@ -50,7 +50,7 @@ mi::DefaultDevice::DefaultDevice(MirInputDeviceId id,
     if (contains(info.capabilities, mi::DeviceCapability::keyboard))
     {
         keyboard = MirKeyboardConfig{};
-        key_mapper->set_keymap_for_device(device_id, keyboard.value().device_keymap_shared());
+        key_mapper->set_keymap_for_device(device_id, keyboard.value().device_keymap());
     }
 }
 
@@ -220,11 +220,11 @@ void mi::DefaultDevice::set_keyboard_configuration(MirKeyboardConfig const& conf
     std::lock_guard<std::mutex> lock(config_mutex);
     if (!actions) // device is disabled
         return;
-    if (!keyboard.value().device_keymap().matches(conf.device_keymap()))
+    if (!keyboard.value().device_keymap()->matches(*conf.device_keymap()))
         keyboard = conf;
     else
         return;
-    key_mapper->set_keymap_for_device(device_id, conf.device_keymap_shared());
+    key_mapper->set_keymap_for_device(device_id, conf.device_keymap());
 }
 
 mir::optional_value<MirTouchscreenConfig> mi::DefaultDevice::touchscreen_configuration() const

--- a/src/server/input/default_device.cpp
+++ b/src/server/input/default_device.cpp
@@ -50,7 +50,7 @@ mi::DefaultDevice::DefaultDevice(MirInputDeviceId id,
     if (contains(info.capabilities, mi::DeviceCapability::keyboard))
     {
         keyboard = MirKeyboardConfig{};
-        key_mapper->set_keymap_for_device(device_id, keyboard.value().device_keymap());
+        key_mapper->set_keymap_for_device(device_id, keyboard.value().device_keymap_shared());
     }
 }
 
@@ -224,7 +224,7 @@ void mi::DefaultDevice::set_keyboard_configuration(MirKeyboardConfig const& conf
         keyboard = conf;
     else
         return;
-    key_mapper->set_keymap_for_device(device_id, conf.device_keymap());
+    key_mapper->set_keymap_for_device(device_id, conf.device_keymap_shared());
 }
 
 mir::optional_value<MirTouchscreenConfig> mi::DefaultDevice::touchscreen_configuration() const

--- a/tests/include/mir/test/doubles/mock_key_mapper.h
+++ b/tests/include/mir/test/doubles/mock_key_mapper.h
@@ -34,9 +34,7 @@ struct MockKeyMapper : input::KeyMapper
 {
     MOCK_METHOD2(set_key_state, void(MirInputDeviceId id, std::vector<uint32_t> const& key_state));
     MOCK_METHOD2(set_keymap_for_device, void(MirInputDeviceId id, input::Keymap const& map));
-    MOCK_METHOD3(set_keymap_for_device, void(MirInputDeviceId id, char const* buffer, size_t len));
     MOCK_METHOD1(set_keymap_for_all_devices, void(input::Keymap const& map));
-    MOCK_METHOD2(set_keymap_for_all_devices, void(char const* buffer, size_t len));
     MOCK_METHOD1(clear_keymap_for_device, void(MirInputDeviceId id));
     MOCK_METHOD0(clear_all_keymaps, void());
     MOCK_METHOD1(map_event, void(MirEvent& event));

--- a/tests/include/mir/test/doubles/mock_key_mapper.h
+++ b/tests/include/mir/test/doubles/mock_key_mapper.h
@@ -33,8 +33,8 @@ namespace doubles
 struct MockKeyMapper : input::KeyMapper
 {
     MOCK_METHOD2(set_key_state, void(MirInputDeviceId id, std::vector<uint32_t> const& key_state));
-    MOCK_METHOD2(set_keymap_for_device, void(MirInputDeviceId id, input::Keymap const& map));
-    MOCK_METHOD1(set_keymap_for_all_devices, void(input::Keymap const& map));
+    MOCK_METHOD2(set_keymap_for_device, void(MirInputDeviceId id, std::shared_ptr<input::Keymap> map));
+    MOCK_METHOD1(set_keymap_for_all_devices, void(std::shared_ptr<input::Keymap> map));
     MOCK_METHOD1(clear_keymap_for_device, void(MirInputDeviceId id));
     MOCK_METHOD0(clear_all_keymaps, void());
     MOCK_METHOD1(map_event, void(MirEvent& event));


### PR DESCRIPTION
In order to property manage and move around keymaps more things will need to hold on to them, so making them available as a shared pointer makes sense. Part of #2111.