### PR TITLE
Refactor KeyboardHelper out of WlKeyboard

### DIFF
--- a/include/miral/miral/wayland_extensions.h
+++ b/include/miral/miral/wayland_extensions.h
@@ -127,9 +127,10 @@ public:
     /// \remark Since MirAL 3.3
     static char const* const zwp_virtual_keyboard_v1;
 
-    /// Allows clients (such as on-screen keyboards) to act as a source of text input for other clients.
-    /// Clients are not required to display anything to send input using this extension, so malicious
-    /// clients could use it to take actions without user input.
+    /// Allows clients (such as on-screen keyboards) to intercept physical key events and act as a
+    /// source of text input for other clients. Input methods are not required to display anything
+    /// to use this extension, so malicious clients could use it to intercept keys events or take
+    /// actions without user input.
     /// \remark Since MirAL 3.3
     static char const* const zwp_input_method_v2;
     /** @} */

--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -26,6 +26,7 @@ set(
   window_wl_surface_role.cpp    window_wl_surface_role.h
   wl_surface.cpp                wl_surface.h
   wl_seat.cpp                   wl_seat.h
+  keyboard_helper.cpp           keyboard_helper.h
   wl_keyboard.cpp               wl_keyboard.h
   wl_pointer.cpp                wl_pointer.h
   wl_touch.cpp                  wl_touch.h

--- a/src/server/frontend_wayland/keyboard_helper.cpp
+++ b/src/server/frontend_wayland/keyboard_helper.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright © 2018-2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#include "keyboard_helper.h"
+
+#include "mir/anonymous_shm_file.h"
+#include "mir/input/keymap.h"
+#include "mir/events/keyboard_event.h"
+#include "mir/input/seat.h"
+
+#include <xkbcommon/xkbcommon.h>
+#include <cstring> // memcpy
+#include <unordered_set>
+
+namespace mf = mir::frontend;
+namespace mw = mir::wayland;
+namespace mi = mir::input;
+
+mf::KeyboardHelper::KeyboardHelper(
+    KeyboardImpl* keyboard_impl,
+    std::shared_ptr<mi::Keymap> const& initial_keymap,
+    std::shared_ptr<input::Seat> const& seat,
+    bool enable_key_repeat)
+    : impl{keyboard_impl},
+      mir_seat{seat},
+      current_keymap{nullptr}, // will be set later in the constructor by set_keymap()
+      compiled_keymap{nullptr, &xkb_keymap_unref},
+      state{nullptr, &xkb_state_unref},
+      context{xkb_context_new(XKB_CONTEXT_NO_FLAGS), &xkb_context_unref}
+{
+    /* The wayland::Keyboard constructor has already run, creating the keyboard
+     * resource. It is thus safe to send a keymap event to it; the client will receive
+     * the keyboard object before this event.
+     */
+    set_keymap(initial_keymap);
+
+    // 25 rate and 600 delay are the default in Weston and Sway
+    // At some point we will want to make this configurable
+    impl->send_repeat_info(enable_key_repeat ? 25 : 0, 600);
+}
+
+void mf::KeyboardHelper::handle_event(MirInputEvent const* event)
+{
+    switch (mir_input_event_get_type(event))
+    {
+    case mir_input_event_type_keyboard_resync:
+        refresh_internal_state();
+        break;
+
+    case mir_input_event_type_key:
+        handle_keyboard_event(mir_input_event_get_keyboard_event(event));
+        break;
+
+    default:;
+    }
+}
+
+auto mf::KeyboardHelper::refresh_internal_state() -> std::vector<uint32_t>
+{
+    auto const pressed_keys{pressed_key_scancodes()};
+    // Rebuild xkb state
+    state = decltype(state)(xkb_state_new(compiled_keymap.get()), &xkb_state_unref);
+    for (auto scancode : pressed_keys)
+    {
+        xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_DOWN);
+    }
+
+    update_modifier_state();
+
+    return pressed_keys;
+}
+
+auto mf::KeyboardHelper::pressed_key_scancodes() const -> std::vector<uint32_t>
+{
+    std::unordered_set<uint32_t> pressed_keys;
+    auto const ev = mir_seat->create_device_state();
+    auto const state_event = mir_event_get_input_device_state_event(ev.get());
+    for (
+        auto dev = 0u;
+        dev < mir_input_device_state_event_device_count(state_event);
+        ++dev)
+    {
+        for (
+            auto idx = 0u;
+            idx < mir_input_device_state_event_device_pressed_keys_count(state_event, dev);
+            ++idx)
+        {
+            pressed_keys.insert(
+                mir_input_device_state_event_device_pressed_keys_for_index(
+                    state_event,
+                    dev,
+                    idx));
+        }
+    }
+    return std::vector<uint32_t>{pressed_keys.begin(), pressed_keys.end()};
+}
+
+void mf::KeyboardHelper::handle_keyboard_event(MirKeyboardEvent const* event)
+{
+    bool down;
+    switch (mir_keyboard_event_action(event))
+    {
+    case mir_keyboard_action_down:
+        down = true;
+        break;
+
+    case mir_keyboard_action_up:
+        down = false;
+        break;
+
+    default:
+        return;
+    }
+
+    auto const timestamp = mir_input_event_get_wayland_timestamp(mir_keyboard_event_input_event(event));
+    int const scancode = mir_keyboard_event_scan_code(event);
+
+    set_keymap(event->keymap());
+    impl->send_key(timestamp, scancode, down);
+    /*
+    * HACK! Maintain our own XKB state, so we can serialise it for
+    * wl_keyboard_send_modifiers
+    */
+    xkb_key_direction const xkb_state = down ? XKB_KEY_DOWN : XKB_KEY_UP;
+    xkb_state_update_key(state.get(), scancode + 8, xkb_state);
+    update_modifier_state();
+}
+
+void mf::KeyboardHelper::set_keymap(std::shared_ptr<mi::Keymap> const& new_keymap)
+{
+    if (!new_keymap || new_keymap == current_keymap)
+    {
+        return;
+    }
+
+    if (current_keymap && current_keymap->matches(*new_keymap))
+    {
+        current_keymap = new_keymap;
+        return;
+    }
+
+    current_keymap = new_keymap;
+    compiled_keymap = new_keymap->make_unique_xkb_keymap(context.get());
+
+    // TODO: We might need to copy across the existing depressed keys?
+    state = decltype(state)(xkb_state_new(compiled_keymap.get()), &xkb_state_unref);
+
+    std::unique_ptr<char, void(*)(void*)> buffer{xkb_keymap_get_as_string(
+        compiled_keymap.get(),
+        XKB_KEYMAP_FORMAT_TEXT_V1),
+        free};
+    auto length = strlen(buffer.get());
+
+    mir::AnonymousShmFile shm_buffer{length};
+    memcpy(shm_buffer.base_ptr(), buffer.get(), length);
+
+    impl->send_keymap_xkb_v1(Fd{IntOwnedFd{shm_buffer.fd()}}, length);
+}
+
+void mf::KeyboardHelper::update_modifier_state()
+{
+    // TODO?
+    // assert_on_wayland_event_loop()
+
+    auto new_depressed_mods = xkb_state_serialize_mods(
+        state.get(),
+        XKB_STATE_MODS_DEPRESSED);
+    auto new_latched_mods = xkb_state_serialize_mods(
+        state.get(),
+        XKB_STATE_MODS_LATCHED);
+    auto new_locked_mods = xkb_state_serialize_mods(
+        state.get(),
+        XKB_STATE_MODS_LOCKED);
+    auto new_group = xkb_state_serialize_layout(
+        state.get(),
+        XKB_STATE_LAYOUT_EFFECTIVE);
+
+    if ((new_depressed_mods != mods_depressed) ||
+        (new_latched_mods != mods_latched) ||
+        (new_locked_mods != mods_locked) ||
+        (new_group != group))
+    {
+        mods_depressed = new_depressed_mods;
+        mods_latched = new_latched_mods;
+        mods_locked = new_locked_mods;
+        group = new_group;
+
+        impl->send_modifiers(mods_depressed, mods_latched, mods_locked, group);
+    }
+}

