### PR TITLE
Add IdleHub and support powering down outputs on idle

### DIFF
--- a/include/test/mir/test/doubles/mock_idle_hub.h
+++ b/include/test/mir/test/doubles/mock_idle_hub.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_TEST_DOUBLES_MOCK_IDLE_HUB_H_
+#define MIR_TEST_DOUBLES_MOCK_IDLE_HUB_H_
+
+#include "mir/scene/idle_hub.h"
+
+namespace mir
+{
+namespace test
+{
+namespace doubles
+{
+
+struct MockIdleHub : mir::scene::IdleHub
+{
+    MOCK_METHOD0(state, mir::scene::IdleState());
+    MOCK_METHOD0(poke, void());
+    MOCK_METHOD1(register_interest, void(std::weak_ptr<mir::scene::IdleStateObserver> const&));
+    MOCK_METHOD2(register_interest, void(std::weak_ptr<mir::scene::IdleStateObserver> const&, mir::Executor&));
+    MOCK_METHOD1(unregister_interest, void(mir::scene::IdleStateObserver const&));
+};
+
+}
+}
+}
+
+#endif // MIR_TEST_DOUBLES_MOCK_IDLE_HUB_H_

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -190,6 +190,7 @@ public:
     std::shared_ptr<cookie::Authority>      the_cookie_authority() override;
     std::shared_ptr<scene::Clipboard>       the_clipboard() override;
     std::shared_ptr<scene::TextInputHub>    the_text_input_hub() override;
+    std::shared_ptr<scene::IdleHub>         the_idle_hub() override;
     std::function<void()>                   the_stop_callback() override;
     void add_wayland_extension(
         std::string const& name,
@@ -412,6 +413,7 @@ protected:
     CachedPtr<scene::SnapshotStrategy>  snapshot_strategy;
     CachedPtr<scene::Clipboard>         clipboard;
     CachedPtr<scene::TextInputHub>      text_input_hub;
+    CachedPtr<scene::IdleHub>           idle_hub;
     CachedPtr<shell::DisplayLayout>     shell_display_layout;
     CachedPtr<compositor::DisplayBufferCompositorFactory> display_buffer_compositor_factory;
     CachedPtr<compositor::Compositor> compositor;

--- a/src/include/server/mir/scene/idle_hub.h
+++ b/src/include/server/mir/scene/idle_hub.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored By: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_SCENE_IDLE_HUB_H_
+#define MIR_SCENE_IDLE_HUB_H_
+
+#include "mir/observer_registrar.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace mir
+{
+namespace scene
+{
+enum class IdleState
+{
+    awake,      ///< Outputs should be on
+    dim,        ///< Outputs should be on, but dimmed
+    standby,    ///< Outputs should be in mir_power_mode_standby
+    off,        ///< Outputs should be in mir_power_mode_off
+};
+
+/// Gets notifications about changes in the idle state
+class IdleStateObserver
+{
+public:
+    IdleStateObserver() = default;
+    virtual ~IdleStateObserver() = default;
+
+    virtual void idle_state_changed(IdleState state) = 0;
+
+private:
+    IdleStateObserver(IdleStateObserver const&) = delete;
+    IdleStateObserver& operator=(IdleStateObserver const&) = delete;
+};
+
+/// Interface allowing for input methods to get state from and send text input to clients. When a new observer is
+/// registered, it is immediately given the initial state on the current thread.
+class IdleHub : public ObserverRegistrar<IdleStateObserver>
+{
+public:
+    virtual ~IdleHub() = default;
+
+    /// Current state
+    virtual auto state() -> IdleState = 0;
+
+    /// Wakes Mir if it's not already awake, and starts the timer from now
+    virtual void poke() = 0;
+};
+}
+}
+
+#endif // MIR_SCENE_IDLE_HUB_H_

--- a/src/include/server/mir/server_configuration.h
+++ b/src/include/server/mir/server_configuration.h
@@ -63,6 +63,7 @@ class ApplicationNotRespondingDetector;
 class Session;
 class Clipboard;
 class TextInputHub;
+class IdleHub;
 }
 
 class MainLoop;
@@ -92,6 +93,7 @@ public:
     virtual std::shared_ptr<scene::ApplicationNotRespondingDetector> the_application_not_responding_detector() = 0;
     virtual std::shared_ptr<scene::Clipboard> the_clipboard() = 0;
     virtual std::shared_ptr<scene::TextInputHub> the_text_input_hub() = 0;
