### PR TITLE
Change extension names to always match global names

### DIFF
--- a/debian/libmiral4.symbols
+++ b/debian/libmiral4.symbols
@@ -401,4 +401,6 @@ libmiral.so.4 libmiral4 #MINVER#
  (c++)"miral::WindowSpecification::focus_mode()@MIRAL_3.3" 3.3.0
  (c++)"miral::toolkit::mir_keyboard_event_keysym(MirKeyboardEvent const*)@MIRAL_3.3" 3.3.0
  MIRAL_3.4@MIRAL_3.4 3.4.0
+ (c++)"miral::WaylandExtensions::zwp_input_method_manager_v2@MIRAL_3.4" 3.4.0
+ (c++)"miral::WaylandExtensions::zwp_virtual_keyboard_manager_v1@MIRAL_3.4" 3.4.0
  (c++)"miral::socket_fd_of(std::shared_ptr<mir::scene::Session> const&)@MIRAL_3.4" 3.4.0

--- a/include/miral/miral/wayland_extensions.h
+++ b/include/miral/miral/wayland_extensions.h
@@ -124,15 +124,24 @@ public:
     /// Allows clients to act as a virtual keyboard, useful for on-screen keyboards.
     /// Clients are not required to display anything to send keyboard events using this extension,
     /// so malicious clients could use it to take actions without user input.
-    /// \remark Since MirAL 3.3
-    static char const* const zwp_virtual_keyboard_v1;
+    /// \remark Since MirAL 3.4
+    static char const* const zwp_virtual_keyboard_manager_v1;
+
 
     /// Allows clients (such as on-screen keyboards) to intercept physical key events and act as a
     /// source of text input for other clients. Input methods are not required to display anything
     /// to use this extension, so malicious clients could use it to intercept keys events or take
     /// actions without user input.
-    /// \remark Since MirAL 3.3
+    /// \remark Since MirAL 3.4
+    static char const* const zwp_input_method_manager_v2;
+
+    /**
+     * \remark Since MirAL 3.3
+     * \deprecated Use the *_manager_* versions instead
+     * @{ */
+    static char const* const zwp_virtual_keyboard_v1;
     static char const* const zwp_input_method_v2;
+    /** @} */
     /** @} */
 
     /// Add a bespoke Wayland extension both to "supported" and "enabled by default".

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -464,5 +464,7 @@ MIRAL_3.4 {
 global:
   extern "C++" {
     miral::socket_fd_of*;
+    miral::WaylandExtensions::zwp_input_method_manager_v2*;
+    miral::WaylandExtensions::zwp_virtual_keyboard_manager_v1*;
   };
 } MIRAL_3.3;

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -37,8 +37,12 @@ namespace mo = mir::options;
 char const* const miral::WaylandExtensions::zwlr_layer_shell_v1{"zwlr_layer_shell_v1"};
 char const* const miral::WaylandExtensions::zxdg_output_manager_v1{"zxdg_output_manager_v1"};
 char const* const miral::WaylandExtensions::zwlr_foreign_toplevel_manager_v1{"zwlr_foreign_toplevel_manager_v1"};
-char const* const miral::WaylandExtensions::zwp_virtual_keyboard_v1{"zwp_virtual_keyboard_v1"};
-char const* const miral::WaylandExtensions::zwp_input_method_v2{"zwp_input_method_v2"};
+/// Not in the header, but keeping around for ABI compat
+char const* const miral::WaylandExtensions::zwp_virtual_keyboard_v1{"zwp_virtual_keyboard_manager_v1"};
+char const* const miral::WaylandExtensions::zwp_virtual_keyboard_manager_v1{"zwp_virtual_keyboard_manager_v1"};
+/// Not in the header, but keeping around for ABI compat
+char const* const miral::WaylandExtensions::zwp_input_method_v2{"zwp_input_method_manager_v2"};
+char const* const miral::WaylandExtensions::zwp_input_method_manager_v2{"zwp_input_method_manager_v2"};
 
 namespace
 {

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -193,20 +193,39 @@ struct miral::WaylandExtensions::Self
         printf("%s = %s\n", __PRETTY_FUNCTION__, builder.name.c_str());
     }
 
