### PR TITLE
Sequence AsyncServerRunner::start_server() setup on one thread

### DIFF
--- a/include/test/mir_test_framework/async_server_runner.h
+++ b/include/test/mir_test_framework/async_server_runner.h
@@ -51,13 +51,6 @@ public:
 
     mir::Server server;
 
-    template<typename Policy, typename ...Args>
-    void override_window_management_policy(Args& ... args)
-    {
-        set_window_management_policy =
-            miral::set_window_management_policy<Policy>(args...);
-    }
-
 private:
     std::list<TemporaryEnvironmentValue> env;
     mir::test::AutoJoinThread server_thread;

--- a/tests/mir_test_framework/async_server_runner.cpp
+++ b/tests/mir_test_framework/async_server_runner.cpp
@@ -47,8 +47,7 @@ namespace
 std::chrono::seconds const timeout{20};
 }
 
-mtf::AsyncServerRunner::AsyncServerRunner() :
-    set_window_management_policy{[](auto&){}}
+mtf::AsyncServerRunner::AsyncServerRunner()
 {
     unsetenv("WAYLAND_DISPLAY");    // We don't want to conflict with any existing Wayland server
     configure_from_commandline(server);
@@ -72,9 +71,7 @@ void mtf::AsyncServerRunner::add_to_environment(char const* key, char const* val
 
 void mtf::AsyncServerRunner::start_server()
 {
-    set_window_management_policy(server);
-
-    server.add_init_callback([&]
+    server.add_init_callback([this]
         {
             auto const main_loop = server.the_main_loop();
             // By enqueuing the notification code in the main loop, we are


### PR DESCRIPTION
Release builds on 21.04 segfault in mir_performance_tests

That happens because the callback passed to `add_init_callback()` executes with an invalid context.

I don't see how this could happen as the `std::functor` that contains it is built before the thread that executes it is started. (So that should be  sequenced-before.)

Anyway, moving the call to `add_init_callback()` onto the "AsyncServer" seems to avoid this and is otherwise harmless.