### PR TITLE
Error on invalid xdg_surface size

### DIFF
--- a/include/wayland/mir/wayland/wayland_base.h
+++ b/include/wayland/mir/wayland/wayland_base.h
@@ -34,6 +34,9 @@ namespace mir
 {
 namespace wayland
 {
+/// For when the protocol does not provide an appropriate error code
+uint32_t const generic_error_code = -1;
+
 /**
  * An exception type representing a Wayland protocol error
  *

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -229,6 +229,13 @@ void mf::XdgSurfaceStable::get_popup(
 
 void mf::XdgSurfaceStable::set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
 {
+    if (width <= 0 || height <= 0)
+    {
+        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+            resource,
+            mw::generic_error_code,
+            "Invalid %s size %dx%d", interface_name, width, height));
+    }
     if (window_role_)
     {
         window_role_.value().set_pending_offset(geom::Displacement{-x, -y});

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -233,6 +233,13 @@ void mf::XdgSurfaceV6::get_popup(wl_resource* new_popup, struct wl_resource* par
 
 void mf::XdgSurfaceV6::set_window_geometry(int32_t x, int32_t y, int32_t width, int32_t height)
 {
+    if (width <= 0 || height <= 0)
+    {
+        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+            resource,
+            mw::generic_error_code,
+            "Invalid %s size %dx%d", interface_name, width, height));
+    }
     if (window_role_)
     {
         window_role_.value().set_pending_offset(geom::Displacement{-x, -y});


### PR DESCRIPTION
I ran into this trying neverball on Arch.

I use `mw::ProtocolError` even though there is not valid error code, because that makes the client show the error. If I threw a `std::runtime_error` it only shows up in the Mir log, which a client dev may not check (I haven't checked if this is true for all clients or just SDL). In any case, I think this is more correct, and it's what wlroots does.