### PR TITLE
Frontend: use std::optional instead of std::experimental::optional

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -486,7 +486,7 @@ Description: Developer files for the Mir ABI-stable abstraction layer
  Contains header files required for development using the MirAL abstraction
  layer.
 
-Package: libmirwayland2
+Package: libmirwayland3
 Section: libs
 Architecture: linux-any
 Multi-Arch: same
@@ -504,7 +504,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirwayland2 (= ${binary:Version}),
+Depends: libmirwayland3 (= ${binary:Version}),
          libmircore-dev (= ${binary:Version}),
          ${misc:Depends},
          libmirwayland-bin (= ${binary:Version})

--- a/debian/libmirwayland2.install
+++ b/debian/libmirwayland2.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmirwayland.so.2

--- a/debian/libmirwayland3.install
+++ b/debian/libmirwayland3.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmirwayland.so.3

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -177,7 +177,7 @@ private:
     void activate(struct wl_resource* seat) override;
     void close() override;
     void set_rectangle(struct wl_resource* surface, int32_t x, int32_t y, int32_t width, int32_t height) override;
-    void set_fullscreen(std::experimental::optional<struct wl_resource*> const& output) override;
+    void set_fullscreen(std::optional<struct wl_resource*> const& output) override;
     void unset_fullscreen() override;
     ///@}
 
@@ -679,10 +679,11 @@ void mf::ForeignToplevelHandleV1::set_rectangle(
     // Nothing must be done with this info. It is not a protocol violation to ignore it
 }
 
-void mf::ForeignToplevelHandleV1::set_fullscreen(std::experimental::optional<struct wl_resource*> const& /*output*/)
+void mf::ForeignToplevelHandleV1::set_fullscreen(std::optional<struct wl_resource*> const& /*output*/)
 {
     shell::SurfaceSpecification spec;
     spec.state = mir_window_state_fullscreen;
+    // TODO: respect output
     attempt_modify_surface(spec);
 }
 

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -96,7 +96,7 @@ public:
 
     ~LayerSurfaceV1() = default;
 
-    static auto from(wl_resource* surface) -> std::experimental::optional<LayerSurfaceV1*>;
+    static auto from(wl_resource* surface) -> std::optional<LayerSurfaceV1*>;
 
 private:
     template<typename T>
@@ -118,18 +118,18 @@ private:
             {
                 _committed = _pending.value();
             }
-            _pending = std::experimental::nullopt;
+            _pending = std::nullopt;
         }
 
     private:
-        std::experimental::optional<T> _pending;
+        std::optional<T> _pending;
         T _committed;
     };
 
     struct OptionalSize
     {
-        std::experimental::optional<geom::Width> width;
-        std::experimental::optional<geom::Height> height;
+        std::optional<geom::Width> width;
+        std::optional<geom::Height> height;
     };
 
     struct Margin
@@ -156,7 +156,7 @@ private:
     auto get_anchored_edge() const -> MirPlacementGravity;
 
     /// Returns the rectangele in surface coords that this surface is exclusive for (if any)
-    auto get_exclusive_rect() const -> std::experimental::optional<geom::Rectangle>;
+    auto get_exclusive_rect() const -> std::optional<geom::Rectangle>;
 
     static auto horiz_padding(Anchors const& anchors, Margin const& margin) -> geom::DeltaX;
     static auto vert_padding(Anchors const& anchors, Margin const& margin) -> geom::DeltaY;
@@ -292,16 +292,16 @@ mf::LayerSurfaceV1::LayerSurfaceV1(
     apply_spec(spec);
 }
 
-auto mf::LayerSurfaceV1::from(wl_resource* surface) -> std::experimental::optional<LayerSurfaceV1*>
+auto mf::LayerSurfaceV1::from(wl_resource* surface) -> std::optional<LayerSurfaceV1*>
 {
     if (!mw::LayerSurfaceV1::is_instance(surface))
-        return std::experimental::nullopt;
+        return std::nullopt;
     auto const mw_surface = mw::LayerSurfaceV1::from(surface);
     auto const mf_surface = dynamic_cast<mf::LayerSurfaceV1*>(mw_surface);
     if (mf_surface)
         return mf_surface;
     else
-        return std::experimental::nullopt;
+        return std::nullopt;
 }
 
 auto mf::LayerSurfaceV1::get_placement_gravity() const -> MirPlacementGravity
@@ -352,11 +352,11 @@ auto mf::LayerSurfaceV1::get_anchored_edge() const -> MirPlacementGravity
         return mir_placement_gravity_center;
 }
 
-auto mf::LayerSurfaceV1::get_exclusive_rect() const -> std::experimental::optional<geom::Rectangle>
+auto mf::LayerSurfaceV1::get_exclusive_rect() const -> std::optional<geom::Rectangle>
 {
     auto zone = exclusive_zone.pending();
     if (zone <= 0)
-        return std::experimental::nullopt;
+        return std::nullopt;
 
     auto edge = get_anchored_edge();
     auto size = pending_size(); // includes margin padding
@@ -384,7 +384,7 @@ auto mf::LayerSurfaceV1::get_exclusive_rect() const -> std::experimental::option
             {size.width, geom::Height{zone} + margin.pending().bottom}};
 
     default:
-        return std::experimental::nullopt;
+        return std::nullopt;
     }
 }
 
@@ -435,7 +435,7 @@ void mf::LayerSurfaceV1::configure()
 {
     // TODO: Error if told to configure on an axis the window is not streatched along
 
-    OptionalSize configure_size{std::experimental::nullopt, std::experimental::nullopt};
+    OptionalSize configure_size{std::nullopt, std::nullopt};
     auto requested = unpadded_requested_size();
 
     if (anchors.committed().left && anchors.committed().right)

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -255,16 +255,12 @@ void mf::LayerShellV1::Instance::get_layer_surface(
     uint32_t layer,
     std::string const& namespace_)
 {
-    (void)namespace_; // Can be ignored if no special behavior is required
-
-    auto const output_id = output ?
-        shell->output_manager->output_id_for(client, output.value()) :
-        std::nullopt;
+    (void)namespace_; // Can be ignored if no special behavior is required;
 
     new LayerSurfaceV1(
         new_layer_surface,
         WlSurface::from(surface),
-        output_id,
+        shell->output_manager->output_id_for(client, output.value_or(nullptr)),
         *shell,
         layer_shell_layer_to_mir_depth_layer(layer));
 }

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -185,7 +185,7 @@ private:
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(
-        std::experimental::optional<geometry::Point> const& /*new_top_left*/,
+        std::optional<geometry::Point> const& /*new_top_left*/,
         geometry::Size const& /*new_size*/) override;
     void handle_close_request() override;
 
@@ -654,7 +654,7 @@ void mf::LayerSurfaceV1::handle_commit()
 }
 
 void mf::LayerSurfaceV1::handle_resize(
-    std::experimental::optional<geom::Point> const& /*new_top_left*/,
+    std::optional<geom::Point> const& /*new_top_left*/,
     geom::Size const& /*new_size*/)
 {
     configure();

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -77,7 +77,7 @@ private:
     void get_layer_surface(
         wl_resource* new_layer_surface,
         wl_resource* surface,
-        std::experimental::optional<wl_resource*> const& output,
+        std::optional<wl_resource*> const& output,
         uint32_t layer,
         std::string const& namespace_) override;
 
@@ -251,7 +251,7 @@ void mf::LayerShellV1::bind(wl_resource* new_resource)
 void mf::LayerShellV1::Instance::get_layer_surface(
     wl_resource* new_layer_surface,
     wl_resource* surface,
-    std::experimental::optional<wl_resource*> const& output,
+    std::optional<wl_resource*> const& output,
     uint32_t layer,
     std::string const& namespace_)
 {

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -90,7 +90,7 @@ public:
     LayerSurfaceV1(
         wl_resource* new_resource,
         WlSurface* surface,
-        std::experimental::optional<graphics::DisplayConfigurationOutputId> output_id,
+        std::optional<graphics::DisplayConfigurationOutputId> output_id,
         LayerShellV1 const& layer_shell,
         MirDepthLayer layer);
 
@@ -259,7 +259,7 @@ void mf::LayerShellV1::Instance::get_layer_surface(
 
     auto const output_id = output ?
         shell->output_manager->output_id_for(client, output.value()) :
-        std::experimental::nullopt;
+        std::nullopt;
 
     new LayerSurfaceV1(
         new_layer_surface,
@@ -274,7 +274,7 @@ void mf::LayerShellV1::Instance::get_layer_surface(
 mf::LayerSurfaceV1::LayerSurfaceV1(
     wl_resource* new_resource,
     WlSurface* surface,
-    std::experimental::optional<graphics::DisplayConfigurationOutputId> output_id,
+    std::optional<graphics::DisplayConfigurationOutputId> output_id,
     LayerShellV1 const& layer_shell,
     MirDepthLayer layer)
     : mw::LayerSurfaceV1(new_resource, Version<4>()),

--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -229,7 +229,7 @@ mf::OutputManager::~OutputManager()
 }
 
 auto mf::OutputManager::output_id_for(wl_client* client, wl_resource* output) const
-    -> std::experimental::optional<graphics::DisplayConfigurationOutputId>
+    -> std::optional<graphics::DisplayConfigurationOutputId>
 {
     for (auto const& dd : outputs)
     {
@@ -243,16 +243,16 @@ auto mf::OutputManager::output_id_for(wl_client* client, wl_resource* output) co
             return dd.first;
     }
 
-    return std::experimental::nullopt;
+    return std::nullopt;
 }
 
-auto mf::OutputManager::output_for(graphics::DisplayConfigurationOutputId id) -> std::experimental::optional<Output*>
+auto mf::OutputManager::output_for(graphics::DisplayConfigurationOutputId id) -> std::optional<Output*>
 {
     auto const result = outputs.find(id);
     if (result != outputs.end())
         return result->second.get();
     else
-        return std::experimental::nullopt;
+        return std::nullopt;
 }
 
 void mf::OutputManager::create_output(mg::DisplayConfigurationOutput const& initial_config)

--- a/src/server/frontend_wayland/output_manager.cpp
+++ b/src/server/frontend_wayland/output_manager.cpp
@@ -231,6 +231,11 @@ mf::OutputManager::~OutputManager()
 auto mf::OutputManager::output_id_for(wl_client* client, wl_resource* output) const
     -> std::optional<graphics::DisplayConfigurationOutputId>
 {
+    if (!output)
+    {
+        return std::nullopt;
+    }
+
     for (auto const& dd : outputs)
     {
         bool found{false};

--- a/src/server/frontend_wayland/output_manager.h
+++ b/src/server/frontend_wayland/output_manager.h
@@ -26,8 +26,7 @@
 #include <wayland-server-core.h>
 #include <wayland-server-protocol.h>
 
-#include <experimental/optional>
-
+#include <optional>
 #include <memory>
 #include <vector>
 #include <unordered_map>
@@ -71,9 +70,9 @@ public:
     ~OutputManager();
 
     auto output_id_for(wl_client* client, wl_resource* output) const
-        -> std::experimental::optional<graphics::DisplayConfigurationOutputId>;
+        -> std::optional<graphics::DisplayConfigurationOutputId>;
 
-    auto output_for(graphics::DisplayConfigurationOutputId id) -> std::experimental::optional<Output*>;
+    auto output_for(graphics::DisplayConfigurationOutputId id) -> std::optional<Output*>;
 
     auto display_config() const -> std::shared_ptr<MirDisplay> {return display_config_;}
 

--- a/src/server/frontend_wayland/output_manager.h
+++ b/src/server/frontend_wayland/output_manager.h
@@ -69,6 +69,7 @@ public:
     OutputManager(wl_display* display, std::shared_ptr<MirDisplay> const& display_config, std::shared_ptr<Executor> const& executor);
     ~OutputManager();
 
+    /// Returns the output ID (if any) associated with the given output resource. Output resource may be nullptr.
     auto output_id_for(wl_client* client, wl_resource* output) const
         -> std::optional<graphics::DisplayConfigurationOutputId>;
 

--- a/src/server/frontend_wayland/pointer_constraints_unstable_v1.cpp
+++ b/src/server/frontend_wayland/pointer_constraints_unstable_v1.cpp
@@ -62,14 +62,14 @@ private:
         wl_resource* id,
         wl_resource* surface,
         wl_resource* pointer,
-        const std::experimental::optional<wl_resource*>& region,
+        const std::optional<wl_resource*>& region,
         uint32_t lifetime) override;
 
     void confine_pointer(
         wl_resource* id,
         wl_resource* surface,
         wl_resource* pointer,
-        const std::experimental::optional<wl_resource*>& region,
+        const std::optional<wl_resource*>& region,
         uint32_t lifetime) override;
 };
 
@@ -81,7 +81,7 @@ public:
         Executor& wayland_executor,
         std::shared_ptr<shell::Shell> shell,
         std::shared_ptr<scene::Surface> const& scene_surface,
-        std::experimental::optional<wl_resource*> const& region,
+        std::optional<wl_resource*> const& region,
         PointerConstraintsV1::Lifetime lifetime);
     ~LockedPointerV1();
 
@@ -94,7 +94,7 @@ private:
     std::shared_ptr<MyWaylandSurfaceObserver> const my_surface_observer;
 
     void set_cursor_position_hint(double /*surface_x*/, double /*surface_y*/) override;
-    void set_region(const std::experimental::optional<wl_resource*>& /*region*/) override;
+    void set_region(const std::optional<wl_resource*>& /*region*/) override;
 };
 
 class ConfinedPointerV1 : public wayland::ConfinedPointerV1
@@ -105,7 +105,7 @@ public:
         Executor& wayland_executor,
         std::shared_ptr<shell::Shell> shell,
         std::shared_ptr<scene::Surface> const& scene_surface,
-        std::experimental::optional<wl_resource*> const& region,
+        std::optional<wl_resource*> const& region,
         PointerConstraintsV1::Lifetime lifetime);
     ~ConfinedPointerV1();
 
@@ -117,7 +117,7 @@ private:
 
     std::shared_ptr<SurfaceObserver> const my_surface_observer;
 
-    void set_region(const std::experimental::optional<wl_resource*>& /*region*/) override;
+    void set_region(const std::optional<wl_resource*>& /*region*/) override;
 };
 
 struct LockedPointerV1::MyWaylandSurfaceObserver : ms::NullSurfaceObserver