+    virtual std::shared_ptr<scene::IdleHub> the_idle_hub() = 0;
     virtual std::function<void()> the_stop_callback() = 0;
     virtual void add_wayland_extension(
         std::string const& name,

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -249,7 +249,19 @@ void mgx::Display::configure(mg::DisplayConfiguration const& new_configuration)
             {
                 *output->config = conf_output;
                 output->display_buffer->set_view_area(output->config->extents());
-                output->display_buffer->set_transformation(output->config->transformation());
+                switch (output->config->power_mode)
+                {
+                case mir_power_mode_on:
+                    output->display_buffer->set_transformation(output->config->transformation());
+                    break;
+
+                case mir_power_mode_standby:
+                case mir_power_mode_suspend:
+                case mir_power_mode_off:
+                    // Simulate an off display by setting a zeroed-out transform
+                    output->display_buffer->set_transformation(glm::mat2{});
+                    break;
+                }
                 found_info = true;
                 break;
             }

--- a/src/server/input/CMakeLists.txt
+++ b/src/server/input/CMakeLists.txt
@@ -25,6 +25,7 @@ set(
   vt_filter.cpp
   seat_observer_multiplexer.cpp
   seat_observer_multiplexer.h
+  idle_poking_dispatcher.cpp
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/input/seat_observer.h
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/input/input_dispatcher.h
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/input/seat.h

--- a/src/server/input/default_configuration.cpp
+++ b/src/server/input/default_configuration.cpp
@@ -33,6 +33,7 @@
 #include "surface_input_dispatcher.h"
 #include "basic_seat.h"
 #include "seat_observer_multiplexer.h"
+#include "idle_poking_dispatcher.h"
 
 #include "mir/input/touch_visualizer.h"
 #include "mir/input/input_probe.h"
@@ -141,8 +142,12 @@ mir::DefaultServerConfiguration::the_input_dispatcher()
             // lp:1675357: Disable generation of key repeat events on nested servers
             auto enable_repeat = options->get<bool>(options::enable_key_repeat_opt);
 
+            auto const idle_poking_dispatcher = std::make_shared<mi::IdlePokingDispatcher>(
+                the_event_filter_chain_dispatcher(),
+                the_idle_hub());
+
             auto const keyboard_resync_dispatcher =
-                std::make_shared<mi::KeyboardResyncDispatcher>(the_event_filter_chain_dispatcher());
+                std::make_shared<mi::KeyboardResyncDispatcher>(idle_poking_dispatcher);
 
             return std::make_shared<mi::KeyRepeatDispatcher>(
                 keyboard_resync_dispatcher, the_main_loop(), the_cookie_authority(),

--- a/src/server/input/idle_poking_dispatcher.cpp
+++ b/src/server/input/idle_poking_dispatcher.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "idle_poking_dispatcher.h"
+#include "mir/events/event.h"
+#include "mir/scene/idle_hub.h"
+
+namespace mi = mir::input;
+
+mi::IdlePokingDispatcher::IdlePokingDispatcher(
+    std::shared_ptr<InputDispatcher> const& next_dispatcher,
+    std::shared_ptr<scene::IdleHub> const& idle_hub)
+    : next_dispatcher{next_dispatcher},
+      idle_hub{idle_hub}
+{
+}
+
+bool mi::IdlePokingDispatcher::dispatch(std::shared_ptr<MirEvent const> const& event)
+{
+    bool const result = next_dispatcher->dispatch(event);
+    switch (mir_event_get_type(event.get()))
+    {
+    case mir_event_type_input:
+        switch (mir_input_event_get_type(mir_event_get_input_event(event.get())))
+        {
+            case mir_input_event_type_key:
+            case mir_input_event_type_pointer:
+            case mir_input_event_type_touch:
+                idle_hub->poke();
+
+            case mir_input_event_type_keyboard_resync:
+            case mir_input_event_types:
+                break;
+        }
+        break;
+
+    default:;
+    }
+    return result;
+}
+
+void mi::IdlePokingDispatcher::start()
+{
+    next_dispatcher->start();
+}
+
+void mi::IdlePokingDispatcher::stop()
+{
+    next_dispatcher->stop();
+}

--- a/src/server/input/idle_poking_dispatcher.h
+++ b/src/server/input/idle_poking_dispatcher.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_INPUT_IDLE_POKING_DISPATCHER_H_
+#define MIR_INPUT_IDLE_POKING_DISPATCHER_H_
+
+#include "mir/input/input_dispatcher.h"
+
+namespace mir
+{
+namespace scene
+{
+class IdleHub;
+}
+namespace input
+{
+class IdlePokingDispatcher : public InputDispatcher
+{
+public:
+    IdlePokingDispatcher(
+        std::shared_ptr<InputDispatcher> const& next_dispatcher,
+        std::shared_ptr<scene::IdleHub> const& idle_hub);
+
+    /// InputDispatcher overrides
+    /// @{
+    bool dispatch(std::shared_ptr<MirEvent const> const& event) override;
+    void start() override;
+    void stop() override;
+    /// @}
+
+private:
+    std::shared_ptr<InputDispatcher> const next_dispatcher;
+    std::shared_ptr<scene::IdleHub> const idle_hub;
+};
+
+}
+}
+
+#endif // MIR_INPUT_IDLE_POKING_DISPATCHER_H_

--- a/src/server/scene/CMakeLists.txt
+++ b/src/server/scene/CMakeLists.txt
@@ -32,6 +32,7 @@ ADD_LIBRARY(
   basic_clipboard.cpp
   surface_state_tracker.cpp
   basic_text_input_hub.cpp
+  basic_idle_hub.cpp
   ${CMAKE_SOURCE_DIR}/src/include/server/mir/scene/surface_observer.h
 )
 

--- a/src/server/scene/basic_idle_hub.cpp
+++ b/src/server/scene/basic_idle_hub.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored By: William Wold <william.wold@canonical.com>
+ */
+
+#include "basic_idle_hub.h"
+#include "mir/time/alarm.h"
+#include "mir/time/alarm_factory.h"
+
+namespace ms = mir::scene;
+namespace mt = mir::time;
+
+namespace
+{
+auto add_awake_at_start(
+    std::vector<ms::BasicIdleHub::StateEntry> const& state_sequence)-> std::vector<ms::BasicIdleHub::StateEntry>
+{
+    std::vector<ms::BasicIdleHub::StateEntry> result{
+        {std::chrono::milliseconds{0}, ms::IdleState::awake}};
+    result.insert(result.end(), state_sequence.begin(), state_sequence.end());
+    return result;
+}
+}
+
+ms::BasicIdleHub::BasicIdleHub(
+        std::vector<StateEntry> const& state_sequence,
+        std::shared_ptr<mt::AlarmFactory> const& alarm_factory)
+    : state_sequence{add_awake_at_start(state_sequence)},
+      next_state_alarm{alarm_factory->create_alarm([this]()
+          {
+              increment_state();
+          })},
+      current_state_index{0}
+{
+    std::unique_lock<std::mutex> lock{mutex};
+    set_state_index(lock, 0);
+}
+
+ms::BasicIdleHub::~BasicIdleHub()
+{
+}
+
+auto ms::BasicIdleHub::state() -> IdleState
+{
+    std::lock_guard<std::mutex> lock{mutex};
+    return state_sequence[current_state_index].state;
+}
+
+void ms::BasicIdleHub::poke()
+{
+    std::unique_lock<std::mutex> lock{mutex};
+    set_state_index(lock, 0);
+}
+
+void ms::BasicIdleHub::increment_state()
+{
+    std::unique_lock<std::mutex> lock{mutex};
+    if (current_state_index < static_cast<int>(state_sequence.size()))
+    {
+        set_state_index(lock, current_state_index + 1);
+    }
+}
+
+void ms::BasicIdleHub::set_state_index(std::unique_lock<std::mutex>& lock, int index)
+{
+    if (index + 1 < static_cast<int>(state_sequence.size()))
+    {
+        next_state_alarm->reschedule_in(state_sequence[index + 1].time_from_previous);
+    }
+    else
+    {
+        next_state_alarm->cancel();
+    }
+    auto const prev_state = state_sequence[current_state_index].state;
+    auto const new_state = state_sequence[index].state;
+    current_state_index = index;
+    lock.unlock();
+    if (prev_state != new_state)
+    {
+        multiplexer.idle_state_changed(new_state);
+    }
+}
+
+void ms::BasicIdleHub::send_initial_state(std::weak_ptr<IdleStateObserver> const& observer)
+{
+    if (auto const shared = observer.lock())
+    {
+        shared->idle_state_changed(state());
+    }
+}

--- a/src/server/scene/basic_idle_hub.h
+++ b/src/server/scene/basic_idle_hub.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2021 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored By: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef MIR_SCENE_BASIC_IDLE_HUB_H_
+#define MIR_SCENE_BASIC_IDLE_HUB_H_
+
+#include "mir/scene/idle_hub.h"
+#include "mir/observer_multiplexer.h"
+
+#include <mutex>
+
+namespace mir
+{
+namespace time
+{
+class Alarm;
+class AlarmFactory;
+}
+namespace scene
+{
+
+class IdleStateMultiplexer: mir::Executor, public ObserverMultiplexer<IdleStateObserver>
+{
+public:
+    IdleStateMultiplexer()
+        : ObserverMultiplexer{static_cast<Executor&>(*this)}
+    {
+    }
+
+    // By default, dispatch events immediately. The user can override this behavior by setting their own executor.
+    void spawn(std::function<void()>&& work) override
+    {
+        work();
+    }
+
+    void idle_state_changed(IdleState state) override
+    {
+        for_each_observer(&IdleStateObserver::idle_state_changed, state);
+    }
+};
+
+class BasicIdleHub : public IdleHub
+{
+public:
+    struct StateEntry
+    {
+        std::chrono::milliseconds time_from_previous;
+        IdleState state;
+    };
+
+    /// IdleState::awake is always the initial state. If state_sequence is empty, it is the only state.
+    BasicIdleHub(
+        std::vector<StateEntry> const& state_sequence,
+        std::shared_ptr<time::AlarmFactory> const& alarm_factory);
+
+    ~BasicIdleHub();
+
+    auto state() -> IdleState override;
+    void poke() override;
+
+    /// Implement ObserverRegistrar<IdleStateObserver>
+    /// @{
+    void register_interest(std::weak_ptr<IdleStateObserver> const& observer) override
+    {
+        multiplexer.register_interest(observer);
+        send_initial_state(observer);
+    }
+    void register_interest(std::weak_ptr<IdleStateObserver> const& observer, Executor& executor) override
+    {
+        multiplexer.register_interest(observer, executor);
+        send_initial_state(observer);
+    }
+    void unregister_interest(IdleStateObserver const& observer) override
+    {
+        multiplexer.unregister_interest(observer);
+    }
+    /// @}
+
+private:
+    void increment_state();
+    /// May unlock the lock
+    void set_state_index(std::unique_lock<std::mutex>& lock, int index);
+    void send_initial_state(std::weak_ptr<IdleStateObserver> const& observer);
+
+    IdleStateMultiplexer multiplexer;
+    std::vector<StateEntry> const state_sequence;
+    std::unique_ptr<time::Alarm> const next_state_alarm;
+    std::mutex mutex;
+    int current_state_index;
+};
+}
+}
+
+#endif // MIR_SCENE_BASIC_IDLE_HUB_H_

--- a/src/server/scene/default_configuration.cpp
+++ b/src/server/scene/default_configuration.cpp
@@ -41,6 +41,7 @@
 #include "timeout_application_not_responding_detector.h"
 #include "basic_clipboard.h"
 #include "basic_text_input_hub.h"
+#include "basic_idle_hub.h"
 #include "mir/options/program_option.h"
 #include "mir/options/default_configuration.h"
 #include "mir/graphics/display_configuration.h"
@@ -228,6 +229,21 @@ auto mir::DefaultServerConfiguration::the_text_input_hub()
         []()
         {
             return std::make_shared<ms::BasicTextInputHub>();
+        });
+}
+
+auto mir::DefaultServerConfiguration::the_idle_hub()
+-> std::shared_ptr<scene::IdleHub>
+{
+    return idle_hub(
+        [this]()
+        {
+            return std::make_shared<ms::BasicIdleHub>(
+                std::vector<ms::BasicIdleHub::StateEntry>{
+                    {std::chrono::milliseconds{5000}, ms::IdleState::off},
+                },
+                the_main_loop()
+            );
         });
 }
 

--- a/src/server/scene/default_configuration.cpp
+++ b/src/server/scene/default_configuration.cpp
@@ -150,7 +150,8 @@ mir::DefaultServerConfiguration::the_mediating_display_changer()
                 the_session_event_handler_register(),
                 the_server_action_queue(),
                 the_display_configuration_observer(),
-                the_main_loop());
+                the_main_loop(),
+                the_idle_hub());
         });
 
 }

