### PR TITLE
Add display-scale option

### DIFF
--- a/src/include/server/mir/graphics/default_display_configuration_policy.h
+++ b/src/include/server/mir/graphics/default_display_configuration_policy.h
@@ -31,21 +31,48 @@ namespace graphics
 class CloneDisplayConfigurationPolicy : public DisplayConfigurationPolicy
 {
 public:
+    CloneDisplayConfigurationPolicy() = default;
+    CloneDisplayConfigurationPolicy(double scale)
+        : scale{scale}
+    {
+    }
+
     void apply_to(DisplayConfiguration& conf);
+
+private:
+    double const scale{1.0};
 };
 
 /// Each screen placed to the right of the previous one
 class SideBySideDisplayConfigurationPolicy : public DisplayConfigurationPolicy
 {
 public:
+    SideBySideDisplayConfigurationPolicy() = default;
+    SideBySideDisplayConfigurationPolicy(double scale)
+        : scale{scale}
+    {
+    }
+
     void apply_to(graphics::DisplayConfiguration& conf);
+
+private:
+    double const scale{1.0};
 };
 
 /// Just use the first screen
 class SingleDisplayConfigurationPolicy : public DisplayConfigurationPolicy
 {
 public:
+    SingleDisplayConfigurationPolicy() = default;
+    SingleDisplayConfigurationPolicy(double scale)
+        : scale{scale}
+    {
+    }
+
     void apply_to(graphics::DisplayConfiguration& conf);
+
+private:
+    double const scale{1.0};
 };
 /** @} */
 }

--- a/src/miral/display_configuration_option.cpp
+++ b/src/miral/display_configuration_option.cpp
@@ -139,7 +139,7 @@ void miral::display_configuration_options(mir::Server& server)
             {
                 if (scale != 1.0)
                 {
-                    mir::fatal_error("Scale can't be set on the command line when using static display configuration");
+                    mir::fatal_error("Display scale option can't be when using static display configuration");
                 }
                 layout_selector = std::make_shared<StaticDisplayConfig>(display_layout.substr(strlen(static_opt_val)));
             }

--- a/src/miral/display_configuration_option.cpp
+++ b/src/miral/display_configuration_option.cpp
@@ -113,16 +113,19 @@ void miral::display_configuration_options(mir::Server& server)
             auto const scale_str = options->get<std::string>(display_scale_opt);
 
             double scale{0};
+            static double const scale_min = 0.01;
+            static double const scale_max = 100.0;
             try
             {
                 scale = std::stod(scale_str);
             }
             catch (std::invalid_argument const&)
             {
+                mir::fatal_error("Failed to parse scale '%s' as double", scale_str.c_str());
             }
-            if (scale < 0.01 || scale > 100.0)
+            if (scale < scale_min || scale > scale_max)
             {
-                mir::fatal_error("Invalid scale %s", scale_str.c_str());
+                mir::fatal_error("Invalid scale %f, must be between %f and %f", scale, scale_min, scale_max);
             }
 
             auto layout_selector = wrapped;

--- a/src/server/graphics/default_display_configuration_policy.cpp
+++ b/src/server/graphics/default_display_configuration_policy.cpp
@@ -83,7 +83,7 @@ void mg::CloneDisplayConfigurationPolicy::apply_to(DisplayConfiguration& conf)
 
             conf_output.used = true;
             conf_output.top_left = geom::Point{0, 0};
-            conf_output.scale = scale;
+            conf_output.scale *= scale;
             conf_output.current_mode_index = preferred_mode_index;
             conf_output.current_format = format;
             conf_output.power_mode = default_power_state;
