### PR TITLE
Clean up our DISABLED tests

### DIFF
--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display.cpp
@@ -707,8 +707,7 @@ TEST_F(MesaDisplayTest, outputs_correct_string_for_successful_drm_mode_set_crtc_
     reporter->report_successful_drm_mode_set_crtc_on_construction();
 }
 
-// Disabled until gbm-kms drm platform and mir platform properly shows support for those extensions
-TEST_F(MesaDisplayTest, DISABLED_constructor_throws_if_egl_khr_image_pixmap_not_supported)
+TEST_F(MesaDisplayTest, constructor_throws_if_egl_khr_image_pixmap_not_supported)
 {
     using namespace ::testing;
 

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display.cpp
@@ -853,43 +853,6 @@ TEST_F(MesaDisplayTest, respects_gl_config)
         null_report};
 }
 
-/*
- * It *would* be nice to support 15bit colour, but the gbm-kms platform
- * has, from the first commit, unconditonally allocated 24-bit framebuffers.
- *
- * It's not clear to me that Mir has ever been successfully tested on a platform
- * that doesn't support 24-bit rendering.
- */
-TEST_F(MesaDisplayTest, DISABLED_supports_as_low_as_15bit_colour)
-{  // Regression test for LP: #1212753
-    using namespace testing;
-
-    mtd::StubGLConfig stub_gl_config;
-
-    EXPECT_CALL(mock_egl,
-                eglChooseConfig(
-                    _,
-                    AllOf(mtd::EGLConfigContainsAttrib(EGL_RED_SIZE, 5),
-                          mtd::EGLConfigContainsAttrib(EGL_GREEN_SIZE, 5),
-                          mtd::EGLConfigContainsAttrib(EGL_BLUE_SIZE, 5),
-                          mtd::EGLConfigContainsAttrib(EGL_ALPHA_SIZE, 0)),
-                    _,_,_))
-        .Times(AtLeast(1))
-        .WillRepeatedly(DoAll(SetArgPointee<2>(mock_egl.fake_configs[0]),
-                        SetArgPointee<4>(1),
-                        Return(EGL_TRUE)));
-
-    auto platform = create_platform();
-    mgg::Display display{
-        platform->drm,
-        platform->gbm,
-        platform->vt,
-        platform->bypass_option(),
-        std::make_shared<mg::CloneDisplayConfigurationPolicy>(),
-        mir::test::fake_shared(stub_gl_config),
-        null_report};
-}
-
 TEST_F(MesaDisplayTest, can_change_configuration_metadata_without_invalidating_display_buffers)
 {
     using namespace testing;

--- a/tests/unit-tests/test_mir_cookie.cpp
+++ b/tests/unit-tests/test_mir_cookie.cpp
@@ -23,21 +23,6 @@
 #include <gmock/gmock.h>
 
 #include <chrono>
-#include <fcntl.h>
-
-namespace {
-
-void drain_dev_random()
-{
-    // Flush the entropy pool
-    int fd = open("/dev/random", O_RDONLY | O_NONBLOCK);
-    ASSERT_THAT(fd, ::testing::Ge(0));
-    char buf[256];
-    while (read(fd, buf, sizeof buf) > 0) {}
-    close(fd);
-}
-
-} // anonymous namespace
 
 
 TEST(MirCookieAuthority, attests_real_timestamp)
@@ -132,36 +117,4 @@ TEST(MirCookieAuthority, optimal_secret_size_is_larger_than_minimum_size)
 
     EXPECT_THAT(mir::cookie::Authority::optimal_secret_size(),
         Ge(mir::cookie::Authority::minimum_secret_size));
-}
-
-TEST(MirCookieAuthority, DISABLED_given_low_entropy_does_not_hang_or_crash)
-{   // Regression test for LP: #1536662 and LP: #1541188
-    using namespace testing;
-
-    drain_dev_random();
-
-    auto start = std::chrono::high_resolution_clock::now();
-
-    EXPECT_NO_THROW( mir::cookie::Authority::create() );
-
-    auto duration = std::chrono::high_resolution_clock::now() - start;
-    int seconds = std::chrono::duration_cast<std::chrono::seconds>(duration).count();
-    EXPECT_THAT(seconds, Lt(15));
-}
-
-TEST(MirCookieAuthority, DISABLED_makes_cookies_quickly)
-{   // Regression test for LP: #1536662 and LP: #1541188
-    using namespace testing;
-
-    drain_dev_random();
-    uint64_t timestamp = 23;
-    std::vector<uint8_t> secret;
-    auto source_authority = mir::cookie::Authority::create_saving(secret);
-
-    drain_dev_random();
-    auto start = std::chrono::high_resolution_clock::now();
-    auto cookie = source_authority->make_cookie(timestamp);
-    auto duration = std::chrono::high_resolution_clock::now() - start;
-    int seconds = std::chrono::duration_cast<std::chrono::seconds>(duration).count();
-    EXPECT_THAT(seconds, Lt(5));
 }


### PR DESCRIPTION
Remove or reinstate DISABLED tests.

There remain some conditionally DISABLED tests, but these are still running in most configurations.

Fixes: #209