--- a/src/server/frontend_wayland/keyboard_helper.h
+++ b/src/server/frontend_wayland/keyboard_helper.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2018-2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ *              William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_FRONTEND_BASIC_WL_KEYBOARD_H
+#define MIR_FRONTEND_BASIC_WL_KEYBOARD_H
+
+#include "wayland_wrapper.h"
+
+#include <vector>
+#include <functional>
+
+struct MirInputEvent;
+struct MirKeyboardEvent;
+
+// from <xkbcommon/xkbcommon.h>
+struct xkb_keymap;
+struct xkb_state;
+struct xkb_context;
+
+namespace mir
+{
+namespace input
+{
+class Keymap;
+class Seat;
+}
+
+namespace frontend
+{
+class KeyboardImpl
+{
+public:
+    KeyboardImpl() = default;
+    virtual ~KeyboardImpl() = default;
+
+    virtual void send_repeat_info(int32_t rate, int32_t delay) = 0;
+    virtual void send_keymap_xkb_v1(mir::Fd const& fd, size_t length) = 0;
+    virtual void send_key(uint32_t timestamp, int scancode, bool down) = 0;
+    virtual void send_modifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group) = 0;
+
+private:
+    KeyboardImpl(KeyboardImpl const&) = delete;
+    KeyboardImpl& operator=(KeyboardImpl const&) = delete;
+};
+
+class KeyboardHelper
+{
+public:
+    KeyboardHelper(
+        KeyboardImpl* keybaord_impl,
+        std::shared_ptr<mir::input::Keymap> const& initial_keymap,
+        std::shared_ptr<input::Seat> const& seat,
+        bool enable_key_repeat);
+
+    void handle_event(MirInputEvent const* event);
+    /// Returns the scancodes of pressed keys
+    auto refresh_internal_state() -> std::vector<uint32_t>;
+
+private:
+    auto pressed_key_scancodes() const -> std::vector<uint32_t>;
+    void handle_keyboard_event(MirKeyboardEvent const* event);
+    void set_keymap(std::shared_ptr<mir::input::Keymap> const& new_keymap);
+    void update_modifier_state();
+
+    KeyboardImpl* const impl;
+    std::shared_ptr<input::Seat> const mir_seat;
+    std::shared_ptr<mir::input::Keymap> current_keymap;
+    std::unique_ptr<xkb_keymap, void (*)(xkb_keymap *)> compiled_keymap;
+    std::unique_ptr<xkb_state, void (*)(xkb_state *)> state;
+    std::unique_ptr<xkb_context, void (*)(xkb_context *)> const context;
+
+    uint32_t mods_depressed{0};
+    uint32_t mods_latched{0};
+    uint32_t mods_locked{0};
+    uint32_t group{0};
+};
+}
+}
+
+#endif // MIR_FRONTEND_BASIC_WL_KEYBOARD_H

