### PR TITLE
Calibrate event timestamps

### DIFF
--- a/include/platform/mir/input/event_builder.h
+++ b/include/platform/mir/input/event_builder.h
@@ -41,6 +41,11 @@ public:
     /// Timestamps in returned events are automatically calibrated to the Mir clock
     using Timestamp = std::chrono::nanoseconds;
 
+    /// True resets timestamp calibration to it's initial state, so the next event with a timestamp will be at the
+    /// "current" time (according to the Mir clock) and subsequent events will be relative to that. False disables
+    /// calibration, so future events will not have their timestamps modified.
+    virtual void calibrate_timestamps(bool enable) = 0;
+
     virtual EventUPtr key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t keysym, int scan_code) = 0;
 
     virtual EventUPtr pointer_event(Timestamp timestamp, MirPointerAction action, MirPointerButtons buttons_pressed,

--- a/include/platform/mir/input/event_builder.h
+++ b/include/platform/mir/input/event_builder.h
@@ -41,10 +41,8 @@ public:
     /// Timestamps in returned events are automatically calibrated to the Mir clock
     using Timestamp = std::chrono::nanoseconds;
 
-    /// True resets timestamp calibration to it's initial state, so the next event with a timestamp will be at the
-    /// "current" time (according to the Mir clock) and subsequent events will be relative to that. False disables
-    /// calibration, so future events will not have their timestamps modified.
-    virtual void calibrate_timestamps(bool enable) = 0;
+    /// Disables calibration, so future events will not have their timestamps modified
+    virtual void disable_timestamp_calibration() = 0;
 
     virtual EventUPtr key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t keysym, int scan_code) = 0;
 

--- a/include/platform/mir/input/event_builder.h
+++ b/include/platform/mir/input/event_builder.h
@@ -41,8 +41,10 @@ public:
     /// Timestamps in returned events are automatically calibrated to the Mir clock
     using Timestamp = std::chrono::nanoseconds;
 
-    /// Disables calibration, so future events will not have their timestamps modified
-    virtual void disable_timestamp_calibration() = 0;
+    /// True resets timestamp calibration to it's initial state, so the next event with a timestamp will be at the
+    /// "current" time (according to the Mir clock) and subsequent events will be relative to that. False disables
+    /// calibration, so future events will not have their timestamps modified.
+    virtual void calibrate_timestamps(bool enable) = 0;
 
     virtual EventUPtr key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t keysym, int scan_code) = 0;
 

--- a/include/platform/mir/input/event_builder.h
+++ b/include/platform/mir/input/event_builder.h
@@ -41,11 +41,6 @@ public:
     /// Timestamps in returned events are automatically calibrated to the Mir clock
     using Timestamp = std::chrono::nanoseconds;
 
-    /// True resets timestamp calibration to it's initial state, so the next event with a timestamp will be at the
-    /// "current" time (according to the Mir clock) and subsequent events will be relative to that. False disables
-    /// calibration, so future events will not have their timestamps modified.
-    virtual void calibrate_timestamps(bool enable) = 0;
-
     virtual EventUPtr key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t keysym, int scan_code) = 0;
 
     virtual EventUPtr pointer_event(Timestamp timestamp, MirPointerAction action, MirPointerButtons buttons_pressed,

--- a/include/platform/mir/input/event_builder.h
+++ b/include/platform/mir/input/event_builder.h
@@ -38,6 +38,7 @@ class EventBuilder
 public:
     EventBuilder() = default;
     virtual ~EventBuilder() = default;
+    /// Timestamps in returned events are automatically calibrated to the Mir clock
     using Timestamp = std::chrono::nanoseconds;
 
     virtual EventUPtr key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t keysym, int scan_code) = 0;

--- a/src/server/input/default_configuration.cpp
+++ b/src/server/input/default_configuration.cpp
@@ -317,6 +317,7 @@ std::shared_ptr<mi::DefaultInputDeviceHub> mir::DefaultServerConfiguration::the_
            auto hub = std::make_shared<mi::DefaultInputDeviceHub>(
                the_seat(),
                the_input_reading_multiplexer(),
+               the_clock(),
                the_cookie_authority(),
                the_key_mapper(),
                the_server_status_listener());