--- a/src/server/scene/mediating_display_changer.cpp
+++ b/src/server/scene/mediating_display_changer.cpp
@@ -483,6 +483,19 @@ bool configuration_has_new_outputs_enabled(
 }
 }
 
+void ms::MediatingDisplayChanger::set_power_mode_for_all_used_outputs(MirPowerMode power_mode)
+{
+    std::shared_ptr<graphics::DisplayConfiguration> const config = display->configuration();
+    config->for_each_output([&](mg::UserDisplayConfigurationOutput& output)
+        {
+            if (output.used)
+            {
+                output.power_mode = power_mode;
+            }
+        });
+    apply_config(config);
+}
+
 void ms::MediatingDisplayChanger::apply_config(
     std::shared_ptr<graphics::DisplayConfiguration> const& conf)
 {

--- a/src/server/scene/mediating_display_changer.cpp
+++ b/src/server/scene/mediating_display_changer.cpp
@@ -513,14 +513,20 @@ bool configuration_has_new_outputs_enabled(
 }
 }
 
-void ms::MediatingDisplayChanger::set_power_mode_for_all_used_outputs(MirPowerMode power_mode)
+void ms::MediatingDisplayChanger::set_power_mode_for_all_used_outputs(MirPowerMode new_power_mode)
 {
+    std::lock_guard<std::mutex> lock{power_mode_mutex};
+    if (new_power_mode == power_mode)
+    {
+        return;
+    }
+    power_mode = new_power_mode;
     std::shared_ptr<graphics::DisplayConfiguration> const config = display->configuration();
     config->for_each_output([&](mg::UserDisplayConfigurationOutput& output)
         {
             if (output.used)
             {
-                output.power_mode = power_mode;
+                output.power_mode = new_power_mode;
             }
         });
     apply_config(config);

--- a/src/server/scene/mediating_display_changer.h
+++ b/src/server/scene/mediating_display_changer.h
@@ -98,6 +98,7 @@ private:
     void no_focus_handler();
     void session_stopping_handler(std::shared_ptr<Session> const& session);
 
+    void set_power_mode_for_all_used_outputs(MirPowerMode power_mode);
     void apply_config(std::shared_ptr<graphics::DisplayConfiguration> const& conf);
     void apply_base_config();
     void send_config_to_all_sessions(

--- a/src/server/scene/mediating_display_changer.h
+++ b/src/server/scene/mediating_display_changer.h
@@ -100,7 +100,7 @@ private:
     void no_focus_handler();
     void session_stopping_handler(std::shared_ptr<Session> const& session);
 
-    void set_power_mode_for_all_used_outputs(MirPowerMode power_mode);
+    void set_power_mode_for_all_used_outputs(MirPowerMode new_power_mode);
     void apply_config(std::shared_ptr<graphics::DisplayConfiguration> const& conf);
     void apply_base_config();
     void send_config_to_all_sessions(
@@ -134,6 +134,11 @@ private:
     /// See configure_for_hardware_change(). The config that will be applied by a currently in-flight server action.
     /// If null, there is no config to apply or hardware config server action queued.
     std::shared_ptr<graphics::DisplayConfiguration> pending_configuration;
+
+    /// Mutex protecting power_mode
+    std::mutex power_mode_mutex;
+    /// Power mode outputs have been set to
+    MirPowerMode power_mode{mir_power_mode_on};
 };
 
 }

--- a/src/server/scene/mediating_display_changer.h
+++ b/src/server/scene/mediating_display_changer.h
@@ -49,6 +49,7 @@ namespace scene
 class SessionEventHandlerRegister;
 class SessionContainer;
 class Session;
+class IdleHub;
 
 class MediatingDisplayChanger : public frontend::DisplayChanger,
                                 public mir::DisplayChanger,
@@ -63,7 +64,8 @@ public:
         std::shared_ptr<SessionEventHandlerRegister> const& session_event_handler_register,
         std::shared_ptr<ServerActionQueue> const& server_action_queue,
         std::shared_ptr<graphics::DisplayConfigurationObserver> const& observer,
-        std::shared_ptr<time::AlarmFactory> const& alarm_factory);
+        std::shared_ptr<time::AlarmFactory> const& alarm_factory,
+        std::shared_ptr<scene::IdleHub> const& idle_hub);
 
     ~MediatingDisplayChanger();
 