+    void throw_unsupported_extension_error(std::string const& name, std::string const& action)
+    {
+        auto message = "Attempted to " + action + " unsupported extension " + name;
+        auto const iter = alternative_extension_names.find(name);
+        if (iter != alternative_extension_names.end())
+        {
+            message += " (perhaps the shell meant to enable " + iter->second + "?)";
+        }
+        BOOST_THROW_EXCEPTION(std::runtime_error(message));
+    }
+
     void enable_extension(std::string name)
     {
         if (supported_extensions.find(name) == supported_extensions.end())
-            BOOST_THROW_EXCEPTION(std::runtime_error("Attempted to enable unsupported extension " + name));
+        {
+            throw_unsupported_extension_error(name, "enable");
+        }
         else
+        {
             default_extensions.insert(name);
+        }
     }
 
     void disable_extension(std::string name)
     {
         if (supported_extensions.find(name) == supported_extensions.end())
-            BOOST_THROW_EXCEPTION(std::runtime_error("Attempted to disable unsupported extension " + name));
+        {
+            throw_unsupported_extension_error(name, "disable");
+        }
         else
+        {
             default_extensions.erase(name);
+        }
     }
 
     std::vector<Builder> wayland_extension_hooks;

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -18,7 +18,6 @@
 
 #include "foreign_toplevel_manager_v1.h"
 
-#include "wlr-foreign-toplevel-management-unstable-v1_wrapper.h"
 #include "wayland_utils.h"
 #include "mir/frontend/surface_stack.h"
 #include "mir/shell/shell.h"
@@ -192,7 +191,8 @@ auto mf::create_foreign_toplevel_manager_v1(
     wl_display* display,
     std::shared_ptr<shell::Shell> const& shell,
     std::shared_ptr<Executor> const& wayland_executor,
-    std::shared_ptr<SurfaceStack> const& surface_stack) -> std::shared_ptr<ForeignToplevelManagerV1Global>
+    std::shared_ptr<SurfaceStack> const& surface_stack)
+-> std::shared_ptr<mw::ForeignToplevelManagerV1::Global>
 {
     return std::make_shared<ForeignToplevelManagerV1Global>(display, shell, wayland_executor, surface_stack);
 }

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.h
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.h
@@ -19,8 +19,9 @@
 #ifndef MIR_FRONTEND_FOREIGN_TOPLEVEL_MANAGER_V1_H
 #define MIR_FRONTEND_FOREIGN_TOPLEVEL_MANAGER_V1_H
 
+#include "wlr-foreign-toplevel-management-unstable-v1_wrapper.h"
+
 #include <memory>
-struct wl_display;
 
 namespace mir
 {
@@ -32,13 +33,13 @@ class Shell;
 namespace frontend
 {
 class SurfaceStack;
-class ForeignToplevelManagerV1Global;
 
 auto create_foreign_toplevel_manager_v1(
     wl_display* display,
     std::shared_ptr<shell::Shell> const& shell,
     std::shared_ptr<Executor> const& wayland_executor,
-    std::shared_ptr<SurfaceStack> const& surface_stack) -> std::shared_ptr<ForeignToplevelManagerV1Global>;
+    std::shared_ptr<SurfaceStack> const& surface_stack)
+-> std::shared_ptr<wayland::ForeignToplevelManagerV1::Global>;
 }
 }
 

--- a/src/server/frontend_wayland/input_method_v2.cpp
+++ b/src/server/frontend_wayland/input_method_v2.cpp
@@ -18,7 +18,6 @@
 
 #include "input_method_v2.h"
 #include "input_method_grab_keyboard_v2.h"
-#include "input-method-unstable-v2_wrapper.h"
 #include "text-input-unstable-v3_wrapper.h"
 #include "wl_seat.h"
 