@@ -253,7 +253,7 @@ void mir::frontend::PointerConstraintsV1::lock_pointer(
     wl_resource* id,
     wl_resource* surface,
     wl_resource* /*pointer*/,
-    std::experimental::optional<wl_resource*> const& region,
+    std::optional<wl_resource*> const& region,
     uint32_t lifetime)
 {
     if (auto const s = WlSurface::from(surface)->scene_surface())
@@ -270,7 +270,7 @@ void mir::frontend::PointerConstraintsV1::confine_pointer(
     wl_resource* id,
     wl_resource* surface,
     wl_resource* /*pointer*/,
-    std::experimental::optional<wl_resource*> const& region,
+    std::optional<wl_resource*> const& region,
     uint32_t lifetime)
 {
     if (auto const s = WlSurface::from(surface)->scene_surface())
@@ -288,7 +288,7 @@ mir::frontend::LockedPointerV1::LockedPointerV1(
     Executor& wayland_executor,
     std::shared_ptr<shell::Shell> shell,
     std::shared_ptr<scene::Surface> const& scene_surface,
-    std::experimental::optional<wl_resource*> const& region,
+    std::optional<wl_resource*> const& region,
     PointerConstraintsV1::Lifetime lifetime) :
     wayland::LockedPointerV1{id, Version<1>{}},
     shell{std::move(shell)},
@@ -346,7 +346,7 @@ void mir::frontend::LockedPointerV1::set_cursor_position_hint(double /*surface_x
 {
 }
 
-void mir::frontend::LockedPointerV1::set_region(const std::experimental::optional<wl_resource*>& /*region*/)
+void mir::frontend::LockedPointerV1::set_region(const std::optional<wl_resource*>& /*region*/)
 {
 }
 
@@ -355,7 +355,7 @@ mir::frontend::ConfinedPointerV1::ConfinedPointerV1(
     Executor& wayland_executor,
     std::shared_ptr<shell::Shell> shell,
     std::shared_ptr<scene::Surface> const& scene_surface,
-    std::experimental::optional<wl_resource*> const& region,
+    std::optional<wl_resource*> const& region,
     PointerConstraintsV1::Lifetime lifetime) :
     wayland::ConfinedPointerV1{id, Version<1>{}},
     shell{std::move(shell)},
@@ -408,6 +408,6 @@ mir::frontend::ConfinedPointerV1::~ConfinedPointerV1()
     }
 }
 
-void mir::frontend::ConfinedPointerV1::set_region(const std::experimental::optional<wl_resource*>& /*region*/)
+void mir::frontend::ConfinedPointerV1::set_region(const std::optional<wl_resource*>& /*region*/)
 {
 }

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -250,7 +250,7 @@ protected:
     void set_fullscreen(
         uint32_t /*method*/,
         uint32_t /*framerate*/,
-        std::experimental::optional<struct wl_resource*> const& output) override
+        std::optional<struct wl_resource*> const& output) override
     {
         WindowWlSurfaceRole::set_fullscreen(output);
     }
@@ -281,7 +281,7 @@ protected:
         apply_spec(mods);
     }
 
-    void set_maximized(std::experimental::optional<struct wl_resource*> const& output) override
+    void set_maximized(std::optional<struct wl_resource*> const& output) override
     {
         (void)output;
         WindowWlSurfaceRole::add_state_now(mir_window_state_maximized);

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -235,8 +235,9 @@ protected:
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
 
-    void handle_resize(std::experimental::optional<geometry::Point> const& /*new_top_left*/,
-                       geometry::Size const& new_size) override
+    void handle_resize(
+        std::optional<geometry::Point> const& /*new_top_left*/,
+        geometry::Size const& new_size) override
     {
         wl_shell_surface_send_configure(resource, WL_SHELL_SURFACE_RESIZE_NONE, new_size.width.as_int(),
                                         new_size.height.as_int());

--- a/src/server/frontend_wayland/wayland_input_dispatcher.h
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.h
@@ -26,7 +26,6 @@
 
 #include <memory>
 #include <chrono>
-#include <experimental/optional>
 
 struct wl_client;
 

--- a/src/server/frontend_wayland/wayland_surface_observer.cpp
+++ b/src/server/frontend_wayland/wayland_surface_observer.cpp
@@ -83,7 +83,7 @@ void mf::WaylandSurfaceObserver::content_resized_to(ms::Surface const*, geom::Si
             if (content_size != impl->window_size)
             {
                 impl->requested_size = content_size;
-                window->handle_resize(std::experimental::nullopt, content_size);
+                window->handle_resize(std::nullopt, content_size);
             }
         });
 }

--- a/src/server/frontend_wayland/wayland_surface_observer.h
+++ b/src/server/frontend_wayland/wayland_surface_observer.h
@@ -24,7 +24,7 @@
 #include <mir/scene/null_surface_observer.h>
 
 #include <memory>
-#include <experimental/optional>
+#include <optional>
 #include <chrono>
 #include <functional>
 
@@ -62,7 +62,7 @@ public:
     }
 
     /// Should only be called from the Wayland thread
-    std::experimental::optional<geometry::Size> requested_window_size()
+    std::optional<geometry::Size> requested_window_size()
     {
         return impl->requested_size;
     }
@@ -91,7 +91,7 @@ private:
         std::unique_ptr<WaylandInputDispatcher> const input_dispatcher;
 
         geometry::Size window_size{};
-        std::experimental::optional<geometry::Size> requested_size{};
+        std::optional<geometry::Size> requested_size{};
         MirWindowState current_state{mir_window_state_unknown};
     };
 

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -265,7 +265,7 @@ void mf::WindowWlSurfaceRole::set_fullscreen(std::optional<struct wl_resource*> 
         mods.state = scene_surface->state_tracker().with(mir_window_state_fullscreen).active_state();
         auto const output_id = output ?
             output_manager->output_id_for(weak_client.value().raw_client(), output.value()) :
-            std::experimental::nullopt;
+            std::nullopt;
         if (output_id)
             mods.output_id = output_id.value();
         shell->modify_surface(session, scene_surface, mods);
@@ -275,7 +275,7 @@ void mf::WindowWlSurfaceRole::set_fullscreen(std::optional<struct wl_resource*> 
         params->state = mir_window_state_fullscreen;
         auto const output_id = output ?
             output_manager->output_id_for(weak_client.value().raw_client(), output.value()) :
-            std::experimental::nullopt;
+            std::nullopt;
         if (output_id)
             params->output_id = output_id.value();
         create_scene_surface();

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -263,21 +263,25 @@ void mf::WindowWlSurfaceRole::set_fullscreen(std::optional<struct wl_resource*> 
     {
         shell::SurfaceSpecification mods;
         mods.state = scene_surface->state_tracker().with(mir_window_state_fullscreen).active_state();
-        auto const output_id = output ?
-            output_manager->output_id_for(weak_client.value().raw_client(), output.value()) :
-            std::nullopt;
+        auto const output_id = output_manager->output_id_for(
+            weak_client.value().raw_client(),
+            output.value_or(nullptr));
         if (output_id)
+        {
             mods.output_id = output_id.value();
+        }
         shell->modify_surface(session, scene_surface, mods);
     }
     else
     {
         params->state = mir_window_state_fullscreen;
-        auto const output_id = output ?
-            output_manager->output_id_for(weak_client.value().raw_client(), output.value()) :
-            std::nullopt;
+        auto const output_id = output_manager->output_id_for(
+            weak_client.value().raw_client(),
+            output.value_or(nullptr));
         if (output_id)
+        {
             params->output_id = output_id.value();
+        }
         create_scene_surface();
     }
 }

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -256,7 +256,7 @@ void mf::WindowWlSurfaceRole::set_min_size(int32_t width, int32_t height)
     }
 }
 
-void mf::WindowWlSurfaceRole::set_fullscreen(std::experimental::optional<struct wl_resource*> const& output)
+void mf::WindowWlSurfaceRole::set_fullscreen(std::optional<struct wl_resource*> const& output)
 {
     // We must process this request immediately (i.e. don't defer until commit())
     if (auto const scene_surface = weak_scene_surface.lock())

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -94,13 +94,13 @@ mf::WindowWlSurfaceRole::~WindowWlSurfaceRole()
     }
 }
 
-auto mf::WindowWlSurfaceRole::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>
+auto mf::WindowWlSurfaceRole::scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>>
 {
     auto shared = weak_scene_surface.lock();
     if (shared)
         return shared;
     else
-        return std::experimental::nullopt;
+        return std::nullopt;
 }
 
 void mf::WindowWlSurfaceRole::populate_spec_with_surface_data(shell::SurfaceSpecification& spec)
@@ -137,17 +137,17 @@ void mf::WindowWlSurfaceRole::apply_spec(mir::shell::SurfaceSpecification const&
     }
 }
 
-void mf::WindowWlSurfaceRole::set_pending_offset(std::experimental::optional<geom::Displacement> const& offset)
+void mf::WindowWlSurfaceRole::set_pending_offset(std::optional<geom::Displacement> const& offset)
 {
     surface->set_pending_offset(offset);
 }
 
-void mf::WindowWlSurfaceRole::set_pending_width(std::experimental::optional<geometry::Width> const& width)
+void mf::WindowWlSurfaceRole::set_pending_width(std::optional<geometry::Width> const& width)
 {
     pending_explicit_width = width;
 }
 
-void mf::WindowWlSurfaceRole::set_pending_height(std::experimental::optional<geometry::Height> const& height)
+void mf::WindowWlSurfaceRole::set_pending_height(std::optional<geometry::Height> const& height)
 {
     pending_explicit_height = height;
 }
@@ -192,7 +192,7 @@ void mf::WindowWlSurfaceRole::initiate_interactive_resize(MirResizeEdge edge)
     }
 }
 
-void mf::WindowWlSurfaceRole::set_parent(std::experimental::optional<std::shared_ptr<scene::Surface>> const& parent)
+void mf::WindowWlSurfaceRole::set_parent(std::optional<std::shared_ptr<scene::Surface>> const& parent)
 {
     if (weak_scene_surface.lock())
     {
@@ -358,7 +358,7 @@ auto mf::WindowWlSurfaceRole::current_size() const -> geom::Size
     return size;
 }
 
-auto mf::WindowWlSurfaceRole::requested_window_size() const -> std::experimental::optional<geom::Size>
+auto mf::WindowWlSurfaceRole::requested_window_size() const -> std::optional<geom::Size>
 {
     return observer->requested_window_size();
 }
@@ -437,8 +437,8 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
         committed_width_set_explicitly = true;
     if (pending_explicit_height)
         committed_height_set_explicitly = true;
-    pending_explicit_width = std::experimental::nullopt;
-    pending_explicit_height = std::experimental::nullopt;
+    pending_explicit_width = std::nullopt;
+    pending_explicit_height = std::nullopt;
 }
 
 void mf::WindowWlSurfaceRole::surface_destroyed()

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -30,6 +30,7 @@
 #include <mir_toolkit/common.h>
 
 #include <experimental/optional>
+#include <optional>
 #include <chrono>
 
 struct wl_client;
@@ -87,7 +88,7 @@ public:
     void set_parent(std::experimental::optional<std::shared_ptr<scene::Surface>> const& parent);
     void set_max_size(int32_t width, int32_t height);
     void set_min_size(int32_t width, int32_t height);
-    void set_fullscreen(std::experimental::optional<wl_resource*> const& output);
+    void set_fullscreen(std::optional<wl_resource*> const& output);
     void set_server_side_decorated(bool server_side_decorated);
     void set_type(MirWindowType type);
 

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -29,7 +29,6 @@
 
 #include <mir_toolkit/common.h>
 
