### PR TITLE
WlKeyboard: if refocus is needed, send key event after it completes

### DIFF
--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -142,7 +142,12 @@ public:
         }
     }
 
-    auto operator==(T const& other) const -> bool
+    auto operator!=(Weak<T> const& other) const -> bool
+    {
+        return !(*this == other);
+    }
+
+    auto is(T const& other) const -> bool
     {
         if (*this)
         {
@@ -152,12 +157,6 @@ public:
         {
             return false;
         }
-    }
-
-    template<typename U>
-    auto operator!=(U const& other) const -> bool
-    {
-        return !(*this == other);
     }
 
     operator bool() const

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -93,7 +93,7 @@ void mf::WlKeyboard::event(MirKeyboardEvent const* event, WlSurface& surface)
     int const scancode = mir_keyboard_event_scan_code(event);
     uint32_t const wayland_state = down ? KeyState::pressed : KeyState::released;
 
-    if (focused_surface != surface)
+    if (!focused_surface.is(surface))
     {
         log_warning(
             "Sending key 0x%2.2x %s to wl_surface@%u even though it was not explicitly given keyboard focus",

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -201,12 +201,12 @@ void mf::WlSeat::for_each_listener(wl_client* client, std::function<void(WlTouch
 
 void mf::WlSeat::notify_focus(WlSurface& surface, bool has_focus)
 {
-    if (has_focus && focused_surface != surface)
+    if (has_focus && !focused_surface.is(surface))
     {
         // give focus to any surface other than the current one
         set_focus_to(&surface);
     }
-    else if (!has_focus && focused_surface == surface)
+    else if (!has_focus && focused_surface.is(surface))
     {
         // only take focus away if the newly unfocused surface is the current one
         set_focus_to(nullptr);

--- a/tests/unit-tests/wayland/test_wayland_weak.cpp
+++ b/tests/unit-tests/wayland/test_wayland_weak.cpp
@@ -169,20 +169,18 @@ TEST_F(WaylandWeakTest, weak_not_equal_to_weak_of_new_resource_with_same_address
     EXPECT_THAT(weak_a, Not(FullyCheckedEq(weak_b)));
 }
 
-TEST_F(WaylandWeakTest, is_equal_to_raw_resource)
+TEST_F(WaylandWeakTest, is_raw_resource)
 {
     mw::Weak<MockResource> const weak{&resource.value()};
     // GTest's Eq() assertion doesn't seem to work with uncopyable types
-    EXPECT_THAT(weak == resource.value(), Eq(true));
-    EXPECT_THAT(weak != resource.value(), Eq(false));
+    EXPECT_THAT(weak.is(resource.value()), Eq(true));
 }
 
-TEST_F(WaylandWeakTest, not_equal_to_different_raw_resource)
+TEST_F(WaylandWeakTest, is_not_different_raw_resource)
 {
     mw::Weak<MockResource> const weak_a{&resource_a.value()};
     // GTest's Eq() assertion doesn't seem to work with uncopyable types
-    EXPECT_THAT(weak_a == resource_b.value(), Eq(false));
-    EXPECT_THAT(weak_a != resource_b.value(), Eq(true));
+    EXPECT_THAT(weak_a.is(resource_b.value()), Eq(false));
 }
 
 TEST_F(WaylandWeakTest, weak_cleared_when_resource_marked_as_destroyed)


### PR DESCRIPTION
If we got a key event to the surface that the keyboard isn't currently on, we used to send the event then refocus the keyboard. This corrects that order.

1. Open LXTerminal
2. Go to Tabs -> Name Tab
3. Click Cancel
4. Type key

__master:__ first letter typed doesn't appear in main window
__this PR:__ first letter does appear