--- a/src/server/frontend_wayland/keyboard_helper.h
+++ b/src/server/frontend_wayland/keyboard_helper.h
@@ -17,8 +17,8 @@
  *              William Wold <william.wold@canonical.com>
  */
 
-#ifndef MIR_FRONTEND_BASIC_WL_KEYBOARD_H
-#define MIR_FRONTEND_BASIC_WL_KEYBOARD_H
+#ifndef MIR_FRONTEND_KEYBOARD_HELPER_H
+#define MIR_FRONTEND_KEYBOARD_HELPER_H
 
 #include "wayland_wrapper.h"
 
@@ -43,11 +43,11 @@ class Seat;
 
 namespace frontend
 {
-class KeyboardImpl
+class KeyboardCallbacks
 {
 public:
-    KeyboardImpl() = default;
-    virtual ~KeyboardImpl() = default;
+    KeyboardCallbacks() = default;
+    virtual ~KeyboardCallbacks() = default;
 
     virtual void send_repeat_info(int32_t rate, int32_t delay) = 0;
     virtual void send_keymap_xkb_v1(mir::Fd const& fd, size_t length) = 0;
@@ -55,15 +55,15 @@ public:
     virtual void send_modifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group) = 0;
 
 private:
-    KeyboardImpl(KeyboardImpl const&) = delete;
-    KeyboardImpl& operator=(KeyboardImpl const&) = delete;
+    KeyboardCallbacks(KeyboardCallbacks const&) = delete;
+    KeyboardCallbacks& operator=(KeyboardCallbacks const&) = delete;
 };
 
 class KeyboardHelper
 {
 public:
     KeyboardHelper(
-        KeyboardImpl* keybaord_impl,
+        KeyboardCallbacks* keybaord_impl,
         std::shared_ptr<mir::input::Keymap> const& initial_keymap,
         std::shared_ptr<input::Seat> const& seat,
         bool enable_key_repeat);
@@ -78,7 +78,7 @@ private:
     void set_keymap(std::shared_ptr<mir::input::Keymap> const& new_keymap);
     void update_modifier_state();
 
-    KeyboardImpl* const impl;
+    KeyboardCallbacks* const callbacks;
     std::shared_ptr<input::Seat> const mir_seat;
     std::shared_ptr<mir::input::Keymap> current_keymap;
     std::unique_ptr<xkb_keymap, void (*)(xkb_keymap *)> compiled_keymap;
@@ -93,4 +93,4 @@ private:
 }
 }
 
-#endif // MIR_FRONTEND_BASIC_WL_KEYBOARD_H
+#endif // MIR_FRONTEND_KEYBOARD_HELPER_H