-#include <experimental/optional>
 #include <optional>
 #include <chrono>
 
@@ -72,20 +71,20 @@ public:
 
     ~WindowWlSurfaceRole() override;
 
-    auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
+    auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>> override;
 
     void populate_spec_with_surface_data(shell::SurfaceSpecification& spec);
     void refresh_surface_data_now() override;
 
     void apply_spec(shell::SurfaceSpecification const& new_spec);
-    void set_pending_offset(std::experimental::optional<geometry::Displacement> const& offset);
-    void set_pending_width(std::experimental::optional<geometry::Width> const& width);
-    void set_pending_height(std::experimental::optional<geometry::Height> const& height);
+    void set_pending_offset(std::optional<geometry::Displacement> const& offset);
+    void set_pending_width(std::optional<geometry::Width> const& width);
+    void set_pending_height(std::optional<geometry::Height> const& height);
     void set_title(std::string const& title);
     void set_application_id(std::string const& application_id);
     void initiate_interactive_move();
     void initiate_interactive_resize(MirResizeEdge edge);
-    void set_parent(std::experimental::optional<std::shared_ptr<scene::Surface>> const& parent);
+    void set_parent(std::optional<std::shared_ptr<scene::Surface>> const& parent);
     void set_max_size(int32_t width, int32_t height);
     void set_min_size(int32_t width, int32_t height);
     void set_fullscreen(std::optional<wl_resource*> const& output);
@@ -102,8 +101,9 @@ public:
 
     virtual void handle_state_change(MirWindowState new_state) = 0;
     virtual void handle_active_change(bool is_now_active) = 0;
-    virtual void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,
-                               geometry::Size const& new_size) = 0;
+    virtual void handle_resize(
+        std::optional<geometry::Point> const& new_top_left,
+        geometry::Size const& new_size) = 0;
     virtual void handle_close_request() = 0;
 
 protected:
@@ -114,7 +114,7 @@ protected:
     auto current_size() const -> geometry::Size;
 
     /// Window size requested by Mir
-    auto requested_window_size() const -> std::experimental::optional<geometry::Size>;
+    auto requested_window_size() const -> std::optional<geometry::Size>;
 
     auto window_state() const -> MirWindowState;
     auto is_active() const -> bool;
@@ -135,8 +135,8 @@ private:
 
     /// The explicitly set (not taken from the surface buffer size) uncommitted window size
     /// @{
-    std::experimental::optional<geometry::Width> pending_explicit_width;
-    std::experimental::optional<geometry::Height> pending_explicit_height;
+    std::optional<geometry::Width> pending_explicit_width;
+    std::optional<geometry::Height> pending_explicit_height;
     /// @}
 
     /// If the committed window size was set explicitly, rather than being taken from the buffer size
@@ -146,7 +146,7 @@ private:
     /// @}
 
     /// The last committed window size (either explicitly set or taken from the surface buffer size)
-    std::experimental::optional<geometry::Size> committed_size;
+    std::optional<geometry::Size> committed_size;
 
     /// The min and max size of the window as of last commit
     /// @{

--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -48,7 +48,7 @@ class mf::WlDataDevice::Offer : public wayland::DataOffer
 public:
     Offer(WlDataDevice* device, std::shared_ptr<scene::ClipboardSource> const& source);
 
-    void accept(uint32_t serial, std::experimental::optional<std::string> const& mime_type) override
+    void accept(uint32_t serial, std::optional<std::string> const& mime_type) override
     {
         (void)serial, (void)mime_type;
     }
@@ -108,7 +108,7 @@ mf::WlDataDevice::~WlDataDevice()
     seat.remove_focus_listener(client, this);
 }
 
-void mf::WlDataDevice::set_selection(std::experimental::optional<struct wl_resource*> const& source, uint32_t serial)
+void mf::WlDataDevice::set_selection(std::optional<wl_resource*> const& source, uint32_t serial)
 {
     // TODO: verify serial
     (void)serial;
@@ -142,6 +142,6 @@ void mf::WlDataDevice::paste_source_set(std::shared_ptr<scene::ClipboardSource> 
     else
     {
         current_offer = {};
-        send_selection_event(std::experimental::nullopt);
+        send_selection_event(std::nullopt);
     }
 }

--- a/src/server/frontend_wayland/wl_data_device.h
+++ b/src/server/frontend_wayland/wl_data_device.h
@@ -46,12 +46,12 @@ public:
     /// Wayland requests
     /// @{
     void start_drag(
-        std::experimental::optional<struct wl_resource*> const& source, struct wl_resource* origin,
-        std::experimental::optional<struct wl_resource*> const& icon, uint32_t serial) override
+        std::optional<wl_resource*> const& source, wl_resource* origin,
+        std::optional<wl_resource*> const& icon, uint32_t serial) override
     {
         (void)source, (void)origin, (void)icon, (void)serial;
     }
-    void set_selection(std::experimental::optional<struct wl_resource*> const& source, uint32_t serial) override;
+    void set_selection(std::optional<wl_resource*> const& source, uint32_t serial) override;
     /// @}
 
 private:

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -193,7 +193,7 @@ void mf::WlPointer::leave(std::optional<MirPointerEvent const*> event)
     send_leave_event(
         serial,
         surface_under_cursor.value().raw_resource());
-    current_position = std::experimental::nullopt;
+    current_position = std::nullopt;
     // Don't clear current_buttons, their state can survive leaving and entering surfaces (note we currently have logic
     // to prevent changing surfaces while buttons are pressed, we wouln't need to clear current_buttons regardless)
     needs_frame = true;
@@ -403,7 +403,7 @@ private:
 
 void mf::WlPointer::set_cursor(
     uint32_t serial,
-    std::experimental::optional<wl_resource*> const& surface,
+    std::optional<wl_resource*> const& surface,
     int32_t hotspot_x, int32_t hotspot_y)
 {
     // We need an explicit conversion before calling make_unique

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -119,7 +119,7 @@ struct mf::WlPointer::Cursor
 {
     virtual void apply_to(WlSurface* surface) = 0;
     virtual void set_hotspot(geom::Displacement const& new_hotspot) = 0;
-    virtual auto cursor_surface() const -> std::experimental::optional<WlSurface*> = 0;
+    virtual auto cursor_surface() const -> std::optional<WlSurface*> = 0;
 
     virtual ~Cursor() = default;
     Cursor() = default;
@@ -134,7 +134,7 @@ struct NullCursor : mf::WlPointer::Cursor
 {
     void apply_to(mf::WlSurface*) override {}
     void set_hotspot(geom::Displacement const&) override {};
-    auto cursor_surface() const -> std::experimental::optional<mf::WlSurface*> override { return {}; };
+    auto cursor_surface() const -> std::optional<mf::WlSurface*> override { return {}; };
 };
 }
 
@@ -374,7 +374,7 @@ struct WlSurfaceCursor : mf::WlPointer::Cursor
 
     void apply_to(mf::WlSurface* surface) override;
     void set_hotspot(geom::Displacement const& new_hotspot) override;
-    auto cursor_surface() const -> std::experimental::optional<mf::WlSurface*> override;
+    auto cursor_surface() const -> std::optional<mf::WlSurface*> override;
 
 private:
     void apply_latest_buffer();
@@ -394,7 +394,7 @@ struct WlHiddenCursor : mf::WlPointer::Cursor
         mf::CommitHandler* commit_handler);
     void apply_to(mf::WlSurface* surface) override;
     void set_hotspot(geom::Displacement const&) override {};
-    auto cursor_surface() const -> std::experimental::optional<mf::WlSurface*> override { return {}; };
+    auto cursor_surface() const -> std::optional<mf::WlSurface*> override { return {}; };
 
 private:
     CursorSurfaceRole surface_role;
@@ -508,7 +508,7 @@ void WlSurfaceCursor::set_hotspot(geom::Displacement const& new_hotspot)
     apply_latest_buffer();
 }
 
-auto WlSurfaceCursor::cursor_surface() const -> std::experimental::optional<mf::WlSurface*>
+auto WlSurfaceCursor::cursor_surface() const -> std::optional<mf::WlSurface*>
 {
     if (surface)
     {

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -93,7 +93,7 @@ private:
     ///@{
     void set_cursor(
         uint32_t serial,
-        std::experimental::optional<wl_resource*> const& surface,
+        std::optional<wl_resource*> const& surface,
         int32_t hotspot_x,
         int32_t hotspot_y) override;
     ///@}
@@ -102,7 +102,7 @@ private:
     wayland::DestroyListenerId destroy_listener_id; ///< ID of this pointer's destroy listener on surface_under_cursor
     bool needs_frame{false};
     MirPointerButtons current_buttons{0};
-    std::experimental::optional<std::pair<float, float>> current_position;
+    std::optional<std::pair<float, float>> current_position;
     std::unique_ptr<Cursor> cursor;
     wayland::Weak<wayland::RelativePointerV1> relative_pointer;
     geometry::Displacement cursor_hotspot;

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -123,11 +123,11 @@ void mf::WlSubsurface::parent_has_committed()
     if (cached_state && synchronized())
     {
         surface->commit(cached_state.value());
-        cached_state = std::experimental::nullopt;
+        cached_state = std::nullopt;
     }
 }
 
-auto mf::WlSubsurface::subsurface_at(geom::Point point) -> std::experimental::optional<WlSurface*>
+auto mf::WlSubsurface::subsurface_at(geom::Point point) -> std::optional<WlSurface*>
 {
     return surface->subsurface_at(point);
 }
@@ -196,7 +196,7 @@ void mf::WlSubsurface::commit(WlSurfaceState const& state)
         surface->commit(cached_state.value());
         if (cached_state.value().surface_data_needs_refresh())
             refresh_surface_data_now();
-        cached_state = std::experimental::nullopt;
+        cached_state = std::nullopt;
     }
 }
 

--- a/src/server/frontend_wayland/wl_subcompositor.cpp
+++ b/src/server/frontend_wayland/wl_subcompositor.cpp
@@ -111,11 +111,11 @@ auto mf::WlSubsurface::synchronized() const -> bool
     return synchronized_ || parent_synchronized;
 }
 
-auto mf::WlSubsurface::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>
+auto mf::WlSubsurface::scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>>
 {
     return parent ?
         parent.value().scene_surface() :
-        std::experimental::nullopt;
+        std::nullopt;
 }
 
 void mf::WlSubsurface::parent_has_committed()

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -61,7 +61,7 @@ public:
 
     auto total_offset() const -> geometry::Displacement override;
     auto synchronized() const -> bool override;
-    auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
+    auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>> override;
 
     void parent_has_committed();
 

--- a/src/server/frontend_wayland/wl_subcompositor.h
+++ b/src/server/frontend_wayland/wl_subcompositor.h
@@ -65,7 +65,7 @@ public:
 
     void parent_has_committed();
 
-    auto subsurface_at(geometry::Point point) -> std::experimental::optional<WlSurface*>;
+    auto subsurface_at(geometry::Point point) -> std::optional<WlSurface*>;
 
 private:
     void set_position(int32_t x, int32_t y) override;
@@ -83,7 +83,7 @@ private:
     wayland::Weak<WlSurface> const parent;
     wayland::Weak<WlClient> const weak_client;
     bool synchronized_;
-    std::experimental::optional<WlSurfaceState> cached_state;
+    std::optional<WlSurfaceState> cached_state;
 };
 
 }

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -122,12 +122,12 @@ bool mf::WlSurface::synchronized() const
     return role->synchronized();
 }
 
-auto mf::WlSurface::subsurface_at(geom::Point point) -> std::experimental::optional<WlSurface*>
+auto mf::WlSurface::subsurface_at(geom::Point point) -> std::optional<WlSurface*>
 {
     if (!buffer_size_)
     {
         // surface not mapped
-        return std::experimental::nullopt;
+        return std::nullopt;
     }
     point = point - offset_;
     // loop backwards so the first subsurface we find that accepts the input is the topmost one
@@ -142,7 +142,7 @@ auto mf::WlSurface::subsurface_at(geom::Point point) -> std::experimental::optio
         if (rect.intersection_with(surface_rect).contains(point))
             return this;
     }
-    return std::experimental::nullopt;
+    return std::nullopt;
 }
 
 auto mf::WlSurface::scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>>
@@ -164,14 +164,7 @@ void mf::WlSurface::clear_role()
 
 void mf::WlSurface::set_pending_offset(std::optional<geom::Displacement> const& offset)
 {
-    if (offset)
-    {
-        pending.offset = *offset;
-    }
-    else
-    {
-        pending.offset = std::experimental::nullopt;
-    }
+    pending.offset = offset;
 }
 
 void mf::WlSurface::add_subsurface(WlSubsurface* child)
@@ -377,7 +370,7 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
         if (buffer == nullptr)
         {
             // TODO: unmap surface, and unmap all subsurfaces
-            buffer_size_ = std::experimental::nullopt;
+            buffer_size_ = std::nullopt;
             send_frame_callbacks();
         }
         else
@@ -435,7 +428,7 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
             stream->submit_buffer(mir_buffer);
             auto const new_buffer_size = stream->stream_size();
 
