### PR TITLE
Miral client_facing_state

### DIFF
--- a/debian/libmiral4.symbols
+++ b/debian/libmiral4.symbols
@@ -402,3 +402,6 @@ libmiral.so.4 libmiral4 #MINVER#
  (c++)"miral::toolkit::mir_keyboard_event_keysym(MirKeyboardEvent const*)@MIRAL_3.3" 3.3.0
  (c++)"miral::WaylandExtensions::zwp_virtual_keyboard_v1@MIRAL_3.3" 3.3.0
  (c++)"miral::WaylandExtensions::zwp_input_method_v2@MIRAL_3.3" 3.3.0
+ (c++)"miral::WindowSpecification::client_facing_state()@MIRAL_3.3" 3.3.0
+ (c++)"miral::WindowSpecification::client_facing_state() const@MIRAL_3.3" 3.3.0
+ (c++)"miral::WindowInfo::client_facing_state() const@MIRAL_3.3" 3.3.0

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -133,11 +133,16 @@ struct WindowInfo
     /// \remark Since MirAL 3.3
     auto focus_mode() const -> MirFocusMode;
 
+    /// If set, the client is given this state instead of the window's real state
+    /// \remark Since MirAL 3.3
+    auto client_facing_state() const -> mir::optional_value<MirWindowState>;
+
 private:
     friend class BasicWindowManager;
     void name(std::string const& name);
     void type(MirWindowType type);
     void state(MirWindowState state);
+    void client_facing_state(mir::optional_value<MirWindowState> state);
     void restore_rect(mir::geometry::Rectangle const& restore_rect);
     void parent(Window const& parent);
     void add_child(Window const& child);

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -172,6 +172,16 @@ public:
     auto focus_mode() -> mir::optional_value<MirFocusMode>&;
     ///@}
 
+    /// Can be used to make the client draw the window as if it's in a state that is different from how the window
+    /// manager treats it. For example if a shell wants a window to draw itself as if it's fullscreen but not cover up
+    /// panels, it could set state() to mir_window_state_maximized and client_facing_state() to
+    /// mir_window_state_fullscreen. mir_window_state_unknown unsets this property and gives the client the real state.
+    /// \remark Since MirAL 3.3
+    ///@{
+    auto client_facing_state() const -> mir::optional_value<MirWindowState> const&;
+    auto client_facing_state() -> mir::optional_value<MirWindowState>&;
+    ///@}
+
 private:
     struct Self;
     std::unique_ptr<Self> self;

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1028,6 +1028,14 @@ void miral::BasicWindowManager::modify_window(WindowInfo& window_info, WindowSpe
 
 #undef COPY_IF_SET
 
+    if (modifications.client_facing_state().is_set())
+    {
+        window_info_tmp.client_facing_state(
+            modifications.client_facing_state().value() == mir_window_state_unknown ?
+            mir::optional_value<MirWindowState>{} :
+            modifications.client_facing_state());
+    }
+
     if (modifications.parent().is_set())
     {
         if (auto const& parent_window = modifications.parent().value().lock())

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1524,7 +1524,6 @@ void miral::BasicWindowManager::set_state(miral::WindowInfo& window_info, MirWin
         }
 
         window_info.state(value);
-        mir_surface->configure(mir_window_attrib_state, value);
         mir_surface->hide();
 
         break;
@@ -1534,7 +1533,6 @@ void miral::BasicWindowManager::set_state(miral::WindowInfo& window_info, MirWin
             !active_window() ||
             active_window().application() == window.application();
         window_info.state(value);
-        mir_surface->configure(mir_window_attrib_state, value);
         mir_surface->show();
         if (was_hidden && can_become_active)
         {
@@ -1648,7 +1646,6 @@ auto miral::BasicWindowManager::select_active_window(Window const& hint) -> mira
                 auto const new_state = scene_surface->state_tracker().without(mir_window_state_minimized).active_state();
                 policy->advise_state_change(info_for_hint, new_state);
                 info_for_hint.state(new_state);
-                mir_surface->configure(mir_window_attrib_state, new_state);
             }
             mir_surface->show();
         }

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -453,10 +453,10 @@ global:
     miral::PrintTo*;
     miral::WaylandExtensions::zwp_input_method_v2*;
     miral::WaylandExtensions::zwp_virtual_keyboard_v1*;
+    miral::WindowInfo::client_facing_state*;
     miral::WindowInfo::focus_mode*;
+    miral::WindowSpecification::client_facing_state*;
     miral::WindowSpecification::focus_mode*;
     miral::toolkit::mir_keyboard_event_keysym*;
-    miral::WindowInfo::client_facing_state*;
-    miral::WindowSpecification::client_facing_state*;
   };
 } MIRAL_3.2;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -456,5 +456,7 @@ global:
     miral::WindowInfo::focus_mode*;
     miral::WindowSpecification::focus_mode*;
     miral::toolkit::mir_keyboard_event_keysym*;
