### PR TITLE
Reinstate #2146

### DIFF
--- a/include/core/mir_toolkit/events/enums.h
+++ b/include/core/mir_toolkit/events/enums.h
@@ -46,6 +46,7 @@ typedef enum {
     mir_input_event_type_key = 0,
     mir_input_event_type_touch = 1,
     mir_input_event_type_pointer = 2,
+    mir_input_event_type_keyboard_resync = 3,
 
     mir_input_event_types
 } MirInputEventType;

--- a/include/test/mir/test/event_matchers.h
+++ b/include/test/mir/test/event_matchers.h
@@ -187,6 +187,15 @@ MATCHER_P(KeyOfScanCode, code, "")
     return true;
 }
 
+MATCHER(KeybaordResyncEvent, "")
+{
+    if (mir_event_get_type(arg.get()) != mir_event_type_input)
+    {
+        return false;
+    }
+    return mir_input_event_get_type(mir_event_get_input_event(arg.get())) == mir_input_event_type_keyboard_resync;
+}
+
 MATCHER_P(MirKeyboardEventMatches, event, "")
 {
     auto expected = maybe_key_event(to_address(event));

--- a/src/common/events/CMakeLists.txt
+++ b/src/common/events/CMakeLists.txt
@@ -19,6 +19,7 @@ set(EVENT_SOURCES
   event.cpp
   event_builders.cpp
   keyboard_event.cpp
+  keyboard_resync_event.cpp
   touch_event.cpp
   pointer_event.cpp
   prompt_session_event.cpp

--- a/src/common/events/keyboard_resync_event.cpp
+++ b/src/common/events/keyboard_resync_event.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "mir/events/input_event.h"
+#include "mir/events/keyboard_resync_event.h"
+
+MirKeyboardResyncEvent::MirKeyboardResyncEvent() :
+    MirInputEvent(mir_input_event_type_keyboard_resync)
+{
+}
+
+auto MirKeyboardResyncEvent::clone() const -> MirKeyboardResyncEvent*
+{
+    return new MirKeyboardResyncEvent{*this};
+}

--- a/src/common/input/input_event.cpp
+++ b/src/common/input/input_event.cpp
@@ -327,6 +327,8 @@ bool mir_input_event_has_cookie(MirInputEvent const* ev) MIR_HANDLE_EVENT_EXCEPT
             }
             break;
         }
+        case mir_input_event_type_keyboard_resync:
+            return false;
         case mir_input_event_types:
             abort();
             break;

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -201,6 +201,7 @@ MIR_COMMON_2.5 {
     MirKeyboardEvent::text*;
     MirKeyboardEvent::keymap*;
     MirKeyboardEvent::set_keymap*;
+    MirKeyboardResyncEvent::MirKeyboardResyncEvent*;
     MirKeymapEvent::MirKeymapEvent*;
     MirKeymapEvent::buffer*;
     MirKeymapEvent::device_id*;

--- a/src/include/common/mir/events/keyboard_resync_event.h
+++ b/src/include/common/mir/events/keyboard_resync_event.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_COMMON_KEYBOARD_RESYNC_EVENT_H_
+#define MIR_COMMON_KEYBOARD_RESYNC_EVENT_H_
+
+#include <vector>
+
+#include "mir/events/input_event.h"
+
+/// Sent when the server restarts and the keyboard needs to be resynced
+struct MirKeyboardResyncEvent : MirInputEvent
+{
+    MirKeyboardResyncEvent();
+    auto clone() const -> MirKeyboardResyncEvent* override;
+
+private:
+};
+
+#endif /* MIR_COMMON_KEYBOARD_RESYNC_EVENT_H_ */

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -649,8 +649,6 @@ void mf::WaylandConnector::start()
             wl_display_run(d);
         },
         display.get()};
-
-    executor->spawn([this]{ seat_global->server_restart(); });
 }
 
 void mf::WaylandConnector::stop()

--- a/src/server/frontend_wayland/wayland_executor.cpp
+++ b/src/server/frontend_wayland/wayland_executor.cpp
@@ -280,6 +280,13 @@ mf::WaylandExecutor::WaylandExecutor(wl_event_loop* loop)
         BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to create Wayland notify source"}));
     }
     EventLoopDestroyedHandler::setup_destruction_handler_for_loop(loop, source, state);
+
+    // Messy, but although the State ctor queues work it can't "notify" the event loop work is pending
+    if (auto err = eventfd_write(notify_fd, 1))
+    {
+        BOOST_THROW_EXCEPTION(
+            (std::system_error{err, std::system_category(), "eventfd_write failed to notify event loop"}));
+    }
 }
 
 mf::WaylandExecutor::~WaylandExecutor()

--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -83,6 +83,14 @@ void mf::WaylandInputDispatcher::handle_event(MirInputEvent const* event)
             });
     }   break;
 