--- a/src/server/input/default_event_builder.cpp
+++ b/src/server/input/default_event_builder.cpp
@@ -41,18 +41,9 @@ mi::DefaultEventBuilder::DefaultEventBuilder(
 {
 }
 
-void mi::DefaultEventBuilder::calibrate_timestamps(bool enable)
+void mi::DefaultEventBuilder::disable_timestamp_calibration()
 {
-    if (enable)
-    {
-        // Reset calibration
-        timestamp_offset = Timestamp::max();
-    }
-    else
-    {
-        // Disable calibration
-        timestamp_offset = Timestamp{0};
-    }
+    timestamp_offset = Timestamp{0};
 }
 
 mir::EventUPtr mi::DefaultEventBuilder::key_event(

--- a/src/server/input/default_event_builder.cpp
+++ b/src/server/input/default_event_builder.cpp
@@ -41,9 +41,18 @@ mi::DefaultEventBuilder::DefaultEventBuilder(
 {
 }
 
-void mi::DefaultEventBuilder::disable_timestamp_calibration()
+void mi::DefaultEventBuilder::calibrate_timestamps(bool enable)
 {
-    timestamp_offset = Timestamp{0};
+    if (enable)
+    {
+        // Reset calibration
+        timestamp_offset = Timestamp::max();
+    }
+    else
+    {
+        // Disable calibration
+        timestamp_offset = Timestamp{0};
+    }
 }
 
 mir::EventUPtr mi::DefaultEventBuilder::key_event(

--- a/src/server/input/default_event_builder.cpp
+++ b/src/server/input/default_event_builder.cpp
@@ -41,6 +41,20 @@ mi::DefaultEventBuilder::DefaultEventBuilder(
 {
 }
 
+void mi::DefaultEventBuilder::calibrate_timestamps(bool enable)
+{
+    if (enable)
+    {
+        // Reset calibration
+        timestamp_offset = Timestamp::max();
+    }
+    else
+    {
+        // Disable calibration
+        timestamp_offset = Timestamp{0};
+    }
+}
+
 mir::EventUPtr mi::DefaultEventBuilder::key_event(
     Timestamp source_timestamp,
     MirKeyboardAction action,

--- a/src/server/input/default_event_builder.cpp
+++ b/src/server/input/default_event_builder.cpp
@@ -41,20 +41,6 @@ mi::DefaultEventBuilder::DefaultEventBuilder(
 {
 }
 
-void mi::DefaultEventBuilder::calibrate_timestamps(bool enable)
-{
-    if (enable)
-    {
-        // Reset calibration
-        timestamp_offset = Timestamp::max();
-    }
-    else
-    {
-        // Disable calibration
-        timestamp_offset = Timestamp{0};
-    }
-}
-
 mir::EventUPtr mi::DefaultEventBuilder::key_event(
     Timestamp source_timestamp,
     MirKeyboardAction action,

--- a/src/server/input/default_event_builder.cpp
+++ b/src/server/input/default_event_builder.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "default_event_builder.h"
+#include "mir/time/clock.h"
 #include "mir/input/seat.h"
 #include "mir/events/event_builders.h"
 #include "mir/cookie/authority.h"
@@ -27,10 +28,13 @@
 namespace me = mir::events;
 namespace mi = mir::input;
 
-mi::DefaultEventBuilder::DefaultEventBuilder(MirInputDeviceId device_id,
-                                             std::shared_ptr<mir::cookie::Authority> const& cookie_authority,
-                                             std::shared_ptr<mi::Seat> const& seat)
+mi::DefaultEventBuilder::DefaultEventBuilder(
+    MirInputDeviceId device_id,
+    std::shared_ptr<time::Clock> const& clock,
+    std::shared_ptr<mir::cookie::Authority> const& cookie_authority,
+    std::shared_ptr<mi::Seat> const& seat)
     : device_id(device_id),
+      clock(clock),
       cookie_authority(cookie_authority),
       seat(seat)
 {

--- a/src/server/input/default_event_builder.h
+++ b/src/server/input/default_event_builder.h
@@ -47,7 +47,7 @@ public:
         std::shared_ptr<cookie::Authority> const& cookie_authority,
         std::shared_ptr<Seat> const& seat);
 
-    void disable_timestamp_calibration() override;
+    void calibrate_timestamps(bool enable) override;
 
     EventUPtr key_event(
         Timestamp source_timestamp,

--- a/src/server/input/default_event_builder.h
+++ b/src/server/input/default_event_builder.h
@@ -47,7 +47,7 @@ public:
         std::shared_ptr<cookie::Authority> const& cookie_authority,
         std::shared_ptr<Seat> const& seat);
 
-    void calibrate_timestamps(bool enable) override;
+    void disable_timestamp_calibration() override;
 
     EventUPtr key_event(
         Timestamp source_timestamp,

--- a/src/server/input/default_event_builder.h
+++ b/src/server/input/default_event_builder.h
@@ -29,6 +29,10 @@ namespace cookie
 {
 class Authority;
 }
+namespace time
+{
+class Clock;
+}
 namespace input
 {
 class Seat;
@@ -36,9 +40,11 @@ class Seat;
 class DefaultEventBuilder : public EventBuilder
 {
 public:
-    explicit DefaultEventBuilder(MirInputDeviceId device_id,
-                                 std::shared_ptr<cookie::Authority> const& cookie_authority,
-                                 std::shared_ptr<Seat> const& seat);
+    explicit DefaultEventBuilder(
+        MirInputDeviceId device_id,
+        std::shared_ptr<time::Clock> const& clock,
+        std::shared_ptr<cookie::Authority> const& cookie_authority,
+        std::shared_ptr<Seat> const& seat);
 
     EventUPtr key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t keysym, int scan_code) override;
 
@@ -55,6 +61,7 @@ public:
 
 private:
     MirInputDeviceId const device_id;
+    std::shared_ptr<time::Clock> const clock;
     std::shared_ptr<cookie::Authority> const cookie_authority;
     std::shared_ptr<Seat> const seat;
 };

--- a/src/server/input/default_event_builder.h
+++ b/src/server/input/default_event_builder.h
@@ -47,8 +47,6 @@ public:
         std::shared_ptr<cookie::Authority> const& cookie_authority,
         std::shared_ptr<Seat> const& seat);
 
-    void calibrate_timestamps(bool enable) override;
-
     EventUPtr key_event(
         Timestamp source_timestamp,
         MirKeyboardAction action,

--- a/src/server/input/default_event_builder.h
+++ b/src/server/input/default_event_builder.h
@@ -47,6 +47,8 @@ public:
         std::shared_ptr<cookie::Authority> const& cookie_authority,
         std::shared_ptr<Seat> const& seat);
 
+    void calibrate_timestamps(bool enable) override;
+
     EventUPtr key_event(
         Timestamp source_timestamp,
         MirKeyboardAction action,

--- a/src/server/input/default_event_builder.h
+++ b/src/server/input/default_event_builder.h
@@ -22,6 +22,7 @@
 
 #include "mir/input/event_builder.h"
 #include <memory>
+#include <atomic>
 
 namespace mir
 {
@@ -46,22 +47,36 @@ public:
         std::shared_ptr<cookie::Authority> const& cookie_authority,
         std::shared_ptr<Seat> const& seat);
 
-    EventUPtr key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t keysym, int scan_code) override;
+    EventUPtr key_event(
+        Timestamp source_timestamp,
+        MirKeyboardAction action,
+        xkb_keysym_t keysym,
+        int scan_code) override;
 
-    EventUPtr touch_event(Timestamp timestamp, std::vector<events::ContactState> const& contacts) override;
+    EventUPtr touch_event(Timestamp source_timestamp, std::vector<events::ContactState> const& contacts) override;
 
-    EventUPtr pointer_event(Timestamp timestamp, MirPointerAction action, MirPointerButtons buttons_pressed,
-                            float hscroll_value, float vscroll_value, float relative_x_value,
-                            float relative_y_value) override;
+    EventUPtr pointer_event(
+        Timestamp source_timestamp,
+        MirPointerAction action,
+        MirPointerButtons buttons_pressed,
+        float hscroll_value, float vscroll_value,
+        float relative_x_value, float relative_y_value) override;
 
-    EventUPtr pointer_event(Timestamp timestamp, MirPointerAction action, MirPointerButtons buttons_pressed,
-                            float x, float y, float hscroll_value, float vscroll_value, float relative_x_value,
-                            float relative_y_value) override;
-
+    EventUPtr pointer_event(
+        Timestamp source_timestamp,
+        MirPointerAction action,
+        MirPointerButtons buttons_pressed,
+        float x, float y,
+        float hscroll_value, float vscroll_value,
+        float relative_x_value, float relative_y_value) override;
 
 private:
+    auto calibrate_timestamp(Timestamp source_timestamp) -> Timestamp;
+
     MirInputDeviceId const device_id;
     std::shared_ptr<time::Clock> const clock;
+    /// Added to input timestams to get calibrated timestamps for events. Is Timestamp::max() until initial event.
+    std::atomic<Timestamp> timestamp_offset;
     std::shared_ptr<cookie::Authority> const cookie_authority;
     std::shared_ptr<Seat> const seat;
 };

--- a/src/server/input/default_input_device_hub.h
+++ b/src/server/input/default_input_device_hub.h
@@ -46,6 +46,10 @@ namespace cookie
 {
 class Authority;
 }
+namespace time
+{
+class Clock;
+}
 namespace dispatch
 {
 class Dispatchable;
@@ -83,11 +87,13 @@ class DefaultInputDeviceHub :
     public InputDeviceHub
 {
 public:
-    DefaultInputDeviceHub(std::shared_ptr<Seat> const& seat,
-                          std::shared_ptr<dispatch::MultiplexingDispatchable> const& input_multiplexer,
-                          std::shared_ptr<cookie::Authority> const& cookie_authority,
-                          std::shared_ptr<KeyMapper> const& key_mapper,
-                          std::shared_ptr<ServerStatusListener> const& server_status_listener);
+    DefaultInputDeviceHub(
+        std::shared_ptr<Seat> const& seat,
+        std::shared_ptr<dispatch::MultiplexingDispatchable> const& input_multiplexer,
+        std::shared_ptr<time::Clock> const& clock,
+        std::shared_ptr<cookie::Authority> const& cookie_authority,
+        std::shared_ptr<KeyMapper> const& key_mapper,
+        std::shared_ptr<ServerStatusListener> const& server_status_listener);
 
     // InputDeviceRegistry - calls from mi::Platform
     void add_device(std::shared_ptr<InputDevice> const& device) override;
@@ -116,6 +122,7 @@ private:
     std::shared_ptr<Seat> const seat;
     std::shared_ptr<dispatch::MultiplexingDispatchable> const input_dispatchable;
     std::shared_ptr<dispatch::ActionQueue> const device_queue;
+    std::shared_ptr<time::Clock> const clock;
     std::shared_ptr<cookie::Authority> const cookie_authority;
     std::shared_ptr<KeyMapper> const key_mapper;
     std::shared_ptr<ServerStatusListener> const server_status_listener;
@@ -125,11 +132,13 @@ private:
     struct RegisteredDevice : public InputSink
     {
     public:
-        RegisteredDevice(std::shared_ptr<InputDevice> const& dev,
-                         MirInputDeviceId dev_id,
-                         std::shared_ptr<dispatch::ActionQueue> const& multiplexer,
-                         std::shared_ptr<cookie::Authority> const& cookie_authority,
-                         std::shared_ptr<DefaultDevice> const& handle);
+        RegisteredDevice(
+            std::shared_ptr<InputDevice> const& dev,
+            MirInputDeviceId dev_id,
+            std::shared_ptr<dispatch::ActionQueue> const& multiplexer,
+            std::shared_ptr<time::Clock> const& clock,
+            std::shared_ptr<cookie::Authority> const& cookie_authority,
+            std::shared_ptr<DefaultDevice> const& handle);
         void handle_input(std::shared_ptr<MirEvent> const& event) override;
         geometry::Rectangle bounding_rectangle() const override;
         input::OutputInfo output_info(uint32_t output_id) const override;
@@ -145,6 +154,7 @@ private:
     private:
         MirInputDeviceId device_id;
         std::unique_ptr<DefaultEventBuilder> builder;
+        std::shared_ptr<time::Clock> const clock;
         std::shared_ptr<cookie::Authority> cookie_authority;
         std::shared_ptr<InputDevice> const device;
         std::shared_ptr<dispatch::ActionQueue> queue;

--- a/tests/integration-tests/input/test_single_seat_setup.cpp
+++ b/tests/integration-tests/input/test_single_seat_setup.cpp
@@ -132,9 +132,13 @@ struct SingleSeatInputDeviceHubSetup : ::testing::Test
                        mt::fake_shared(mock_cursor_listener), mt::fake_shared(display_config),
                        mt::fake_shared(key_mapper),           mt::fake_shared(clock),
                        mt::fake_shared(mock_seat_observer)};
-    mi::DefaultInputDeviceHub hub{mt::fake_shared(seat), mt::fake_shared(multiplexer),
-                                  cookie_authority,      mt::fake_shared(key_mapper),
-                                  mt::fake_shared(mock_status_listener)};
+    mi::DefaultInputDeviceHub hub{
+        mt::fake_shared(seat),
+        mt::fake_shared(multiplexer),
+        mt::fake_shared(clock),
+        cookie_authority,
+        mt::fake_shared(key_mapper),
+        mt::fake_shared(mock_status_listener)};
     NiceMock<mtd::MockInputDeviceObserver> mock_observer;
     mi::ConfigChanger changer{
         mt::fake_shared(mock_input_manager),

--- a/tests/mir_test_framework/fake_input_device_impl.cpp
+++ b/tests/mir_test_framework/fake_input_device_impl.cpp
@@ -328,9 +328,6 @@ void mtf::FakeInputDeviceImpl::InputDevice::map_touch_coordinates(float& x, floa
 
 void mtf::FakeInputDeviceImpl::InputDevice::start(mi::InputSink* destination, mi::EventBuilder* event_builder)
 {
-    // We keep track of events based on their timestamps, so we can't have those being modified
-    event_builder->calibrate_timestamps(false);
-
     sink = destination;
     builder = event_builder;
     mtf::StubInputPlatform::register_dispatchable(queue);

--- a/tests/mir_test_framework/fake_input_device_impl.cpp
+++ b/tests/mir_test_framework/fake_input_device_impl.cpp
@@ -25,6 +25,7 @@
 #include "mir/input/pointer_settings.h"
 #include "mir/input/touchpad_settings.h"
 #include "mir/input/event_builder.h"
+#include "mir/events/input_event.h"
 #include "mir/dispatch/action_queue.h"
 #include "mir/geometry/displacement.h"
 #include "src/platforms/evdev/button_utils.h"
@@ -173,6 +174,7 @@ void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::ButtonP
                                                scroll.y.as_int(),
                                                0.0f,
                                                0.0f);
+    button_event->to_input()->set_event_time(event_time);
 
     if (!sink)
         BOOST_THROW_EXCEPTION(std::runtime_error("Device is not started."));
@@ -215,6 +217,7 @@ void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::MotionP
                                                 scroll.y.as_int(),
                                                 rel_x,
                                                 rel_y);
+    pointer_event->to_input()->set_event_time(event_time);
 
     sink->handle_input(std::move(pointer_event));
 }
@@ -243,6 +246,7 @@ void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::TouchPa
         auto touch_event = builder->touch_event(
             event_time,
             {{MirTouchId{1}, touch_action, mir_touch_tooltype_finger, abs_x, abs_y, 1.0f, 8.0f, 5.0f, 0.0f}});
+        touch_event->to_input()->set_event_time(event_time);
 
         sink->handle_input(std::move(touch_event));
     }

--- a/tests/mir_test_framework/fake_input_device_impl.cpp
+++ b/tests/mir_test_framework/fake_input_device_impl.cpp
@@ -324,6 +324,9 @@ void mtf::FakeInputDeviceImpl::InputDevice::map_touch_coordinates(float& x, floa
 
 void mtf::FakeInputDeviceImpl::InputDevice::start(mi::InputSink* destination, mi::EventBuilder* event_builder)
 {
+    // We keep track of events based on their timestamps, so we can't have those being modified
+    event_builder->calibrate_timestamps(false);
+
     sink = destination;
     builder = event_builder;
     mtf::StubInputPlatform::register_dispatchable(queue);

--- a/tests/mir_test_framework/fake_input_device_impl.cpp
+++ b/tests/mir_test_framework/fake_input_device_impl.cpp
@@ -325,7 +325,7 @@ void mtf::FakeInputDeviceImpl::InputDevice::map_touch_coordinates(float& x, floa
 void mtf::FakeInputDeviceImpl::InputDevice::start(mi::InputSink* destination, mi::EventBuilder* event_builder)
 {
     // We keep track of events based on their timestamps, so we can't have those being modified
-    event_builder->calibrate_timestamps(false);
+    event_builder->disable_timestamp_calibration();
 
     sink = destination;
     builder = event_builder;

--- a/tests/mir_test_framework/fake_input_device_impl.cpp
+++ b/tests/mir_test_framework/fake_input_device_impl.cpp
@@ -329,7 +329,7 @@ void mtf::FakeInputDeviceImpl::InputDevice::map_touch_coordinates(float& x, floa
 void mtf::FakeInputDeviceImpl::InputDevice::start(mi::InputSink* destination, mi::EventBuilder* event_builder)
 {
     // We keep track of events based on their timestamps, so we can't have those being modified
-    event_builder->disable_timestamp_calibration();
+    event_builder->calibrate_timestamps(false);
 
     sink = destination;
     builder = event_builder;

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -105,8 +105,6 @@ struct MockEventBuilder : mi::EventBuilder
                                   }));
     }
     using EventBuilder::Timestamp;
-    MOCK_METHOD1(calibrate_timestamps, void(bool enable));
-
     MOCK_METHOD4(key_event, mir::EventUPtr(Timestamp, MirKeyboardAction, xkb_keysym_t, int));
 
     MOCK_METHOD2(touch_event, mir::EventUPtr(Timestamp, std::vector<mir::events::ContactState> const&));

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -32,6 +32,7 @@
 #include "mir/test/doubles/mock_libinput.h"
 #include "mir/test/doubles/mock_input_seat.h"
 #include "mir/test/doubles/mock_input_sink.h"
+#include "mir/test/doubles/advanceable_clock.h"
 #include "mir/test/gmock_fixes.h"
 #include "mir/test/fake_shared.h"
 #include "mir/udev/wrapper.h"
@@ -70,7 +71,12 @@ struct MockEventBuilder : mi::EventBuilder
 {
     std::shared_ptr<mir::cookie::Authority> const cookie_authority = mir::cookie::Authority::create();
     mtd::MockInputSeat seat;
-    mi::DefaultEventBuilder builder{MirInputDeviceId{3}, cookie_authority, mt::fake_shared(seat)};
+    mtd::AdvanceableClock clock;
+    mi::DefaultEventBuilder builder{
+        MirInputDeviceId{3},
+        mt::fake_shared(clock),
+        cookie_authority,
+        mt::fake_shared(seat)};
     MockEventBuilder()
     {
         ON_CALL(*this, key_event(_,_,_,_))

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -105,7 +105,7 @@ struct MockEventBuilder : mi::EventBuilder
                                   }));
     }
     using EventBuilder::Timestamp;
-    MOCK_METHOD0(disable_timestamp_calibration, void());
+    MOCK_METHOD1(calibrate_timestamps, void(bool enable));
 
     MOCK_METHOD4(key_event, mir::EventUPtr(Timestamp, MirKeyboardAction, xkb_keysym_t, int));
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -105,7 +105,7 @@ struct MockEventBuilder : mi::EventBuilder
                                   }));
     }
     using EventBuilder::Timestamp;
-    MOCK_METHOD1(calibrate_timestamps, void(bool enable));
+    MOCK_METHOD0(disable_timestamp_calibration, void());
 
     MOCK_METHOD4(key_event, mir::EventUPtr(Timestamp, MirKeyboardAction, xkb_keysym_t, int));
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -105,6 +105,8 @@ struct MockEventBuilder : mi::EventBuilder
                                   }));
     }
     using EventBuilder::Timestamp;