@@ -123,6 +125,9 @@ private:
     std::weak_ptr<scene::Session> currently_previewing_session;
     struct SessionObserver;
     std::unique_ptr<SessionObserver> const session_observer;
+    std::shared_ptr<scene::IdleHub> const idle_hub;
+    struct IdleStateObserver;
+    std::shared_ptr<IdleStateObserver> const idle_state_observer;
 
     /// Mutex protecting pending_configuration
     std::mutex pending_configuration_mutex;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -917,6 +917,7 @@ MIR_SERVER_2.5 {
     VTT?for?mir::shell::SystemCompositorWindowManager;
     mir::DefaultServerConfiguration::the_text_input_hub*;
     mir::input::ResyncKeyboardDispatcher*;
+    mir::DefaultServerConfiguration::the_idle_hub*;
   };
  local: *;
 };

--- a/tests/unit-tests/scene/test_mediating_display_changer.cpp
+++ b/tests/unit-tests/scene/test_mediating_display_changer.cpp
@@ -33,6 +33,7 @@
 #include "mir/test/display_config_matchers.h"
 #include "mir/test/doubles/fake_alarm_factory.h"
 #include "mir/test/doubles/mock_display_configuration_observer.h"
+#include "mir/test/doubles/mock_idle_hub.h"
 
 #include <mutex>
 #include <boost/throw_exception.hpp>
