### PR TITLE
X11 platform: use synthisized timestamps instead of last timestamp

### DIFF
--- a/include/platform/mir/input/event_builder.h
+++ b/include/platform/mir/input/event_builder.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <chrono>
 #include <vector>
+#include <optional>
 
 namespace mir
 {
@@ -38,21 +39,34 @@ class EventBuilder
 public:
     EventBuilder() = default;
     virtual ~EventBuilder() = default;
-    /// Timestamps in returned events are automatically calibrated to the Mir clock
+    /// Timestamps in returned events are automatically calibrated to the Mir clock. If nullopt is given current mir
+    /// clock time is used.
     using Timestamp = std::chrono::nanoseconds;
 
-    virtual EventUPtr key_event(Timestamp timestamp, MirKeyboardAction action, xkb_keysym_t keysym, int scan_code) = 0;
+    virtual EventUPtr key_event(
+        std::optional<Timestamp> timestamp,
+        MirKeyboardAction action,
+        xkb_keysym_t keysym,
+        int scan_code) = 0;
 
-    virtual EventUPtr pointer_event(Timestamp timestamp, MirPointerAction action, MirPointerButtons buttons_pressed,
-                                    float hscroll_value, float vscroll_value, float relative_x_value,
-                                    float relative_y_value) = 0;
+    virtual EventUPtr pointer_event(
+        std::optional<Timestamp> timestamp,
+        MirPointerAction action,
+        MirPointerButtons buttons_pressed,
+        float hscroll_value, float vscroll_value,
+        float relative_x_value, float relative_y_value) = 0;
 
-    virtual EventUPtr pointer_event(Timestamp timestamp, MirPointerAction action, MirPointerButtons buttons_pressed,
-                                    float x_position, float y_position,
-                                    float hscroll_value, float vscroll_value, float relative_x_value,
-                                    float relative_y_value) = 0;
+    virtual EventUPtr pointer_event(
+        std::optional<Timestamp> timestamp,
+        MirPointerAction action,
+        MirPointerButtons buttons_pressed,
+        float x_position, float y_position,
+        float hscroll_value, float vscroll_value,
+        float relative_x_value, float relative_y_value) = 0;
 
-    virtual EventUPtr touch_event(Timestamp timestamp, std::vector<mir::events::ContactState> const& contacts) = 0;
+    virtual EventUPtr touch_event(
+        std::optional<Timestamp> timestamp,
+        std::vector<mir::events::ContactState> const& contacts) = 0;
 protected:
     EventBuilder(EventBuilder const&) = delete;
     EventBuilder& operator=(EventBuilder const&) = delete;

--- a/src/platforms/x11/input/input_device.cpp
+++ b/src/platforms/x11/input/input_device.cpp
@@ -137,7 +137,7 @@ bool mix::XInputDevice::started() const
     return sink && builder;
 }
 