+    MOCK_METHOD1(calibrate_timestamps, void(bool enable));
+
     MOCK_METHOD4(key_event, mir::EventUPtr(Timestamp, MirKeyboardAction, xkb_keysym_t, int));
 
     MOCK_METHOD2(touch_event, mir::EventUPtr(Timestamp, std::vector<mir::events::ContactState> const&));

--- a/tests/unit-tests/input/test_default_input_device_hub.cpp
+++ b/tests/unit-tests/input/test_default_input_device_hub.cpp
@@ -28,6 +28,7 @@
 #include "mir/test/doubles/stub_cursor_listener.h"
 #include "mir/test/doubles/stub_touch_visualizer.h"
 #include "mir/test/doubles/triggered_main_loop.h"
+#include "mir/test/doubles/advanceable_clock.h"
 #include "mir/test/event_matchers.h"
 #include "mir/test/fake_shared.h"
 #include "mir/test/fd_utils.h"
@@ -83,9 +84,14 @@ struct InputDeviceHubTest : ::testing::Test
     NiceMock<mtd::MockInputSeat> mock_seat;
     NiceMock<mtd::MockKeyMapper> mock_key_mapper;
     NiceMock<mtd::MockServerStatusListener> mock_server_status_listener;
-    mi::DefaultInputDeviceHub hub{mt::fake_shared(mock_seat), mt::fake_shared(multiplexer),
-                                  cookie_authority, mt::fake_shared(mock_key_mapper),
-                                  mt::fake_shared(mock_server_status_listener)};
+    mtd::AdvanceableClock clock;
+    mi::DefaultInputDeviceHub hub{
+        mt::fake_shared(mock_seat),
+        mt::fake_shared(multiplexer),
+        mt::fake_shared(clock),
+        cookie_authority,
+        mt::fake_shared(mock_key_mapper),
+        mt::fake_shared(mock_server_status_listener)};
     NiceMock<mtd::MockInputDeviceObserver> mock_observer;
     NiceMock<mtd::MockInputDevice> device{"device","dev-1", mi::DeviceCapability::unknown};
     NiceMock<mtd::MockInputDevice> another_device{"another_device","dev-2", mi::DeviceCapability::keyboard};