--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -75,19 +75,11 @@ void mf::WaylandInputDispatcher::handle_event(MirInputEvent const* event)
     switch (mir_input_event_get_type(event))
     {
     case mir_input_event_type_key:
-    {
-        auto const keyboard_event = mir_input_event_get_keyboard_event(event);
-        seat->for_each_listener(client, [&](WlKeyboard* keyboard)
-            {
-                keyboard->event(keyboard_event, wl_surface.value());
-            });
-    }   break;
-
     case mir_input_event_type_keyboard_resync:
     {
         seat->for_each_listener(client, [&](WlKeyboard* keyboard)
             {
-                keyboard->resync_keyboard();
+                keyboard->handle_event(event, wl_surface.value());
             });
     }   break;
 

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -19,6 +19,7 @@
 #include "wl_keyboard.h"
 
 #include "wl_surface.h"
+#include "wl_seat.h"
 #include "mir/log.h"
 #include "mir/fatal.h"
 
@@ -29,13 +30,9 @@ namespace mf = mir::frontend;
 namespace mw = mir::wayland;
 namespace mi = mir::input;
 
-mf::WlKeyboard::WlKeyboard(
-    wl_resource* new_resource,
-    std::shared_ptr<mir::input::Keymap> const& initial_keymap,
-    std::shared_ptr<input::Seat> const& seat,
-    bool enable_key_repeat)
+mf::WlKeyboard::WlKeyboard(wl_resource* new_resource, WlSeat& seat)
     : wayland::Keyboard{new_resource, Version<6>()},
-      helper{std::make_unique<KeyboardHelper>(this, initial_keymap, seat, enable_key_repeat)}
+      helper{seat.make_keyboard_helper(this)}
 {
 }
 

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -18,21 +18,11 @@
 
 #include "wl_keyboard.h"
 
-#include "wayland_utils.h"
 #include "wl_surface.h"
-#include "wl_seat.h"
-
-#include "mir/executor.h"
-#include "mir/anonymous_shm_file.h"
-#include "mir/input/keymap.h"
-#include "mir/input/xkb_mapper.h"
 #include "mir/log.h"
 #include "mir/fatal.h"
-#include "mir/events/keyboard_event.h"
 
 #include <xkbcommon/xkbcommon.h>
-#include <boost/throw_exception.hpp>
-
 #include <cstring> // memcpy
 
 namespace mf = mir::frontend;
@@ -41,26 +31,12 @@ namespace mi = mir::input;
 
 mf::WlKeyboard::WlKeyboard(
     wl_resource* new_resource,
-    std::shared_ptr<mi::Keymap> const& initial_keymap,
-    std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state,
+    std::shared_ptr<mir::input::Keymap> const& initial_keymap,
+    std::shared_ptr<input::Seat> const& seat,
     bool enable_key_repeat)
-    : Keyboard(new_resource, Version<6>()),
-      current_keymap{nullptr}, // will be set later in the constructor by set_keymap()
-      compiled_keymap{nullptr, &xkb_keymap_unref},
-      state{nullptr, &xkb_state_unref},
-      context{xkb_context_new(XKB_CONTEXT_NO_FLAGS), &xkb_context_unref},
-      acquire_current_keyboard_state{acquire_current_keyboard_state}
+    : wayland::Keyboard{new_resource, Version<6>()},
+      helper{std::make_unique<KeyboardHelper>(this, initial_keymap, seat, enable_key_repeat)}
 {
-    /* The wayland::Keyboard constructor has already run, creating the keyboard
-     * resource. It is thus safe to send a keymap event to it; the client will receive
-     * the keyboard object before this event.
-     */
-    set_keymap(initial_keymap);
-
-    // 25 rate and 600 delay are the default in Weston and Sway
-    // At some point we will want to make this configurable
-    if (version_supports_repeat_info())
-        send_repeat_info_event(enable_key_repeat? 25 : 0, 600);
 }
 
 mf::WlKeyboard::~WlKeyboard()
@@ -71,46 +47,18 @@ mf::WlKeyboard::~WlKeyboard()
     }
 }
 
