### PR TITLE
eglstream-kms: Drop superfluous mge::Platform

### DIFF
--- a/src/platforms/eglstream-kms/server/platform.cpp
+++ b/src/platforms/eglstream-kms/server/platform.cpp
@@ -100,41 +100,23 @@ mir::UniqueModulePtr<mg::Display> mge::DisplayPlatform::create_display(
     return retval;
 }
 
-mir::UniqueModulePtr<mg::GraphicBufferAllocator> mge::RenderingPlatform::create_buffer_allocator(
-    mg::Display const& output)
-{
-    return mir::make_module_ptr<mge::BufferAllocator>(output);
-}
-
 namespace
 {
 const auto mir_xwayland_option = "MIR_XWAYLAND_OPTION";
 }
 
-mge::Platform::Platform(
-    std::shared_ptr<RenderingPlatform> const& rendering,
-    std::shared_ptr<DisplayPlatform> const& display) :
-    rendering(rendering),
-    display(display)
+mge::RenderingPlatform::RenderingPlatform()
 {
     setenv(mir_xwayland_option, "-eglstream", 1);
 }
 
-mir::graphics::eglstream::Platform::~Platform()
+mge::RenderingPlatform::~RenderingPlatform()
 {
     unsetenv(mir_xwayland_option);
 }
 
-mir::UniqueModulePtr<mg::GraphicBufferAllocator>
-    mge::Platform::create_buffer_allocator(mg::Display const& output)
+mir::UniqueModulePtr<mg::GraphicBufferAllocator> mge::RenderingPlatform::create_buffer_allocator(
+    mg::Display const& output)
 {
-    return rendering->create_buffer_allocator(output);
+    return mir::make_module_ptr<mge::BufferAllocator>(output);
 }
-
-mir::UniqueModulePtr<mg::Display> mge::Platform::create_display(
-    std::shared_ptr<DisplayConfigurationPolicy> const& policy,
-    std::shared_ptr<GLConfig> const& config)
-{
-    return display->create_display(policy, config);
-}
-

--- a/src/platforms/eglstream-kms/server/platform.h
+++ b/src/platforms/eglstream-kms/server/platform.h
@@ -45,6 +45,9 @@ namespace eglstream
 class RenderingPlatform : public graphics::RenderingPlatform
 {
 public:
+    RenderingPlatform();
+    ~RenderingPlatform() override;
+
     UniqueModulePtr<GraphicBufferAllocator>
         create_buffer_allocator(Display const& output) override;
 };
@@ -66,27 +69,6 @@ private:
     EGLDisplay display;
     mir::Fd drm_node;
     std::unique_ptr<mir::Device> drm_device;
-};
-
-class Platform : public graphics::DisplayPlatform,
-                 public graphics::RenderingPlatform
-{
-public:
-    Platform(
-        std::shared_ptr<RenderingPlatform> const&,
-        std::shared_ptr<DisplayPlatform> const&);
-    ~Platform();
-
-    UniqueModulePtr<GraphicBufferAllocator>
-        create_buffer_allocator(Display const& output) override;
-
-    UniqueModulePtr<Display> create_display(
-        std::shared_ptr<DisplayConfigurationPolicy> const& /*initial_conf_policy*/,
-        std::shared_ptr<GLConfig> const& /*gl_config*/) override;
-
-private:
-    std::shared_ptr<RenderingPlatform> const rendering;
-    std::shared_ptr<DisplayPlatform> const display;
 };
 }
 }

--- a/src/platforms/eglstream-kms/server/platform_symbols.cpp
+++ b/src/platforms/eglstream-kms/server/platform_symbols.cpp
@@ -98,9 +98,7 @@ mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
         mg::initialise_egl_logger(logger);
     }
 
-    return mir::make_module_ptr<mge::Platform>(
-        std::make_shared<mge::RenderingPlatform>(),
-        std::make_shared<mge::DisplayPlatform>(*console, find_device(), display_report));
+    return mir::make_module_ptr<mge::DisplayPlatform>(*console, find_device(), display_report);
 }
 
 auto create_rendering_platform(


### PR DESCRIPTION
This was an artefact from before the Dispaly/Rendering split.