+    miral::WindowInfo::client_facing_state*;
+    miral::WindowSpecification::client_facing_state*;
   };
 } MIRAL_3.2;

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -280,7 +280,11 @@ auto miral::WindowInfo::type() const -> MirWindowType
 
 auto miral::WindowInfo::state() const -> MirWindowState
 {
-    if (std::shared_ptr<mir::scene::Surface> const surface = self->window)
+    if (self->miral_state_override)
+    {
+        return self->miral_state_override.value();
+    }
+    else if (std::shared_ptr<mir::scene::Surface> const surface = window())
     {
         return surface->state();
     }
@@ -489,5 +493,24 @@ auto miral::WindowInfo::focus_mode() const -> MirFocusMode
     else
     {
         return mir_focus_mode_disabled;
+    }
+}
+
+auto miral::WindowInfo::client_facing_state() const -> mir::optional_value<MirWindowState>
+{
+    if (self->miral_state_override)
+    {
+        if (std::shared_ptr<mir::scene::Surface> const surface = window())
+        {
+            return surface->state();
+        }
+        else
+        {
+            return mir_window_state_unknown;
+        }
+    }
+    else
+    {
+        return {};
     }
 }

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -280,7 +280,14 @@ auto miral::WindowInfo::type() const -> MirWindowType
 
 auto miral::WindowInfo::state() const -> MirWindowState
 {
-    return self->state;
+    if (std::shared_ptr<mir::scene::Surface> const surface = self->window)
+    {
+        return surface->state();
+    }
+    else
+    {
+        return mir_window_state_unknown;
+    }
 }
 
 auto miral::WindowInfo::restore_rect() const -> mir::geometry::Rectangle
