### PR TITLE
Allow globals with unknown names

### DIFF
--- a/include/miral/miral/wayland_extensions.h
+++ b/include/miral/miral/wayland_extensions.h
@@ -82,7 +82,7 @@ public:
     /// \remark Since MirAL 2.5
     struct Builder
     {
-        /// Name of the protocol extension
+        /// Name of the protocol extension's Wayland global
         std::string name;
 
         /// Functor that creates and registers an extension protocol

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -463,22 +463,11 @@ auto mf::create_wl_shell(
 
 void mf::WaylandExtensions::init(Context const& context)
 {
-    valid_global_names.insert({
-        mw::Compositor::interface_name,
-        mw::Subcompositor::interface_name,
-        mw::Shm::interface_name,
-        mw::Seat::interface_name,
-        mw::Output::interface_name,
-        mw::DataDeviceManager::interface_name,
-        "wl_drm",
-        "zwp_linux_dmabuf_v1",
-    });
     custom_extensions(context);
 }
 
 void mf::WaylandExtensions::add_extension(std::string const name, std::shared_ptr<void> implementation)
 {
-    valid_global_names.insert(name);
     extension_protocols[std::move(name)] = std::move(implementation);
 }
 
@@ -493,11 +482,6 @@ auto mir::frontend::WaylandExtensions::get_extension(std::string const& name) co
         return result->second;
 
     return {};
-}
-
-auto mf::WaylandExtensions::is_valid_global_name(std::string const& name) const -> bool
-{
-    return valid_global_names.find(name) != valid_global_names.end();
 }
 
 void mf::WaylandExtensions::run_builders(wl_display*, std::function<void(std::function<void()>&& work)> const&)
@@ -786,14 +770,6 @@ bool mf::WaylandConnector::wl_display_global_filter_func_thunk(wl_client const* 
 bool mf::WaylandConnector::wl_display_global_filter_func(wl_client const* client, wl_global const* global) const
 {
     auto const* const interface = wl_global_get_interface(global);
-    if (!extensions->is_valid_global_name(interface->name))
-    {
-        fatal_error(
-            "Unknown global %s. "
-            "Custom extension may have been added with incorrect name, "
-            "or default global may need to be added to mf::WaylandExtensions::init()",
-            interface->name);
-    }
     auto const session = get_session(const_cast<wl_client*>(client));
     return extension_filter(session, interface->name);
 }

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -103,7 +103,6 @@ public:
     void init(Context const& context);
 
     auto get_extension(std::string const& name) const -> std::shared_ptr<void>;
-    auto is_valid_global_name(std::string const& name) const -> bool;
 
 protected:
 
@@ -112,7 +111,6 @@ protected:
 
 private:
     std::unordered_map<std::string, std::shared_ptr<void>> extension_protocols;
-    std::unordered_set<std::string> valid_global_names;
 };
 
 class WaylandConnector : public Connector


### PR DESCRIPTION
Fixes #2227. We lose a diagnostic, but I don't see a good way of keeping it.