### PR TITLE
Add BufferKeymap

### DIFF
--- a/include/common/mir/input/buffer_keymap.h
+++ b/include/common/mir/input/buffer_keymap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Canonical Ltd.
+ * Copyright © 2021 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 2 or 3,
@@ -13,8 +13,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by:
- *   Andreas Pokorny <andreas.pokorny@canonical.com>
+ * Authored by: William Wold <william.wold@canonical.com>
  */
 
 #ifndef MIR_INPUT_BUFFER_KEYMAP_H_

--- a/include/common/mir/input/buffer_keymap.h
+++ b/include/common/mir/input/buffer_keymap.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2016 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by:
+ *   Andreas Pokorny <andreas.pokorny@canonical.com>
+ */
+
+#ifndef MIR_INPUT_BUFFER_KEYMAP_H_
+#define MIR_INPUT_BUFFER_KEYMAP_H_
+
+#include "keymap.h"
+
+#include <vector>
+#include <string>
+#include <memory>
+#include <xkbcommon/xkbcommon.h>
+
+namespace mir
+{
+namespace input
+{
+
+class BufferKeymap
+    : public Keymap
+{
+public:
+    BufferKeymap(std::string name, std::vector<char> buffer, xkb_keymap_format format);
+
+    auto matches(Keymap const& other) const -> bool override;
+    auto model() const -> std::string override;
+    auto make_unique_xkb_keymap(xkb_context* context) const -> XKBKeymapPtr override;
+
+private:
+    std::string const name;
+    std::vector<char> const buffer;
+    xkb_keymap_format const format;
+};
+
+}
+}
+
+#endif // MIR_INPUT_BUFFER_KEYMAP_H_
+

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(mircommon SHARED
   input/input_event.cpp
   input/xkb_mapper.cpp
   input/parameter_keymap.cpp
+  input/buffer_keymap.cpp
   ${PROJECT_SOURCE_DIR}/include/common/mir/input/mir_input_config.h
   ${PROJECT_SOURCE_DIR}/include/common/mir/input/mir_pointer_config.h
   ${PROJECT_SOURCE_DIR}/include/common/mir/input/mir_touchpad_config.h

--- a/src/common/input/buffer_keymap.cpp
+++ b/src/common/input/buffer_keymap.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored By: William Wold <william.wold@canoncical.com>
+ */
+
+#include "mir/input/buffer_keymap.h"
+
+#include <stdexcept>
+#include <boost/throw_exception.hpp>
+#include <cstring>
+
+namespace mi = mir::input;
+
+mi::BufferKeymap::BufferKeymap(std::string name, std::vector<char> buffer, xkb_keymap_format format)
+    : name{name},
+      buffer{std::move(buffer)},
+      format{format}
+{
+    static_assert(sizeof(buffer[0]) == 1, "implemenation assumes buffer.size() is in bytes");
+}
+
+auto mi::BufferKeymap::matches(Keymap const& other) const -> bool
+{
+    auto const keymap = dynamic_cast<BufferKeymap const*>(&other);
+    return keymap &&
+        buffer.size() == keymap->buffer.size() &&
+        memcmp(buffer.data(), keymap->buffer.data(), buffer.size()) == 0;
+}
+
+auto mi::BufferKeymap::model() const -> std::string
+{
+    return name;
+}
+
+auto mi::BufferKeymap::make_unique_xkb_keymap(xkb_context* context) const -> XKBKeymapPtr
+{
+    auto keymap_ptr = xkb_keymap_new_from_buffer(
+        context,
+        buffer.data(),
+        buffer.size(),
+        format,
+        xkb_keymap_compile_flags(0));
+
+    if (!keymap_ptr)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("failed to build keymap from buffer for " + name));
+    }
+    return {keymap_ptr, &xkb_keymap_unref};
+}

