### PR TITLE
test/graphics-dummy: Guard against unwanted symbol export.

### DIFF
--- a/tests/mir_test_framework/open_wrapper.cpp
+++ b/tests/mir_test_framework/open_wrapper.cpp
@@ -30,6 +30,7 @@
 #include <dlfcn.h>
 #include <cstdarg>
 #include <fcntl.h>
+#include <boost/throw_exception.hpp>
 
 namespace mtf = mir_test_framework;
 
@@ -116,6 +117,13 @@ int open(char const* path, int flags, ...)
     int (*real_open)(char const *path, int flags, ...);
     *(void **)(&real_open) = dlsym(RTLD_NEXT, "open");
 
+    if (!real_open)
+    {
+        using namespace std::literals::string_literals;
+        // Oops! What has gone on here?!
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to find open() symbol: "s + dlerror()}));
+    }
+
     if (mode_parameter)
     {
         return (*real_open)(path, flags, *mode_parameter);
@@ -146,6 +154,13 @@ int open64(char const* path, int flags, ...)
 
     int (*real_open64)(char const *path, int flags, ...);
     *(void **)(&real_open64) = dlsym(RTLD_NEXT, "open64");
+
+    if (!real_open64)
+    {
+        using namespace std::literals::string_literals;
+        // Oops! What has gone on here?!
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to find open64() symbol: "s + dlerror()}));
+    }
 
     if (mode_parameter)
     {
@@ -178,6 +193,12 @@ int __open(char const* path, int flags, ...)
     int (*real_open)(char const *path, int flags, ...);
     *(void **)(&real_open) = dlsym(RTLD_NEXT, "__open");
 
+    if (!real_open)
+    {
+        using namespace std::literals::string_literals;
+        // Oops! What has gone on here?!
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to find __open() symbol: "s + dlerror()}));
+    }
     if (mode_parameter)
     {
         return (*real_open)(path, flags, *mode_parameter);
@@ -208,6 +229,12 @@ int __open64(char const* path, int flags, ...)
     int (*real_open64)(char const *path, int flags, ...);
     *(void **)(&real_open64) = dlsym(RTLD_NEXT, "__open64");
 
+    if (!real_open64)
+    {
+        using namespace std::literals::string_literals;
+        // Oops! What has gone on here?!
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to find __open64() symbol: "s + dlerror()}));
+    }
     if (mode_parameter)
     {
         return (*real_open64)(path, flags, *mode_parameter);
@@ -225,6 +252,12 @@ int __open_2(char const* path, int flags)
     int (*real_open_2)(char const *path, int flags);
     *(void **)(&real_open_2) = dlsym(RTLD_NEXT, "__open_2");
 
+    if (!real_open_2)
+    {
+        using namespace std::literals::string_literals;
+        // Oops! What has gone on here?!
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to find __open_2() symbol: "s + dlerror()}));
+    }
     return (*real_open_2)(path, flags);
 }
 
@@ -238,6 +271,12 @@ int __open64_2(char const* path, int flags)
     int (*real_open64_2)(char const *path, int flags);
     *(void **)(&real_open64_2) = dlsym(RTLD_NEXT, "__open64_2");
 
+    if (!real_open64_2)
+    {
+        using namespace std::literals::string_literals;
+        // Oops! What has gone on here?!
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to find __open64_2() symbol: "s + dlerror()}));
+    }
     return (*real_open64_2)(path, flags);
 
 }

--- a/tests/mir_test_framework/symbols-server.map.in
+++ b/tests/mir_test_framework/symbols-server.map.in
@@ -7,6 +7,11 @@ MIR_STUB_PLATFORM_SYMBOLS {
     add_fake_input_device*;
 };
 
+WORK_AROUND_MUSL_RTLD_NEXT_BUG {
+  global:
+    open;
+};
+
 @MIR_SERVER_GRAPHICS_PLATFORM_VERSION@ {
   global:
     add_graphics_platform_options;

--- a/tests/mir_test_framework/symbols-server.map.in
+++ b/tests/mir_test_framework/symbols-server.map.in
@@ -1,3 +1,12 @@
+MIR_STUB_PLATFORM_SYMBOLS {
+  global:
+    create_stub_platform*;
+    create_stub_render_platform*;
+    set_next_display_rects*;
+    set_next_preset_display*;
+    add_fake_input_device*;
+};
+
 @MIR_SERVER_GRAPHICS_PLATFORM_VERSION@ {
   global:
     add_graphics_platform_options;
@@ -8,4 +17,6 @@
     probe_display_platform;
     probe_rendering_platform;
     describe_graphics_module;
+  local:
+    *;
 };


### PR DESCRIPTION
GoogleTest *very conveniently* uses at least one global with a non-trivial
destructor. Due to the vagaries of static linking, these globals are
exported in the symbol table unless you explicitly hide them.

This interacts badly with `dlopen()`. The object will get constructed during
the initial loading process, along with the other globals, and then will
be constructed *again* when the ELF-module-constructor machinery runs
to load the `dlopen`ed DSO.

Even better, during process teardown the DSO's ELF-destructor will run
the destructor for the global. *Then* the executable's ELF-destructor will
run the destructor for the global *again*. This is rarely what you want,
and in *this* case it results in GoogleTest hitting an `abort()` when it
tries to destroy a `pthread_key_t` a second time.

Hiding every symbol we don't explicitly want to export solves this. The
main executable has a GoogleTest global, and graphics-dummy.so has a
GoogleTest global, but they're now at different addresses and so we
don't double destruct a single object.