+    case mir_input_event_type_keyboard_resync:
+    {
+        seat->for_each_listener(client, [&](WlKeyboard* keyboard)
+            {
+                keyboard->resync_keyboard();
+            });
+    }   break;
+
     case mir_input_event_type_pointer:
     {
         auto const pointer_event = mir_input_event_get_pointer_event(event);

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -349,11 +349,3 @@ void mf::WlSeat::remove_focus_listener(wl_client* client, FocusListener* listene
 {
     focus_listeners->unregister_listener(client, listener);
 }
-
-void mf::WlSeat::server_restart()
-{
-    if (focused_client)
-    {
-        for_each_listener(focused_client, [](WlKeyboard* keyboard) { keyboard->resync_keyboard(); });
-    }
-}

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -80,8 +80,6 @@ public:
     void remove_focus_listener(wl_client* client, FocusListener* listener);
     void notify_focus(WlSurface& surface, bool has_focus);
 
-    void server_restart();
-
 private:
     void set_focus_to(WlSurface* surface);
 

--- a/src/server/input/CMakeLists.txt
+++ b/src/server/input/CMakeLists.txt
@@ -16,6 +16,7 @@ set(
   input_modifier_utils.cpp
   input_probe.cpp
   key_repeat_dispatcher.cpp
+  keyboard_resync_dispatcher.cpp
   null_input_dispatcher.cpp
   seat_input_device_tracker.cpp
   surface_input_dispatcher.cpp

--- a/src/server/input/default_configuration.cpp
+++ b/src/server/input/default_configuration.cpp
@@ -19,6 +19,7 @@
 #include "mir/default_server_configuration.h"
 
 #include "key_repeat_dispatcher.h"
+#include "keyboard_resync_dispatcher.h"
 #include "event_filter_chain_dispatcher.h"
 #include "config_changer.h"
 #include "cursor_controller.h"
@@ -140,8 +141,11 @@ mir::DefaultServerConfiguration::the_input_dispatcher()
             // lp:1675357: Disable generation of key repeat events on nested servers
             auto enable_repeat = options->get<bool>(options::enable_key_repeat_opt);
 
+            auto const keyboard_resync_dispatcher =
+                std::make_shared<mi::KeyboardResyncDispatcher>(the_event_filter_chain_dispatcher());
+
             return std::make_shared<mi::KeyRepeatDispatcher>(
-                the_event_filter_chain_dispatcher(), the_main_loop(), the_cookie_authority(),
+                keyboard_resync_dispatcher, the_main_loop(), the_cookie_authority(),
                 enable_repeat, key_repeat_timeout, key_repeat_delay, false);
         });
 }

--- a/src/server/input/keyboard_resync_dispatcher.cpp
+++ b/src/server/input/keyboard_resync_dispatcher.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "keyboard_resync_dispatcher.h"
+
+#include "mir/input/seat.h"
+#include "mir/events/keyboard_resync_event.h"
+
+#include <unordered_set>
+
+namespace mi = mir::input;
+
+mi::KeyboardResyncDispatcher::KeyboardResyncDispatcher(std::shared_ptr<InputDispatcher> const& next_dispatcher)
+    : next_dispatcher{next_dispatcher}
+{
+}
+
+bool mi::KeyboardResyncDispatcher::dispatch(std::shared_ptr<MirEvent const> const& event)
+{
+    return next_dispatcher->dispatch(event);
+}
+
+void mi::KeyboardResyncDispatcher::start()
+{
+    next_dispatcher->start();
+    auto const ev = std::make_shared<MirKeyboardResyncEvent>();
+    next_dispatcher->dispatch(ev);
+}
+
+void mi::KeyboardResyncDispatcher::stop()
+{
+    next_dispatcher->stop();
+}

--- a/src/server/input/keyboard_resync_dispatcher.h
+++ b/src/server/input/keyboard_resync_dispatcher.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_INPUT_KEYBOARD_RESYNC_DISPATCHER_H_
+#define MIR_INPUT_KEYBOARD_RESYNC_DISPATCHER_H_
+
+#include "mir/input/input_dispatcher.h"
+
+#include <vector>
+
+namespace mir
+{
+namespace input
+{
+class Seat;
+
+class KeyboardResyncDispatcher : public InputDispatcher
+{
+public:
+    KeyboardResyncDispatcher(std::shared_ptr<InputDispatcher> const& next_dispatcher);
+
+    /// InputDispatcher overrides
+    /// @{
+    bool dispatch(std::shared_ptr<MirEvent const> const& event) override;
+    void start() override;
+    void stop() override;
+    /// @}
+
+private:
+    std::shared_ptr<InputDispatcher> const next_dispatcher;
+};
+
+}
+}
+
+#endif // MIR_INPUT_KEYBOARD_RESYNC_DISPATCHER_H_

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -644,6 +644,7 @@ bool mi::SurfaceInputDispatcher::dispatch(std::shared_ptr<MirEvent const> const&
     switch (mir_input_event_get_type(iev))
     {
     case mir_input_event_type_key:
+    case mir_input_event_type_keyboard_resync:
         return dispatch_key(event.get());
     case mir_input_event_type_touch:
         return dispatch_touch(id, event.get());

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -596,6 +596,9 @@ bool msh::AbstractShell::handle(MirEvent const& event)
 
     case mir_input_event_type_pointer:
         return window_manager->handle_pointer_event(mir_input_event_get_pointer_event(input_event));
+
+    case mir_input_event_type_keyboard_resync:
+        return false;
     
     case mir_input_event_types:
         abort();

--- a/src/server/shell/decoration/input.cpp
+++ b/src/server/shell/decoration/input.cpp
@@ -108,6 +108,7 @@ struct msd::InputManager::Observer
         }   break;
 
         case mir_input_event_type_key:
+        case mir_input_event_type_keyboard_resync:
         case mir_input_event_types:
             break;
         }

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -933,6 +933,7 @@ MIR_SERVER_2.5 {
     VTT?for?mir::shell::ShellWrapper;
     VTT?for?mir::shell::SystemCompositorWindowManager;
     mir::DefaultServerConfiguration::the_text_input_hub*;
+    mir::input::ResyncKeyboardDispatcher*;
   };
  local: *;
 };

