### PR TITLE
Enable running smoke tests and performance tests in CMake

### DIFF
--- a/tests/performance-tests/CMakeLists.txt
+++ b/tests/performance-tests/CMakeLists.txt
@@ -17,3 +17,28 @@ add_custom_target(mir-smoke-test-runner ALL
 install(PROGRAMS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir-smoke-test-runner
     DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
 )
+
+find_program(XVFB_RUN_EXECUTABLE xvfb-run)
+find_program(GLMARK2_EXECUTABLE glmark2-es2-wayland)
+
+CMAKE_DEPENDENT_OPTION(
+  MIR_RUN_SMOKE_TESTS "Run mir-smoke-test-runner as part of testsuite" ON
+  "XVFB_RUN_EXECUTABLE" OFF
+)
+
+CMAKE_DEPENDENT_OPTION(
+  MIR_RUN_PERFORMANCE_TESTS "Run mir_performance_tests as part of testsuite" ON
+  "XVFB_RUN_EXECUTABLE;GLMARK2_EXECUTABLE" OFF
+)
+
+if(MIR_RUN_SMOKE_TESTS)
+  mir_add_test(NAME mir-smoke-test-runner
+      COMMAND "xvfb-run" "--auto-servernum" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir-smoke-test-runner"
+  )
+endif()
+
+if(MIR_RUN_PERFORMANCE_TESTS)
+  mir_add_test(NAME mir_performance_tests
+    COMMAND "xvfb-run" "--auto-servernum" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir_performance_tests"
+  )
+endif()

--- a/tools/mir-smoke-test-runner.sh
+++ b/tools/mir-smoke-test-runner.sh
@@ -23,6 +23,8 @@ client_list=`find ${root} -name mir_demo_client_* | grep -v bin$ | sed s?${root}
 echo "I: client_list=" ${client_list}
 
 ### Run Tests ###
+# The CI environment sets this test-specific env var, mir_demo_server doesn't know it
+unset MIR_SERVER_LOGGING
 
 # Start with eglinfo for the system
 echo Running eglinfo client
@@ -32,6 +34,12 @@ WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-cli
 date --utc --iso-8601=seconds | xargs echo "[timestamp] End :" ${client}
 
 for client in ${client_list}; do
+  if [[ "$XAUTHORITY" =~ .*xvfb-run.* ]]; then
+    if [[ "${client}" = mir_demo_client_wayland_egl_spinner ]]; then
+      # Skipped because of https://github.com/MirServer/mir/issues/2154
+      continue
+    fi
+  fi
     echo running client ${client}
     date --utc --iso-8601=seconds | xargs echo "[timestamp] Start :" ${client}
     echo WAYLAND_DISPLAY=${wayland_display} ${root}/mir_demo_server ${options} --test-client ${root}/${client}


### PR DESCRIPTION
This provides new MIR_RUN_SMOKE_TESTS and MIR_RUN_PERFORMANCE_TESTS options to cmake.

These options are enabled (and default to ON) when xvfb-run exists (and also glmark2-es2-wayland for mir_performance_tests).

(The end goal of getting these test to run in CI is for a future PR.)