### PR TITLE
Use SurfaceStateTracker to track X11 window state

### DIFF
--- a/src/include/server/mir/scene/surface_state_tracker.h
+++ b/src/include/server/mir/scene/surface_state_tracker.h
@@ -64,9 +64,6 @@ public:
     [[nodiscard]]
     auto without(MirWindowState state) const -> SurfaceStateTracker;
 
-    /// Returns if all states are equal
-    auto operator==(SurfaceStateTracker const& other) const -> bool;
-
 private:
     SurfaceStateTracker()
         : hidden{false},
@@ -84,6 +81,8 @@ private:
     /// Copies the base tracker with the given state present or not present
     SurfaceStateTracker(SurfaceStateTracker base, MirWindowState state, bool present);
 
+    friend auto operator==(SurfaceStateTracker const& lhs, SurfaceStateTracker const& rhs) -> bool;
+
     /// Functionally const except for asignment and construction
     /// @{
     bool hidden : 1;
@@ -94,6 +93,10 @@ private:
     bool vert_maximized : 1;
     /// @}
 };
+
+/// Returns if all states are equal
+auto operator==(SurfaceStateTracker const& lhs, SurfaceStateTracker const& rhs) -> bool;
+inline auto operator!=(SurfaceStateTracker const& lhs, SurfaceStateTracker const& rhs) -> bool { return !(lhs == rhs); }
 }
 }
 

--- a/src/include/server/mir/scene/surface_state_tracker.h
+++ b/src/include/server/mir/scene/surface_state_tracker.h
@@ -64,6 +64,9 @@ public:
     [[nodiscard]]
     auto without(MirWindowState state) const -> SurfaceStateTracker;
 
+    /// Returns if all states are equal
+    auto operator==(SurfaceStateTracker const& other) const -> bool;
+
 private:
     SurfaceStateTracker()
         : hidden{false},

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -248,9 +248,13 @@ auto apply_state_change(
     {
         state = mir_window_state_minimized;
     }
-    else if (net_wm_state == connection->_NET_WM_STATE_MAXIMIZED_HORZ) // assume vert is also set
+    else if (net_wm_state == connection->_NET_WM_STATE_MAXIMIZED_HORZ)
     {
-        state = mir_window_state_maximized;
+        state = mir_window_state_horizmaximized;
+    }
+    else if (net_wm_state == connection->_NET_WM_STATE_MAXIMIZED_VERT)
+    {
+        state = mir_window_state_vertmaximized;
     }
     else if (net_wm_state == connection->_NET_WM_STATE_FULLSCREEN)
     {
@@ -1032,9 +1036,12 @@ void mf::XWaylandSurface::inform_client_of_window_state(
         {
             net_wm_states.push_back(connection->_NET_WM_STATE_HIDDEN);
         }
-        if (new_window_state->has(mir_window_state_maximized))
+        if (new_window_state->has(mir_window_state_horizmaximized))
         {
             net_wm_states.push_back(connection->_NET_WM_STATE_MAXIMIZED_HORZ);
+        }
+        if (new_window_state->has(mir_window_state_vertmaximized))
+        {
             net_wm_states.push_back(connection->_NET_WM_STATE_MAXIMIZED_VERT);
         }
         if (new_window_state->has(mir_window_state_fullscreen))

--- a/src/server/scene/surface_state_tracker.cpp
+++ b/src/server/scene/surface_state_tracker.cpp
@@ -105,16 +105,6 @@ auto ms::SurfaceStateTracker::without(MirWindowState state) const -> SurfaceStat
     return SurfaceStateTracker{*this, state, false};
 }
 
-auto ms::SurfaceStateTracker::operator==(SurfaceStateTracker const& other) const -> bool
-{
-    return hidden == other.hidden &&
-           minimized == other.minimized &&
-           fullscreen == other.fullscreen &&
-           attached == other.attached &&
-           horiz_maximized == other.horiz_maximized &&
-           vert_maximized == other.vert_maximized;
-}
-
 ms::SurfaceStateTracker::SurfaceStateTracker(SurfaceStateTracker base, MirWindowState active)
     : SurfaceStateTracker{base}
 {
@@ -227,4 +217,14 @@ ms::SurfaceStateTracker::SurfaceStateTracker(SurfaceStateTracker base, MirWindow
     default:
         fatal_error("Invalid window state: %d", state);
     }
+}
+
+auto ms::operator==(ms::SurfaceStateTracker const& lhs, ms::SurfaceStateTracker const& rhs) -> bool
+{
+    return lhs.hidden == rhs.hidden &&
+           lhs.minimized == rhs.minimized &&
+           lhs.fullscreen == rhs.fullscreen &&
+           lhs.attached == rhs.attached &&
+           lhs.horiz_maximized == rhs.horiz_maximized &&
+           lhs.vert_maximized == rhs.vert_maximized;
 }

--- a/src/server/scene/surface_state_tracker.cpp
+++ b/src/server/scene/surface_state_tracker.cpp
@@ -105,6 +105,16 @@ auto ms::SurfaceStateTracker::without(MirWindowState state) const -> SurfaceStat
     return SurfaceStateTracker{*this, state, false};
 }
 
+auto ms::SurfaceStateTracker::operator==(SurfaceStateTracker const& other) const -> bool
+{
+    return hidden == other.hidden &&
+           minimized == other.minimized &&
+           fullscreen == other.fullscreen &&
+           attached == other.attached &&
+           horiz_maximized == other.horiz_maximized &&
+           vert_maximized == other.vert_maximized;
+}
+
 ms::SurfaceStateTracker::SurfaceStateTracker(SurfaceStateTracker base, MirWindowState active)
     : SurfaceStateTracker{base}
 {


### PR DESCRIPTION
Not too long ago we introduced `SurfaceStateTracker` to store multiple surface states at once. Previously the XWayland frontend was using it's own class to do this. With this PR, it uses the common one. Fixes #1217.