### PR TITLE
Send keymaps as needed

### DIFF
--- a/src/common/input/xkb_mapper.cpp
+++ b/src/common/input/xkb_mapper.cpp
@@ -317,6 +317,7 @@ bool mircv::XKBMapper::XkbMappingState::update_and_map(MirEvent& event, mircv::X
     // TODO we should also indicate effective/consumed modifier state to properly
     // implement short cuts with keys that are only reachable via modifier keys
     key_ev.set_modifiers(expand_modifiers(modifier_state));
+    key_ev.set_keymap(keymap);
 
     return old_state != modifier_state;
 }

--- a/src/common/input/xkb_mapper.cpp
+++ b/src/common/input/xkb_mapper.cpp
@@ -195,11 +195,13 @@ mircv::XKBMapper::XkbMappingState* mircv::XKBMapper::get_keymapping_state(MirInp
     }
     if (default_keymap)
     {
+        auto mapping_state = std::make_unique<XkbMappingState>(default_keymap, default_compiled_keymap);
         decltype(device_mapping.begin()) insertion_pos;
         std::tie(insertion_pos, std::ignore) =
-            device_mapping.emplace(std::piecewise_construct,
-                                   std::forward_as_tuple(id),
-                                   std::forward_as_tuple(std::make_unique<XkbMappingState>(default_keymap)));
+            device_mapping.emplace(
+                std::piecewise_construct,
+                std::forward_as_tuple(id),
+                std::forward_as_tuple(std::move(mapping_state)));
 
         return insertion_pos->second.get();
     }
@@ -208,29 +210,34 @@ mircv::XKBMapper::XkbMappingState* mircv::XKBMapper::get_keymapping_state(MirInp
 
 void mircv::XKBMapper::set_keymap_for_all_devices(std::shared_ptr<Keymap> new_keymap)
 {
-    set_keymap(new_keymap->make_unique_xkb_keymap(context.get()));
+    set_keymap(new_keymap);
 }
 
-void mircv::XKBMapper::set_keymap(XKBKeymapPtr new_keymap)
+void mircv::XKBMapper::set_keymap(std::shared_ptr<Keymap> new_keymap)
 {
     std::lock_guard<std::mutex> lg(guard);
     default_keymap = std::move(new_keymap);
+    default_compiled_keymap = default_keymap->make_unique_xkb_keymap(context.get());
     device_mapping.clear();
 }
 
 void mircv::XKBMapper::set_keymap_for_device(MirInputDeviceId id, std::shared_ptr<Keymap> new_keymap)
 {
-    set_keymap(id, new_keymap->make_unique_xkb_keymap(context.get()));
+    set_keymap(id, std::move(new_keymap));
 }
 
-void mircv::XKBMapper::set_keymap(MirInputDeviceId id, XKBKeymapPtr new_keymap)
+void mircv::XKBMapper::set_keymap(MirInputDeviceId id, std::shared_ptr<Keymap> new_keymap)
 {
     std::lock_guard<std::mutex> lg(guard);
 
+    auto compiled_keymap = new_keymap->make_unique_xkb_keymap(context.get());
+    auto mapping_state = std::make_unique<XkbMappingState>(std::move(new_keymap), std::move(compiled_keymap));
+
     device_mapping.erase(id);
-    device_mapping.emplace(std::piecewise_construct,
-                           std::forward_as_tuple(id),
-                           std::forward_as_tuple(std::make_unique<XkbMappingState>(std::move(new_keymap))));
+    device_mapping.emplace(
+        std::piecewise_construct,
+        std::forward_as_tuple(id),
+        std::forward_as_tuple(std::move(mapping_state)));
 }
 
 void mircv::XKBMapper::clear_all_keymaps()
@@ -266,14 +273,17 @@ MirInputEventModifiers mircv::XKBMapper::device_modifiers(MirInputDeviceId id) c
     return expand_modifiers(it->second->modifiers());
 }
 
