### PR TITLE
Allow zwp_linux_buffer_params_v1.add() with DRM_FORMAT_MOD_INVALID

### DIFF
--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -738,6 +738,21 @@ private:
                 }
             }
         }
+
+        // The specification of zwp_linux_buffer_params_v1.add says:
+        //
+        //        Warning: It should be an error if the format/modifier pair was not
+        //        advertised with the modifier event. This is not enforced yet because
+        //        some implementations always accept `DRM_FORMAT_MOD_INVALID`. Also
+        //        version 2 of this protocol does not have the modifier event.
+        //
+        // So don't enforce the error for this case
+        if (requested_modifier == DRM_FORMAT_MOD_INVALID)
+        {
+            mir::log_warning("Client requested unsupported format modifier: DRM_FORMAT_MOD_INVALID");
+            return Tex2D;
+        }
+
         BOOST_THROW_EXCEPTION((
             mw::ProtocolError{
                 resource,

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -749,7 +749,6 @@ private:
         // So don't enforce the error for this case
         if (requested_modifier == DRM_FORMAT_MOD_INVALID)
         {
-            mir::log_warning("Client requested unsupported format modifier: DRM_FORMAT_MOD_INVALID");
             return Tex2D;
         }
 


### PR DESCRIPTION
Some clients make this technically invalid request.

Fixes: #2177