@@ -239,7 +238,8 @@ auto mf::create_input_method_manager_v2(
     wl_display* display,
     std::shared_ptr<Executor> const& wayland_executor,
     std::shared_ptr<scene::TextInputHub> const& text_input_hub,
-    std::shared_ptr<input::CompositeEventFilter> const event_filter) -> std::shared_ptr<InputMethodManagerV2Global>
+    std::shared_ptr<input::CompositeEventFilter> const event_filter)
+-> std::shared_ptr<mw::InputMethodManagerV2::Global>
 {
     auto ctx = std::shared_ptr<InputMethodV2Ctx>{new InputMethodV2Ctx{wayland_executor, text_input_hub, event_filter}};
     return std::make_shared<InputMethodManagerV2Global>(display, std::move(ctx));

--- a/src/server/frontend_wayland/input_method_v2.h
+++ b/src/server/frontend_wayland/input_method_v2.h
@@ -19,8 +19,10 @@
 #ifndef MIR_FRONTEND_INPUT_METHOD_V2_H
 #define MIR_FRONTEND_INPUT_METHOD_V2_H
 
+
+#include "input-method-unstable-v2_wrapper.h"
+
 #include <memory>
-struct wl_display;
 
 namespace mir
 {
@@ -35,13 +37,12 @@ class CompositeEventFilter;
 }
 namespace frontend
 {
-class InputMethodManagerV2Global;
-
 auto create_input_method_manager_v2(
     wl_display* display,
     std::shared_ptr<Executor> const& wayland_executor,
     std::shared_ptr<scene::TextInputHub> const& text_input_hub,
-    std::shared_ptr<input::CompositeEventFilter> const event_filter) -> std::shared_ptr<InputMethodManagerV2Global>;
+    std::shared_ptr<input::CompositeEventFilter> const event_filter)
+-> std::shared_ptr<wayland::InputMethodManagerV2::Global>;
 }
 }
 

--- a/src/server/frontend_wayland/pointer_constraints_unstable_v1.cpp
+++ b/src/server/frontend_wayland/pointer_constraints_unstable_v1.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "pointer_constraints_unstable_v1.h"
-#include "pointer-constraints-unstable-v1_wrapper.h"
 #include "wl_region.h"
 #include "wl_surface.h"
 
@@ -224,8 +223,11 @@ void ConfinedPointerV1::SurfaceObserver::attrib_changed(
 }
 }
 
-auto mir::frontend::create_pointer_constraints_unstable_v1(wl_display* display, Executor& wayland_executor, std::shared_ptr<shell::Shell> shell)
-    -> std::shared_ptr<void>
+auto mir::frontend::create_pointer_constraints_unstable_v1(
+    wl_display* display,
+    Executor& wayland_executor,
+    std::shared_ptr<shell::Shell> shell)
+-> std::shared_ptr<mw::PointerConstraintsV1::Global>
 {
     return std::make_shared<PointerConstraintsV1::Global>(display, wayland_executor, std::move(shell));
 }

--- a/src/server/frontend_wayland/pointer_constraints_unstable_v1.h
+++ b/src/server/frontend_wayland/pointer_constraints_unstable_v1.h
@@ -17,6 +17,8 @@
 #ifndef MIR_FRONTEND_POINTER_CONSTRAINTS_UNSTABLE_V1_H
 #define MIR_FRONTEND_POINTER_CONSTRAINTS_UNSTABLE_V1_H
 
+#include "pointer-constraints-unstable-v1_wrapper.h"
+
 #include <memory>
 
 struct wl_display;
@@ -33,7 +35,8 @@ class WlSeat;
 auto create_pointer_constraints_unstable_v1(
     wl_display* display,
     Executor& wayland_executor,
-    std::shared_ptr<shell::Shell> shell) -> std::shared_ptr<void>;
+    std::shared_ptr<shell::Shell> shell)
+-> std::shared_ptr<wayland::PointerConstraintsV1::Global>;
 
 }
 }