@@ -290,7 +297,7 @@ auto miral::WindowInfo::restore_rect() const -> mir::geometry::Rectangle
     {
         Size restore_size{};
         // If the window is restored or partially restored, us its current size
-        switch (self->state)
+        switch (state())
         {
         case mir_window_state_restored:
             restore_size = self->window.size();

--- a/src/miral/window_info_internal.cpp
+++ b/src/miral/window_info_internal.cpp
@@ -75,7 +75,6 @@ miral::WindowInfo::Self::Self(Window window, WindowSpecification const& params) 
     window{window},
     name{params.name().value()},
     type{optional_value_or_default(params.type(), mir_window_type_normal)},
-    state{optional_value_or_default(params.state(), mir_window_state_restored)},
     restore_rect{},
     min_width{optional_value_or_default(params.min_width(), miral::default_min_width)},
     min_height{optional_value_or_default(params.min_height(), miral::default_min_height)},
@@ -103,7 +102,6 @@ miral::WindowInfo::Self::Self(Window window, WindowSpecification const& params) 
 
 miral::WindowInfo::Self::Self() :
     type{mir_window_type_normal},
-    state{mir_window_state_unknown},
     preferred_orientation{mir_orientation_mode_any},
     shell_chrome{mir_shell_chrome_normal}
 {
@@ -121,7 +119,10 @@ void miral::WindowInfo::type(MirWindowType type)
 
 void miral::WindowInfo::state(MirWindowState state)
 {
-    self->state = state;
+    if (std::shared_ptr<mir::scene::Surface> const surface = self->window)
+    {
+        surface->configure(mir_window_attrib_state, state);
+    }
 }
 
 void miral::WindowInfo::restore_rect(mir::geometry::Rectangle const& restore_rect)

--- a/src/miral/window_info_internal.h
+++ b/src/miral/window_info_internal.h
@@ -30,6 +30,8 @@ struct miral::WindowInfo::Self
     Window window;
     std::string name;
     MirWindowType type;
+    /// Only set if the miral state differs from the underlying surface state (aka client_facing_state)
+    std::optional<MirWindowState> miral_state_override;
     /// Not exposed as an optional, lazily calculated instead
     std::optional<mir::geometry::Rectangle> restore_rect;
     Window parent;

--- a/src/miral/window_info_internal.h
+++ b/src/miral/window_info_internal.h
@@ -30,7 +30,6 @@ struct miral::WindowInfo::Self
     Window window;
     std::string name;
     MirWindowType type;
-    MirWindowState state;
     /// Not exposed as an optional, lazily calculated instead
     std::optional<mir::geometry::Rectangle> restore_rect;
     Window parent;

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -47,6 +47,7 @@ struct miral::WindowSpecification::Self
     mir::optional_value<int> output_id;
     mir::optional_value<MirWindowType> type;
     mir::optional_value<MirWindowState> state;
+    mir::optional_value<MirWindowState> client_facing_state;
     mir::optional_value<MirOrientationMode> preferred_orientation;
     std::weak_ptr<mir::frontend::BufferStream> content;
     mir::optional_value<Rectangle> aux_rect;
@@ -294,6 +295,7 @@ void miral::WindowSpecification::Self::update(mir::scene::SurfaceCreationParamet
     copy_if_set(params.output_id, output_id);
     copy_if_set(params.type, type);
     copy_if_set(params.state, state);
+    copy_if_set(params.state, client_facing_state); // client_facing_state should override state
     copy_if_set(params.preferred_orientation, preferred_orientation);
     copy_if_set(params.content, content);
     copy_if_set(params.aux_rect, aux_rect);
@@ -390,6 +392,11 @@ auto miral::WindowSpecification::type() const -> mir::optional_value<MirWindowTy
 auto miral::WindowSpecification::state() const -> mir::optional_value<MirWindowState> const&
 {
     return self->state;
+}
+
+auto miral::WindowSpecification::client_facing_state() const -> mir::optional_value<MirWindowState> const&
+{
+    return self->client_facing_state;
 }
 
 auto miral::WindowSpecification::preferred_orientation() const -> mir::optional_value<MirOrientationMode> const&
@@ -536,6 +543,11 @@ auto miral::WindowSpecification::type() -> mir::optional_value<MirWindowType>&
 auto miral::WindowSpecification::state() -> mir::optional_value<MirWindowState>&
 {
     return self->state;
+}
+
+auto miral::WindowSpecification::client_facing_state() -> mir::optional_value<MirWindowState>&
+{
+    return self->client_facing_state;
 }
 
 auto miral::WindowSpecification::preferred_orientation() -> mir::optional_value<MirOrientationMode>&

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -89,9 +89,16 @@ struct StubSurface : mir::test::doubles::StubSurface
         MirWindowType type,
         mir::geometry::Point top_left,
         mir::geometry::Size size,
+        MirWindowState state,
         MirDepthLayer depth_layer,
         MirFocusMode focus_mode)
-        : name_{name}, type_{type}, top_left_{top_left}, size_{size}, depth_layer_{depth_layer}, focus_mode_{focus_mode}
+        : name_{name},
+          type_{type},
+          top_left_{top_left},
+          size_{size},
+          state_{state},
+          depth_layer_{depth_layer},
+          focus_mode_{focus_mode}
     {
     }
 
@@ -143,7 +150,7 @@ struct StubSurface : mir::test::doubles::StubSurface
     MirWindowType type_;
     mir::geometry::Point top_left_;
     mir::geometry::Size size_;
-    MirWindowState state_ = mir_window_state_restored;
+    MirWindowState state_;
     MirDepthLayer depth_layer_;
     mir::geometry::Displacement content_offset_;
     mir::geometry::Displacement content_size_offset;
@@ -163,6 +170,9 @@ struct StubStubSession : mir::test::doubles::StubSession
             params.type.value(),
             params.top_left,
             params.size,
+            params.state.is_set() ?
+                params.state.value()
+                : mir_window_state_restored,
             params.depth_layer.is_set() ?
                 params.depth_layer.value()
                 : mir_depth_layer_application,

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -296,6 +296,8 @@ mt::TestWindowManagerTools::TestWindowManagerTools()
             {
                 auto policy = std::make_unique<testing::NiceMock<MockWindowManagerPolicy>>(tools);
                 window_manager_policy = policy.get();
+                ON_CALL(*window_manager_policy, place_new_window(testing::_, testing::_))
+                    .WillByDefault([](auto, auto spec){ return spec; });
                 window_manager_tools = tools;
                 return policy;
             }

--- a/tests/miral/test_window_manager_tools.h
+++ b/tests/miral/test_window_manager_tools.h
@@ -49,6 +49,9 @@ struct MockWindowManagerPolicy
     bool handle_pointer_event(MirPointerEvent const* /*event*/) { return false; }
     bool handle_keyboard_event(MirKeyboardEvent const* /*event*/) { return false; }
 
+    MOCK_METHOD2(place_new_window, miral::WindowSpecification(
+        miral::ApplicationInfo const& app_info,
+        miral::WindowSpecification const& request_parameters));
     MOCK_METHOD1(advise_new_window, void (miral::WindowInfo const& window_info));
     MOCK_METHOD2(advise_move_to, void(miral::WindowInfo const& window_info, mir::geometry::Point top_left));
     MOCK_METHOD2(advise_resize, void(miral::WindowInfo const& window_info, mir::geometry::Size const& new_size));


### PR DESCRIPTION
This introduces a 2nd way for shells to set window states. They may now set a `client_facing_state` that is different from the `state` used for window management. If the client facing state is not set, `state` is used by default. 

In the short term this helps https://github.com/MirServer/ubuntu-frame/pull/15, because it allows us to make clients look fullscreen but behave as if they're maximized (critically, this causes them to get out of the way of the OSK). In the long term it may also be useful for tiling window managers, and other shells that want fine-graned control over how clients behave.

Marked as draft until I've written tests.