### PR TITLE
Run the mir_performance_tests and mir-smoke-test-runner tests under Xvfb

### DIFF
--- a/spread/build/alpine/task.yaml
+++ b/spread/build/alpine/task.yaml
@@ -31,7 +31,11 @@ execute: |
         py3-pillow \
         umockdev-dev \
         wayland-dev \
-        yaml-cpp-dev
+        yaml-cpp-dev \
+        xvfb \
+        xauth \
+        xwayland \
+        breeze
 
     BUILD_DIR=$(mktemp -d)
     cmake -H$SPREAD_PATH -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DMIR_USE_LD=ld -DMIR_ENABLE_WLCS_TESTS=OFF

--- a/spread/build/alpine/task.yaml
+++ b/spread/build/alpine/task.yaml
@@ -36,7 +36,7 @@ execute: |
         xvfb-run \
         xauth \
         xwayland \
-        breeze
+        dmz-cursor-theme
 
     BUILD_DIR=$(mktemp -d)
     cmake -H$SPREAD_PATH -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DMIR_USE_LD=ld -DMIR_ENABLE_WLCS_TESTS=OFF

--- a/spread/build/alpine/task.yaml
+++ b/spread/build/alpine/task.yaml
@@ -36,7 +36,7 @@ execute: |
         xvfb-run \
         xauth \
         xwayland \
-        dmz-cursor-theme
+        capitaine-cursors
 
     BUILD_DIR=$(mktemp -d)
     cmake -H$SPREAD_PATH -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DMIR_USE_LD=ld -DMIR_ENABLE_WLCS_TESTS=OFF

--- a/spread/build/alpine/task.yaml
+++ b/spread/build/alpine/task.yaml
@@ -33,6 +33,7 @@ execute: |
         wayland-dev \
         yaml-cpp-dev \
         xvfb \
+        xvfb-run \
         xauth \
         xwayland \
         breeze

--- a/spread/build/fedora/task.yaml
+++ b/spread/build/fedora/task.yaml
@@ -43,6 +43,15 @@ execute: |
         systemtap-sdt-devel \
         libdrm-devel
 
+    ## Would enables mir_performance_tests and mir-smoke-test-runner tests - but they fail weirdly
+    # dnf install --assumeyes --allowerasing \
+    #    xorg-x11-server-Xvfb \
+    #    xorg-x11-xauth \
+    #    xorg-x11-server-Xwayland \
+    #    glmark2 \
+    #    dmz-cursor-themes \
+    #    mesa-dri-drivers
+
     BUILD_DIR=$(mktemp --directory)
     cmake -H$SPREAD_PATH -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DMIR_ENABLE_WLCS_TESTS=OFF
     # Run cmake again to pick up wlcs?!?!?!?!

--- a/spread/build/sbuild/task.yaml
+++ b/spread/build/sbuild/task.yaml
@@ -58,14 +58,9 @@ execute: |
       # if not cross-building
       if [ "${DEB_BUILD_ARCH}" = "${DEB_HOST_ARCH}" ]; then
         # Add mir-smoke-test-runner dependencies
-        apt-get install \
-          --yes \
-          --no-install-recommends \
-          xvfb \
-          xauth \
-          xwayland \
-          dmz-cursor-theme \
-          glmark2-es2-wayland
+        SBUILD_OPTS+=(
+          --pre-build-commands="apt-get install --yes --no-install-recommends xvfb xauth xwayland dmz-cursor-theme glmark2-es2-wayland"
+        )
       fi
     fi
 

--- a/spread/build/sbuild/task.yaml
+++ b/spread/build/sbuild/task.yaml
@@ -54,6 +54,19 @@ execute: |
         --extra-repository="deb http://ppa.launchpad.net/mir-team/dev/ubuntu ${RELEASE} main"
         --extra-repository-key=${SPREAD_PATH}/${SPREAD_TASK}/mir-team.asc
       )
+
+      # if not cross-building
+      if [ "${DEB_BUILD_ARCH}" = "${DEB_HOST_ARCH}" ]; then
+        # Add mir-smoke-test-runner dependencies
+        apt-get install \
+          --yes \
+          --no-install-recommends \
+          xvfb \
+          xauth \
+          xwayland \
+          dmz-cursor-theme \
+          glmark2-es2-wayland
+      fi
     fi
 
     # Cross building

--- a/tests/performance-tests/CMakeLists.txt
+++ b/tests/performance-tests/CMakeLists.txt
@@ -17,3 +17,17 @@ add_custom_target(mir-smoke-test-runner ALL
 install(PROGRAMS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir-smoke-test-runner
     DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
 )
+
+find_program(XVFB_RUN_EXECUTABLE xvfb-run)
+if(XVFB_RUN_EXECUTABLE)
+  find_program(GLMARK2_EXECUTABLE glmark2-es2-wayland)
+  if(GLMARK2_EXECUTABLE)
+    mir_add_test(NAME mir_performance_tests
+      COMMAND "xvfb-run" "--auto-servernum" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir_performance_tests"
+    )
+  endif()
+
+  mir_add_test(NAME mir-smoke-test-runner
+      COMMAND "xvfb-run" "--auto-servernum" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir-smoke-test-runner"
+  )
+endif()

--- a/tools/mir-smoke-test-runner.sh
+++ b/tools/mir-smoke-test-runner.sh
@@ -23,6 +23,8 @@ client_list=`find ${root} -name mir_demo_client_* | grep -v bin$ | sed s?${root}
 echo "I: client_list=" ${client_list}
 
 ### Run Tests ###
+# The CI environment sets this test-specific env var, mir_demo_server doesn't know it
+unset MIR_SERVER_LOGGING
 
 # Start with eglinfo for the system
 echo Running eglinfo client
@@ -32,6 +34,12 @@ WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-cli
 date --utc --iso-8601=seconds | xargs echo "[timestamp] End :" ${client}
 
 for client in ${client_list}; do
+  if [[ "$XAUTHORITY" =~ .*xvfb-run.* ]]; then
+    if [[ "${client}" = mir_demo_client_wayland_egl_spinner ]]; then
+      # Skipped because of https://github.com/MirServer/mir/issues/2154
+      continue
+    fi
+  fi
     echo running client ${client}
     date --utc --iso-8601=seconds | xargs echo "[timestamp] Start :" ${client}
     echo WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client ${root}/${client}


### PR DESCRIPTION
This adds tests that uses Xvfb to run the mir_performance_tests and mir-smoke-test-runner tests. These tests are enabled when `xvfb-run` exists (and also `glmark2-es2-wayland` for mir_performance_tests).

In CI we run these tests wherever we can do so reliably (by adding the above programs):

1. In "sbuild" jobs we can run both mir_performance_tests and mir-smoke-test-runner tests
2. On Alpine we can run only the mir-smoke-test-runner tests: The archive is missing a package with glmark2-es2-wayland for mir_performance_tests
3. Running on Fedora, we get odd failures in the xvfb-run script => don't run the tests (yet)
4. In "ubuntu:clang" jobs only the first attempt to connect to Xvfb works => don't run the tests
5. In "ubuntu:rpi" jobs we cross-build => don't run the tests