-mircv::XKBMapper::XkbMappingState::XkbMappingState(std::shared_ptr<xkb_keymap> const& keymap)
-    : keymap{keymap}, state{make_unique_state(this->keymap.get())}
+mircv::XKBMapper::XkbMappingState::XkbMappingState(
+    std::shared_ptr<Keymap> keymap,
+    std::shared_ptr<xkb_keymap> compiled_keymap)
+    : keymap{std::move(keymap)},
+      compiled_keymap{std::move(compiled_keymap)},
+      state{make_unique_state(this->compiled_keymap.get())}
 {
 }
 
 void mircv::XKBMapper::XkbMappingState::set_key_state(std::vector<uint32_t> const& key_state)
 {
-    state = make_unique_state(keymap.get());
     modifier_state = mir_input_event_modifier_none;
     std::unordered_set<uint32_t> pressed_codes;
     std::string t;

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -28,6 +28,7 @@
 #include "mir/input/xkb_mapper.h"
 #include "mir/log.h"
 #include "mir/fatal.h"
+#include "mir/events/keyboard_event.h"
 
 #include <xkbcommon/xkbcommon.h>
 #include <boost/throw_exception.hpp>
@@ -50,12 +51,6 @@ mf::WlKeyboard::WlKeyboard(
       context{xkb_context_new(XKB_CONTEXT_NO_FLAGS), &xkb_context_unref},
       acquire_current_keyboard_state{acquire_current_keyboard_state}
 {
-    // TODO: We should really grab the keymap for the focused surface when
-    // we receive focus.
-
-    // TODO: Maintain per-device keymaps, and send the appropriate map before
-    // sending an event from a keyboard with a different map.
-
     /* The wayland::Keyboard constructor has already run, creating the keyboard
      * resource. It is thus safe to send a keymap event to it; the client will receive
      * the keyboard object before this event.
@@ -78,6 +73,8 @@ mf::WlKeyboard::~WlKeyboard()
 
 void mf::WlKeyboard::event(MirKeyboardEvent const* event, WlSurface& surface)
 {
+    set_keymap(event->keymap());
+
     bool down;
     switch (mir_keyboard_event_action(event))
     {

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -51,7 +51,7 @@ class WlKeyboard : public wayland::Keyboard
 public:
     WlKeyboard(
         wl_resource* new_resource,
-        mir::input::Keymap const& initial_keymap,
+        std::shared_ptr<mir::input::Keymap> const& initial_keymap,
         std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state,
         bool enable_key_repeat);
 
@@ -62,11 +62,12 @@ public:
     void resync_keyboard();
 
 private:
-    void set_keymap(mir::input::Keymap const& new_keymap);
+    void set_keymap(std::shared_ptr<mir::input::Keymap> const& new_keymap);
     void update_modifier_state();
     void update_keyboard_state(std::vector<uint32_t> const& keyboard_state);
 
-    std::unique_ptr<xkb_keymap, void (*)(xkb_keymap *)> keymap;
+    std::shared_ptr<mir::input::Keymap> current_keymap;
+    std::unique_ptr<xkb_keymap, void (*)(xkb_keymap *)> compiled_keymap;
     std::unique_ptr<xkb_state, void (*)(xkb_state *)> state;
     std::unique_ptr<xkb_context, void (*)(xkb_context *)> const context;
 

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -240,7 +240,7 @@ void mf::WlSeat::Instance::get_keyboard(wl_resource* new_keyboard)
 {
     auto const keyboard = new WlKeyboard{
         new_keyboard,
-        *seat->keymap,
+        seat->keymap,
         [seat = seat->seat]()
         {
             std::unordered_set<uint32_t> pressed_keys;


### PR DESCRIPTION
When a key event comes through with a different keymap, send the keymap event to Wayland clients before sending the key. Based on #2114 and #2113. Part of #2111.