-            if (!input_shape && std::experimental::make_optional(new_buffer_size) != buffer_size_)
+            if (!input_shape && std::make_optional(new_buffer_size) != buffer_size_)
             {
                 state.invalidate_surface_data(); // input shape needs to be recalculated for the new size
             }
@@ -457,13 +450,13 @@ void mf::WlSurface::commit(WlSurfaceState const& state)
 void mf::WlSurface::commit()
 {
     if (pending.offset && *pending.offset == offset_)
-        pending.offset = std::experimental::nullopt;
+        pending.offset = std::nullopt;
 
     // The same input shape could be represented by the same rectangles in a different order, or even
     // different rectangles. We don't check for that, however, because it would only cause an unnecessary
     // update and not do any real harm. Checking for identical vectors should cover most cases.
     if (pending.input_shape && *pending.input_shape == input_shape)
-        pending.input_shape = std::experimental::nullopt;
+        pending.input_shape = std::nullopt;
 
     // order is important
     auto const state = std::move(pending);

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -251,7 +251,7 @@ void mf::WlSurface::send_frame_callbacks()
     frame_callbacks.clear();
 }
 
-void mf::WlSurface::attach(std::experimental::optional<wl_resource*> const& buffer, int32_t x, int32_t y)
+void mf::WlSurface::attach(std::optional<wl_resource*> const& buffer, int32_t x, int32_t y)
 {
     if (x != 0 || y != 0)
     {
@@ -285,13 +285,13 @@ void mf::WlSurface::frame(wl_resource* new_callback)
     pending.frame_callbacks.push_back(wayland::make_weak(callback));
 }
 
-void mf::WlSurface::set_opaque_region(std::experimental::optional<wl_resource*> const& region)
+void mf::WlSurface::set_opaque_region(std::optional<wl_resource*> const& region)
 {
     (void)region;
     // This isn't essential, but could enable optimizations
 }
 
-void mf::WlSurface::set_input_region(std::experimental::optional<wl_resource*> const& region)
+void mf::WlSurface::set_input_region(std::optional<wl_resource*> const& region)
 {
     if (region)
     {

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -145,7 +145,7 @@ auto mf::WlSurface::subsurface_at(geom::Point point) -> std::experimental::optio
     return std::experimental::nullopt;
 }
 
-auto mf::WlSurface::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>
+auto mf::WlSurface::scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>>
 {
     return role->scene_surface();
 }
@@ -162,9 +162,16 @@ void mf::WlSurface::clear_role()
     role = &null_role;
 }
 
-void mf::WlSurface::set_pending_offset(std::experimental::optional<geom::Displacement> const& offset)
+void mf::WlSurface::set_pending_offset(std::optional<geom::Displacement> const& offset)
 {
-    pending.offset = offset;
+    if (offset)
+    {
+        pending.offset = *offset;
+    }
+    else
+    {
+        pending.offset = std::experimental::nullopt;
+    }
 }
 
 void mf::WlSurface::add_subsurface(WlSubsurface* child)
@@ -493,9 +500,9 @@ mf::NullWlSurfaceRole::NullWlSurfaceRole(WlSurface* surface) :
 {
 }
 
-auto mf::NullWlSurfaceRole::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>
+auto mf::NullWlSurfaceRole::scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>>
 {
-    return std::experimental::nullopt;
+    return std::nullopt;
 }
 void mf::NullWlSurfaceRole::refresh_surface_data_now() {}
 void mf::NullWlSurfaceRole::commit(WlSurfaceState const& state) { surface->commit(state); }

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -27,6 +27,7 @@
 #include "mir/geometry/size.h"
 #include "mir/geometry/point.h"
 
+#include <experimental/optional>
 #include <vector>
 #include <map>
 
@@ -96,7 +97,7 @@ class NullWlSurfaceRole : public WlSurfaceRole
 {
 public:
     NullWlSurfaceRole(WlSurface* surface);
-    auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
+    auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>> override;
     void refresh_surface_data_now() override;
     void commit(WlSurfaceState const& state) override;
     void surface_destroyed() override;
@@ -121,11 +122,11 @@ public:
     bool synchronized() const;
     auto subsurface_at(geometry::Point point) -> std::experimental::optional<WlSurface*>;
     wl_resource* raw_resource() const { return resource; }
-    auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>;
+    auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>>;
 
     void set_role(WlSurfaceRole* role_);
     void clear_role();
-    void set_pending_offset(std::experimental::optional<geometry::Displacement> const& offset);
+    void set_pending_offset(std::optional<geometry::Displacement> const& offset);
     void add_subsurface(WlSubsurface* child);
     void remove_subsurface(WlSubsurface* child);
     void refresh_surface_data_now();

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -158,11 +158,11 @@ private:
 
     void send_frame_callbacks();
 
-    void attach(std::experimental::optional<wl_resource*> const& buffer, int32_t x, int32_t y) override;
+    void attach(std::optional<wl_resource*> const& buffer, int32_t x, int32_t y) override;
     void damage(int32_t x, int32_t y, int32_t width, int32_t height) override;
     void frame(wl_resource* callback) override;
-    void set_opaque_region(std::experimental::optional<wl_resource*> const& region) override;
-    void set_input_region(std::experimental::optional<wl_resource*> const& region) override;
+    void set_opaque_region(std::optional<wl_resource*> const& region) override;
+    void set_input_region(std::optional<wl_resource*> const& region) override;
     void commit() override;
     void damage_buffer(int32_t x, int32_t y, int32_t width, int32_t height) override;
     void set_buffer_transform(int32_t transform) override;

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -27,7 +27,6 @@
 #include "mir/geometry/size.h"
 #include "mir/geometry/point.h"
 
-#include <experimental/optional>
 #include <vector>
 #include <map>
 
@@ -78,11 +77,11 @@ struct WlSurfaceState
     // NOTE: buffer can be both nullopt and nullptr (I know, sounds dumb, but bare with me)
     // if it's nullopt, there is not a new buffer and no value should be copied to current state
     // if it's nullptr, there is a new buffer and it is a null buffer, which should replace the current buffer
-    std::experimental::optional<wl_resource*> buffer;
+    std::optional<wl_resource*> buffer;
 
-    std::experimental::optional<int> scale;
-    std::experimental::optional<geometry::Displacement> offset;
-    std::experimental::optional<std::experimental::optional<std::vector<geometry::Rectangle>>> input_shape;
+    std::optional<int> scale;
+    std::optional<geometry::Displacement> offset;
+    std::optional<std::optional<std::vector<geometry::Rectangle>>> input_shape;
     std::vector<wayland::Weak<Callback>> frame_callbacks;
 
 private:
@@ -118,9 +117,9 @@ public:
 
     geometry::Displacement offset() const { return offset_; }
     geometry::Displacement total_offset() const { return offset_ + role->total_offset(); }
-    std::experimental::optional<geometry::Size> buffer_size() const { return buffer_size_; }
+    std::optional<geometry::Size> buffer_size() const { return buffer_size_; }
     bool synchronized() const;
-    auto subsurface_at(geometry::Point point) -> std::experimental::optional<WlSurface*>;
+    auto subsurface_at(geometry::Point point) -> std::optional<WlSurface*>;
     wl_resource* raw_resource() const { return resource; }
     auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>>;
 
@@ -153,9 +152,9 @@ private:
 
     WlSurfaceState pending;
     geometry::Displacement offset_;
-    std::experimental::optional<geometry::Size> buffer_size_;
+    std::optional<geometry::Size> buffer_size_;
     std::vector<wayland::Weak<WlSurfaceState::Callback>> frame_callbacks;
-    std::experimental::optional<std::vector<mir::geometry::Rectangle>> input_shape;
+    std::optional<std::vector<mir::geometry::Rectangle>> input_shape;
 
     void send_frame_callbacks();
 

--- a/src/server/frontend_wayland/wl_surface_role.h
+++ b/src/server/frontend_wayland/wl_surface_role.h
@@ -25,7 +25,7 @@
 #include <mir_toolkit/common.h>
 
 #include <memory>
-#include <experimental/optional>
+#include <optional>
 
 namespace mir
 {
@@ -42,7 +42,7 @@ class WlSurfaceRole
 public:
     virtual bool synchronized() const { return false; }
     virtual auto total_offset() const -> geometry::Displacement { return {}; }
-    virtual auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> = 0;
+    virtual auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>> = 0;
     virtual void refresh_surface_data_now() = 0;
     virtual void commit(WlSurfaceState const& state) = 0;
     virtual void surface_destroyed() = 0;

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -98,8 +98,7 @@ public:
     void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override;
     void handle_active_change(bool /*is_now_active*/) override;
-    void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,
-                       geometry::Size const& new_size) override;
+    void handle_resize(std::optional<geometry::Point> const& new_top_left, geometry::Size const& new_size) override;
     void handle_close_request() override;
 
 private:
@@ -340,8 +339,9 @@ void mf::XdgPopupStable::grab(struct wl_resource* seat, uint32_t serial)
     set_type(mir_window_type_menu);
 }
 
-void mf::XdgPopupStable::handle_resize(const std::experimental::optional<geometry::Point>& new_top_left_,
-                                       const geometry::Size& new_size)
+void mf::XdgPopupStable::handle_resize(
+    std::optional<geometry::Point> const& new_top_left_,
+    geometry::Size const& new_size)
 {
     auto new_top_left{new_top_left_};
     if (new_top_left)
@@ -526,8 +526,9 @@ void mf::XdgToplevelStable::handle_active_change(bool /*is_now_active*/)
     send_toplevel_configure();
 }
 
-void mf::XdgToplevelStable::handle_resize(std::experimental::optional<geometry::Point> const& /*new_top_left*/,
-                                          geometry::Size const& /*new_size*/)
+void mf::XdgToplevelStable::handle_resize(
+    std::optional<geometry::Point> const& /*new_top_left*/,
+    geometry::Size const& /*new_size*/)
 {
     send_toplevel_configure();
 }

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -208,7 +208,7 @@ void mf::XdgSurfaceStable::get_popup(
     std::optional<struct wl_resource*> const& parent_surface,
     wl_resource* positioner)
 {
-    std::experimental::optional<WlSurfaceRole*> parent_role;
+    std::optional<WlSurfaceRole*> parent_role;
     if (parent_surface)
     {
         XdgSurfaceStable* parent_xdg_surface = XdgSurfaceStable::from(parent_surface.value());
@@ -269,7 +269,7 @@ void mf::XdgSurfaceStable::set_window_role(WindowWlSurfaceRole* role)
 mf::XdgPopupStable::XdgPopupStable(
     wl_resource* new_resource,
     XdgSurfaceStable* xdg_surface,
-    std::experimental::optional<WlSurfaceRole*> parent_role,
+    std::optional<WlSurfaceRole*> parent_role,
     struct wl_resource* positioner,
     WlSurface* surface)
     : mw::XdgPopup(new_resource, Version<1>()),

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -51,7 +51,7 @@ public:
     void get_toplevel(wl_resource* new_toplevel) override;
     void get_popup(
         wl_resource* new_popup,
-        std::experimental::optional<wl_resource*> const& parent_surface,
+        std::optional<wl_resource*> const& parent_surface,
         wl_resource* positioner) override;
     void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) override;
     void ack_configure(uint32_t serial) override;
@@ -81,7 +81,7 @@ public:
         XdgSurfaceStable* xdg_surface,
         WlSurface* surface);
 
-    void set_parent(std::experimental::optional<struct wl_resource*> const& parent) override;
+    void set_parent(std::optional<struct wl_resource*> const& parent) override;
     void set_title(std::string const& title) override;
     void set_app_id(std::string const& app_id) override;
     void show_window_menu(struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y) override;
@@ -91,7 +91,7 @@ public:
     void set_min_size(int32_t width, int32_t height) override;
     void set_maximized() override;
     void unset_maximized() override;
-    void set_fullscreen(std::experimental::optional<struct wl_resource*> const& output) override;
+    void set_fullscreen(std::optional<struct wl_resource*> const& output) override;
     void unset_fullscreen() override;
     void set_minimized() override;
 
@@ -206,7 +206,7 @@ void mf::XdgSurfaceStable::get_toplevel(wl_resource* new_toplevel)
 
 void mf::XdgSurfaceStable::get_popup(
     wl_resource* new_popup,
-    std::experimental::optional<struct wl_resource*> const& parent_surface,
+    std::optional<struct wl_resource*> const& parent_surface,
     wl_resource* positioner)
 {
     std::experimental::optional<WlSurfaceRole*> parent_role;
@@ -399,7 +399,7 @@ mf::XdgToplevelStable::XdgToplevelStable(wl_resource* new_resource, XdgSurfaceSt
     xdg_surface->send_configure();
 }
 
-void mf::XdgToplevelStable::set_parent(std::experimental::optional<struct wl_resource*> const& parent)
+void mf::XdgToplevelStable::set_parent(std::optional<struct wl_resource*> const& parent)
 {
     if (parent && parent.value())
     {
@@ -498,7 +498,7 @@ void mf::XdgToplevelStable::unset_maximized()
     remove_state_now(mir_window_state_maximized);
 }
 
-void mf::XdgToplevelStable::set_fullscreen(std::experimental::optional<struct wl_resource*> const& output)
+void mf::XdgToplevelStable::set_fullscreen(std::optional<struct wl_resource*> const& output)
 {
     WindowWlSurfaceRole::set_fullscreen(output);
 }

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -22,6 +22,8 @@
 #include "xdg-shell_wrapper.h"
 #include "window_wl_surface_role.h"
 
+#include <experimental/optional>
+
 namespace mir
 {
 namespace scene
@@ -78,15 +80,15 @@ public:
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(
-        std::experimental::optional<geometry::Point> const& new_top_left,
+        std::optional<geometry::Point> const& new_top_left,
         geometry::Size const& new_size) override;
     void handle_close_request() override;
 
     static auto from(wl_resource* resource) -> XdgPopupStable*;
 
 private:
-    std::experimental::optional<geometry::Point> cached_top_left;
-    std::experimental::optional<geometry::Size> cached_size;
+    std::optional<geometry::Point> cached_top_left;
+    std::optional<geometry::Size> cached_size;
 
     std::shared_ptr<shell::Shell> const shell;
     XdgSurfaceStable* const xdg_surface;

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -22,8 +22,6 @@
 #include "xdg-shell_wrapper.h"
 #include "window_wl_surface_role.h"
 
-#include <experimental/optional>
-
 namespace mir
 {
 namespace scene
@@ -66,7 +64,7 @@ public:
     XdgPopupStable(
         wl_resource* new_resource,
         XdgSurfaceStable* xdg_surface,
-        std::experimental::optional<WlSurfaceRole*> parent_role,
+        std::optional<WlSurfaceRole*> parent_role,
         wl_resource* positioner,
         WlSurface* surface);
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -100,7 +100,7 @@ class XdgToplevelV6 : mw::XdgToplevelV6, public WindowWlSurfaceRole
 public:
     XdgToplevelV6(wl_resource* new_resource, XdgSurfaceV6* xdg_surface, WlSurface* surface);
 
-    void set_parent(std::experimental::optional<struct wl_resource*> const& parent) override;
+    void set_parent(std::optional<struct wl_resource*> const& parent) override;
     void set_title(std::string const& title) override;
     void set_app_id(std::string const& app_id) override;
     void show_window_menu(struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y) override;
@@ -110,7 +110,7 @@ public:
     void set_min_size(int32_t width, int32_t height) override;
     void set_maximized() override;
     void unset_maximized() override;
-    void set_fullscreen(std::experimental::optional<struct wl_resource*> const& output) override;
+    void set_fullscreen(std::optional<struct wl_resource*> const& output) override;
     void unset_fullscreen() override;
     void set_minimized() override;
 
@@ -354,7 +354,7 @@ mf::XdgToplevelV6::XdgToplevelV6(struct wl_resource* new_resource, XdgSurfaceV6*
     xdg_surface->send_configure();
 }
 
-void mf::XdgToplevelV6::set_parent(std::experimental::optional<struct wl_resource*> const& parent)
+void mf::XdgToplevelV6::set_parent(std::optional<struct wl_resource*> const& parent)
 {
     if (parent && parent.value())
     {
@@ -453,7 +453,7 @@ void mf::XdgToplevelV6::unset_maximized()
     remove_state_now(mir_window_state_maximized);
 }
 
-void mf::XdgToplevelV6::set_fullscreen(std::experimental::optional<struct wl_resource*> const& output)
+void mf::XdgToplevelV6::set_fullscreen(std::optional<struct wl_resource*> const& output)
 {
     WindowWlSurfaceRole::set_fullscreen(output);
 }

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -84,13 +84,13 @@ public:
     void handle_state_change(MirWindowState /*new_state*/) override {};
     void handle_active_change(bool /*is_now_active*/) override {};
     void handle_resize(
-        std::experimental::optional<geometry::Point> const& new_top_left,
+        std::optional<geometry::Point> const& new_top_left,
         geometry::Size const& new_size) override;
     void handle_close_request() override;
 
 private:
-    std::experimental::optional<geom::Point> cached_top_left;
-    std::experimental::optional<geom::Size> cached_size;
+    std::optional<geom::Point> cached_top_left;
+    std::optional<geom::Size> cached_size;
 
     XdgSurfaceV6* const xdg_surface;
 };
@@ -117,8 +117,9 @@ public:
     void handle_commit() override {};
     void handle_state_change(MirWindowState /*new_state*/) override;
     void handle_active_change(bool /*is_now_active*/) override;
-    void handle_resize(std::experimental::optional<geometry::Point> const& new_top_left,
-                       geometry::Size const& new_size) override;
+    void handle_resize(
+        std::optional<geometry::Point> const& new_top_left,
+        geometry::Size const& new_size) override;
     void handle_close_request() override;
 
 private:
@@ -291,7 +292,7 @@ mf::XdgPopupV6::XdgPopupV6(
                                         wl_resource_get_user_data(positioner))));
 
     auto const& parent_role = parent_surface->window_role();
-    auto parent_scene_surface = parent_role ? parent_role.value().scene_surface() : std::experimental::nullopt;
+    auto parent_scene_surface = parent_role ? parent_role.value().scene_surface() : std::nullopt;
 
     specification->type = mir_window_type_gloss;
     specification->placement_hints = mir_placement_hints_slide_any;
@@ -309,8 +310,9 @@ void mf::XdgPopupV6::grab(struct wl_resource* seat, uint32_t serial)
     set_type(mir_window_type_menu);
 }
 
-void mf::XdgPopupV6::handle_resize(const std::experimental::optional<geometry::Point>& new_top_left,
-                                   const geometry::Size& new_size)
+void mf::XdgPopupV6::handle_resize(
+    std::optional<geometry::Point> const& new_top_left,
+    geometry::Size const& new_size)
 {
     bool const needs_configure = (new_top_left != cached_top_left) || (new_size != cached_size);
 
@@ -480,8 +482,9 @@ void mf::XdgToplevelV6::handle_active_change(bool /*is_now_active*/)
     send_toplevel_configure();
 }
 
-void mf::XdgToplevelV6::handle_resize(std::experimental::optional<geometry::Point> const& /*new_top_left*/,
-                       geometry::Size const& /*new_size*/)
+void mf::XdgToplevelV6::handle_resize(
+    std::optional<geometry::Point> const& /*new_top_left*/,
+    geometry::Size const& /*new_size*/)
 {
     send_toplevel_configure();
 }

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -382,10 +382,10 @@ auto mf::XCBConnection::read_property(
 
 void mf::XCBConnection::configure_window(
     xcb_window_t window,
-    std::experimental::optional<geometry::Point> position,
-    std::experimental::optional<geometry::Size> size,
-    std::experimental::optional<xcb_window_t> sibling,
-    std::experimental::optional<xcb_stack_mode_t> stack_mode) const
+    std::optional<geometry::Point> position,
+    std::optional<geometry::Size> size,
+    std::optional<xcb_window_t> sibling,
+    std::optional<xcb_stack_mode_t> stack_mode) const
 {
     std::vector<uint32_t> values;
     uint32_t mask = 0;

--- a/src/server/frontend_xwayland/xcb_connection.h
+++ b/src/server/frontend_xwayland/xcb_connection.h
@@ -32,7 +32,7 @@
 #include <functional>
 #include <mutex>
 #include <atomic>
-#include <experimental/optional>
+#include <optional>
 
 namespace mir
 {
@@ -237,10 +237,10 @@ public:
     /// Wrapper around xcb_configure_window
     void configure_window(
         xcb_window_t window,
-        std::experimental::optional<geometry::Point> position,
-        std::experimental::optional<geometry::Size> size,
-        std::experimental::optional<xcb_window_t> sibling,
-        std::experimental::optional<xcb_stack_mode_t> stack_mode) const;
+        std::optional<geometry::Point> position,
+        std::optional<geometry::Size> size,
+        std::optional<xcb_window_t> sibling,
+        std::optional<xcb_stack_mode_t> stack_mode) const;
 
     /// Send client message
     /// @{

--- a/src/server/frontend_xwayland/xwayland_cursors.h
+++ b/src/server/frontend_xwayland/xwayland_cursors.h
@@ -21,7 +21,7 @@
 
 #include <memory>
 #include <vector>
-#include <experimental/optional>
+#include <optional>
 #include <X11/Xcursor/Xcursor.h>
 #include <xcb/composite.h>
 #include <xcb/xcb.h>
@@ -59,7 +59,7 @@ private:
     struct Loader
     {
         struct Formats {
-            std::experimental::optional<xcb_render_pictforminfo_t> rgba;
+            std::optional<xcb_render_pictforminfo_t> rgba;
         };
 
         Loader(std::shared_ptr<XCBConnection> const& connection);

--- a/src/server/frontend_xwayland/xwayland_server.h
+++ b/src/server/frontend_xwayland/xwayland_server.h
@@ -24,7 +24,7 @@
 #include <memory>
 #include <string>
 #include <mutex>
-#include <experimental/optional>
+#include <optional>
 
 struct wl_client;
 

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -32,7 +32,6 @@
 
 #include <string.h>
 #include <algorithm>
-#include <experimental/optional>
 
 namespace mf = mir::frontend;
 namespace msh = mir::shell;
@@ -139,7 +138,7 @@ enum MotifWmHintsFlags: uint32_t
 };
 }
 
-auto wm_resize_edge_to_mir_resize_edge(NetWmMoveresize wm_resize_edge) -> std::experimental::optional<MirResizeEdge>
+auto wm_resize_edge_to_mir_resize_edge(NetWmMoveresize wm_resize_edge) -> std::optional<MirResizeEdge>
 {
     switch (wm_resize_edge)
     {
@@ -157,7 +156,7 @@ auto wm_resize_edge_to_mir_resize_edge(NetWmMoveresize wm_resize_edge) -> std::e
     case NetWmMoveresize::CANCEL:               break;
     }
 
-    return std::experimental::nullopt;
+    return std::nullopt;
 }
 
 template<typename T>
@@ -359,7 +358,7 @@ void mf::XWaylandSurface::close()
         {
             observer = surface_observer.value();
         }
-        surface_observer = std::experimental::nullopt;
+        surface_observer = std::nullopt;
     }
 
     if (scene_surface)
@@ -499,8 +498,8 @@ void mf::XWaylandSurface::configure_request(xcb_configure_request_event_t* event
             window,
             top_left,
             size,
-            std::experimental::nullopt,
-            std::experimental::nullopt);
+            std::nullopt,
+            std::nullopt);
 
         connection->flush();
     }
