### PR TITLE
gbm-kms: Try harder to pick a working GBM framebuffer format

### DIFF
--- a/include/test/mir/test/doubles/mock_egl.h
+++ b/include/test/mir/test/doubles/mock_egl.h
@@ -89,6 +89,11 @@ MATCHER_P2(EGLConfigContainsAttrib, attrib, value, "")
         ++arg_mut;
     }
 
+    size_t end{0};
+    for (; arg[end] != EGL_NONE; ++end);
+
+    *result_listener << "attribute list is " << testing::PrintToString(std::vector<EGLint>(arg, arg + end));
+
     return false;
 }
 

--- a/src/platforms/gbm-kms/server/display_helpers.cpp
+++ b/src/platforms/gbm-kms/server/display_helpers.cpp
@@ -283,6 +283,7 @@ mgmh::GBMHelper::GBMHelper(mir::Fd const& drm_fd)
 mgg::GBMSurfaceUPtr mgmh::GBMHelper::create_scanout_surface(
     uint32_t width,
     uint32_t height,
+    uint32_t gbm_format,
     bool sharable) const
 {
     auto format_flags = GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT;
@@ -300,9 +301,7 @@ mgg::GBMSurfaceUPtr mgmh::GBMHelper::create_scanout_surface(
 #endif
     }
 
-    auto surface_raw = gbm_surface_create(device, width, height,
-                                          GBM_FORMAT_XRGB8888,
-                                          format_flags);
+    auto surface_raw = gbm_surface_create(device, width, height, gbm_format, format_flags);
 
     auto gbm_surface_deleter = [](gbm_surface *p) { if (p) gbm_surface_destroy(p); };
     GBMSurfaceUPtr surface{surface_raw, gbm_surface_deleter};

--- a/src/platforms/gbm-kms/server/display_helpers.h
+++ b/src/platforms/gbm-kms/server/display_helpers.h
@@ -84,7 +84,7 @@ public:
     GBMHelper(const GBMHelper&) = delete;
     GBMHelper& operator=(const GBMHelper&) = delete;
 
-    GBMSurfaceUPtr create_scanout_surface(uint32_t width, uint32_t height, bool sharable) const;
+    GBMSurfaceUPtr create_scanout_surface(uint32_t width, uint32_t height, uint32_t gbm_format, bool sharable) const;
 
     gbm_device* const device;
 };

