### PR TITLE
Add exclusive_mode property to windows

### DIFF
--- a/include/core/mir_toolkit/common.h
+++ b/include/core/mir_toolkit/common.h
@@ -428,4 +428,16 @@ typedef enum MirFocusMode
                                       leaving it as long as it has this mode */
 } MirFocusMode;
 
+/**
+ * Controls this surface's exclusive rect is applied. Only revenant to attached surfaces that have an exclusive rect.
+ */
+typedef enum MirExclusiveMode
+{
+    mir_exclusive_mode_enabled,             /**< If this surface is attached it's exclusive rect will affect the
+                                                 application zone */
+    mir_exclusive_mode_disabled,            /**< This surface's exclusive rect will not affect the application zone */
+    mir_exclusive_mode_affect_fullscreen,   /**< Same as mir_exclusive_mode_enabled, except this surface's exclusive
+                                                 rect will also effect fullscreen surfaces */
+} MirExclusiveMode;
+
 #endif

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -133,6 +133,10 @@ struct WindowInfo
     /// \remark Since MirAL 3.3
     auto focus_mode() const -> MirFocusMode;
 
+    /// If the window's exclusive rect should affect the application zone
+    /// \remark Since MirAL 3.3
+    auto exclusive_mode() const -> MirExclusiveMode;
+
 private:
     friend class BasicWindowManager;
     void name(std::string const& name);
@@ -159,6 +163,7 @@ private:
     void exclusive_rect(mir::optional_value<mir::geometry::Rectangle> const& rect);
     void application_id(std::string const& application_id);
     void focus_mode(MirFocusMode focus_mode);
+    void exclusive_mode(MirExclusiveMode exclusive_mode);
 
     struct Self;
     std::unique_ptr<Self> self;

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -170,6 +170,13 @@ public:
     auto focus_mode() -> mir::optional_value<MirFocusMode>&;
     ///@}
 
+    /// How this window interacts with exclusive zones
+    /// \remark Since MirAL 3.3
+    ///@{
+    auto exclusive_mode() const -> mir::optional_value<MirExclusiveMode> const&;
+    auto exclusive_mode() -> mir::optional_value<MirExclusiveMode>&;
+    ///@}
+
 private:
     friend auto make_surface_spec(WindowSpecification const& miral_spec) -> mir::shell::SurfaceSpecification;
     struct Self;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -453,9 +453,10 @@ global:
     miral::PrintTo*;
     miral::WaylandExtensions::zwp_input_method_v2*;
     miral::WaylandExtensions::zwp_virtual_keyboard_v1*;
+    miral::WindowInfo::exclusive_mode*;
     miral::WindowInfo::focus_mode*;
+    miral::WindowSpecification::exclusive_mode*;
     miral::WindowSpecification::focus_mode*;
     miral::toolkit::mir_keyboard_event_keysym*;
-    miral::WindowSpecification::apply_to*;
   };
 } MIRAL_3.2;

--- a/src/miral/window_info.cpp
+++ b/src/miral/window_info.cpp
@@ -484,3 +484,8 @@ auto miral::WindowInfo::focus_mode() const -> MirFocusMode
         return mir_focus_mode_disabled;
     }
 }
+
+auto miral::WindowInfo::exclusive_mode() const -> MirExclusiveMode
+{
+    return self->exclusive_mode;
+}

--- a/src/miral/window_info_internal.cpp
+++ b/src/miral/window_info_internal.cpp
@@ -89,7 +89,8 @@ miral::WindowInfo::Self::Self(Window window, WindowSpecification const& params) 
     max_aspect(optional_value_or_default(params.max_aspect(), default_max_aspect_ratio)),
     shell_chrome(optional_value_or_default(params.shell_chrome(), mir_shell_chrome_normal)),
     depth_layer(optional_value_or_default(params.depth_layer(), mir_depth_layer_application)),
-    attached_edges(optional_value_or_default(params.attached_edges(), mir_placement_gravity_center))
+    attached_edges(optional_value_or_default(params.attached_edges(), mir_placement_gravity_center)),
+    exclusive_mode(optional_value_or_default(params.exclusive_mode(), mir_exclusive_mode_enabled))
 {
     if (params.output_id().is_set())
         output_id = params.output_id().value();
@@ -105,7 +106,8 @@ miral::WindowInfo::Self::Self() :
     type{mir_window_type_normal},
     state{mir_window_state_unknown},
     preferred_orientation{mir_orientation_mode_any},
-    shell_chrome{mir_shell_chrome_normal}
+    shell_chrome{mir_shell_chrome_normal},
+    exclusive_mode{mir_exclusive_mode_enabled}
 {
 }
 
@@ -239,4 +241,9 @@ void miral::WindowInfo::focus_mode(MirFocusMode focus_mode)
 {
     if (std::shared_ptr<mir::scene::Surface> const surface = self->window)
         surface->set_focus_mode(focus_mode);
+}
+
+void miral::WindowInfo::exclusive_mode(MirExclusiveMode exclusive_mode)
+{
+    self->exclusive_mode = exclusive_mode;
 }

--- a/src/miral/window_info_internal.h
+++ b/src/miral/window_info_internal.h
@@ -51,6 +51,7 @@ struct miral::WindowInfo::Self
     MirDepthLayer depth_layer;
     MirPlacementGravity attached_edges;
     mir::optional_value<mir::geometry::Rectangle> exclusive_rect;
+    MirExclusiveMode exclusive_mode;
     std::shared_ptr<void> userdata;
 };
 

--- a/src/miral/window_specification.cpp
+++ b/src/miral/window_specification.cpp
@@ -441,6 +441,16 @@ auto miral::WindowSpecification::focus_mode() -> mir::optional_value<MirFocusMod
     return self->focus_mode;
 }
 
+auto miral::WindowSpecification::exclusive_mode() const -> mir::optional_value<MirExclusiveMode> const&
+{
+    return self->exclusive_mode;
+}
+
+auto miral::WindowSpecification::exclusive_mode() -> mir::optional_value<MirExclusiveMode>&
+{
+    return self->exclusive_mode;
+}
+
 auto miral::WindowSpecification::userdata() -> mir::optional_value<std::shared_ptr<void>>&
 {
     return self->userdata;

--- a/src/miral/window_specification_internal.h
+++ b/src/miral/window_specification_internal.h
@@ -74,6 +74,7 @@ struct WindowSpecification::Self
     mir::optional_value<std::string> application_id;
     mir::optional_value<bool> server_side_decorated;
     mir::optional_value<MirFocusMode> focus_mode;
+    mir::optional_value<MirExclusiveMode> exclusive_mode;
     mir::optional_value<std::shared_ptr<void>> userdata;
 };
 


### PR DESCRIPTION
Adds a property that allows shells to control if attached surfaces should push fullscreen surfaces out of the way. With this PR, application zones are refreshed ever time a surfaces becomes fullscreened or unfullscreened. It doesn't have tests yet, or pass existing tests (I'm working on it). Alternative to #2183.