@@ -697,7 +696,7 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
         window,
         scaled_top_left_of(*surface) + scaled_content_offset_of(*surface),
         scaled_content_size_of(*surface),
-        std::experimental::nullopt,
+        std::nullopt,
         XCB_STACK_MODE_ABOVE);
 
     {
@@ -850,9 +849,9 @@ void mf::XWaylandSurface::scene_surface_state_set(MirWindowState new_state)
     {
         connection->configure_window(
             window,
-            std::experimental::nullopt,
-            std::experimental::nullopt,
-            std::experimental::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
             XCB_STACK_MODE_BELOW);
     }
 }
@@ -861,10 +860,10 @@ void mf::XWaylandSurface::scene_surface_resized(geometry::Size const& new_size)
 {
     connection->configure_window(
         window,
-        std::experimental::nullopt,
+        std::nullopt,
         new_size,
-        std::experimental::nullopt,
-        std::experimental::nullopt);
+        std::nullopt,
+        std::nullopt);
     connection->flush();
 }
 
@@ -879,9 +878,9 @@ void mf::XWaylandSurface::scene_surface_moved_to(geometry::Point const& new_top_
     connection->configure_window(
         window,
         new_top_left + content_offset,
-        std::experimental::nullopt,
-        std::experimental::nullopt,
-        std::experimental::nullopt);
+        std::nullopt,
+        std::nullopt,
+        std::nullopt);
     connection->flush();
 }
 
@@ -948,12 +947,12 @@ auto mf::XWaylandSurface::pending_spec(std::lock_guard<std::mutex> const&) -> ms
 }
 
 auto mf::XWaylandSurface::consume_pending_spec(
-    std::lock_guard<std::mutex> const&) -> std::experimental::optional<std::unique_ptr<msh::SurfaceSpecification>>
+    std::lock_guard<std::mutex> const&) -> std::optional<std::unique_ptr<msh::SurfaceSpecification>>
 {
     if (nullable_pending_spec)
         return move(nullable_pending_spec);
     else
-        return std::experimental::nullopt;
+        return std::nullopt;
 }
 
 void mf::XWaylandSurface::is_transient_for(xcb_window_t transient_for)
