### PR TITLE
WlTouch: use Clock to synthisize timestamps

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -492,6 +492,7 @@ void mf::WaylandExtensions::run_builders(wl_display*, std::function<void(std::fu
 mf::WaylandConnector::WaylandConnector(
     std::shared_ptr<msh::Shell> const& shell,
     std::shared_ptr<MirDisplay> const& display_config,
+    std::shared_ptr<time::Clock> const& clock,
     std::shared_ptr<mi::InputDeviceHub> const& input_hub,
     std::shared_ptr<mi::Seat> const& seat,
     std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
@@ -546,7 +547,7 @@ mf::WaylandConnector::WaylandConnector(
         std::make_shared<FrameExecutor>(*main_loop),
         this->allocator);
     subcompositor_global = std::make_unique<mf::WlSubcompositor>(display.get());
-    seat_global = std::make_unique<mf::WlSeat>(display.get(), input_hub, seat, enable_key_repeat);
+    seat_global = std::make_unique<mf::WlSeat>(display.get(), clock, input_hub, seat, enable_key_repeat);
     output_manager = std::make_unique<mf::OutputManager>(
         display.get(),
         display_config,

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -54,6 +54,10 @@ namespace scene
 {
 class Surface;
 }
+namespace time
+{
+class Clock;
+}
 namespace frontend
 {
 class WlCompositor;
@@ -110,6 +114,7 @@ public:
     WaylandConnector(
         std::shared_ptr<shell::Shell> const& shell,
         std::shared_ptr<MirDisplay> const& display_config,
+        std::shared_ptr<time::Clock> const& clock,
         std::shared_ptr<input::InputDeviceHub> const& input_hub,
         std::shared_ptr<input::Seat> const& seat,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -252,6 +252,7 @@ std::shared_ptr<mf::Connector>
             return std::make_shared<mf::WaylandConnector>(
                 the_shell(),
                 display_config,
+                the_clock(),
                 the_input_device_hub(),
                 the_seat(),
                 the_buffer_allocator(),

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -149,6 +149,7 @@ private:
 
 mf::WlSeat::WlSeat(
     wl_display* display,
+    std::shared_ptr<time::Clock> const& clock,
     std::shared_ptr<mi::InputDeviceHub> const& input_hub,
     std::shared_ptr<mi::Seat> const& seat,
     bool enable_key_repeat)
@@ -164,6 +165,7 @@ mf::WlSeat::WlSeat(
         pointer_listeners{std::make_shared<ListenerList<WlPointer>>()},
         keyboard_listeners{std::make_shared<ListenerList<WlKeyboard>>()},
         touch_listeners{std::make_shared<ListenerList<WlTouch>>()},
+        clock{clock},
         input_hub{input_hub},
         seat{seat},
         enable_key_repeat{enable_key_repeat}
@@ -278,7 +280,7 @@ void mf::WlSeat::Instance::get_keyboard(wl_resource* new_keyboard)
 
 void mf::WlSeat::Instance::get_touch(wl_resource* new_touch)
 {
-    auto const touch = new WlTouch{new_touch};
+    auto const touch = new WlTouch{new_touch, seat->clock};
     seat->touch_listeners->register_listener(client, touch);
     touch->add_destroy_listener(
         [listeners = seat->touch_listeners, listener = touch, client = client]()

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -33,6 +33,10 @@ class InputDeviceHub;
 class Seat;
 class Keymap;
 }
+namespace time
+{
+class Clock;
+}
 namespace frontend
 {
 class WlPointer;
@@ -44,6 +48,7 @@ class WlSeat : public wayland::Seat::Global
 public:
     WlSeat(
         wl_display* display,
+        std::shared_ptr<time::Clock> const& clock,
         std::shared_ptr<mir::input::InputDeviceHub> const& input_hub,
         std::shared_ptr<mir::input::Seat> const& seat,
         bool enable_key_repeat);
@@ -102,6 +107,7 @@ private:
     std::shared_ptr<ListenerList<WlKeyboard>> const keyboard_listeners;
     std::shared_ptr<ListenerList<WlTouch>> const touch_listeners;
 
+    std::shared_ptr<time::Clock> const clock;
     std::shared_ptr<input::InputDeviceHub> const input_hub;
     std::shared_ptr<input::Seat> const seat;
     bool const enable_key_repeat;

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -32,6 +32,10 @@ struct MirTouchEvent;
 namespace mir
 {
 class Executor;
+namespace time
+{
+class Clock;
+}
 
 namespace frontend
 {
@@ -40,7 +44,7 @@ class WlSurface;
 class WlTouch : public wayland::Touch
 {
 public:
-    WlTouch(wl_resource* new_resource);
+    WlTouch(wl_resource* new_resource, std::shared_ptr<time::Clock> const& clock);
 
     ~WlTouch();
 
@@ -55,6 +59,7 @@ private:
         wayland::DestroyListenerId destroy_listener_id;
     };
 
+    std::shared_ptr<time::Clock> const clock;
     /// Maps touch IDs to the surfaces the touch is on
     std::unordered_map<int32_t, TouchedSurface> touch_id_to_surface;
     bool needs_frame{false};


### PR DESCRIPTION
Instead of the old, hacky system of using `steady_clock` with an offset. Most of the code is getting the clock to the `WlTouch`. May not produce correct behavior until #2117 lands, as it assumes event timestamps have the same base as the Mir clock.