--- a/src/platforms/gbm-kms/server/kms/display.cpp
+++ b/src/platforms/gbm-kms/server/kms/display.cpp
@@ -528,6 +528,7 @@ void mgg::Display::configure_locked(
 
                 for (auto const& group : kms_output_groups)
                 {
+                    uint32_t const gbm_format = GBM_FORMAT_XRGB8888;
                     /*
                      * In a hybrid setup a scanout surface needs to be allocated differently if it
                      * needs to be able to be shared across GPUs. This likely reduces performance.
@@ -535,7 +536,7 @@ void mgg::Display::configure_locked(
                      * As a first cut, assume every scanout buffer in a hybrid setup might need
                      * to be shared.
                      */
-                    auto surface = gbm->create_scanout_surface(width, height, drm.size() != 1);
+                    auto surface = gbm->create_scanout_surface(width, height, gbm_format, drm.size() != 1);
                     auto const raw_surface = surface.get();
 
                     auto db = std::make_unique<DisplayBuffer>(
@@ -550,6 +551,7 @@ void mgg::Display::configure_locked(
                                 *gl_config,
                                 *gbm,
                                 raw_surface,
+                                gbm_format,
                                 shared_egl.context()
                             }
                         },

--- a/src/platforms/gbm-kms/server/kms/display.cpp
+++ b/src/platforms/gbm-kms/server/kms/display.cpp
@@ -215,8 +215,6 @@ mgg::Display::Display(std::vector<std::shared_ptr<helpers::DRMHelper>> const& dr
     initial_conf_policy->apply_to(current_display_configuration);
 
     configure(current_display_configuration);
-
-    shared_egl.make_current();
 }
 
 // please don't remove this empty destructor, it's here for the

--- a/src/platforms/gbm-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.cpp
@@ -236,7 +236,7 @@ public:
         mir::Fd const& drm_fd,
         uint32_t width,
         uint32_t height,
-        uint32_t /*format*/)
+        uint32_t format)
         : eglCreateImageKHR{
               reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(eglGetProcAddress("eglCreateImageKHR"))},
           eglDestroyImageKHR{
@@ -246,10 +246,10 @@ public:
           device{drm_fd},
           width{width},
           height{height},
-          surface{device.create_scanout_surface(width, height, false)},
+          surface{device.create_scanout_surface(width, height, format, false)},
           egl{NoAuxGlConfig{}}
     {
-        egl.setup(device, surface.get(), EGL_NO_CONTEXT, true);
+        egl.setup(device, surface.get(), format, EGL_NO_CONTEXT, true);
 
         require_gl_extensions({
             "GL_OES_EGL_image"

--- a/src/platforms/gbm-kms/server/kms/egl_helper.cpp
+++ b/src/platforms/gbm-kms/server/kms/egl_helper.cpp
@@ -26,7 +26,6 @@
 #include "mir/log.h"
 
 namespace mg = mir::graphics;
-namespace mgg = mir::graphics::gbm;
 namespace mgmh = mir::graphics::gbm::helpers;
 
 mgmh::EGLHelper::EGLHelper(GLConfig const& gl_config)

--- a/src/platforms/gbm-kms/server/kms/egl_helper.cpp
+++ b/src/platforms/gbm-kms/server/kms/egl_helper.cpp
@@ -21,6 +21,7 @@
 #include "mir/graphics/egl_error.h"
 #include <boost/exception/errinfo_errno.hpp>
 #include <boost/throw_exception.hpp>
+#include <gbm.h>
 
 #define MIR_LOG_COMPONENT "EGL"
 #include "mir/log.h"
@@ -41,10 +42,11 @@ mgmh::EGLHelper::EGLHelper(
     GLConfig const& gl_config,
     GBMHelper const& gbm,
     gbm_surface* surface,
+    uint32_t gbm_format,
     EGLContext shared_context)
     : EGLHelper(gl_config)
 {
-    setup(gbm, surface, shared_context, false);
+    setup(gbm, surface, gbm_format, shared_context, false);
 }
 
 mgmh::EGLHelper::EGLHelper(EGLHelper&& from)
@@ -62,6 +64,48 @@ mgmh::EGLHelper::EGLHelper(EGLHelper&& from)
     from.egl_surface = EGL_NO_SURFACE;
 }
 
+namespace
+{
+void initialise_egl(EGLDisplay dpy, int minimum_major_version, int minimum_minor_version)
+{
+    EGLint major, minor;
+
+    if (eglInitialize(dpy, &major, &minor) == EGL_FALSE)
+        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to initialize EGL display"));
+
+    if ((major < minimum_major_version) ||
+        (major == minimum_major_version && minor < minimum_minor_version))
+    {
+        BOOST_THROW_EXCEPTION(
+            boost::enable_error_info(std::runtime_error("Incompatible EGL version")));
+        // TODO: Insert egl version major and minor into exception
+    }
+}
+
+std::vector<EGLConfig> get_matching_configs(EGLDisplay dpy, EGLint const attr[])
+{
+    EGLint num_egl_configs;
+
+    // First query the number of matching configs…
+    if ((eglChooseConfig(dpy, attr, nullptr, 0, &num_egl_configs) == EGL_FALSE) ||
+        (num_egl_configs == 0))
+    {
+        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to enumerate any matching EGL configs"));
+    }
+
+    std::vector<EGLConfig> matching_configs(static_cast<size_t>(num_egl_configs));
+    if ((eglChooseConfig(dpy, attr, matching_configs.data(), static_cast<EGLint>(matching_configs.size()), &num_egl_configs) == EGL_FALSE) ||
+        (num_egl_configs == 0))
+    {
+        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to acquire matching EGL configs"));
+    }
+
+    matching_configs.resize(static_cast<size_t>(num_egl_configs));
+    return matching_configs;
+}
+
+}
+
 void mgmh::EGLHelper::setup(GBMHelper const& gbm)
 {
     eglBindAPI(EGL_OPENGL_ES_API);
@@ -71,8 +115,14 @@ void mgmh::EGLHelper::setup(GBMHelper const& gbm)
         EGL_NONE
     };
 
-    // TODO: Take the required format as a parameter, so we can select the framebuffer format.
-    setup_internal(gbm, true, GBM_FORMAT_XRGB8888);
+    egl_display = egl_display_for_gbm_device(gbm.device);
+    initialise_egl(egl_display, 1, 4);
+    should_terminate_egl = true;
+
+    // This is a context solely used for sharing GL object IDs; we will not do any rendering
+    // with it, so we do not care what EGLconfig is used *at all*.
+    EGLint const no_attribs[] = {EGL_NONE};
+    egl_config = get_matching_configs(egl_display, no_attribs)[0];
 
     egl_context = eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT, context_attr);
     if (egl_context == EGL_NO_CONTEXT)
@@ -88,8 +138,19 @@ void mgmh::EGLHelper::setup(GBMHelper const& gbm, EGLContext shared_context)
         EGL_NONE
     };
 
-    // TODO: Take the required format as a parameter, so we can select the framebuffer format.
-    setup_internal(gbm, false, GBM_FORMAT_XRGB8888);
+    egl_display = egl_display_for_gbm_device(gbm.device);
+
+    // Might as well copy the EGLConfig from shared_context
+    EGLint config_id;
+    if (eglQueryContext(egl_display, shared_context, EGL_CONFIG_ID, &config_id) != EGL_TRUE)
+    {
+        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to query EGLConfig of shared EGLContext"));
+    }
+    EGLint const context_attribs[] = {
+        EGL_CONFIG_ID, config_id,
+        EGL_NONE
+    };
+    egl_config = get_matching_configs(egl_display, context_attribs)[0];
 
     egl_context = eglCreateContext(egl_display, egl_config, shared_context, context_attr);
     if (egl_context == EGL_NO_CONTEXT)
@@ -99,6 +160,7 @@ void mgmh::EGLHelper::setup(GBMHelper const& gbm, EGLContext shared_context)
 void mgmh::EGLHelper::setup(
     GBMHelper const& gbm,
     gbm_surface* surface_gbm,
+    uint32_t gbm_format,
     EGLContext shared_context,
     bool owns_egl)
 {
@@ -109,8 +171,14 @@ void mgmh::EGLHelper::setup(
         EGL_NONE
     };
 
-    // TODO: Take the required format as a parameter, so we can select the framebuffer format.
-    setup_internal(gbm, owns_egl, GBM_FORMAT_XRGB8888);
+    egl_display = egl_display_for_gbm_device(gbm.device);
+    if (owns_egl)
+    {
+        initialise_egl(egl_display, 1, 4);
+        should_terminate_egl = owns_egl;
+    }
+
+    egl_config = egl_config_for_format(gbm_format);
 
     egl_surface = platform_base.eglCreatePlatformWindowSurface(
         egl_display,
@@ -161,32 +229,19 @@ bool mgmh::EGLHelper::release_current() const
     return (ret == EGL_TRUE);
 }
 
-namespace
+auto mgmh::EGLHelper::egl_display_for_gbm_device(struct gbm_device* const device) -> EGLDisplay
 {
-std::vector<EGLConfig> get_matching_configs(EGLDisplay dpy, EGLint const attr[])
-{
-    EGLint num_egl_configs;
+    auto const egl_display = platform_base.eglGetPlatformDisplay(
+        EGL_PLATFORM_GBM_KHR,      // EGL_PLATFORM_GBM_MESA has the same value.
+        static_cast<EGLNativeDisplayType>(device),
+        nullptr);
+    if (egl_display == EGL_NO_DISPLAY)
+        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to get EGL display"));
 
-    // First query the number of matching configs…
-    if ((eglChooseConfig(dpy, attr, nullptr, 0, &num_egl_configs) == EGL_FALSE) ||
-        (num_egl_configs == 0))
-    {
-        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to enumerate any matching EGL configs"));
-    }
-
-    std::vector<EGLConfig> matching_configs(static_cast<size_t>(num_egl_configs));
-    if ((eglChooseConfig(dpy, attr, matching_configs.data(), static_cast<EGLint>(matching_configs.size()), &num_egl_configs) == EGL_FALSE) ||
-        (num_egl_configs == 0))
-    {
-        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to acquire matching EGL configs"));
-    }
-
-    matching_configs.resize(static_cast<size_t>(num_egl_configs));
-    return matching_configs;
-}
+    return egl_display;
 }
 
-void mgmh::EGLHelper::setup_internal(GBMHelper const& gbm, bool initialize, EGLint gbm_format)
+auto mgmh::EGLHelper::egl_config_for_format(EGLint gbm_format) -> EGLConfig
 {
     // TODO: Get the required EGL_{RED,GREEN,BLUE}_SIZE values out of gbm_format
     EGLint const config_attr[] = {
@@ -200,34 +255,6 @@ void mgmh::EGLHelper::setup_internal(GBMHelper const& gbm, bool initialize, EGLi
         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
         EGL_NONE
     };
-
-    static const EGLint required_egl_version_major = 1;
-    static const EGLint required_egl_version_minor = 4;
-
-    egl_display = platform_base.eglGetPlatformDisplay(
-        EGL_PLATFORM_GBM_KHR,      // EGL_PLATFORM_GBM_MESA has the same value.
-        static_cast<EGLNativeDisplayType>(gbm.device),
-        nullptr);
-    if (egl_display == EGL_NO_DISPLAY)
-        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to get EGL display"));
-
-    if (initialize)
-    {
-        EGLint major, minor;
-
-        if (eglInitialize(egl_display, &major, &minor) == EGL_FALSE)
-            BOOST_THROW_EXCEPTION(mg::egl_error("Failed to initialize EGL display"));
-
-        if ((major < required_egl_version_major) ||
-            (major == required_egl_version_major && minor < required_egl_version_minor))
-        {
-            BOOST_THROW_EXCEPTION(
-                boost::enable_error_info(std::runtime_error("Incompatible EGL version")));
-            // TODO: Insert egl version major and minor into exception
-        }
-
-        should_terminate_egl = true;
-    }
 
     for (auto const& config : get_matching_configs(egl_display, config_attr))
     {
@@ -243,8 +270,7 @@ void mgmh::EGLHelper::setup_internal(GBMHelper const& gbm, bool initialize, EGLi
         if (id == gbm_format)
         {
             // We've found our matching format, so we're done here.
-            egl_config = config;
-            return;
+            return config;
         }
     }
     BOOST_THROW_EXCEPTION((

--- a/src/platforms/gbm-kms/server/kms/egl_helper.cpp
+++ b/src/platforms/gbm-kms/server/kms/egl_helper.cpp
@@ -273,11 +273,16 @@ auto mgmh::EGLHelper::egl_config_for_format(EGLint gbm_format) -> EGLConfig
             return config;
         }
     }
-    BOOST_THROW_EXCEPTION((
-        std::runtime_error{std::string{"Failed to find EGL config matching "} + std::to_string(gbm_format)}));
+    BOOST_THROW_EXCEPTION((NoMatchingEGLConfig{static_cast<uint32_t>(gbm_format)}));
 }
 
 void mgmh::EGLHelper::report_egl_configuration(std::function<void(EGLDisplay, EGLConfig)> f)
 {
     f(egl_display, egl_config);
+}
+
+mgmh::EGLHelper::NoMatchingEGLConfig::NoMatchingEGLConfig(uint32_t /*format*/)
+    : std::runtime_error("Failed to find matching EGL config")
+{
+    // TODO: Include the format string; need to extract from linux_dmabuf.cpp
 }

--- a/src/platforms/gbm-kms/server/kms/egl_helper.h
+++ b/src/platforms/gbm-kms/server/kms/egl_helper.h
@@ -21,6 +21,7 @@
 
 #include "display_helpers.h"
 #include "mir/graphics/egl_extensions.h"
+#include <stdexcept>
 #include <EGL/egl.h>
 
 namespace mir
@@ -59,6 +60,12 @@ public:
     EGLContext context() const { return egl_context; }
 
     void report_egl_configuration(std::function<void(EGLDisplay, EGLConfig)>);
+
+    class NoMatchingEGLConfig : public std::runtime_error
+    {
+    public:
+        NoMatchingEGLConfig(uint32_t format);
+    };
 private:
     auto egl_config_for_format(EGLint gbm_format) -> EGLConfig;
 

--- a/src/platforms/gbm-kms/server/kms/egl_helper.h
+++ b/src/platforms/gbm-kms/server/kms/egl_helper.h
@@ -40,6 +40,7 @@ public:
         GLConfig const& gl_config,
         GBMHelper const& gbm,
         gbm_surface* surface,
+        uint32_t gbm_format,
         EGLContext shared_context);
     ~EGLHelper() noexcept;
     EGLHelper(EGLHelper&& from);
@@ -49,7 +50,7 @@ public:
 
     void setup(GBMHelper const& gbm);
     void setup(GBMHelper const& gbm, EGLContext shared_context);
-    void setup(GBMHelper const& gbm, gbm_surface* surface_gbm, EGLContext shared_context, bool owns_egl);
+    void setup(GBMHelper const& gbm, gbm_surface* surface_gbm, uint32_t gbm_format, EGLContext shared_context, bool owns_egl);
 
     bool swap_buffers();
     bool make_current() const;
@@ -59,7 +60,9 @@ public:
 
     void report_egl_configuration(std::function<void(EGLDisplay, EGLConfig)>);
 private:
-    void setup_internal(GBMHelper const& gbm, bool initialize, EGLint gbm_format);
+    auto egl_config_for_format(EGLint gbm_format) -> EGLConfig;
+
+    auto egl_display_for_gbm_device(struct gbm_device* const device) -> EGLDisplay;
 
     EGLint const depth_buffer_bits;
     EGLint const stencil_buffer_bits;

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_buffer_allocator.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_buffer_allocator.cpp
@@ -76,6 +76,15 @@ protected:
                     SetArgPointee<3>(GBM_FORMAT_XRGB8888),
                     Return(EGL_TRUE)));
 
+        // We sometimes want to copy the config of an existing context.
+        // Since our mocks don't check what config attribs we're asking for,
+        // we can just make something up.
+        ON_CALL(mock_egl, eglQueryContext(_,_,EGL_CONFIG_ID,_))
+            .WillByDefault(
+                DoAll(
+                    SetArgPointee<3>(0xabadbaab),
+                    Return(EGL_TRUE)));
+
         mock_egl.provide_egl_extensions();
         mock_gl.provide_gles_extensions();
 

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display.cpp
@@ -822,6 +822,7 @@ TEST_F(MesaDisplayTest, respects_gl_config)
         .Times(AtLeast(1))
         .WillRepeatedly(Return(stencil_bits));
 
+    // We create at least one rendering context, with the requested attributes…
     EXPECT_CALL(mock_egl,
                 eglChooseConfig(
                     _,
@@ -829,6 +830,16 @@ TEST_F(MesaDisplayTest, respects_gl_config)
                           mtd::EGLConfigContainsAttrib(EGL_STENCIL_SIZE, stencil_bits)),
                     NotNull(),_,_))
         .Times(AtLeast(1))