--- a/src/common/input/buffer_keymap.cpp
+++ b/src/common/input/buffer_keymap.cpp
@@ -36,6 +36,7 @@ auto mi::BufferKeymap::matches(Keymap const& other) const -> bool
 {
     auto const keymap = dynamic_cast<BufferKeymap const*>(&other);
     return keymap &&
+        format == keymap->format &&
         buffer.size() == keymap->buffer.size() &&
         memcmp(buffer.data(), keymap->buffer.data(), buffer.size()) == 0;
 }

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -477,6 +477,9 @@ MIR_COMMON_2.5 {
     mir::input::ParameterKeymap::with_layout*;
     typeinfo?for?mir::input::ParameterKeymap;
     vtable?for?mir::input::ParameterKeymap;
+    mir::input::BufferKeymap::BufferKeymap*;
+    typeinfo?for?mir::input::BufferKeymap;
+    vtable?for?mir::input::BufferKeymap;
   };
   local: *;
 };

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -474,10 +474,12 @@ MIR_COMMON_2.5 {
     MirKeyboardConfig::device_keymap_shared*;
     mir::input::ParameterKeymap::ParameterKeymap*;
     mir::input::ParameterKeymap::make_unique_xkb_keymap*;
+    mir::input::ParameterKeymap::matches*;
     mir::input::ParameterKeymap::with_layout*;
     typeinfo?for?mir::input::ParameterKeymap;
     vtable?for?mir::input::ParameterKeymap;
     mir::input::BufferKeymap::BufferKeymap*;
+    mir::input::BufferKeymap::matches*;
     typeinfo?for?mir::input::BufferKeymap;
     vtable?for?mir::input::BufferKeymap;
   };

--- a/tests/unit-tests/input/CMakeLists.txt
+++ b/tests/unit-tests/input/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND UNIT_TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/test_seat_input_device_tracker.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_key_repeat_dispatcher.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_validator.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_buffer_keymap.cpp
 )
 
 list(APPEND UMOCK_UNIT_TEST_SOURCES

--- a/tests/unit-tests/input/test_buffer_keymap.cpp
+++ b/tests/unit-tests/input/test_buffer_keymap.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "mir/input/buffer_keymap.h"
+#include "mir/input/parameter_keymap.h"
+#include "mir/test/fake_shared.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace mi = mir::input;
+namespace mt = mir::test;
+
+using namespace ::testing;
+
+TEST(BufferKeymap, can_create_buffer_keymap)
+{
+    mi::BufferKeymap keymap{"test-keymap", {}, XKB_KEYMAP_FORMAT_TEXT_V1};
+}
+
+TEST(BufferKeymap, matches_matching_buffer_keymap)
+{
+    mi::BufferKeymap keymap_a{"test-keymap", {1, 2, 3}, XKB_KEYMAP_FORMAT_TEXT_V1};
+    mi::BufferKeymap keymap_b{"test-keymap", {1, 2, 3}, XKB_KEYMAP_FORMAT_TEXT_V1};
+    EXPECT_THAT(static_cast<mi::Keymap&>(keymap_a).matches(keymap_b), Eq(true));
+    EXPECT_THAT(static_cast<mi::Keymap&>(keymap_b).matches(keymap_a), Eq(true));
+}
+
+TEST(BufferKeymap, different_buffers_fail_to_match)
+{
+    mi::BufferKeymap keymap_a{"test-keymap", {1, 2, 3}, XKB_KEYMAP_FORMAT_TEXT_V1};
+    mi::BufferKeymap keymap_b{"test-keymap", {4, 5, 6}, XKB_KEYMAP_FORMAT_TEXT_V1};
+    EXPECT_THAT(static_cast<mi::Keymap&>(keymap_a).matches(keymap_b), Eq(false));
+    EXPECT_THAT(static_cast<mi::Keymap&>(keymap_b).matches(keymap_a), Eq(false));
+}
+
+TEST(BufferKeymap, different_formats_fail_to_match)
+{
+    mi::BufferKeymap keymap_a{"test-keymap", {1, 2, 3}, XKB_KEYMAP_FORMAT_TEXT_V1};
+    mi::BufferKeymap keymap_b{"test-keymap", {1, 2, 3}, static_cast<xkb_keymap_format>(99)};
+    EXPECT_THAT(static_cast<mi::Keymap&>(keymap_a).matches(keymap_b), Eq(false));
+    EXPECT_THAT(static_cast<mi::Keymap&>(keymap_b).matches(keymap_a), Eq(false));
+}
+
+TEST(BufferKeymap, param_keymap_fail_to_match)
+{
+    mi::BufferKeymap keymap_a{"test-keymap", {1, 2, 3}, XKB_KEYMAP_FORMAT_TEXT_V1};
+    mi::ParameterKeymap keymap_b{};
+    EXPECT_THAT(static_cast<mi::Keymap&>(keymap_a).matches(keymap_b), Eq(false));
+    EXPECT_THAT(static_cast<mi::Keymap&>(keymap_b).matches(keymap_a), Eq(false));
+}


### PR DESCRIPTION
Adds a new keymap implementation based on a character buffer of data. Used for keymaps provided through the Wayland protocol, such as for OSKs. Part of #2111.