### PR TITLE
MirKeyboardEvent: add keymap property

### DIFF
--- a/src/common/events/keyboard_event.cpp
+++ b/src/common/events/keyboard_event.cpp
@@ -68,3 +68,13 @@ void MirKeyboardEvent::set_text(char const* str)
 {
     text_ = str;
 }
+
+std::shared_ptr<mir::input::Keymap> MirKeyboardEvent::keymap() const
+{
+    return keymap_;
+}
+
+void MirKeyboardEvent::set_keymap(std::shared_ptr<mir::input::Keymap> keymap)
+{
+    keymap_ = std::move(keymap);
+}

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -199,6 +199,8 @@ MIR_COMMON_2.5 {
     MirKeyboardEvent::set_text*;
     MirKeyboardEvent::source_id*;
     MirKeyboardEvent::text*;
+    MirKeyboardEvent::keymap*;
+    MirKeyboardEvent::set_keymap*;
     MirKeymapEvent::MirKeymapEvent*;
     MirKeymapEvent::buffer*;
     MirKeymapEvent::device_id*;

--- a/src/include/common/mir/events/keyboard_event.h
+++ b/src/include/common/mir/events/keyboard_event.h
@@ -21,8 +21,17 @@
 
 #include <cstdint>
 #include <string>
+#include <memory>
 
 #include "mir/events/input_event.h"
+
+namespace mir
+{
+namespace input
+{
+class Keymap;
+}
+}
 
 struct MirKeyboardEvent : MirInputEvent
 {
@@ -41,11 +50,15 @@ struct MirKeyboardEvent : MirInputEvent
     char const* text() const;
     void set_text(char const* str);
 
+    std::shared_ptr<mir::input::Keymap> keymap() const;
+    void set_keymap(std::shared_ptr<mir::input::Keymap> keymap);
+
 private:
     MirKeyboardAction action_ = {};
     int32_t keysym_ = 0;
     int32_t scan_code_ = 0;
     std::string text_ = {};
+    std::shared_ptr<mir::input::Keymap> keymap_;
 };
 
 #endif /* MIR_COMMON_KEYBOARD_EVENT_H_ */


### PR DESCRIPTION
Allow setting the keymap for a key event. In a subsequent PR the `KeyMapper` will set this property and the Wayland frontend will use it to determine if a new keymap needs to be sent.