@@ -1080,7 +1079,7 @@ auto mf::XWaylandSurface::latest_input_timestamp(std::lock_guard<std::mutex> con
 void mf::XWaylandSurface::apply_any_mods_to_scene_surface()
 {
     std::shared_ptr<mir::scene::Surface> scene_surface;
-    std::experimental::fundamentals_v1::optional<std::unique_ptr<mir::shell::SurfaceSpecification>> spec;
+    std::optional<std::unique_ptr<mir::shell::SurfaceSpecification>> spec;
 
     {
         std::lock_guard<std::mutex> lock{mutex};

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -931,13 +931,13 @@ void mf::XWaylandSurface::wl_surface_destroyed()
     close();
 }
 
-auto mf::XWaylandSurface::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>
+auto mf::XWaylandSurface::scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>>
 {
     std::lock_guard<std::mutex> lock{mutex};
     if (auto const scene_surface = weak_scene_surface.lock())
         return scene_surface;
     else
-        return std::experimental::nullopt;
+        return std::nullopt;
 }
 
 auto mf::XWaylandSurface::pending_spec(std::lock_guard<std::mutex> const&) -> msh::SurfaceSpecification&

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -122,7 +122,7 @@ private:
 
     /// Clears the pending spec and returns what it was
     auto consume_pending_spec(
-        std::lock_guard<std::mutex> const&) -> std::experimental::optional<std::unique_ptr<shell::SurfaceSpecification>>;
+        std::lock_guard<std::mutex> const&) -> std::optional<std::unique_ptr<shell::SurfaceSpecification>>;
 
     /// Updates the pending spec
     void is_transient_for(xcb_window_t transient_for);
@@ -199,7 +199,7 @@ private:
     } cached;
 
     /// Set in set_wl_surface and cleared when a scene surface is created from it
-    std::experimental::optional<std::shared_ptr<XWaylandSurfaceObserver>> surface_observer;
+    std::optional<std::shared_ptr<XWaylandSurfaceObserver>> surface_observer;
     std::unique_ptr<shell::SurfaceSpecification> nullable_pending_spec;
     std::shared_ptr<XWaylandClientManager::Session> client_session;
     std::weak_ptr<scene::Surface> weak_scene_surface;

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -113,7 +113,7 @@ private:
     /// Should only be called on the Wayland thread
     /// @{
     void wl_surface_destroyed() override;
-    auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
+    auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>> override;
     /// @}
 
     /// Creates a pending spec if needed and returns a reference

--- a/src/server/frontend_xwayland/xwayland_surface_observer.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.cpp
@@ -52,7 +52,7 @@ mf::XWaylandSurfaceObserver::XWaylandSurfaceObserver(
 mf::XWaylandSurfaceObserver::~XWaylandSurfaceObserver()
 {
     std::lock_guard<std::mutex> lock{input_dispatcher->mutex};
-    input_dispatcher->dispatcher = std::experimental::nullopt;
+    input_dispatcher->dispatcher = std::nullopt;
 }
 
 void mf::XWaylandSurfaceObserver::attrib_changed(ms::Surface const*, MirWindowAttrib attrib, int value)

--- a/src/server/frontend_xwayland/xwayland_surface_observer.h
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.h
@@ -25,7 +25,7 @@
 #include <mutex>
 #include <chrono>
 #include <functional>
-#include <experimental/optional>
+#include <optional>
 
 struct wl_client;
 
@@ -74,7 +74,7 @@ private:
 
         // Innter value should only be used from the Wayland thread and while the mutex is locked
         // Can be nullified from any thread as long as the mutex is locked
-        std::experimental::optional<std::unique_ptr<WaylandInputDispatcher>> dispatcher;
+        std::optional<std::unique_ptr<WaylandInputDispatcher>> dispatcher;
     };
 
     XWaylandSurfaceObserverSurface* const wm_surface;

--- a/src/server/frontend_xwayland/xwayland_surface_role.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_role.cpp
@@ -97,12 +97,12 @@ void mf::XWaylandSurfaceRole::populate_surface_data_scaled(
     }
 }
 
-auto mf::XWaylandSurfaceRole::scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>>
+auto mf::XWaylandSurfaceRole::scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>>
 {
     if (auto const wm_surface = weak_wm_surface.lock())
         return wm_surface->scene_surface();
     else
-        return std::experimental::nullopt;
+        return std::nullopt;
 }
 
 void mf::XWaylandSurfaceRole::refresh_surface_data_now()

--- a/src/server/frontend_xwayland/xwayland_surface_role.h
+++ b/src/server/frontend_xwayland/xwayland_surface_role.h
@@ -67,7 +67,7 @@ private:
 
     /// Overrides from WlSurfaceRole
     /// @{
-    auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> override;
+    auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>> override;
     void refresh_surface_data_now() override;
     void commit(WlSurfaceState const& state) override;
     void surface_destroyed() override;

--- a/src/server/frontend_xwayland/xwayland_surface_role_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface_role_surface.h
@@ -20,7 +20,7 @@
 #define MIR_FRONTEND_XWAYLAND_SURFACE_ROLE_SURFACE_H
 
 #include <memory>
-#include <experimental/optional>
+#include <optional>
 
 namespace mir
 {
@@ -40,7 +40,7 @@ public:
     virtual ~XWaylandSurfaceRoleSurface() = default;
 
     virtual void wl_surface_destroyed() = 0;
-    virtual auto scene_surface() const -> std::experimental::optional<std::shared_ptr<scene::Surface>> = 0;
+    virtual auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>> = 0;
 
 private:
     XWaylandSurfaceRoleSurface(XWaylandSurfaceRoleSurface const&) = delete;

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -298,18 +298,18 @@ void mf::XWaylandWM::handle_events()
 }
 
 auto mf::XWaylandWM::get_wm_surface(
-    xcb_window_t xcb_window) -> std::experimental::optional<std::shared_ptr<XWaylandSurface>>
+    xcb_window_t xcb_window) -> std::optional<std::shared_ptr<XWaylandSurface>>
 {
     std::lock_guard<std::mutex> lock{mutex};
 
     auto const surface = surfaces.find(xcb_window);
     if (surface == surfaces.end())
-        return std::experimental::nullopt;
+        return std::nullopt;
     else
         return surface->second;
 }
 
-auto mf::XWaylandWM::get_focused_window() -> std::experimental::optional<xcb_window_t>
+auto mf::XWaylandWM::get_focused_window() -> std::optional<xcb_window_t>
 {
     std::lock_guard<std::mutex> lock{mutex};
     return focused_window;
@@ -336,7 +336,7 @@ void mf::XWaylandWM::set_focus(xcb_window_t xcb_window, bool should_be_focused)
         if (should_be_focused)
             focused_window = xcb_window;
         else
-            focused_window = std::experimental::nullopt;
+            focused_window = std::nullopt;
     }
 
     if (should_be_focused)
@@ -436,8 +436,8 @@ void mf::XWaylandWM::restack_surfaces()
 
             connection->configure_window(
                 window,
-                std::experimental::nullopt,
-                std::experimental::nullopt,
+                std::nullopt,
+                std::nullopt,
                 window_below,
                 XCB_STACK_MODE_ABOVE);
         }

--- a/src/server/frontend_xwayland/xwayland_wm.h
+++ b/src/server/frontend_xwayland/xwayland_wm.h
@@ -27,7 +27,7 @@
 #include <map>
 #include <set>
 #include <thread>
-#include <experimental/optional>
+#include <optional>
 #include <mutex>
 
 #include <wayland-server-core.h>
@@ -73,8 +73,8 @@ public:
     /// Called by the XWayland connector when there may be new events
     void handle_events();
 
-    auto get_wm_surface(xcb_window_t xcb_window) -> std::experimental::optional<std::shared_ptr<XWaylandSurface>>;
-    auto get_focused_window() -> std::experimental::optional<xcb_window_t>;
+    auto get_wm_surface(xcb_window_t xcb_window) -> std::optional<std::shared_ptr<XWaylandSurface>>;
+    auto get_focused_window() -> std::optional<xcb_window_t>;
     void set_focus(xcb_window_t xcb_window, bool should_be_focused);
     void remember_scene_surface(std::weak_ptr<scene::Surface> const& scene_surface, xcb_window_t window);
     void forget_scene_surface(std::weak_ptr<scene::Surface> const& scene_surface);
@@ -130,7 +130,7 @@ private:
         std::owner_less<std::weak_ptr<scene::Surface>>> scene_surfaces;
     /// Could be regenerated from scene_surfaces at any time, but more efficient to keep this up to date
     std::set<std::weak_ptr<scene::Surface>, std::owner_less<std::weak_ptr<scene::Surface>>> scene_surface_set;
-    std::experimental::optional<xcb_window_t> focused_window;
+    std::optional<xcb_window_t> focused_window;
 };
 } /* frontend */
 } /* mir */

--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MIRWAYLAND_ABI 2)
+set(MIRWAYLAND_ABI 3)
 set(symbol_map ${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)
 add_compile_definitions(MIR_LOG_COMPONENT_FALLBACK="mirwayland")
 

--- a/src/wayland/generated/pointer-constraints-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/pointer-constraints-unstable-v1_wrapper.cpp
@@ -71,7 +71,7 @@ struct mw::PointerConstraintsV1::Thunks
             wl_client_post_no_memory(client);
             BOOST_THROW_EXCEPTION((std::bad_alloc{}));
         }
-        std::experimental::optional<struct wl_resource*> region_resolved;
+        std::optional<struct wl_resource*> region_resolved;
         if (region != nullptr)
         {
             region_resolved = {region};
@@ -100,7 +100,7 @@ struct mw::PointerConstraintsV1::Thunks
             wl_client_post_no_memory(client);
             BOOST_THROW_EXCEPTION((std::bad_alloc{}));
         }
-        std::experimental::optional<struct wl_resource*> region_resolved;
+        std::optional<struct wl_resource*> region_resolved;
         if (region != nullptr)
         {
             region_resolved = {region};
@@ -269,7 +269,7 @@ struct mw::LockedPointerV1::Thunks
 
     static void set_region_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* region)
     {
-        std::experimental::optional<struct wl_resource*> region_resolved;
+        std::optional<struct wl_resource*> region_resolved;
         if (region != nullptr)
         {
             region_resolved = {region};
@@ -383,7 +383,7 @@ struct mw::ConfinedPointerV1::Thunks
 
     static void set_region_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* region)
     {
-        std::experimental::optional<struct wl_resource*> region_resolved;
+        std::optional<struct wl_resource*> region_resolved;
         if (region != nullptr)
         {
             region_resolved = {region};

--- a/src/wayland/generated/pointer-constraints-unstable-v1_wrapper.h
+++ b/src/wayland/generated/pointer-constraints-unstable-v1_wrapper.h
@@ -8,7 +8,7 @@
 #ifndef MIR_FRONTEND_WAYLAND_POINTER_CONSTRAINTS_UNSTABLE_V1_XML_WRAPPER
 #define MIR_FRONTEND_WAYLAND_POINTER_CONSTRAINTS_UNSTABLE_V1_XML_WRAPPER
 
-#include <experimental/optional>
+#include <optional>
 
 #include "mir/fd.h"
 #include <wayland-server-core.h>
@@ -65,8 +65,8 @@ public:
     };
 
 private:
-    virtual void lock_pointer(struct wl_resource* id, struct wl_resource* surface, struct wl_resource* pointer, std::experimental::optional<struct wl_resource*> const& region, uint32_t lifetime) = 0;
-    virtual void confine_pointer(struct wl_resource* id, struct wl_resource* surface, struct wl_resource* pointer, std::experimental::optional<struct wl_resource*> const& region, uint32_t lifetime) = 0;
+    virtual void lock_pointer(struct wl_resource* id, struct wl_resource* surface, struct wl_resource* pointer, std::optional<struct wl_resource*> const& region, uint32_t lifetime) = 0;
+    virtual void confine_pointer(struct wl_resource* id, struct wl_resource* surface, struct wl_resource* pointer, std::optional<struct wl_resource*> const& region, uint32_t lifetime) = 0;
 };
 
 class LockedPointerV1 : public Resource
@@ -97,7 +97,7 @@ public:
 
 private:
     virtual void set_cursor_position_hint(double surface_x, double surface_y) = 0;
-    virtual void set_region(std::experimental::optional<struct wl_resource*> const& region) = 0;
+    virtual void set_region(std::optional<struct wl_resource*> const& region) = 0;
 };
 
 class ConfinedPointerV1 : public Resource
@@ -127,7 +127,7 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void set_region(std::experimental::optional<struct wl_resource*> const& region) = 0;
+    virtual void set_region(std::optional<struct wl_resource*> const& region) = 0;
 };
 
 }

--- a/src/wayland/generated/relative-pointer-unstable-v1_wrapper.h
+++ b/src/wayland/generated/relative-pointer-unstable-v1_wrapper.h
@@ -8,7 +8,7 @@
 #ifndef MIR_FRONTEND_WAYLAND_RELATIVE_POINTER_UNSTABLE_V1_XML_WRAPPER
 #define MIR_FRONTEND_WAYLAND_RELATIVE_POINTER_UNSTABLE_V1_XML_WRAPPER
 
