### PR TITLE
Fix open() interposer

### DIFF
--- a/tests/include/mir/test/doubles/mock_drm.h
+++ b/tests/include/mir/test/doubles/mock_drm.h
@@ -93,7 +93,7 @@ public:
     MockDRM();
     ~MockDRM() noexcept;
 
-    MOCK_METHOD3(open, int(char const* path, int flags, mode_t mode));
+    MOCK_METHOD2(open, int(char const* path, int flags));
     MOCK_METHOD2(drmOpen, int(const char *name, const char *busid));
     MOCK_METHOD3(drmIoctl, int(int fd, unsigned long request, void *arg));
 

--- a/tests/include/mir_test_framework/open_wrapper.h
+++ b/tests/include/mir_test_framework/open_wrapper.h
@@ -20,14 +20,14 @@
 
 #include <functional>
 #include <memory>
-#include <experimental/optional>
+#include <optional>
 #include <sys/stat.h>
 
 namespace mir_test_framework
 {
 using OpenHandlerHandle = std::unique_ptr<void, void(*)(void*)>;
 using OpenHandler =
-    std::function<std::experimental::optional<int>(char const* path, int flags, mode_t mode)>;
+    std::function<std::optional<int>(char const* path, int flags, std::optional<mode_t> mode)>;
 /**
  * Add a function to the open() interposer.
  *
@@ -38,7 +38,9 @@ using OpenHandler =
  *          before any existing handler on open().
  *
  * \param handler [in]  Handler to call when open() is called. The handler should return an
- *                          occupied optional<int> only when it wants to claim this invocation.
+ *                      occupied optional<int> only when it wants to claim this invocation.
+ *                      ::open() is a variadic C function; to simplify implementations of
+ *                      OpenHandlers, the handler is passed an optional<mode_t> instead.
  * \return  An opaque handle to this instance of the handler. Dropping the handle unregisters the
  *          open() handler.
  */

--- a/tests/mir_test_doubles/mock_drm.cpp
+++ b/tests/mir_test_doubles/mock_drm.cpp
@@ -234,15 +234,13 @@ drmModeModeInfo mtd::FakeDRMResources::create_mode(uint16_t hdisplay, uint16_t v
 
 mtd::MockDRM::MockDRM()
     : open_interposer{mir_test_framework::add_open_handler(
-        [this](char const* path, int flags, std::optional<mode_t> mode) -> std::optional<int>
+        [this](char const* path, int flags, std::optional<mode_t>) -> std::optional<int>
         {
             char const* const drm_prefix = "/dev/dri/";
             if (!strncmp(path, drm_prefix, strlen(drm_prefix)))
             {
-                if (mode)
-                {
-                    BOOST_THROW_EXCEPTION((std::logic_error{"Attempt to call unimplemented 3-parameter open() version for DRM node"}));
-                }
+                // I don't think we need to be able to distinguish based on mode. ppc64el (at least) *does*
+                // call the 3-parameter open()
                 return this->open(path, flags);
             }
             return {};

--- a/tests/mir_test_framework/open_wrapper.cpp
+++ b/tests/mir_test_framework/open_wrapper.cpp
@@ -64,7 +64,7 @@ public:
                 return val;
             }
         }
-        return {};
+        return std::nullopt;
     }
 
 private:

--- a/tests/mir_test_framework/open_wrapper.cpp
+++ b/tests/mir_test_framework/open_wrapper.cpp
@@ -16,6 +16,13 @@
  * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
  */
 
+/* As suggested by umockdev, _FILE_OFFSET_BITS breaks our open() interposing,
+ * as it results in a (platform dependent!) subset of {__open64, __open64_2,
+ * __open, __open_2} being defined (not just declared) in the header, causing
+ * the build to fail with duplicate definitions.
+ */
+#undef _FILE_OFFSET_BITS
+
 #include "mir_test_framework/open_wrapper.h"
 
 #include <list>

--- a/tests/mir_test_framework/open_wrapper.cpp
+++ b/tests/mir_test_framework/open_wrapper.cpp
@@ -123,6 +123,7 @@ int open(char const* path, int flags, ...)
     return (*real_open)(path, flags);
 }
 
+#ifndef open64 // Alpine does weird stuff
 int open64(char const* path, int flags, ...)
 {
     std::optional<mode_t> mode_parameter = std::nullopt;
@@ -152,6 +153,7 @@ int open64(char const* path, int flags, ...)
     }
     return (*real_open64)(path, flags);
 }