--- a/tests/unit-tests/input/CMakeLists.txt
+++ b/tests/unit-tests/input/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND UNIT_TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/test_surface_input_dispatcher.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_seat_input_device_tracker.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_key_repeat_dispatcher.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_keyboard_resync_dispatcher.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_validator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_buffer_keymap.cpp
 )

--- a/tests/unit-tests/input/test_keyboard_resync_dispatcher.cpp
+++ b/tests/unit-tests/input/test_keyboard_resync_dispatcher.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "src/server/input/keyboard_resync_dispatcher.h"
+
+#include "mir/events/keyboard_event.h"
+
+#include "mir/test/fake_shared.h"
+#include "mir/test/event_matchers.h"
+#include "mir/test/doubles/mock_input_dispatcher.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace mi = mir::input;
+namespace mev = mir::events;
+namespace mt = mir::test;
+namespace mtd = mt::doubles;
+
+using namespace ::testing;
+
+namespace
+{
+struct KeyboardResyncDispatcher : public testing::Test
+{
+    KeyboardResyncDispatcher()
+        : dispatcher(mt::fake_shared(mock_next_dispatcher))
+    {
+    }
+
+    StrictMock<mtd::MockInputDispatcher> mock_next_dispatcher;
+    mi::KeyboardResyncDispatcher dispatcher;
+};
+}
+
+TEST_F(KeyboardResyncDispatcher, forwards_events)
+{
+    EXPECT_CALL(mock_next_dispatcher, dispatch(mt::KeyDownEvent()));
+
+    MirKeyboardEvent key_ev;
+    key_ev.set_action(mir_keyboard_action_down);
+    dispatcher.dispatch(mt::fake_shared(key_ev));
+}
+
+TEST_F(KeyboardResyncDispatcher, forwards_start_stop)
+{
+    EXPECT_CALL(mock_next_dispatcher, dispatch(_)).Times(AnyNumber());
+    Expectation start_called = EXPECT_CALL(mock_next_dispatcher, start());
+    EXPECT_CALL(mock_next_dispatcher, stop()).After(start_called);
+
+    dispatcher.start();
+    dispatcher.stop();
+}
+
+TEST_F(KeyboardResyncDispatcher, sends_resync_on_start)
+{
+    EXPECT_CALL(mock_next_dispatcher, dispatch(mt::KeybaordResyncEvent()));
+    EXPECT_CALL(mock_next_dispatcher, start()).Times(AnyNumber());
+    EXPECT_CALL(mock_next_dispatcher, stop()).Times(AnyNumber());
+
+    dispatcher.start();
+}
+
+TEST_F(KeyboardResyncDispatcher, sends_resync_every_start)
+{
+    EXPECT_CALL(mock_next_dispatcher, dispatch(mt::KeybaordResyncEvent())).Times(3);
+    EXPECT_CALL(mock_next_dispatcher, start()).Times(AnyNumber());
+    EXPECT_CALL(mock_next_dispatcher, stop()).Times(AnyNumber());
+
+    dispatcher.start();
+    dispatcher.stop();
+    dispatcher.start();
+    dispatcher.stop();
+    dispatcher.start();
+}

--- a/tests/unit-tests/wayland/test_wayland_executor.cpp
+++ b/tests/unit-tests/wayland/test_wayland_executor.cpp
@@ -57,6 +57,13 @@ TEST_F(WaylandExecutorTest, spawning_a_task_makes_event_loop_fd_dispatchable)
 {
     mf::WaylandExecutor executor{the_event_loop};
 
+    // Drain any initialization work
+    while (mt::fd_is_readable(event_loop_fd))
+    {
+        wl_event_loop_dispatch(the_event_loop, 0);
+        wl_event_loop_dispatch_idle(the_event_loop);
+    }
+
     EXPECT_THAT(event_loop_fd, Not(FdIsReadable()));
 
     executor.spawn([](){});


### PR DESCRIPTION
Reverts the revert and ensures WaylandConnector initializes in a timely manner.