### PR TITLE
WlSeat: improve focus listeners

### DIFF
--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -51,12 +51,11 @@ void mf::WaylandInputDispatcher::set_focus(bool has_focus)
         return;
     }
 
-    if (has_focus)
-        seat->notify_focus(client);
-
+    auto const surface = &wl_surface.value();
+    seat->notify_focus(*surface, has_focus);
     seat->for_each_listener(client, [&](WlKeyboard* keyboard)
         {
-            keyboard->focussed(wl_surface.value(), has_focus);
+            keyboard->focussed(*surface, has_focus);
         });
 }
 

--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -98,14 +98,14 @@ mf::WlDataDevice::WlDataDevice(
       clipboard_observer{std::make_shared<ClipboardObserver>(this)}
 {
     clipboard.register_interest(clipboard_observer, wayland_executor);
-    seat.add_focus_listener(this);
-    focus_on(seat.current_focused_client());
+    // this will call focus_on() with the initial state
+    seat.add_focus_listener(client, this);
 }
 
 mf::WlDataDevice::~WlDataDevice()
 {
     clipboard.unregister_interest(*clipboard_observer);
-    seat.remove_focus_listener(this);
+    seat.remove_focus_listener(client, this);
 }
 
 void mf::WlDataDevice::set_selection(std::experimental::optional<struct wl_resource*> const& source, uint32_t serial)
@@ -123,9 +123,9 @@ void mf::WlDataDevice::set_selection(std::experimental::optional<struct wl_resou
     }
 }
 