+#endif
 
 int __open(char const* path, int flags, ...)
 {

--- a/tests/unit-tests/console/test_minimal_console_services.cpp
+++ b/tests/unit-tests/console/test_minimal_console_services.cpp
@@ -77,8 +77,8 @@ public:
         mir::Fd stub_fd{::open("/dev/null", O_RDWR | O_CLOEXEC)};
         expectations.emplace_back(
             mtf::add_open_handler(
-                [stub_fd, device_path = std::string{device_name}](char const* path, int, mode_t)
-                    -> std::experimental::optional<int>
+                [stub_fd, device_path = std::string{device_name}](char const* path, int, std::optional<mode_t>)
+                    -> std::optional<int>
                 {
                     if (device_path == path)
                     {
@@ -98,7 +98,7 @@ public:
         set_expectations_for_uevent_probe(226, minor, uevent_content.c_str());
 
         mir::Fd stub_fd{::open("/dev/null", O_RDWR | O_CLOEXEC)};
-        ON_CALL(drm, open(StrEq(device_name), _, _)).WillByDefault(
+        ON_CALL(drm, open(StrEq(device_name), _)).WillByDefault(
             InvokeWithoutArgs([stub_fd]() { return stub_fd; }));
         return stub_fd;
     }
@@ -115,8 +115,8 @@ private:
 
         expectations.emplace_back(
             mtf::add_open_handler(
-                [expected_filename = expected_filename.str(), uevent](char const* path, int flags, mode_t)
-                    -> std::experimental::optional<int>
+                [expected_filename = expected_filename.str(), uevent](char const* path, int flags, std::optional<mode_t>)
+                    -> std::optional<int>
                 {
                     if (expected_filename == path)
                     {
@@ -235,7 +235,7 @@ TEST_F(MinimalConsoleServicesTest, failure_to_open_device_node_returns_exception
     set_expectations_for_uevent_probe_of_device(33, 5, device_path);
 
     auto error_on_device_open = mtf::add_open_handler(
-        [device_path](char const* path, int, mode_t) -> std::experimental::optional<int>
+        [device_path](char const* path, int, std::optional<mode_t>) -> std::optional<int>
         {
             if (!strcmp(device_path, path))
             {
@@ -277,7 +277,7 @@ TEST_F(MinimalConsoleServicesTest, failure_to_open_sys_file_results_in_immediate
     set_expectations_for_uevent_probe_of_device(33, 5, "/dev/input/event2");
 
     auto error_on_device_open = mtf::add_open_handler(
-        [](char const* path, int, mode_t) -> std::experimental::optional<int>
+        [](char const* path, int, std::optional<mode_t>) -> std::optional<int>
         {
             if (!strncmp("/sys", path, strlen("/sys")))
             {
@@ -329,7 +329,7 @@ TEST_F(MinimalConsoleServicesTest, opens_input_devices_in_nonblocking_mode)
         [device_path, fd = mir::Fd{::open("/dev/null", O_RDWR)}](
             char const* path,
             int flags,
-            mode_t) -> std::experimental::optional<int>
+            std::optional<mode_t>) -> std::optional<int>
         {
             if (strcmp(path, device_path))
             {
@@ -368,7 +368,7 @@ TEST_F(MinimalConsoleServicesTest, does_not_open_drm_devices_in_nonblocking_mode
         [device_path, fd = mir::Fd{::open("/dev/null", O_RDWR)}](
             char const* path,
             int flags,
-            mode_t) -> std::experimental::optional<int>
+            std::optional<mode_t>) -> std::optional<int>
         {
             if (strcmp(path, device_path))
             {

--- a/tests/unit-tests/platforms/eglstream-kms/server/test_threaded_drm_event_handler.cpp
+++ b/tests/unit-tests/platforms/eglstream-kms/server/test_threaded_drm_event_handler.cpp
@@ -45,7 +45,7 @@ private:
 
 public:
     ThreadedDRMEventHandlerTest()
-        : mock_drm_fd{mock_drm.open(device_node, 0, 0)}
+        : mock_drm_fd{mock_drm.open(device_node, 0)}
     {
         ON_CALL(mock_drm, drmHandleEvent(static_cast<int>(mock_drm_fd), _))
             .WillByDefault(

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display.cpp
@@ -344,7 +344,7 @@ TEST_F(MesaDisplayTest, create_display_drm_failure)
 {
     using namespace testing;
 
-    EXPECT_CALL(mock_drm, open(_,_,_))
+    EXPECT_CALL(mock_drm, open(_,_))
         .Times(AtLeast(1))
         .WillRepeatedly(
             DoAll(
@@ -409,8 +409,8 @@ TEST_F(MesaDisplayTest, ignores_non_modesetting_nodes)
     using namespace testing;
 
     // The platform should open all DRM nodes. In particular, it should open the second one…
-    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card0"), _, _)).Times(AtLeast(1));
-    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card1"), _, _)).Times(AtLeast(1));
+    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card0"), _)).Times(AtLeast(1));
+    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card1"), _)).Times(AtLeast(1));
 
     // …mark the second DRM node as not supporting modesetting…
     char const busid[] = "pci:00:01:02:03";
@@ -436,8 +436,8 @@ TEST_F(MesaDisplayTest, handles_first_card_not_supporting_modeset)
     using namespace testing;
 
     // The platform should open all DRM nodes.
-    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card0"), _, _)).Times(AtLeast(1));
-    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card1"), _, _)).Times(AtLeast(1));
+    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card0"), _)).Times(AtLeast(1));
+    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card1"), _)).Times(AtLeast(1));
 
     // First device is rendering only…
     mock_drm.reset("/dev/dri/card0");

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_drm_helper.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_drm_helper.cpp
@@ -57,7 +57,7 @@ TEST_F(DRMHelperTest, closes_drm_fd_on_exec)
 
     fake_devices.add_standard_device("standard-drm-render-nodes");
 
-    EXPECT_CALL(mock_drm, open(_, FlagSet(O_CLOEXEC), _));
+    EXPECT_CALL(mock_drm, open(_, FlagSet(O_CLOEXEC)));
 
     auto helper = mgg::helpers::DRMHelper::open_any_render_node(
         std::make_shared<mir::udev::Context>());

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_platform.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_platform.cpp
@@ -124,7 +124,7 @@ TEST_F(MesaGraphicsPlatform, a_failure_while_creating_a_platform_results_in_an_e
 {
     using namespace ::testing;
 
-    EXPECT_CALL(mock_drm, open(_,_,_))
+    EXPECT_CALL(mock_drm, open(_,_))
             .WillRepeatedly(SetErrnoAndReturn(EINVAL, -1));
 
     try
@@ -375,9 +375,9 @@ TEST_F(MesaGraphicsPlatform, display_probe_does_not_touch_quirked_device)
      */
     auto const options_with_quirk = parsed_options_from_args({"--driver-quirks=skip:devnode:/dev/dri/card1"}, po);
 
-    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card0"), _, _))
+    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card0"), _))
         .Times(AtLeast(1));
-    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card1"), _, _))
+    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card1"), _))
         .Times(0);
 
     auto probe = platform_lib.load_function<mg::PlatformProbe>(display_platform_probe_symbol);
@@ -412,9 +412,9 @@ TEST_F(MesaGraphicsPlatform, render_probe_does_not_touch_quirked_device)
      */
     auto const options_with_quirk = parsed_options_from_args({"--driver-quirks=skip:devnode:/dev/dri/card1"}, po);
 
-    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card0"), _, _))
+    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card0"), _))
         .Times(AtLeast(1));
-    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card1"), _, _))
+    EXPECT_CALL(mock_drm, open(StrEq("/dev/dri/card1"), _))
         .Times(0);
 
     auto probe = platform_lib.load_function<mg::PlatformProbe>(rendering_platform_probe_symbol);


### PR DESCRIPTION
So, `open()` is actually a varargs function, taking an optional `mode_t` third parameter.

We've always interposed this with a `open(char const*, int, mode_t)` function, which is
a) Obviously not varargs, and so any calls to `open()` were being handled by a function with incompatible signature, but
b) We never hit the UB this introduced… until now.

Fixes the build on ppc64el. Tested on ppc64el and x86-64.