+        .WillRepeatedly(DoAll(SetArgPointee<2>(mock_egl.fake_configs[0]),
+                        SetArgPointee<4>(1),
+                        Return(EGL_TRUE)));
+    //…we *also* create zero-or-more non-rendering contexts; we don't care what they ask for
+    EXPECT_CALL(mock_egl,
+                eglChooseConfig(
+                    _,
+                    Pointee(EGL_NONE),
+                    NotNull(),_,_))
+        .Times(AnyNumber())
         .WillRepeatedly(DoAll(SetArgPointee<2>(mock_egl.fake_configs[0]),
                         SetArgPointee<4>(1),
                         Return(EGL_TRUE)));

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_generic.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_generic.cpp
@@ -61,6 +61,15 @@ public:
                     SetArgPointee<3>(GBM_FORMAT_XRGB8888),
                     Return(EGL_TRUE)));
 
+        // We sometimes want to copy the config of an existing context.
+        // Since our mocks don't check what config attribs we're asking for,
+        // we can just make something up.
+        ON_CALL(mock_egl, eglQueryContext(_,_,EGL_CONFIG_ID,_))
+            .WillByDefault(
+                DoAll(
+                    SetArgPointee<3>(0xabadbaab),
+                    Return(EGL_TRUE)));
+
         mock_egl.provide_egl_extensions();
         mock_gl.provide_gles_extensions();
 

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
@@ -328,10 +328,6 @@ TEST_F(MesaDisplayMultiMonitorTest, create_display_creates_shared_egl_contexts)
         EXPECT_CALL(mock_egl, eglMakeCurrent(_,_,_,Ne(shared_context)))
             .Times(AtLeast(1));
 
-        /* The shared context is made current finally */
-        EXPECT_CALL(mock_egl, eglMakeCurrent(_,_,_,shared_context))
-            .Times(1);
-
         /* Contexts are released at teardown */
         EXPECT_CALL(mock_egl, eglMakeCurrent(_,_,_,EGL_NO_CONTEXT))
             .Times(AtLeast(1));


### PR DESCRIPTION
Some drivers (*cough* Mali) don't support rendering to `RGBX` GBM buffers. We don't care about the difference between `RGBX` and `RGBA` for framebuffers, so check whether `RGBX` will work and try to fall back to `RGBA` if it doesn't.

There are some obvious points of further work here - checking what formats the *display* hardware supports and using that to populate the `MirDisplayConfiguration`, respecting the pixel format specified in the `MirDisplayConfiguration`, and so on - but that should be deferred until we make the switch to Atomic KMS.

Closes: #2226