### PR TITLE
Consolidate ProofOfMutexLock

### DIFF
--- a/include/core/mir/proof_of_mutex_lock.h
+++ b/include/core/mir/proof_of_mutex_lock.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+#ifndef MIR_PROOF_OF_MUTEX_LOCK_H_
+#define MIR_PROOF_OF_MUTEX_LOCK_H_
+
+#include "fatal.h"
+#include <mutex>
+
+namespace mir
+{
+/// A method can take an instance of this class by reference to require callers to hold a mutex lock, without requiring
+/// a specific type of lock
+class ProofOfMutexLock
+{
+public:
+    ProofOfMutexLock(std::lock_guard<std::mutex> const&) {}
+    ProofOfMutexLock(std::unique_lock<std::mutex> const& lock)
+    {
+        if (!lock.owns_lock())
+        {
+            fatal_error("ProofOfMutexLock created with unlocked unique_lock");
+        }
+    }
+    ProofOfMutexLock(ProofOfMutexLock const&) = delete;
+    ProofOfMutexLock operator=(ProofOfMutexLock const&) = delete;
+};
+} // namespace mir
+
+#endif // MIR_PROOF_OF_MUTEX_LOCK_H_

--- a/src/server/frontend_xwayland/xwayland_surface.h
+++ b/src/server/frontend_xwayland/xwayland_surface.h
@@ -24,6 +24,7 @@
 #include "xwayland_client_manager.h"
 #include "xwayland_surface_role_surface.h"
 #include "xwayland_surface_observer_surface.h"
+#include "mir/proof_of_mutex_lock.h"
 
 #include <xcb/xcb.h>
 
@@ -99,20 +100,6 @@ private:
         auto operator==(WindowState const& that) const -> bool;
         auto mir_window_state() const -> MirWindowState;
         auto updated_from(MirWindowState state) const -> WindowState; ///< Does not change original
-    };
-
-    struct ProofOfMutexLock
-    {
-        ProofOfMutexLock(std::lock_guard<std::mutex> const&) {}
-        ProofOfMutexLock(std::unique_lock<std::mutex> const& lock)
-        {
-            if (!lock.owns_lock())
-            {
-                fatal_error("ProofOfMutexLock created with unlocked unique_lock");
-            }
-        }
-        ProofOfMutexLock(ProofOfMutexLock const&) = delete;
-        ProofOfMutexLock operator=(ProofOfMutexLock const&) = delete;
     };
 
     /// Overrides from XWaylandSurfaceObserverSurface

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -161,12 +161,6 @@ void ms::SurfaceObservers::application_id_set_to(Surface const* surf, std::strin
                  { observer->application_id_set_to(surf, application_id); });
 }
 
-ms::BasicSurface::ProofOfMutexLock::ProofOfMutexLock(std::unique_lock<std::mutex> const& lock)
-{
-    if (!lock.owns_lock())
-        fatal_error("ProofOfMutexLock created with unlocked unique_lock");
-}
-
 struct ms::CursorStreamImageAdapter
 {
     CursorStreamImageAdapter(ms::BasicSurface &surface)

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -21,6 +21,7 @@
 
 #include "mir/scene/surface.h"
 #include "mir/basic_observers.h"
+#include "mir/proof_of_mutex_lock.h"
 #include "mir/scene/surface_observers.h"
 
 #include "mir/geometry/rectangle.h"
@@ -169,14 +170,6 @@ public:
     void set_focus_mode(MirFocusMode focus_mode) override;
 
 private:
-    struct ProofOfMutexLock
-    {
-        ProofOfMutexLock(std::lock_guard<std::mutex> const&) {}
-        ProofOfMutexLock(std::unique_lock<std::mutex> const& lock);
-        ProofOfMutexLock(ProofOfMutexLock const&) = delete;
-        ProofOfMutexLock operator=(ProofOfMutexLock const&) = delete;
-    };
-
     bool visible(ProofOfMutexLock const&) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
     MirWindowState set_state(MirWindowState s);


### PR DESCRIPTION
We now use `ProofOfMutexLock` in two places, and it stands to reason it will be useful in more. This moves it to it's own header `core/mir/proof_of_mutex_lock.h`.