-void mix::XInputDevice::key_press(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int scan_code)
+void mix::XInputDevice::key_press(EventTime event_time, xkb_keysym_t keysym, int scan_code)
 {
     sink->handle_input(builder->key_event(
         event_time,
@@ -147,7 +147,7 @@ void mix::XInputDevice::key_press(std::chrono::nanoseconds event_time, xkb_keysy
 
 }
 
-void mix::XInputDevice::key_release(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int scan_code)
+void mix::XInputDevice::key_release(EventTime event_time, xkb_keysym_t keysym, int scan_code)
 {
     sink->handle_input(builder->key_event(
         event_time,
@@ -162,7 +162,7 @@ void mix::XInputDevice::update_button_state(int button)
 }
 
 void mix::XInputDevice::pointer_press(
-    std::chrono::nanoseconds event_time,
+    EventTime event_time,
     int button,
     mir::geometry::PointF pos,
     mir::geometry::DisplacementF scroll)
@@ -186,7 +186,7 @@ void mix::XInputDevice::pointer_press(
 }
 
 void mix::XInputDevice::pointer_release(
-    std::chrono::nanoseconds event_time,
+    EventTime event_time,
     int button,
     mir::geometry::PointF pos,
     mir::geometry::DisplacementF scroll)
@@ -211,7 +211,7 @@ void mix::XInputDevice::pointer_release(
 }
 
 void mix::XInputDevice::pointer_motion(
-    std::chrono::nanoseconds event_time,
+    EventTime event_time,
     mir::geometry::PointF pos,
     mir::geometry::DisplacementF scroll)
 {

--- a/src/platforms/x11/input/input_device.h
+++ b/src/platforms/x11/input/input_device.h
@@ -27,6 +27,7 @@
 #include "mir/optional_value.h"
 
 #include <chrono>
+#include <optional>
 
 namespace mir
 {
@@ -39,6 +40,8 @@ namespace X
 class XInputDevice : public input::InputDevice
 {
 public:
+    using EventTime = std::optional<std::chrono::nanoseconds>;
+
     XInputDevice(InputDeviceInfo const& info);
 
     std::shared_ptr<dispatch::Dispatchable> dispatchable();
@@ -54,21 +57,21 @@ public:
     virtual void apply_settings(TouchscreenSettings const&) override;
 
     bool started() const;
-    void key_press(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int scan_code);
-    void key_release(std::chrono::nanoseconds event_time, xkb_keysym_t keysym, int scan_code);
+    void key_press(EventTime event_time, xkb_keysym_t keysym, int scan_code);
+    void key_release(EventTime event_time, xkb_keysym_t keysym, int scan_code);
     void update_button_state(int button);
     void pointer_press(
-        std::chrono::nanoseconds event_time,
+        EventTime event_time,
         int button,
         mir::geometry::PointF pos,
         mir::geometry::DisplacementF scroll);
     void pointer_release(
-        std::chrono::nanoseconds event_time,
+        EventTime event_time,
         int button,
         mir::geometry::PointF pos,
         mir::geometry::DisplacementF scroll);
     void pointer_motion(
-        std::chrono::nanoseconds event_time,
+        EventTime event_time,
         mir::geometry::PointF pos,
         mir::geometry::DisplacementF scroll);
 

--- a/src/platforms/x11/input/input_platform.cpp
+++ b/src/platforms/x11/input/input_platform.cpp
@@ -381,9 +381,7 @@ void mix::XInputPlatform::process_input_event(xcb_generic_event_t* event)
     case XCB_KEY_PRESS:
     {
         auto const press_ev = reinterpret_cast<xcb_key_press_event_t*>(event);
-        auto const event_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-            std::chrono::milliseconds{press_ev->time});
-        key_pressed(event_time, press_ev->detail);
+        key_pressed(std::chrono::milliseconds{press_ev->time}, press_ev->detail);
     }   break;
 
     case XCB_KEY_RELEASE:
@@ -405,9 +403,7 @@ void mix::XInputPlatform::process_input_event(xcb_generic_event_t* event)
                     }
                 }
 
-                auto const event_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                    std::chrono::milliseconds{time});
-                key_released(event_time, xcb_keycode);
+                key_released(std::chrono::milliseconds{time}, xcb_keycode);
                 return false; // do not consume next event, process it normally
             };
     }   break;
@@ -416,8 +412,7 @@ void mix::XInputPlatform::process_input_event(xcb_generic_event_t* event)
     {
         auto const press_ev = reinterpret_cast<xcb_button_press_event_t*>(event);
 
-        auto const event_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-            std::chrono::milliseconds{press_ev->time});
+        auto const event_time = std::chrono::milliseconds{press_ev->time};
         auto const pos = get_pos_on_output(x11_resources.get(), press_ev->event, press_ev->event_x, press_ev->event_y);
         core_pointer->update_button_state(press_ev->state);
 
@@ -459,8 +454,7 @@ void mix::XInputPlatform::process_input_event(xcb_generic_event_t* event)
             break;
 
         default:
-            auto const event_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                std::chrono::milliseconds{release_ev->time});
+            auto const event_time = std::chrono::milliseconds{release_ev->time};
             auto const pos = get_pos_on_output(
                 x11_resources.get(),
                 release_ev->event,
@@ -474,8 +468,7 @@ void mix::XInputPlatform::process_input_event(xcb_generic_event_t* event)
     {
         auto const motion_ev = reinterpret_cast<xcb_motion_notify_event_t*>(event);
         core_pointer->update_button_state(motion_ev->state);
-        auto const event_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                std::chrono::milliseconds{motion_ev->time});
+        auto const event_time = std::chrono::milliseconds{motion_ev->time};
         auto pos = get_pos_on_output(x11_resources.get(), motion_ev->event, motion_ev->event_x, motion_ev->event_y);
         core_pointer->pointer_motion(event_time, pos, {});
     }   break;
@@ -549,8 +542,7 @@ void mix::XInputPlatform::process_xkb_event(xcb_generic_event_t* event)
         {
             modifiers.insert(state_ev->keycode);
         }
-        auto const event_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-            std::chrono::milliseconds{state_ev->time});
+        auto const event_time = std::chrono::milliseconds{state_ev->time};
         switch (state_ev->eventType)
         {
         case XCB_KEY_PRESS:

--- a/src/platforms/x11/input/input_platform.h
+++ b/src/platforms/x11/input/input_platform.h
@@ -24,6 +24,7 @@
 #include <optional>
 #include <vector>
 #include <set>
+#include <chrono>
 #include <xcb/xcb.h>
 
 struct xkb_context;
@@ -68,8 +69,8 @@ private:
     void process_input_events();
     void process_input_event(xcb_generic_event_t* event);
     void process_xkb_event(xcb_generic_event_t* event);
-    void key_pressed(xcb_keycode_t key, xcb_timestamp_t timestamp);
-    void key_released(xcb_keycode_t key, xcb_timestamp_t timestamp);
+    void key_pressed(std::optional<std::chrono::nanoseconds> event_time, xcb_keycode_t key);
+    void key_released(std::optional<std::chrono::nanoseconds> event_time, xcb_keycode_t key);
     /// Defer work until all pending events are processed. Should only be called while processing events.
     void defer(std::function<void()>&& work);
     std::shared_ptr<mir::X::X11Resources> const x11_resources;
@@ -81,7 +82,6 @@ private:
     xkb_context* const xkb_ctx;
     xkb_keymap* const keymap;
     xkb_state* const key_state;
-    xcb_timestamp_t last_timestamp{0};
     std::set<xcb_keycode_t> pressed_keys;
     std::set<xcb_keycode_t> modifiers;
     bool kbd_grabbed;

--- a/src/server/input/default_event_builder.h
+++ b/src/server/input/default_event_builder.h
@@ -48,22 +48,24 @@ public:
         std::shared_ptr<Seat> const& seat);
 
     EventUPtr key_event(
-        Timestamp source_timestamp,
+        std::optional<Timestamp> source_timestamp,
         MirKeyboardAction action,
         xkb_keysym_t keysym,
         int scan_code) override;
 