@@ -119,7 +120,8 @@ struct MediatingDisplayChangerTest : public ::testing::Test
                       mt::fake_shared(session_event_sink),
                       mt::fake_shared(server_action_queue),
                       mt::fake_shared(display_configuration_observer),
-                      mt::fake_shared(alarm_factory));
+                      mt::fake_shared(alarm_factory),
+                      mt::fake_shared(idle_hub));
     }
 
     testing::NiceMock<MockDisplay> mock_display;
@@ -131,6 +133,7 @@ struct MediatingDisplayChangerTest : public ::testing::Test
     StubServerActionQueue server_action_queue;
     mtd::MockDisplayConfigurationObserver display_configuration_observer;
     mtd::FakeAlarmFactory alarm_factory;
+    mtd::MockIdleHub idle_hub;
     std::shared_ptr<ms::MediatingDisplayChanger> changer;
 };
 
@@ -678,7 +681,8 @@ TEST_F(MediatingDisplayChangerTest, uses_server_action_queue_for_configuration_a
       mt::fake_shared(session_event_sink),
       mt::fake_shared(mock_server_action_queue),
       mt::fake_shared(display_configuration_observer),
-      mt::fake_shared(alarm_factory));
+      mt::fake_shared(alarm_factory),
+      mt::fake_shared(idle_hub));
 
     void const* owner{nullptr};
 