--- a/src/server/frontend_wayland/relative_pointer_unstable_v1.cpp
+++ b/src/server/frontend_wayland/relative_pointer_unstable_v1.cpp
@@ -15,12 +15,13 @@
  */
 
 #include "relative_pointer_unstable_v1.h"
-#include "relative-pointer-unstable-v1_wrapper.h"
 #include "wl_pointer.h"
 
 #include <mir/scene/surface.h>
 #include <mir/shell/shell.h>
 #include <mir/shell/surface_specification.h>
+
+namespace mw = mir::wayland;
 
 namespace mir
 {
@@ -59,7 +60,7 @@ private:
 }
 
 auto mir::frontend::create_relative_pointer_unstable_v1(wl_display *display, std::shared_ptr<shell::Shell> shell)
-    -> std::shared_ptr<void>
+-> std::shared_ptr<mw::RelativePointerManagerV1::Global>
 {
     return std::make_shared<RelativePointerManagerV1::Global>(display, std::move(shell));
 }

--- a/src/server/frontend_wayland/relative_pointer_unstable_v1.h
+++ b/src/server/frontend_wayland/relative_pointer_unstable_v1.h
@@ -17,9 +17,9 @@
 #ifndef MIR_FRONTEND_RELATIVE_POINTER_UNSTABLE_V1_H
 #define MIR_FRONTEND_RELATIVE_POINTER_UNSTABLE_V1_H
 
-#include <memory>
+#include "relative-pointer-unstable-v1_wrapper.h"
 
-struct wl_display;
+#include <memory>
 
 namespace mir
 {
@@ -27,7 +27,10 @@ namespace shell { class Shell; }
 
 namespace frontend
 {
-auto create_relative_pointer_unstable_v1(wl_display* display, std::shared_ptr<shell::Shell> shell) -> std::shared_ptr<void>;
+auto create_relative_pointer_unstable_v1(
+    wl_display* display,
+    std::shared_ptr<shell::Shell> shell)
+-> std::shared_ptr<wayland::RelativePointerManagerV1::Global>;
 }
 }
 

--- a/src/server/frontend_wayland/text_input_v3.cpp
+++ b/src/server/frontend_wayland/text_input_v3.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "text_input_v3.h"
-#include "text-input-unstable-v3_wrapper.h"
 
 #include "wl_seat.h"
 #include "wl_surface.h"
@@ -231,7 +230,7 @@ auto mf::create_text_input_manager_v3(
     wl_display* display,
     std::shared_ptr<Executor> const& wayland_executor,
     std::shared_ptr<scene::TextInputHub> const& text_input_hub)
--> std::shared_ptr<TextInputManagerV3Global>
+-> std::shared_ptr<mw::TextInputManagerV3::Global>
 {
     auto ctx = std::shared_ptr<TextInputV3Ctx>{new TextInputV3Ctx{wayland_executor, text_input_hub}};
     return std::make_shared<TextInputManagerV3Global>(display, std::move(ctx));

--- a/src/server/frontend_wayland/text_input_v3.h
+++ b/src/server/frontend_wayland/text_input_v3.h
@@ -19,8 +19,9 @@
 #ifndef MIR_FRONTEND_TEXT_INPUT_V3_H
 #define MIR_FRONTEND_TEXT_INPUT_V3_H
 
+#include "text-input-unstable-v3_wrapper.h"
+
 #include <memory>
-struct wl_display;
 
 namespace mir
 {
@@ -31,13 +32,11 @@ class TextInputHub;
 }
 namespace frontend
 {
-class TextInputManagerV3Global;
-
 auto create_text_input_manager_v3(
     wl_display* display,
     std::shared_ptr<Executor> const& wayland_executor,
     std::shared_ptr<scene::TextInputHub> const& text_input_hub)
--> std::shared_ptr<TextInputManagerV3Global>;
+-> std::shared_ptr<wayland::TextInputManagerV3::Global>;
 }
 }
 