-    EventUPtr touch_event(Timestamp source_timestamp, std::vector<events::ContactState> const& contacts) override;
+    EventUPtr touch_event(
+        std::optional<Timestamp> source_timestamp,
+        std::vector<events::ContactState> const& contacts) override;
 
     EventUPtr pointer_event(
-        Timestamp source_timestamp,
+        std::optional<Timestamp> source_timestamp,
         MirPointerAction action,
         MirPointerButtons buttons_pressed,
         float hscroll_value, float vscroll_value,
         float relative_x_value, float relative_y_value) override;
 
     EventUPtr pointer_event(
-        Timestamp source_timestamp,
+        std::optional<Timestamp> source_timestamp,
         MirPointerAction action,
         MirPointerButtons buttons_pressed,
         float x, float y,
@@ -71,7 +73,7 @@ public:
         float relative_x_value, float relative_y_value) override;
 
 private:
-    auto calibrate_timestamp(Timestamp source_timestamp) -> Timestamp;
+    auto calibrate_timestamp(std::optional<Timestamp> source_timestamp) -> Timestamp;
 
     MirInputDeviceId const device_id;
     std::shared_ptr<time::Clock> const clock;


### PR DESCRIPTION
This changes the `EventBuilder` interface to take optional timestamps, and to synthesize a timestamp from current time if none is given. It also uses that in the X11 platform where before we were using the last timestamp we saw. Stacked on top of #2117.