### PR TITLE
Use state tracker for foreign toplevel control

### DIFF
--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -95,6 +95,8 @@ set(EXPECTED_FAILURES
   LayerShellPopup/XdgPopupTest.non_grabbed_popup_does_not_get_keyboard_focus/0
   LayerShellPopup/XdgPopupTest.grabbed_popup_does_not_get_keyboard_focus/0
   LayerShellPopup/XdgPopupTest.grabbed_popup_gets_done_event_when_new_toplevel_created/0
+
+  ForeignToplevelHandleTest.can_maximize_foreign_while_fullscreen # https://github.com/MirServer/mir/issues/2164
 )
 
 if (MIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN)


### PR DESCRIPTION
Makes our foreign toplevel implementation simpler and more robust by not keeping track of surface state in the frontend. This does cause one WLCS test to fail, which is explained in #2164. I do not consider changing non-active state to be particularly important, and if it is doing it by keeping a cache in the frontend is not the way to go about it.