-void mf::WlKeyboard::event(MirKeyboardEvent const* event, WlSurface& surface)
+void mf::WlKeyboard::handle_event(MirInputEvent const* event, WlSurface& surface)
 {
-    bool down;
-    switch (mir_keyboard_event_action(event))
-    {
-    case mir_keyboard_action_down:
-        down = true;
-        break;
-
-    case mir_keyboard_action_up:
-        down = false;
-        break;
-
-    default:
-        return;
-    }
-
-    auto const serial = wl_display_next_serial(wl_client_get_display(client));
-    auto const timestamp = mir_input_event_get_wayland_timestamp(mir_keyboard_event_input_event(event));
-    int const scancode = mir_keyboard_event_scan_code(event);
-    uint32_t const wayland_state = down ? KeyState::pressed : KeyState::released;
-
     if (!focused_surface.is(surface))
     {
         log_warning(
-            "Sending key 0x%2.2x %s to wl_surface@%u even though it was not explicitly given keyboard focus",
-            scancode, down ? "press" : "release", wl_resource_get_id(surface.resource));
+            "Sending keyboard event to wl_surface@%u even though it was not explicitly given keyboard focus",
+            wl_resource_get_id(surface.resource));
 
         focussed(surface, true);
     }
 
-    set_keymap(event->keymap());
-    send_key_event(serial, timestamp, scancode, wayland_state);
-    /*
-    * HACK! Maintain our own XKB state, so we can serialise it for
-    * wl_keyboard_send_modifiers
-    */
-    xkb_key_direction const xkb_state = down ? XKB_KEY_DOWN : XKB_KEY_UP;
-    xkb_state_update_key(state.get(), scancode + 8, xkb_state);
-    update_modifier_state();
+    helper->handle_event(event);
 }
 
 void mf::WlKeyboard::focussed(WlSurface& surface, bool should_be_focused)
@@ -136,15 +84,14 @@ void mf::WlKeyboard::focussed(WlSurface& surface, bool should_be_focused)
     {
         // TODO: Send the surface's keymap here
 
-        auto const keyboard_state = acquire_current_keyboard_state();
-        update_keyboard_state(keyboard_state);
+        auto const pressed_keys = helper->refresh_internal_state();
 
         wl_array key_state;
         wl_array_init(&key_state);
 
         auto* const array_storage = wl_array_add(
             &key_state,
-            keyboard_state.size() * sizeof(decltype(keyboard_state)::value_type));
+            pressed_keys.size() * sizeof(decltype(pressed_keys)::value_type));
 
         if (!array_storage)
         {
@@ -152,12 +99,12 @@ void mf::WlKeyboard::focussed(WlSurface& surface, bool should_be_focused)
             BOOST_THROW_EXCEPTION(std::bad_alloc());
         }
 
-        if (!keyboard_state.empty())
+        if (!pressed_keys.empty())
         {
             std::memcpy(
                 array_storage,
-                keyboard_state.data(),
-                keyboard_state.size() * sizeof(decltype(keyboard_state)::value_type));
+                pressed_keys.data(),
+                pressed_keys.size() * sizeof(decltype(pressed_keys)::value_type));
         }
 
         destroy_listener_id = surface.add_destroy_listener(
@@ -179,88 +126,28 @@ void mf::WlKeyboard::focussed(WlSurface& surface, bool should_be_focused)
     }
 }
 
-void mf::WlKeyboard::update_keyboard_state(std::vector<uint32_t> const& keyboard_state)
+void mf::WlKeyboard::send_repeat_info(int32_t rate, int32_t delay)
 {
-    // Rebuild xkb state
-    state = decltype(state)(xkb_state_new(compiled_keymap.get()), &xkb_state_unref);
-    for (auto scancode : keyboard_state)
+    if (version_supports_repeat_info())
     {
-        xkb_state_update_key(state.get(), scancode + 8, XKB_KEY_DOWN);
-    }
-
-    update_modifier_state();
-}
-
-void mf::WlKeyboard::set_keymap(std::shared_ptr<mi::Keymap> const& new_keymap)
-{
-    if (!new_keymap || new_keymap == current_keymap)
-    {
-        return;
-    }
-
-    if (current_keymap && current_keymap->matches(*new_keymap))
-    {
-        current_keymap = new_keymap;
-        return;
-    }
-
-    current_keymap = new_keymap;
-    compiled_keymap = new_keymap->make_unique_xkb_keymap(context.get());
-
-    // TODO: We might need to copy across the existing depressed keys?
-    state = decltype(state)(xkb_state_new(compiled_keymap.get()), &xkb_state_unref);
-
-    std::unique_ptr<char, void(*)(void*)> buffer{xkb_keymap_get_as_string(
-        compiled_keymap.get(),
-        XKB_KEYMAP_FORMAT_TEXT_V1),
-        free};
-    auto length = strlen(buffer.get());
-
-    mir::AnonymousShmFile shm_buffer{length};
-    memcpy(shm_buffer.base_ptr(), buffer.get(), length);
-
-    send_keymap_event(KeymapFormat::xkb_v1,
-                      Fd{IntOwnedFd{shm_buffer.fd()}},
-                      length);
-}
-
-void mf::WlKeyboard::update_modifier_state()
-{
-    // TODO?
-    // assert_on_wayland_event_loop()
-
-    auto new_depressed_mods = xkb_state_serialize_mods(
-        state.get(),
-        XKB_STATE_MODS_DEPRESSED);
-    auto new_latched_mods = xkb_state_serialize_mods(
-        state.get(),
-        XKB_STATE_MODS_LATCHED);
-    auto new_locked_mods = xkb_state_serialize_mods(
-        state.get(),
-        XKB_STATE_MODS_LOCKED);
-    auto new_group = xkb_state_serialize_layout(
-        state.get(),
-        XKB_STATE_LAYOUT_EFFECTIVE);
-
-    if ((new_depressed_mods != mods_depressed) ||
-        (new_latched_mods != mods_latched) ||
-        (new_locked_mods != mods_locked) ||
-        (new_group != group))
-    {
-        mods_depressed = new_depressed_mods;
-        mods_latched = new_latched_mods;
-        mods_locked = new_locked_mods;
-        group = new_group;
-
-        send_modifiers_event(wl_display_get_serial(wl_client_get_display(client)),
-                             mods_depressed,
-                             mods_latched,
-                             mods_locked,
-                             group);
+        send_repeat_info_event(rate, delay);
     }
 }
 