--- a/tests/unit-tests/input/test_seat_input_device_tracker.cpp
+++ b/tests/unit-tests/input/test_seat_input_device_tracker.cpp
@@ -62,9 +62,21 @@ struct SeatInputDeviceTracker : ::testing::Test
     std::shared_ptr<mir::cookie::Authority> cookie_factory = mir::cookie::Authority::create();
     mtd::AdvanceableClock clock;
 
-    mi::DefaultEventBuilder some_device_builder{some_device, cookie_factory, mt::fake_shared(mock_seat)};
-    mi::DefaultEventBuilder another_device_builder{another_device, cookie_factory, mt::fake_shared(mock_seat)};
-    mi::DefaultEventBuilder third_device_builder{third_device, cookie_factory, mt::fake_shared(mock_seat)};
+    mi::DefaultEventBuilder some_device_builder{
+        some_device,
+        mt::fake_shared(clock),
+        cookie_factory,
+        mt::fake_shared(mock_seat)};
+    mi::DefaultEventBuilder another_device_builder{
+        another_device,
+        mt::fake_shared(clock),
+        cookie_factory,
+        mt::fake_shared(mock_seat)};
+    mi::DefaultEventBuilder third_device_builder{
+        third_device,
+        mt::fake_shared(clock),
+        cookie_factory,
+        mt::fake_shared(mock_seat)};
     mi::receiver::XKBMapper mapper;
     mi::SeatInputDeviceTracker tracker{
         mt::fake_shared(mock_dispatcher), mt::fake_shared(mock_visualizer), mt::fake_shared(mock_cursor_listener),

--- a/tests/unit-tests/input/test_x11_platform.cpp
+++ b/tests/unit-tests/input/test_x11_platform.cpp
@@ -33,6 +33,7 @@
 #include "mir/test/doubles/mock_x11.h"
 #include "mir/test/doubles/mock_xkb.h"
 #include "mir/test/doubles/mock_x11_resources.h"
+#include "mir/test/doubles/advanceable_clock.h"
 #include "mir/test/fake_shared.h"
 #include "mir/cookie/authority.h"
 #include "mir/test/event_matchers.h"
@@ -55,7 +56,12 @@ struct X11PlatformTest : ::testing::Test
     NiceMock<mtd::MockX11> mock_x11;
     NiceMock<mtd::MockXkb> mock_xkb;
     NiceMock<mtd::MockInputDeviceRegistry> mock_registry;
-    mir::input::DefaultEventBuilder builder{0, mir::cookie::Authority::create(), mt::fake_shared(mock_seat)};
+    mtd::AdvanceableClock clock;
+    mir::input::DefaultEventBuilder builder{
+        0,
+        mt::fake_shared(clock),
+        mir::cookie::Authority::create(),
+        mt::fake_shared(mock_seat)};
 
     mir::input::X::XInputPlatform x11_platform{
         mt::fake_shared(mock_registry),


### PR DESCRIPTION
With this PR, `DefaultEventBuilder` holds a `time::Clock`, which is uses to calibrate incoming events with. This way events coming from multiple sources (each with an undefined timestamp base) and events generated inside Mir will all have correct timestamps relative to each other. The `EventBuilder` interface is not changed, and no changes are needed for users of it.