@@ -732,7 +736,8 @@ TEST_F(MediatingDisplayChangerTest, does_not_block_IPC_thread_for_inactive_sessi
         mt::fake_shared(session_event_sink),
         mt::fake_shared(mock_server_action_queue),
         mt::fake_shared(display_configuration_observer),
-        mt::fake_shared(alarm_factory));
+        mt::fake_shared(alarm_factory),
+        mt::fake_shared(idle_hub));
 
     EXPECT_CALL(mock_server_action_queue, enqueue(_, _));
     session_event_sink.handle_focus_change(active_session);
@@ -858,7 +863,8 @@ TEST_F(MediatingDisplayChangerTest, notifies_observer_on_set_base_configuration)
         mt::fake_shared(session_event_sink),
         mt::fake_shared(server_action_queue),
         mt::fake_shared(display_configuration_observer),
-        mt::fake_shared(alarm_factory));
+        mt::fake_shared(alarm_factory),
+        mt::fake_shared(idle_hub));
 
     mtd::NullDisplayConfiguration conf;
 


### PR DESCRIPTION
So far:
- Adds new `IdleHub` interface and implementation
- Pokes the idle hub on input events
- Observes the idle state from `` and powers down outputs when needed

Still to do:
- Tests
- Configuration (currently hard-coded in `DefaultServerConfiguration::the_idle_hub()` in src/server/scene/default_configuration.cpp)
- Support for the various relevant Wayland protocols (which will include support for wakelocks)
- Display dimming to warn it will soon be shut off