-void mir::frontend::WlKeyboard::resync_keyboard()
+void mf::WlKeyboard::send_keymap_xkb_v1(mir::Fd const& fd, size_t length)
 {
-    update_keyboard_state(acquire_current_keyboard_state());
+    send_keymap_event(KeymapFormat::xkb_v1, fd, length);
+}
+
+void mf::WlKeyboard::send_key(uint32_t timestamp, int scancode, bool down)
+{
+    auto const serial = wl_display_next_serial(wl_client_get_display(client));
+    auto const state = down ? KeyState::pressed : KeyState::released;
+    send_key_event(serial, timestamp, scancode, state);
+}
+
+void mf::WlKeyboard::send_modifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group)
+{
+    auto const serial = wl_display_get_serial(wl_client_get_display(client));
+    send_modifiers_event(serial, depressed, latched, locked, group);
 }

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -27,17 +27,14 @@ namespace mir
 namespace frontend
 {
 class WlSurface;
+class WlSeat;
 
 class WlKeyboard
     : public wayland::Keyboard,
       public KeyboardImpl
 {
 public:
-    WlKeyboard(
-        wl_resource* new_resource,
-        std::shared_ptr<mir::input::Keymap> const& initial_keymap,
-        std::shared_ptr<input::Seat> const& seat,
-        bool enable_key_repeat);
+    WlKeyboard(wl_resource* new_resource, WlSeat& seat);
 
     ~WlKeyboard();
 

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -31,7 +31,7 @@ class WlSeat;
 
 class WlKeyboard
     : public wayland::Keyboard,
-      public KeyboardImpl
+      private KeyboardCallbacks
 {
 public:
     WlKeyboard(wl_resource* new_resource, WlSeat& seat);
@@ -46,7 +46,7 @@ private:
     wayland::Weak<WlSurface> focused_surface;
     wayland::DestroyListenerId destroy_listener_id;
 
-    /// KeyboardImpl overrides
+    /// KeyboardCallbacks overrides
     /// @{
     void send_repeat_info(int32_t rate, int32_t delay) override;
     void send_keymap_xkb_v1(mir::Fd const& fd, size_t length) override;

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -20,66 +20,42 @@
 #define MIR_FRONTEND_WL_KEYBOARD_H
 
 #include "wayland_wrapper.h"
-
-#include <vector>
-#include <functional>
-#include <chrono>
-
-struct MirKeyboardEvent;
-
-// from <xkbcommon/xkbcommon.h>
-struct xkb_keymap;
-struct xkb_state;
-struct xkb_context;
+#include "keyboard_helper.h"
 
 namespace mir
 {
-
-class Executor;
-
-namespace input
-{
-class Keymap;
-}
-
 namespace frontend
 {
 class WlSurface;
 
-class WlKeyboard : public wayland::Keyboard
+class WlKeyboard
+    : public wayland::Keyboard,
+      public KeyboardImpl
 {
 public:
     WlKeyboard(
         wl_resource* new_resource,
         std::shared_ptr<mir::input::Keymap> const& initial_keymap,
-        std::function<std::vector<uint32_t>()> const& acquire_current_keyboard_state,
+        std::shared_ptr<input::Seat> const& seat,
         bool enable_key_repeat);
 
     ~WlKeyboard();
 
-    void event(MirKeyboardEvent const* event, WlSurface& surface);
+    void handle_event(MirInputEvent const* event, WlSurface& surface);
     void focussed(WlSurface& surface, bool should_be_focused);
-    void resync_keyboard();
 
 private:
-    void set_keymap(std::shared_ptr<mir::input::Keymap> const& new_keymap);
-    void update_modifier_state();
-    void update_keyboard_state(std::vector<uint32_t> const& keyboard_state);
-
-    std::shared_ptr<mir::input::Keymap> current_keymap;
-    std::unique_ptr<xkb_keymap, void (*)(xkb_keymap *)> compiled_keymap;
-    std::unique_ptr<xkb_state, void (*)(xkb_state *)> state;
-    std::unique_ptr<xkb_context, void (*)(xkb_context *)> const context;
-
-    std::function<std::vector<uint32_t>()> const acquire_current_keyboard_state;
-
+    std::unique_ptr<KeyboardHelper> const helper;
     wayland::Weak<WlSurface> focused_surface;
     wayland::DestroyListenerId destroy_listener_id;
 
-    uint32_t mods_depressed{0};
-    uint32_t mods_latched{0};
-    uint32_t mods_locked{0};
-    uint32_t group{0};
+    /// KeyboardImpl overrides
+    /// @{
+    void send_repeat_info(int32_t rate, int32_t delay) override;
+    void send_keymap_xkb_v1(mir::Fd const& fd, size_t length) override;
+    void send_key(uint32_t timestamp, int scancode, bool down) override;
+    void send_modifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group) override;
+    /// @}
 };
 }
 }

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -203,6 +203,11 @@ void mf::WlSeat::for_each_listener(wl_client* client, std::function<void(WlTouch
     touch_listeners->for_each(client, func);
 }
 
+auto mf::WlSeat::make_keyboard_helper(KeyboardImpl* impl) -> std::unique_ptr<KeyboardHelper>
+{
+    return std::make_unique<KeyboardHelper>(impl, keymap, seat, enable_key_repeat);
+}
+
 void mf::WlSeat::notify_focus(WlSurface& surface, bool has_focus)
 {
     if (has_focus && !focused_surface.is(surface))

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -135,12 +135,11 @@ void mf::WlSeat::ConfigObserver::changes_complete()
 class mf::WlSeat::Instance : public wayland::Seat
 {
 public:
-    Instance(wl_resource* new_resource, mf::WlSeat* seat, bool enable_key_repeat);
+    Instance(wl_resource* new_resource, mf::WlSeat* seat);
 
     mf::WlSeat* const seat;
 
 private:
-    bool const enable_key_repeat;
     void get_pointer(wl_resource* new_pointer) override;
     void get_keyboard(wl_resource* new_keyboard) override;
     void get_touch(wl_resource* new_touch) override;
@@ -224,7 +223,7 @@ void mf::WlSeat::notify_focus(WlSurface& surface, bool has_focus)
 
 void mf::WlSeat::bind(wl_resource* new_wl_seat)
 {
-    new Instance{new_wl_seat, this, enable_key_repeat};
+    new Instance{new_wl_seat, this};
 }
 
 void mf::WlSeat::set_focus_to(WlSurface* new_surface)
@@ -261,10 +260,9 @@ void mf::WlSeat::set_focus_to(WlSurface* new_surface)
         });
 }
 
-mf::WlSeat::Instance::Instance(wl_resource* new_resource, mf::WlSeat* seat, bool enable_key_repeat)
+mf::WlSeat::Instance::Instance(wl_resource* new_resource, mf::WlSeat* seat)
     : mw::Seat(new_resource, Version<6>()),
-      seat{seat},
-      enable_key_repeat{enable_key_repeat}
+      seat{seat}
 {
     // TODO: Read the actual capabilities. Do we have a keyboard? Mouse? Touch?
     send_capabilities_event(Capability::pointer | Capability::keyboard | Capability::touch);

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -202,9 +202,9 @@ void mf::WlSeat::for_each_listener(wl_client* client, std::function<void(WlTouch
     touch_listeners->for_each(client, func);
 }
 
-auto mf::WlSeat::make_keyboard_helper(KeyboardImpl* impl) -> std::unique_ptr<KeyboardHelper>
+auto mf::WlSeat::make_keyboard_helper(KeyboardCallbacks* callbacks) -> std::unique_ptr<KeyboardHelper>
 {
-    return std::make_unique<KeyboardHelper>(impl, keymap, seat, enable_key_repeat);
+    return std::make_unique<KeyboardHelper>(callbacks, keymap, seat, enable_key_repeat);
 }
 
 void mf::WlSeat::notify_focus(WlSurface& surface, bool has_focus)

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -28,7 +28,6 @@
 
 #include "mir/input/input_device_observer.h"
 #include "mir/input/input_device_hub.h"
-#include "mir/input/seat.h"
 #include "mir/input/device.h"
 #include "mir/input/parameter_keymap.h"
 #include "mir/input/mir_keyboard_config.h"
@@ -284,34 +283,8 @@ void mf::WlSeat::Instance::get_keyboard(wl_resource* new_keyboard)
     auto const keyboard = new WlKeyboard{
         new_keyboard,
         seat->keymap,
-        [seat = seat->seat]()
-        {
-            std::unordered_set<uint32_t> pressed_keys;
-
-            auto const ev = seat->create_device_state();
-            auto const state_event = mir_event_get_input_device_state_event(ev.get());
-            for (
-                auto dev = 0u;
-                dev < mir_input_device_state_event_device_count(state_event);
-                ++dev)
-            {
-                for (
-                    auto idx = 0u;
-                    idx < mir_input_device_state_event_device_pressed_keys_count(state_event, dev);
-                    ++idx)
-                {
-                    pressed_keys.insert(
-                        mir_input_device_state_event_device_pressed_keys_for_index(
-                            state_event,
-                            dev,
-                            idx));
-                }
-            }
-
-            return std::vector<uint32_t>{pressed_keys.begin(), pressed_keys.end()};
-        },
-        enable_key_repeat
-    };
+        seat->seat,
+        enable_key_repeat};
 
     seat->keyboard_listeners->register_listener(client, keyboard);
     keyboard->add_destroy_listener(

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -285,11 +285,7 @@ void mf::WlSeat::Instance::get_pointer(wl_resource* new_pointer)
 
 void mf::WlSeat::Instance::get_keyboard(wl_resource* new_keyboard)
 {
-    auto const keyboard = new WlKeyboard{
-        new_keyboard,
-        seat->keymap,
-        seat->seat,
-        enable_key_repeat};
+    auto const keyboard = new WlKeyboard{new_keyboard, *seat};
 
     seat->keyboard_listeners->register_listener(client, keyboard);
     keyboard->add_destroy_listener(

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -43,7 +43,7 @@ class WlPointer;
 class WlKeyboard;
 class WlTouch;
 class WlSurface;
-class KeyboardImpl;
+class KeyboardCallbacks;
 class KeyboardHelper;
 
 class WlSeat : public wayland::Seat::Global
@@ -77,7 +77,7 @@ public:
         FocusListener& operator=(FocusListener const&) = delete;
     };
 
-    auto make_keyboard_helper(KeyboardImpl* impl) -> std::unique_ptr<KeyboardHelper>;
+    auto make_keyboard_helper(KeyboardCallbacks* callbacks) -> std::unique_ptr<KeyboardHelper>;
 
     /// Adds the listener for future use, and makes a call into it to inform of initial state
     void add_focus_listener(wl_client* client, FocusListener* listener);

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -43,6 +43,8 @@ class WlPointer;
 class WlKeyboard;
 class WlTouch;
 class WlSurface;
+class KeyboardImpl;
+class KeyboardHelper;
 
 class WlSeat : public wayland::Seat::Global
 {
@@ -74,6 +76,8 @@ public:
         FocusListener(FocusListener const&) = delete;
         FocusListener& operator=(FocusListener const&) = delete;
     };
+
+    auto make_keyboard_helper(KeyboardImpl* impl) -> std::unique_ptr<KeyboardHelper>;
 
     /// Adds the listener for future use, and makes a call into it to inform of initial state
     void add_focus_listener(wl_client* client, FocusListener* listener);


### PR DESCRIPTION
One of the initially unimplemented components of the input method protocol is keyboard grabs. Squeekboard doesn't grab the keybaord, but CJK input methods (such as [wlanthy](https://github.com/st3r4g/wlanthy) do need to. `zwp_input_method_keyboard_grab_v2` is a separate interface than `wl_keyboard` and will need a separate implementation, but requires much of the same functionality.

After several attempts involving inheritance, I settled on a more composition-oriented approach. `KeybaordHelper` implements the common keyboard logic, and calls into `KeyboardImpl` to send events. In this PR `WlKeyboard` is the only `KeyboardImpl`, but an upcoming PR will add a new grab keybaord implementation.