### PR TITLE
[Wayland-platform] Don't block forever in swap_buffers

### DIFF
--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -388,7 +388,7 @@ void mgw::DisplayClient::Output::swap_buffers()
         void wait_for_done()
         {
             std::unique_lock<decltype(mutex)> lock{mutex};
-            cv.wait(lock, [this]{ return posted; });
+            cv.wait_for(lock, std::chrono::milliseconds{100}, [this]{ return posted; });
         }
 
         std::mutex mutex;


### PR DESCRIPTION
When the display turns off on a Mesa system, the mir_frontend's swap_buffers will hang after one successful frame. This is because Mesa throttles Wayland frame callbacks to no more than one per vsync, and the vsync has stopped when the display is off.

This causes Mir servers using the Wayland platform to hang from the time the display turns off until it turns back on. This was a particular problem for Lomiri since the Qt main thread has to sync with the render thread. So blocking the render thread also blocks the main thread. [1]

If we just don't wait *forever* for frame callbacks, we don't end up hanging the rendering thread indefinitely.

This probably isn't 100% of the correct solution. See the discussion in [2] for more information on the whole right solution.

[1] https://gitlab.com/ubports/core/lomiri-system-compositor/-/issues/11
[2] https://github.com/MirServer/mir/issues/2136