-void mf::WlDataDevice::focus_on(wl_client* focus)
+void mf::WlDataDevice::focus_on(WlSurface* surface)
 {
-    has_focus = client == focus;
+    has_focus = static_cast<bool>(surface);
     auto const paste_source = clipboard.paste_source();
     if (has_focus && paste_source && !current_offer)
     {

--- a/src/server/frontend_wayland/wl_data_device.h
+++ b/src/server/frontend_wayland/wl_data_device.h
@@ -59,7 +59,7 @@ private:
     class Offer;
 
     /// Override from WlSeat::FocusListener
-    void focus_on(wl_client *client) override;
+    void focus_on(WlSurface* surface) override;
 
     /// Called by the clipboard observer
     void paste_source_set(std::shared_ptr<scene::ClipboardSource> const& source);

--- a/src/server/frontend_wayland/wl_data_device.h
+++ b/src/server/frontend_wayland/wl_data_device.h
@@ -33,7 +33,7 @@ class ClipboardSource;
 
 namespace frontend
 {
-class WlDataDevice : public wayland::DataDevice, public WlSeat::ListenerTracker
+class WlDataDevice : public wayland::DataDevice, public WlSeat::FocusListener
 {
 public:
     WlDataDevice(
@@ -58,7 +58,7 @@ private:
     class ClipboardObserver;
     class Offer;
 
-    /// Override from WlSeat::ListenerTracker
+    /// Override from WlSeat::FocusListener
     void focus_on(wl_client *client) override;
 
     /// Called by the clipboard observer

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -293,12 +293,12 @@ auto mf::WlSeat::current_focused_client() const -> wl_client*
     return focused_client;
 }
 
-void mf::WlSeat::add_focus_listener(ListenerTracker* listener)
+void mf::WlSeat::add_focus_listener(FocusListener* listener)
 {
     focus_listeners.push_back(listener);
 }
 
-void mf::WlSeat::remove_focus_listener(ListenerTracker* listener)
+void mf::WlSeat::remove_focus_listener(FocusListener* listener)
 {
     focus_listeners.erase(remove(begin(focus_listeners), end(focus_listeners), listener), end(focus_listeners));
 }

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -171,7 +171,6 @@ mf::WlSeat::WlSeat(
         enable_key_repeat{enable_key_repeat}
 {
     input_hub->add_observer(config_observer);
-    add_focus_listener(&focus);
 }
 
 mf::WlSeat::~WlSeat()
@@ -306,6 +305,8 @@ void mf::WlSeat::remove_focus_listener(ListenerTracker* listener)
 
 void mf::WlSeat::server_restart()
 {
-    if (focus.client)
-        for_each_listener(focus.client, [](WlKeyboard* keyboard) { keyboard->resync_keyboard(); });
+    if (focused_client)
+    {
+        for_each_listener(focused_client, [](WlKeyboard* keyboard) { keyboard->resync_keyboard(); });
+    }
 }

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -61,27 +61,27 @@ public:
     void for_each_listener(wl_client* client, std::function<void(WlKeyboard*)> func);
     void for_each_listener(wl_client* client, std::function<void(WlTouch*)> func);
 
-    class ListenerTracker
+    class FocusListener
     {
     public:
         virtual void focus_on(wl_client* client) = 0;
 
-        ListenerTracker() = default;
-        virtual ~ListenerTracker() = default;
-        ListenerTracker(ListenerTracker const&) = delete;
-        ListenerTracker& operator=(ListenerTracker const&) = delete;
+        FocusListener() = default;
+        virtual ~FocusListener() = default;
+        FocusListener(FocusListener const&) = delete;
+        FocusListener& operator=(FocusListener const&) = delete;
     };
 
     auto current_focused_client() const -> wl_client*;
-    void add_focus_listener(ListenerTracker* listener);
-    void remove_focus_listener(ListenerTracker* listener);
+    void add_focus_listener(FocusListener* listener);
+    void remove_focus_listener(FocusListener* listener);
     void notify_focus(wl_client* focus);
 
     void server_restart();
 
 private:
     wl_client* focused_client{nullptr}; ///< Can be null
-    std::vector<ListenerTracker*> focus_listeners;
+    std::vector<FocusListener*> focus_listeners;
 
     template<class T>
     class ListenerList;

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -83,16 +83,6 @@ private:
     wl_client* focused_client{nullptr}; ///< Can be null
     std::vector<ListenerTracker*> focus_listeners;
 
-    struct FocusClient : ListenerTracker
-    {
-        wl_client* client = nullptr;
-
-        void focus_on(wl_client* client) override
-        {
-            this->client = client;
-        }
-    } focus;
-
     template<class T>
     class ListenerList;
 

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -42,6 +42,7 @@ namespace frontend
 class WlPointer;
 class WlKeyboard;
 class WlTouch;
+class WlSurface;
 
 class WlSeat : public wayland::Seat::Global
 {
@@ -64,7 +65,9 @@ public:
     class FocusListener
     {
     public:
-        virtual void focus_on(wl_client* client) = 0;
+        /// The surface that has focus if the currently focused surface belongs to the relevant client. nullptr if there
+        /// is no focused surface or it belongs to a different client.
+        virtual void focus_on(WlSurface* surface) = 0;
 
         FocusListener() = default;
         virtual ~FocusListener() = default;
@@ -72,16 +75,18 @@ public:
         FocusListener& operator=(FocusListener const&) = delete;
     };
 
-    auto current_focused_client() const -> wl_client*;
-    void add_focus_listener(FocusListener* listener);
-    void remove_focus_listener(FocusListener* listener);
-    void notify_focus(wl_client* focus);
+    /// Adds the listener for future use, and makes a call into it to inform of initial state
+    void add_focus_listener(wl_client* client, FocusListener* listener);
+    void remove_focus_listener(wl_client* client, FocusListener* listener);
+    void notify_focus(WlSurface& surface, bool has_focus);
 
     void server_restart();
 
 private:
+    void set_focus_to(WlSurface* surface);
+
     wl_client* focused_client{nullptr}; ///< Can be null
-    std::vector<FocusListener*> focus_listeners;
+    wayland::Weak<WlSurface> focused_surface;
 
     template<class T>
     class ListenerList;
@@ -93,6 +98,7 @@ private:
     std::shared_ptr<ConfigObserver> const config_observer;
 
     // listener list are shared pointers so devices can keep them around long enough to remove themselves
+    std::shared_ptr<ListenerList<FocusListener>> const focus_listeners;
     std::shared_ptr<ListenerList<WlPointer>> const pointer_listeners;
     std::shared_ptr<ListenerList<WlKeyboard>> const keyboard_listeners;
     std::shared_ptr<ListenerList<WlTouch>> const touch_listeners;


### PR DESCRIPTION
This renames and refactors `WlSeat::ListenerTracker` to `WlSeat::FocusListener`. Focus listeners are tied to a single client and only get notifications relevant to that client, and they are told what surface is focused. These things will help implement `zwp_text_input_v3`, as it needs to respond to changing focus.