--- a/src/server/frontend_wayland/virtual_keyboard_v1.cpp
+++ b/src/server/frontend_wayland/virtual_keyboard_v1.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "virtual_keyboard_v1.h"
-#include "virtual-keyboard-unstable-v1_wrapper.h"
 #include "wayland_wrapper.h"
 
 #include "mir/input/event_builder.h"
@@ -217,7 +216,8 @@ private:
 
 auto mf::create_virtual_keyboard_manager_v1(
     wl_display* display,
-    std::shared_ptr<mi::InputDeviceRegistry> const& device_registry) -> std::shared_ptr<VirtualKeyboardManagerV1Global>
+    std::shared_ptr<mi::InputDeviceRegistry> const& device_registry)
+-> std::shared_ptr<mw::VirtualKeyboardManagerV1::Global>
 {
     auto ctx = std::shared_ptr<VirtualKeyboardV1Ctx>{new VirtualKeyboardV1Ctx{device_registry}};
     return std::make_shared<VirtualKeyboardManagerV1Global>(display, std::move(ctx));

--- a/src/server/frontend_wayland/virtual_keyboard_v1.h
+++ b/src/server/frontend_wayland/virtual_keyboard_v1.h
@@ -19,8 +19,9 @@
 #ifndef MIR_FRONTEND_VIRTUAL_KEYBOARD_V1_H
 #define MIR_FRONTEND_VIRTUAL_KEYBOARD_V1_H
 
+#include "virtual-keyboard-unstable-v1_wrapper.h"
+
 #include <memory>
-struct wl_display;
 
 namespace mir
 {
@@ -30,12 +31,10 @@ class InputDeviceRegistry;
 }
 namespace frontend
 {
-class VirtualKeyboardManagerV1Global;
-
 auto create_virtual_keyboard_manager_v1(
     wl_display* display,
     std::shared_ptr<input::InputDeviceRegistry> const& device_registry)
--> std::shared_ptr<VirtualKeyboardManagerV1Global>;
+-> std::shared_ptr<wayland::VirtualKeyboardManagerV1::Global>;
 }
 }
 

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -32,8 +32,6 @@
 #include "output_manager.h"
 #include "wayland_executor.h"
 
-#include "wayland_wrapper.h"
-
 #include "mir/frontend/wayland.h"
 
 #include "mir/main_loop.h"
@@ -458,7 +456,7 @@ auto mf::create_wl_shell(
     std::shared_ptr<msh::Shell> const& shell,
     WlSeat* seat,
     OutputManager* const output_manager)
--> std::shared_ptr<void>
+-> std::shared_ptr<mw::Shell::Global>
 {
     return std::make_shared<mf::WlShell>(display, wayland_executor, shell, *seat, output_manager);
 }

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -463,7 +463,7 @@ auto mf::create_wl_shell(
 
 void mf::WaylandExtensions::init(Context const& context)
 {
-    valid_global_names = {
+    valid_global_names.insert({
         mw::Compositor::interface_name,
         mw::Subcompositor::interface_name,
         mw::Shm::interface_name,
@@ -472,7 +472,7 @@ void mf::WaylandExtensions::init(Context const& context)
         mw::DataDeviceManager::interface_name,
         "wl_drm",
         "zwp_linux_dmabuf_v1",
-    };
+    });
     custom_extensions(context);
 }
 

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -19,6 +19,7 @@
 #ifndef MIR_FRONTEND_WAYLAND_CONNECTOR_H_
 #define MIR_FRONTEND_WAYLAND_CONNECTOR_H_
 
+#include "wayland_wrapper.h"
 #include "mir/frontend/connector.h"
 #include "mir/fd.h"
 #include "mir/optional_value.h"
@@ -185,7 +186,7 @@ auto create_wl_shell(
     Executor& wayland_executor,
     std::shared_ptr<shell::Shell> const& shell,
     WlSeat* seat,
-    OutputManager* const output_manager) -> std::shared_ptr<void>;
+    OutputManager* const output_manager) -> std::shared_ptr<wayland::Shell::Global>;
 
 auto get_wl_shell_window(wl_resource* surface) -> std::shared_ptr<scene::Surface>;
 }

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -26,6 +26,7 @@
 
 #include <wayland-server-core.h>
 #include <unordered_map>
