### PR TITLE
WlSeat: notify focus observers when focused surface is destroyed

### DIFF
--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -183,9 +183,10 @@ mf::WlSeat::~WlSeat()
     }
 }
 
-auto mf::WlSeat::from(struct wl_resource* seat) -> WlSeat*
+auto mf::WlSeat::from(struct wl_resource* resource) -> WlSeat*
 {
-    return static_cast<mf::WlSeat::Instance*>(wayland::Seat::from(seat))->seat;
+    auto const instance = static_cast<mf::WlSeat::Instance*>(wayland::Seat::from(resource));
+    return instance ? instance->seat : nullptr;
 }
 
 void mf::WlSeat::for_each_listener(wl_client* client, std::function<void(WlPointer*)> func)

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -177,6 +177,10 @@ mf::WlSeat::WlSeat(
 mf::WlSeat::~WlSeat()
 {
     input_hub->remove_observer(config_observer);
+    if (focused_surface)
+    {
+        focused_surface.value().remove_destroy_listener(focused_surface_destroy_listener_id);
+    }
 }
 
 auto mf::WlSeat::from(struct wl_resource* seat) -> WlSeat*
@@ -228,8 +232,23 @@ void mf::WlSeat::set_focus_to(WlSurface* new_surface)
                 listener->focus_on(nullptr);
             });
     }
+    if (focused_surface)
+    {
+        focused_surface.value().remove_destroy_listener(focused_surface_destroy_listener_id);
+    }
     focused_client = new_client;
     focused_surface = mw::make_weak(new_surface);
+    if (new_surface)
+    {
+        focused_surface_destroy_listener_id = new_surface->add_destroy_listener([this]()
+            {
+                set_focus_to(nullptr);
+            });
+    }
+    else
+    {
+        focused_surface_destroy_listener_id = {};
+    }
     focus_listeners->for_each(new_client, [&](FocusListener* listener)
         {
             listener->focus_on(new_surface);

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -241,6 +241,7 @@ void mf::WlSeat::set_focus_to(WlSurface* new_surface)
     focused_surface = mw::make_weak(new_surface);
     if (new_surface)
     {
+        // This listener will be removed when either the focus changes or the seat is destroyed
         focused_surface_destroy_listener_id = new_surface->add_destroy_listener([this]()
             {
                 set_focus_to(nullptr);

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -87,6 +87,7 @@ private:
 
     wl_client* focused_client{nullptr}; ///< Can be null
     wayland::Weak<WlSurface> focused_surface;
+    wayland::DestroyListenerId focused_surface_destroy_listener_id{};
 
     template<class T>
     class ListenerList;

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -56,7 +56,7 @@ public:
 
     ~WlSeat();
 
-    static auto from(struct wl_resource* seat) -> WlSeat*;
+    static auto from(struct wl_resource* resource) -> WlSeat*;
 
     void for_each_listener(wl_client* client, std::function<void(WlPointer*)> func);
     void for_each_listener(wl_client* client, std::function<void(WlKeyboard*)> func);


### PR DESCRIPTION
Currently the only `FocusObserver` is the data device. The effect of this PR is that when the focused surface is destroyed `has_focus` will be set to false for that client and future data offers will not be given to it. In practice this behavior causing problems is unlikely, but the new behavior is more correct for data device and useful for text input.