### PR TITLE
Layer shell: allow destroying surface before the role object

### DIFF
--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -188,6 +188,7 @@ private:
         std::optional<geometry::Point> const& /*new_top_left*/,
         geometry::Size const& /*new_size*/) override;
     void handle_close_request() override;
+    void surface_destroyed() override;
 
     DoubleBuffered<uint32_t> exclusive_zone{0};
     DoubleBuffered<Anchors> anchors;
@@ -659,4 +660,11 @@ void mf::LayerSurfaceV1::handle_resize(
 void mf::LayerSurfaceV1::handle_close_request()
 {
     send_closed_event();
+}
+
+void mf::LayerSurfaceV1::surface_destroyed()
+{
+    // Squeekboard (and possibly other purism apps) violate the protocol by destroying the surface before the role.
+    // Until it gets fixed we ignore this error for layer shell specifically.
+    // See: https://gitlab.gnome.org/World/Phosh/squeekboard/-/issues/285
 }

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -667,4 +667,12 @@ void mf::LayerSurfaceV1::surface_destroyed()
     // Squeekboard (and possibly other purism apps) violate the protocol by destroying the surface before the role.
     // Until it gets fixed we ignore this error for layer shell specifically.
     // See: https://gitlab.gnome.org/World/Phosh/squeekboard/-/issues/285
+    try
+    {
+        WindowWlSurfaceRole::surface_destroyed();
+    }
+    catch (std::exception const& err)
+    {
+        log_warning("Ignoring layer shell protocol violation: %s", err.what());
+    }
 }

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -403,11 +403,12 @@ auto mf::WindowWlSurfaceRole::latest_timestamp() const -> std::chrono::nanosecon
 
 void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
 {
-    if (surface)
+    if (!surface)
     {
-        surface.value().commit(state);
+        return;
     }
 
+    surface.value().commit(state);
     handle_commit();
 
     auto size = pending_size();
@@ -416,7 +417,7 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
     if (auto const scene_surface = weak_scene_surface.lock())
     {
         bool const is_mapped = scene_surface->visible();
-        bool const should_be_mapped = surface && static_cast<bool>(surface.value().buffer_size());
+        bool const should_be_mapped = static_cast<bool>(surface.value().buffer_size());
         if (!is_mapped && should_be_mapped && scene_surface->state() == mir_window_state_hidden)
         {
             spec().state = mir_window_state_restored;

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -470,6 +470,7 @@ void mf::WindowWlSurfaceRole::surface_destroyed()
     {
         // "When a client wants to destroy a wl_surface, they must destroy this 'role object' before the wl_surface"
         // NOTE: the wl_shell_surface specification seems contradictory, so this method is overridden in it's implementation
+        // NOTE: it's also overridden in layer shell, for reasons explained there
         BOOST_THROW_EXCEPTION(std::runtime_error{
             "wl_surface@" +
             (surface ? std::to_string(wl_resource_get_id(surface.value().resource)) : "?") +

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -124,7 +124,7 @@ protected:
     void surface_destroyed() override;
 
 private:
-    WlSurface* const surface;
+    wayland::Weak<WlSurface> const surface;
     wayland::Weak<WlClient> const weak_client;
     std::shared_ptr<shell::Shell> const shell;
     std::shared_ptr<scene::Session> const session;


### PR DESCRIPTION
As noted in my old bug report [here](https://gitlab.gnome.org/World/Phosh/squeekboard/-/issues/285), Squeekboard violates the protocol when it closes it's layer surface. Currently on Mir, this causes it to be disconnected. With several days to a week of time investment I could probably solve this, which may or may not get merged upstream in a timely manor. In possibly a little less time I could make a patch for wlroots which would force all clients to do the right thing, which again may or may not be merged.

In the short term we need Squeekboard to work. This PR allows the protocol violation in Mir. In `WindowWlSurfaceRole`, `surface` had to be changed to a `wayland::Weak` to make these changes safe.

Part of #2139