+#include <unordered_set>
 #include <thread>
 #include <vector>
 #include <mir/server_configuration.h>
@@ -102,6 +103,7 @@ public:
     void init(Context const& context);
 
     auto get_extension(std::string const& name) const -> std::shared_ptr<void>;
+    auto is_valid_global_name(std::string const& name) const -> bool;
 
 protected:
 
@@ -110,6 +112,7 @@ protected:
 
 private:
     std::unordered_map<std::string, std::shared_ptr<void>> extension_protocols;
+    std::unordered_set<std::string> valid_global_names;
 };
 
 class WaylandConnector : public Connector

--- a/src/server/frontend_wayland/xdg_output_v1.cpp
+++ b/src/server/frontend_wayland/xdg_output_v1.cpp
@@ -76,7 +76,7 @@ private:
 }
 
 auto mf::create_xdg_output_manager_v1(struct wl_display* display, OutputManager* const output_manager)
-    -> std::shared_ptr<XdgOutputManagerV1>
+    -> std::shared_ptr<mw::XdgOutputManagerV1::Global>
 {
     return std::make_shared<XdgOutputManagerV1>(display, output_manager);
 }

--- a/src/server/frontend_wayland/xdg_output_v1.h
+++ b/src/server/frontend_wayland/xdg_output_v1.h
@@ -19,6 +19,7 @@
 #ifndef MIR_FRONTEND_XDG_OUTPUT_V1_H
 #define MIR_FRONTEND_XDG_OUTPUT_V1_H
 
+#include "xdg-output-unstable-v1_wrapper.h"
 #include <memory>
 
 struct wl_display;
@@ -27,11 +28,10 @@ namespace mir
 {
 namespace frontend
 {
-class XdgOutputManagerV1;
 class OutputManager;
 
 auto create_xdg_output_manager_v1(struct wl_display* display, OutputManager* const output_manager)
-    -> std::shared_ptr<XdgOutputManagerV1>;
+    -> std::shared_ptr<wayland::XdgOutputManagerV1::Global>;
 
 }
 }

--- a/tests/miral/wayland_extensions.cpp
+++ b/tests/miral/wayland_extensions.cpp
@@ -529,3 +529,19 @@ TEST_F(WaylandExtensions, drop_extensions_option_removes_extensions)
     EXPECT_THAT(*enumerator_client.interfaces, Not(Contains(Eq("xdg_wm_base"))));
     EXPECT_THAT(*enumerator_client.interfaces, Not(Contains(Eq("zwlr_layer_shell_v1"))));
 }
+
+TEST_F(WaylandExtensions, add_extensions_option_adds_extensions_if_name_is_not_global_name)
+{
+    miral::WaylandExtensions extensions;
+    ClientGlobalEnumerator enumerator_client;
+
+    add_to_environment("MIR_SERVER_ADD_WAYLAND_EXTENSIONS", "zwp_input_method_v2:zwp_virtual_keyboard_v1");
+
+    add_server_init(extensions);
+    start_server();
+
+    run_as_client(enumerator_client);
+
+    EXPECT_THAT(*enumerator_client.interfaces, Contains(Eq("zwp_input_method_manager_v2")));
+    EXPECT_THAT(*enumerator_client.interfaces, Contains(Eq("zwp_virtual_keyboard_manager_v1")));
+}


### PR DESCRIPTION
Fixes #2208. Extension names are now automatically deduced for built-in extensions, and if a bespoke extension with an invalid name is enabled, a fatal error is raised at startup.