### PR TITLE
Implement fullscreen_shell_chrome miral setting

### DIFF
--- a/include/miral/miral/window_manager_tools.h
+++ b/include/miral/miral/window_manager_tools.h
@@ -241,6 +241,14 @@ public:
         std::shared_ptr<Workspace> const& workspace,
         std::function<void(Window const& window)> const& callback);
 
+    /**
+     * Enable or disable shell chrome (panels, on-screen keyboards, etc) when a window is fullscreen.
+     * @param chrome
+     * @{
+     */
+    void set_fullscreen_shell_chrome(MirShellChrome chrome);
+    auto fullscreen_shell_chrome() const -> MirShellChrome;
+    /** @} */
 /** @} */
 
     /** Multi-thread support

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -192,6 +192,9 @@ public:
     auto id_for_window(Window const& window) const -> std::string override;
     void place_and_size_for_state(WindowSpecification& modifications, WindowInfo const& window_info) const override;
 
+    void set_fullscreen_shell_chrome(MirShellChrome chrome) override;
+    auto fullscreen_shell_chrome() const -> MirShellChrome override;
+
     void invoke_under_lock(std::function<void()> const& callback) override;
 
 private:
@@ -264,6 +267,7 @@ private:
     std::vector<std::shared_ptr<DisplayArea>> display_areas;
     /// If output configuration has changed and application zones need to be updated
     bool application_zones_need_update{false};
+    MirShellChrome fullscreen_shell_chrome_{mir_shell_chrome_low};
 
     friend class Workspace;
     using wwbimap_t = boost::bimap<

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -457,5 +457,7 @@ global:
     miral::WindowSpecification::focus_mode*;
     miral::toolkit::mir_keyboard_event_keysym*;
     miral::WindowSpecification::apply_to*;
+    miral::WindowManagerTools::set_fullscreen_shell_chrome*;
+    miral::WindowManagerTools::fullscreen_shell_chrome*;
   };
 } MIRAL_3.2;

--- a/src/miral/window_management_trace.cpp
+++ b/src/miral/window_management_trace.cpp
@@ -670,6 +670,19 @@ try {
 }
 MIRAL_TRACE_EXCEPTION
 
+void miral::WindowManagementTrace::set_fullscreen_shell_chrome(MirShellChrome chrome)
+try {
+    mir::log_info("%s chrome=%d", __func__, chrome);
+    wrapped.set_fullscreen_shell_chrome(chrome);
+}
+MIRAL_TRACE_EXCEPTION
+
+auto miral::WindowManagementTrace::fullscreen_shell_chrome() const -> MirShellChrome
+try {
+    return wrapped.fullscreen_shell_chrome();
+}
+MIRAL_TRACE_EXCEPTION
+
 auto miral::WindowManagementTrace::place_new_window(
     ApplicationInfo const& app_info,
     WindowSpecification const& requested_specification) -> WindowSpecification

--- a/src/miral/window_management_trace.h
+++ b/src/miral/window_management_trace.h
@@ -113,6 +113,9 @@ private:
     void for_each_window_in_workspace(
         std::shared_ptr<Workspace> const& workspace, std::function<void(Window const&)> const& callback) override;
 
+    void set_fullscreen_shell_chrome(MirShellChrome chrome) override;
+    auto fullscreen_shell_chrome() const -> MirShellChrome override;
+
     void handle_request_drag_and_drop(WindowInfo& window_info) override;
 
     void handle_request_move(WindowInfo& window_info, MirInputEvent const* input_event) override;

--- a/src/miral/window_manager_tools.cpp
+++ b/src/miral/window_manager_tools.cpp
@@ -139,3 +139,9 @@ void miral::WindowManagerTools::for_each_window_in_workspace(
     std::shared_ptr<miral::Workspace> const& workspace,
     std::function<void(miral::Window const&)> const& callback)
 { tools->for_each_window_in_workspace(workspace, callback); }
+
+void miral::WindowManagerTools::set_fullscreen_shell_chrome(MirShellChrome chrome)
+{ tools->set_fullscreen_shell_chrome(chrome); }
+
+auto miral::WindowManagerTools::fullscreen_shell_chrome() const -> MirShellChrome
+{ return tools->fullscreen_shell_chrome(); }

--- a/src/miral/window_manager_tools_implementation.h
+++ b/src/miral/window_manager_tools_implementation.h
@@ -88,6 +88,9 @@ public:
     virtual void for_each_window_in_workspace(
         std::shared_ptr<Workspace> const& workspace,
         std::function<void(Window const& window)> const& callback) = 0;
+    virtual void set_fullscreen_shell_chrome(MirShellChrome chrome) = 0;
+    virtual auto fullscreen_shell_chrome() const -> MirShellChrome = 0;
+
 
 /** @} */
 


### PR DESCRIPTION
Allows shell to toggle if fullscreen windows should have shell chrome. Doesn't have tests yet. I'm not sure if this is the best way to execute the "OSKs acting consistently on maximized and fullscreen windows" feature.