@@ -102,7 +102,7 @@ void mg::SideBySideDisplayConfigurationPolicy::apply_to(graphics::DisplayConfigu
             {
                 conf_output.used = true;
                 conf_output.top_left = geom::Point{max_x, 0};
-                conf_output.scale = scale;
+                conf_output.scale *= scale;
                 size_t preferred_mode_index{select_mode_index(conf_output.preferred_mode_index, conf_output.modes)};
                 conf_output.current_mode_index = preferred_mode_index;
                 conf_output.power_mode = mir_power_mode_on;
@@ -129,7 +129,7 @@ void mg::SingleDisplayConfigurationPolicy::apply_to(graphics::DisplayConfigurati
             {
                 conf_output.used = true;
                 conf_output.top_left = geom::Point{0, 0};
-                conf_output.scale = scale;
+                conf_output.scale *= scale;
                 size_t preferred_mode_index{select_mode_index(conf_output.preferred_mode_index, conf_output.modes)};
                 conf_output.current_mode_index = preferred_mode_index;
                 conf_output.power_mode = mir_power_mode_on;

--- a/src/server/graphics/default_display_configuration_policy.cpp
+++ b/src/server/graphics/default_display_configuration_policy.cpp
@@ -83,6 +83,7 @@ void mg::CloneDisplayConfigurationPolicy::apply_to(DisplayConfiguration& conf)
 
             conf_output.used = true;
             conf_output.top_left = geom::Point{0, 0};
+            conf_output.scale = scale;
             conf_output.current_mode_index = preferred_mode_index;
             conf_output.current_format = format;
             conf_output.power_mode = default_power_state;
@@ -101,6 +102,7 @@ void mg::SideBySideDisplayConfigurationPolicy::apply_to(graphics::DisplayConfigu
             {
                 conf_output.used = true;
                 conf_output.top_left = geom::Point{max_x, 0};
+                conf_output.scale = scale;
                 size_t preferred_mode_index{select_mode_index(conf_output.preferred_mode_index, conf_output.modes)};
                 conf_output.current_mode_index = preferred_mode_index;
                 conf_output.power_mode = mir_power_mode_on;
@@ -127,6 +129,7 @@ void mg::SingleDisplayConfigurationPolicy::apply_to(graphics::DisplayConfigurati
             {
                 conf_output.used = true;
                 conf_output.top_left = geom::Point{0, 0};
+                conf_output.scale = scale;
                 size_t preferred_mode_index{select_mode_index(conf_output.preferred_mode_index, conf_output.modes)};
                 conf_output.current_mode_index = preferred_mode_index;
                 conf_output.power_mode = mir_power_mode_on;

--- a/tests/unit-tests/graphics/test_default_display_configuration_policy.cpp
+++ b/tests/unit-tests/graphics/test_default_display_configuration_policy.cpp
@@ -407,8 +407,6 @@ TEST(SideBySideDisplayConfigurationPolicyTest, uses_specified_scale_multiplyer)
 
     policy.apply_to(conf);
 
-    Point expected_position;
-
     conf.for_each_output([&](DisplayConfigurationOutput const& output)
     {
         if (output.connected && output.modes.size() > 0)

--- a/tests/unit-tests/graphics/test_default_display_configuration_policy.cpp
+++ b/tests/unit-tests/graphics/test_default_display_configuration_policy.cpp
@@ -236,6 +236,24 @@ TEST(CloneDisplayConfigurationPolicyTest, accept_transparency_when_only_option)
     });
 }
 
+TEST(CloneDisplayConfigurationPolicyTest, uses_specified_scale_multiplyer)
+{
+    using namespace ::testing;
+
+    CloneDisplayConfigurationPolicy policy{3.0};
+    StubDisplayConfiguration conf{create_default_configuration()};
+
+    policy.apply_to(conf);
+
+    conf.for_each_output([&](DisplayConfigurationOutput const& output)
+    {
+        if (output.connected && output.modes.size() > 0)
+        {
+            EXPECT_EQ(output.scale, 3.0);
+        }
+    });
+}
+
 TEST(SingleDisplayConfigurationPolicyTest, uses_first_of_connected_valid_outputs)
 {
     using namespace ::testing;
@@ -298,6 +316,24 @@ TEST(SingleDisplayConfigurationPolicyTest, default_orientation_is_normal)
     });
 }
 
+TEST(SingleDisplayConfigurationPolicyTest, uses_specified_scale_multiplyer)
+{
+    using namespace ::testing;
+
+    SingleDisplayConfigurationPolicy policy{3.0};
+    auto conf = create_default_configuration();
+
+    policy.apply_to(conf);
+
+    conf.for_each_output([&](DisplayConfigurationOutput const& output)
+    {
+        if (output.used)
+        {
+            EXPECT_EQ(output.scale, 3.0);
+        }
+    });
+}
+
 TEST(SideBySideDisplayConfigurationPolicyTest, uses_all_connected_valid_outputs)
 {
     using namespace ::testing;
@@ -353,6 +389,31 @@ TEST(SideBySideDisplayConfigurationPolicyTest, placement_respects_scale)
         else
         {
             EXPECT_FALSE(output.used);
+        }
+    });
+}
+
+TEST(SideBySideDisplayConfigurationPolicyTest, uses_specified_scale_multiplyer)
+{
+    using namespace ::testing;
+
+    SideBySideDisplayConfigurationPolicy policy{3.0};
+    StubDisplayConfiguration conf{create_default_configuration()};
+
+    conf.for_each_output([&](UserDisplayConfigurationOutput const& output)
+    {
+        output.scale = 2.0f;
+    });
+
+    policy.apply_to(conf);
+
+    Point expected_position;
+
+    conf.for_each_output([&](DisplayConfigurationOutput const& output)
+    {
+        if (output.connected && output.modes.size() > 0)
+        {
+            EXPECT_EQ(output.scale, 6.0);
         }
     });
 }


### PR DESCRIPTION
This may be useful in all sorts of contexts. It only allows specifying one scale for all outputs, but in many cases that's all you need.