-#include <experimental/optional>
+#include <optional>
 
 #include "mir/fd.h"
 #include <wayland-server-core.h>

--- a/src/wayland/generated/virtual-keyboard-unstable-v1_wrapper.h
+++ b/src/wayland/generated/virtual-keyboard-unstable-v1_wrapper.h
@@ -8,7 +8,7 @@
 #ifndef MIR_FRONTEND_WAYLAND_VIRTUAL_KEYBOARD_UNSTABLE_V1_XML_WRAPPER
 #define MIR_FRONTEND_WAYLAND_VIRTUAL_KEYBOARD_UNSTABLE_V1_XML_WRAPPER
 
-#include <experimental/optional>
+#include <optional>
 
 #include "mir/fd.h"
 #include <wayland-server-core.h>

--- a/src/wayland/generated/wayland_wrapper.cpp
+++ b/src/wayland/generated/wayland_wrapper.cpp
@@ -621,7 +621,7 @@ struct mw::DataOffer::Thunks
 
     static void accept_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial, char const* mime_type)
     {
-        std::experimental::optional<std::string> mime_type_resolved;
+        std::optional<std::string> mime_type_resolved;
         if (mime_type != nullptr)
         {
             mime_type_resolved = {mime_type};
@@ -880,7 +880,7 @@ mw::DataSource::~DataSource()
     wl_resource_set_implementation(resource, nullptr, nullptr, nullptr);
 }
 
-void mw::DataSource::send_target_event(std::experimental::optional<std::string> const& mime_type) const
+void mw::DataSource::send_target_event(std::optional<std::string> const& mime_type) const
 {
     const char* mime_type_resolved = nullptr;
     if (mime_type)
@@ -972,12 +972,12 @@ struct mw::DataDevice::Thunks
 
     static void start_drag_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* source, struct wl_resource* origin, struct wl_resource* icon, uint32_t serial)
     {
-        std::experimental::optional<struct wl_resource*> source_resolved;
+        std::optional<struct wl_resource*> source_resolved;
         if (source != nullptr)
         {
             source_resolved = {source};
         }
-        std::experimental::optional<struct wl_resource*> icon_resolved;
+        std::optional<struct wl_resource*> icon_resolved;
         if (icon != nullptr)
         {
             icon_resolved = {icon};
@@ -999,7 +999,7 @@ struct mw::DataDevice::Thunks
 
     static void set_selection_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* source, uint32_t serial)
     {
-        std::experimental::optional<struct wl_resource*> source_resolved;
+        std::optional<struct wl_resource*> source_resolved;
         if (source != nullptr)
         {
             source_resolved = {source};
@@ -1073,7 +1073,7 @@ void mw::DataDevice::send_data_offer_event(struct wl_resource* id) const
     wl_resource_post_event(resource, Opcode::data_offer, id);
 }
 
-void mw::DataDevice::send_enter_event(uint32_t serial, struct wl_resource* surface, double x, double y, std::experimental::optional<struct wl_resource*> const& id) const
+void mw::DataDevice::send_enter_event(uint32_t serial, struct wl_resource* surface, double x, double y, std::optional<struct wl_resource*> const& id) const
 {
     wl_fixed_t x_resolved{wl_fixed_from_double(x)};
     wl_fixed_t y_resolved{wl_fixed_from_double(y)};
@@ -1102,7 +1102,7 @@ void mw::DataDevice::send_drop_event() const
     wl_resource_post_event(resource, Opcode::drop);
 }
 
-void mw::DataDevice::send_selection_event(std::experimental::optional<struct wl_resource*> const& id) const
+void mw::DataDevice::send_selection_event(std::optional<struct wl_resource*> const& id) const
 {
     struct wl_resource* id_resolved = nullptr;
     if (id)
@@ -1544,7 +1544,7 @@ struct mw::ShellSurface::Thunks
 
     static void set_fullscreen_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t method, uint32_t framerate, struct wl_resource* output)
     {
-        std::experimental::optional<struct wl_resource*> output_resolved;
+        std::optional<struct wl_resource*> output_resolved;
         if (output != nullptr)
         {
             output_resolved = {output};
@@ -1583,7 +1583,7 @@ struct mw::ShellSurface::Thunks
 
     static void set_maximized_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* output)
     {
-        std::experimental::optional<struct wl_resource*> output_resolved;
+        std::optional<struct wl_resource*> output_resolved;
         if (output != nullptr)
         {
             output_resolved = {output};
@@ -1790,7 +1790,7 @@ struct mw::Surface::Thunks
 
     static void attach_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* buffer, int32_t x, int32_t y)
     {
-        std::experimental::optional<struct wl_resource*> buffer_resolved;
+        std::optional<struct wl_resource*> buffer_resolved;
         if (buffer != nullptr)
         {
             buffer_resolved = {buffer};
@@ -1853,7 +1853,7 @@ struct mw::Surface::Thunks
 
     static void set_opaque_region_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* region)
     {
-        std::experimental::optional<struct wl_resource*> region_resolved;
+        std::optional<struct wl_resource*> region_resolved;
         if (region != nullptr)
         {
             region_resolved = {region};
@@ -1875,7 +1875,7 @@ struct mw::Surface::Thunks
 
     static void set_input_region_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* region)
     {
-        std::experimental::optional<struct wl_resource*> region_resolved;
+        std::optional<struct wl_resource*> region_resolved;
         if (region != nullptr)
         {
             region_resolved = {region};
@@ -2296,7 +2296,7 @@ struct mw::Pointer::Thunks
 
     static void set_cursor_thunk(struct wl_client* client, struct wl_resource* resource, uint32_t serial, struct wl_resource* surface, int32_t hotspot_x, int32_t hotspot_y)
     {
-        std::experimental::optional<struct wl_resource*> surface_resolved;
+        std::optional<struct wl_resource*> surface_resolved;
         if (surface != nullptr)
         {
             surface_resolved = {surface};

--- a/src/wayland/generated/wayland_wrapper.h
+++ b/src/wayland/generated/wayland_wrapper.h
@@ -8,7 +8,7 @@
 #ifndef MIR_FRONTEND_WAYLAND_WAYLAND_XML_WRAPPER
 #define MIR_FRONTEND_WAYLAND_WAYLAND_XML_WRAPPER
 
-#include <experimental/optional>
+#include <optional>
 
 #include "mir/fd.h"
 #include <wayland-server-core.h>
@@ -305,7 +305,7 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void accept(uint32_t serial, std::experimental::optional<std::string> const& mime_type) = 0;
+    virtual void accept(uint32_t serial, std::optional<std::string> const& mime_type) = 0;
     virtual void receive(std::string const& mime_type, mir::Fd fd) = 0;
     virtual void finish() = 0;
     virtual void set_actions(uint32_t dnd_actions, uint32_t preferred_action) = 0;
@@ -321,7 +321,7 @@ public:
     DataSource(struct wl_resource* resource, Version<3>);
     virtual ~DataSource();
 
-    void send_target_event(std::experimental::optional<std::string> const& mime_type) const;
+    void send_target_event(std::optional<std::string> const& mime_type) const;
     void send_send_event(std::string const& mime_type, mir::Fd fd) const;
     void send_cancelled_event() const;
     bool version_supports_dnd_drop_performed();
@@ -370,11 +370,11 @@ public:
     virtual ~DataDevice();
 
     void send_data_offer_event(struct wl_resource* id) const;
-    void send_enter_event(uint32_t serial, struct wl_resource* surface, double x, double y, std::experimental::optional<struct wl_resource*> const& id) const;
+    void send_enter_event(uint32_t serial, struct wl_resource* surface, double x, double y, std::optional<struct wl_resource*> const& id) const;
     void send_leave_event() const;
     void send_motion_event(uint32_t time, double x, double y) const;
     void send_drop_event() const;
-    void send_selection_event(std::experimental::optional<struct wl_resource*> const& id) const;
+    void send_selection_event(std::optional<struct wl_resource*> const& id) const;
 
     struct wl_client* const client;
     struct wl_resource* const resource;
@@ -399,8 +399,8 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void start_drag(std::experimental::optional<struct wl_resource*> const& source, struct wl_resource* origin, std::experimental::optional<struct wl_resource*> const& icon, uint32_t serial) = 0;
-    virtual void set_selection(std::experimental::optional<struct wl_resource*> const& source, uint32_t serial) = 0;
+    virtual void start_drag(std::optional<struct wl_resource*> const& source, struct wl_resource* origin, std::optional<struct wl_resource*> const& icon, uint32_t serial) = 0;
+    virtual void set_selection(std::optional<struct wl_resource*> const& source, uint32_t serial) = 0;
 };
 
 class DataDeviceManager : public Resource
@@ -549,9 +549,9 @@ private:
     virtual void resize(struct wl_resource* seat, uint32_t serial, uint32_t edges) = 0;
     virtual void set_toplevel() = 0;
     virtual void set_transient(struct wl_resource* parent, int32_t x, int32_t y, uint32_t flags) = 0;
-    virtual void set_fullscreen(uint32_t method, uint32_t framerate, std::experimental::optional<struct wl_resource*> const& output) = 0;
+    virtual void set_fullscreen(uint32_t method, uint32_t framerate, std::optional<struct wl_resource*> const& output) = 0;
     virtual void set_popup(struct wl_resource* seat, uint32_t serial, struct wl_resource* parent, int32_t x, int32_t y, uint32_t flags) = 0;
-    virtual void set_maximized(std::experimental::optional<struct wl_resource*> const& output) = 0;
+    virtual void set_maximized(std::optional<struct wl_resource*> const& output) = 0;
     virtual void set_title(std::string const& title) = 0;
     virtual void set_class(std::string const& class_) = 0;
 };
@@ -589,11 +589,11 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void attach(std::experimental::optional<struct wl_resource*> const& buffer, int32_t x, int32_t y) = 0;
+    virtual void attach(std::optional<struct wl_resource*> const& buffer, int32_t x, int32_t y) = 0;
     virtual void damage(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
     virtual void frame(struct wl_resource* callback) = 0;
-    virtual void set_opaque_region(std::experimental::optional<struct wl_resource*> const& region) = 0;
-    virtual void set_input_region(std::experimental::optional<struct wl_resource*> const& region) = 0;
+    virtual void set_opaque_region(std::optional<struct wl_resource*> const& region) = 0;
+    virtual void set_input_region(std::optional<struct wl_resource*> const& region) = 0;
     virtual void commit() = 0;
     virtual void set_buffer_transform(int32_t transform) = 0;
     virtual void set_buffer_scale(int32_t scale) = 0;
@@ -722,7 +722,7 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void set_cursor(uint32_t serial, std::experimental::optional<struct wl_resource*> const& surface, int32_t hotspot_x, int32_t hotspot_y) = 0;
+    virtual void set_cursor(uint32_t serial, std::optional<struct wl_resource*> const& surface, int32_t hotspot_x, int32_t hotspot_y) = 0;
 };
 
 class Keyboard : public Resource

--- a/src/wayland/generated/wlr-foreign-toplevel-management-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-foreign-toplevel-management-unstable-v1_wrapper.cpp
@@ -316,7 +316,7 @@ struct mw::ForeignToplevelHandleV1::Thunks
 
     static void set_fullscreen_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* output)
     {
-        std::experimental::optional<struct wl_resource*> output_resolved;
+        std::optional<struct wl_resource*> output_resolved;
         if (output != nullptr)
         {
             output_resolved = {output};

--- a/src/wayland/generated/wlr-foreign-toplevel-management-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-foreign-toplevel-management-unstable-v1_wrapper.h
@@ -8,7 +8,7 @@
 #ifndef MIR_FRONTEND_WAYLAND_WLR_FOREIGN_TOPLEVEL_MANAGEMENT_UNSTABLE_V1_XML_WRAPPER
 #define MIR_FRONTEND_WAYLAND_WLR_FOREIGN_TOPLEVEL_MANAGEMENT_UNSTABLE_V1_XML_WRAPPER
 
-#include <experimental/optional>
+#include <optional>
 
 #include "mir/fd.h"
 #include <wayland-server-core.h>
@@ -124,7 +124,7 @@ private:
     virtual void activate(struct wl_resource* seat) = 0;
     virtual void close() = 0;
     virtual void set_rectangle(struct wl_resource* surface, int32_t x, int32_t y, int32_t width, int32_t height) = 0;
-    virtual void set_fullscreen(std::experimental::optional<struct wl_resource*> const& output) = 0;
+    virtual void set_fullscreen(std::optional<struct wl_resource*> const& output) = 0;
     virtual void unset_fullscreen() = 0;
 };
 

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.cpp
@@ -54,7 +54,7 @@ struct mw::LayerShellV1::Thunks
             wl_client_post_no_memory(client);
             BOOST_THROW_EXCEPTION((std::bad_alloc{}));
         }
-        std::experimental::optional<struct wl_resource*> output_resolved;
+        std::optional<struct wl_resource*> output_resolved;
         if (output != nullptr)
         {
             output_resolved = {output};

--- a/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
+++ b/src/wayland/generated/wlr-layer-shell-unstable-v1_wrapper.h
@@ -8,7 +8,7 @@
 #ifndef MIR_FRONTEND_WAYLAND_WLR_LAYER_SHELL_UNSTABLE_V1_XML_WRAPPER
 #define MIR_FRONTEND_WAYLAND_WLR_LAYER_SHELL_UNSTABLE_V1_XML_WRAPPER
 
-#include <experimental/optional>
+#include <optional>
 
 #include "mir/fd.h"
 #include <wayland-server-core.h>
@@ -68,7 +68,7 @@ public:
     };
 
 private:
-    virtual void get_layer_surface(struct wl_resource* id, struct wl_resource* surface, std::experimental::optional<struct wl_resource*> const& output, uint32_t layer, std::string const& namespace_) = 0;
+    virtual void get_layer_surface(struct wl_resource* id, struct wl_resource* surface, std::optional<struct wl_resource*> const& output, uint32_t layer, std::string const& namespace_) = 0;
 };
 
 class LayerSurfaceV1 : public Resource

--- a/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
+++ b/src/wayland/generated/xdg-output-unstable-v1_wrapper.h
@@ -8,7 +8,7 @@
 #ifndef MIR_FRONTEND_WAYLAND_XDG_OUTPUT_UNSTABLE_V1_XML_WRAPPER
 #define MIR_FRONTEND_WAYLAND_XDG_OUTPUT_UNSTABLE_V1_XML_WRAPPER
 
-#include <experimental/optional>
+#include <optional>
 
 #include "mir/fd.h"
 #include <wayland-server-core.h>

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.cpp
@@ -624,7 +624,7 @@ struct mw::XdgToplevelV6::Thunks
 
     static void set_parent_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* parent)
     {
-        std::experimental::optional<struct wl_resource*> parent_resolved;
+        std::optional<struct wl_resource*> parent_resolved;
         if (parent != nullptr)
         {
             parent_resolved = {parent};
@@ -799,7 +799,7 @@ struct mw::XdgToplevelV6::Thunks
 
     static void set_fullscreen_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* output)
     {
-        std::experimental::optional<struct wl_resource*> output_resolved;
+        std::optional<struct wl_resource*> output_resolved;
         if (output != nullptr)
         {
             output_resolved = {output};

--- a/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
+++ b/src/wayland/generated/xdg-shell-unstable-v6_wrapper.h
@@ -8,7 +8,7 @@
 #ifndef MIR_FRONTEND_WAYLAND_XDG_SHELL_UNSTABLE_V6_XML_WRAPPER
 #define MIR_FRONTEND_WAYLAND_XDG_SHELL_UNSTABLE_V6_XML_WRAPPER
 
-#include <experimental/optional>
+#include <optional>
 
 #include "mir/fd.h"
 #include <wayland-server-core.h>
@@ -224,7 +224,7 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void set_parent(std::experimental::optional<struct wl_resource*> const& parent) = 0;
+    virtual void set_parent(std::optional<struct wl_resource*> const& parent) = 0;
     virtual void set_title(std::string const& title) = 0;
     virtual void set_app_id(std::string const& app_id) = 0;
     virtual void show_window_menu(struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y) = 0;
@@ -234,7 +234,7 @@ private:
     virtual void set_min_size(int32_t width, int32_t height) = 0;
     virtual void set_maximized() = 0;
     virtual void unset_maximized() = 0;
-    virtual void set_fullscreen(std::experimental::optional<struct wl_resource*> const& output) = 0;
+    virtual void set_fullscreen(std::optional<struct wl_resource*> const& output) = 0;
     virtual void unset_fullscreen() = 0;
     virtual void set_minimized() = 0;
 };

--- a/src/wayland/generated/xdg-shell_wrapper.cpp
+++ b/src/wayland/generated/xdg-shell_wrapper.cpp
@@ -477,7 +477,7 @@ struct mw::XdgSurface::Thunks
             wl_client_post_no_memory(client);
             BOOST_THROW_EXCEPTION((std::bad_alloc{}));
         }
-        std::experimental::optional<struct wl_resource*> parent_resolved;
+        std::optional<struct wl_resource*> parent_resolved;
         if (parent != nullptr)
         {
             parent_resolved = {parent};
@@ -629,7 +629,7 @@ struct mw::XdgToplevel::Thunks
 
     static void set_parent_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* parent)
     {
-        std::experimental::optional<struct wl_resource*> parent_resolved;
+        std::optional<struct wl_resource*> parent_resolved;
         if (parent != nullptr)
         {
             parent_resolved = {parent};
@@ -804,7 +804,7 @@ struct mw::XdgToplevel::Thunks
 
     static void set_fullscreen_thunk(struct wl_client* client, struct wl_resource* resource, struct wl_resource* output)
     {
-        std::experimental::optional<struct wl_resource*> output_resolved;
+        std::optional<struct wl_resource*> output_resolved;
         if (output != nullptr)
         {
             output_resolved = {output};

--- a/src/wayland/generated/xdg-shell_wrapper.h
+++ b/src/wayland/generated/xdg-shell_wrapper.h
@@ -8,7 +8,7 @@
 #ifndef MIR_FRONTEND_WAYLAND_XDG_SHELL_XML_WRAPPER
 #define MIR_FRONTEND_WAYLAND_XDG_SHELL_XML_WRAPPER
 
-#include <experimental/optional>
+#include <optional>
 
 #include "mir/fd.h"
 #include <wayland-server-core.h>
@@ -179,7 +179,7 @@ public:
 
 private:
     virtual void get_toplevel(struct wl_resource* id) = 0;
-    virtual void get_popup(struct wl_resource* id, std::experimental::optional<struct wl_resource*> const& parent, struct wl_resource* positioner) = 0;
+    virtual void get_popup(struct wl_resource* id, std::optional<struct wl_resource*> const& parent, struct wl_resource* positioner) = 0;
     virtual void set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height) = 0;
     virtual void ack_configure(uint32_t serial) = 0;
 };
@@ -232,7 +232,7 @@ public:
     static bool is_instance(wl_resource* resource);
 
 private:
-    virtual void set_parent(std::experimental::optional<struct wl_resource*> const& parent) = 0;
+    virtual void set_parent(std::optional<struct wl_resource*> const& parent) = 0;
     virtual void set_title(std::string const& title) = 0;
     virtual void set_app_id(std::string const& app_id) = 0;
     virtual void show_window_menu(struct wl_resource* seat, uint32_t serial, int32_t x, int32_t y) = 0;
@@ -242,7 +242,7 @@ private:
     virtual void set_min_size(int32_t width, int32_t height) = 0;
     virtual void set_maximized() = 0;
     virtual void unset_maximized() = 0;
-    virtual void set_fullscreen(std::experimental::optional<struct wl_resource*> const& output) = 0;
+    virtual void set_fullscreen(std::optional<struct wl_resource*> const& output) = 0;
     virtual void unset_fullscreen() = 0;
     virtual void set_minimized() = 0;
 };

--- a/src/wayland/generator/argument.cpp
+++ b/src/wayland/generator/argument.cpp
@@ -71,7 +71,7 @@ Emitter string_mir2wl(Argument const* me)
 Emitter optional_object_wl2mir(Argument const* me)
 {
     return Lines{
-        {"std::experimental::optional<struct wl_resource*> ", me->name, "_resolved;"},
+        {"std::optional<struct wl_resource*> ", me->name, "_resolved;"},
         {"if (", me->name, " != nullptr)"},
         Block{
             {me->name, "_resolved = {", me->name, "};"}
@@ -93,7 +93,7 @@ Emitter optional_object_mir2wl(Argument const* me)
 Emitter optional_string_wl2mir(Argument const* me)
 {
     return Lines{
-        {"std::experimental::optional<std::string> ", me->name, "_resolved;"},
+        {"std::optional<std::string> ", me->name, "_resolved;"},
         {"if (", me->name, " != nullptr)"},
         Block{
             {me->name, "_resolved = {", me->name, "};"}
@@ -124,8 +124,8 @@ std::unordered_map<std::string, Argument::TypeDescriptor const> const request_ty
 };
 
 std::unordered_map<std::string, Argument::TypeDescriptor const> const request_optional_type_map = {
-    { "object", { "std::experimental::optional<struct wl_resource*> const&", "struct wl_resource*", "?o", { optional_object_wl2mir } }},
-    { "string", { "std::experimental::optional<std::string> const&", "char const*",  "?s",{ optional_string_wl2mir } }},
+    { "object", { "std::optional<struct wl_resource*> const&", "struct wl_resource*", "?o", { optional_object_wl2mir } }},
+    { "string", { "std::optional<std::string> const&", "char const*",  "?s",{ optional_string_wl2mir } }},
 };
 
 std::unordered_map<std::string, Argument::TypeDescriptor const> const event_type_map = {
@@ -140,8 +140,8 @@ std::unordered_map<std::string, Argument::TypeDescriptor const> const event_type
 };
 
 std::unordered_map<std::string, Argument::TypeDescriptor const> const event_optional_type_map = {
-    { "object", { "std::experimental::optional<struct wl_resource*> const&", "struct wl_resource*", "?o", {optional_object_mir2wl} }},
-    { "string", { "std::experimental::optional<std::string> const&", "char const*", "?s", { optional_string_mir2wl } }},
+    { "object", { "std::optional<struct wl_resource*> const&", "struct wl_resource*", "?o", {optional_object_mir2wl} }},
+    { "string", { "std::optional<std::string> const&", "char const*", "?s", { optional_string_mir2wl } }},
 };
 }
 

--- a/src/wayland/generator/wrapper_generator.cpp
+++ b/src/wayland/generator/wrapper_generator.cpp
@@ -46,7 +46,7 @@ Emitter include_guard_top(std::string const& macro)
 Emitter header_includes()
 {
     return Lines{
-        "#include <experimental/optional>",
+        "#include <optional>",
         empty_line,
         "#include \"mir/fd.h\"",
         "#include <wayland-server-core.h>",

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -1,4 +1,4 @@
-MIRWAYLAND_2.0 {
+MIRWAYLAND_2.5 {
 global:
   extern "C++" {
     mir::wayland::Buffer::*;
@@ -329,13 +329,7 @@ global:
     virtual?thunk?to?mir::wayland::XdgToplevelV6::?XdgToplevelV6*;
     virtual?thunk?to?mir::wayland::XdgToplevel::?XdgToplevel*;
     virtual?thunk?to?mir::wayland::XdgWmBase::?XdgWmBase*;
-  };
-  local: *;
-};
 
-MIRWAYLAND_2.1 {
-global:
-  extern "C++" {
     mir::wayland::ForeignToplevelManagerV1::*;
     non-virtual?thunk?to?mir::wayland::ForeignToplevelManagerV1::*;
     virtual?thunk?to?mir::wayland::ForeignToplevelManagerV1::?ForeignToplevelManagerV1*;
@@ -360,12 +354,7 @@ global:
     mir::wayland::ProtocolError::resource*;
     typeinfo?for?mir::wayland::ProtocolError;
     vtable?for?mir::wayland::ProtocolError;
-  };
-} MIRWAYLAND_2.0;
 
-MIRWAYLAND_2.2.1 {
-global:
-  extern "C++" {
     mir::wayland::PointerConstraintsV1::*;
     non-virtual?thunk?to?mir::wayland::PointerConstraintsV1::*;
     typeinfo?for?mir::wayland::PointerConstraintsV1;
@@ -399,12 +388,7 @@ global:
     typeinfo?for?mir::wayland::RelativePointerV1;
     vtable?for?mir::wayland::RelativePointerV1;
     virtual?thunk?to?mir::wayland::RelativePointerV1::?RelativePointerV1*;
-  };
-} MIRWAYLAND_2.1;
 
-MIRWAYLAND_2.5 {
-global:
-  extern "C++" {
     mir::wayland::VirtualKeyboardManagerV1::*;
     non-virtual?thunk?to?mir::wayland::VirtualKeyboardManagerV1::*;
     typeinfo?for?mir::wayland::VirtualKeyboardManagerV1;
@@ -419,4 +403,5 @@ global:
     vtable?for?mir::wayland::VirtualKeyboardV1;
     virtual?thunk?to?mir::wayland::VirtualKeyboardV1::?VirtualKeyboardV1*;
   };
-} MIRWAYLAND_2.2.1;
+  local: *;
+};

--- a/tests/miral/generated/server-decoration_wrapper.h
+++ b/tests/miral/generated/server-decoration_wrapper.h
@@ -8,7 +8,7 @@
 #ifndef MIR_FRONTEND_WAYLAND_SERVER_DECORATION_XML_WRAPPER
 #define MIR_FRONTEND_WAYLAND_SERVER_DECORATION_XML_WRAPPER
 
-#include <experimental/optional>
+#include <optional>
 
 #include "mir/fd.h"
 #include <wayland-server-core.h>


### PR DESCRIPTION
We've been on C++17 for quite a while. Inconsistent usage of `std::experimental::optional` was annoying me. Better to pull the band aid off all at once than clutter up the diffs of a bunch of future PRs.