### PR TITLE
gbm-kms: Be more relaxed in the rendering probe.

### DIFF
--- a/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
@@ -317,7 +317,9 @@ mg::PlatformPriority probe_rendering_platform(
     }
 
     // Check for suitability
-    auto maximum_suitability = mg::PlatformPriority::unsupported;
+    // The implementation claims to support the GBM EGL platform, so it *should*
+    // be at least minimally functional…
+    auto maximum_suitability = mg::PlatformPriority::supported;
     for (auto& device : drm_devices)
     {
         if (quirks.should_skip(device))
@@ -366,7 +368,6 @@ mg::PlatformPriority probe_rendering_platform(
                     strlen("llvmpipe")) == 0)
                 {
                     mir::log_info("Detected software renderer: %s", renderer_string);
-                    maximum_suitability = mg::PlatformPriority::supported;
                 }
                 else
                 {

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_platform.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_platform.cpp
@@ -250,6 +250,25 @@ TEST_F(MesaGraphicsPlatform, probe_returns_unsupported_when_gbm_platform_not_sup
     EXPECT_EQ(mg::PlatformPriority::unsupported, probe(stub_vt, options));
 }
 
+TEST_F(MesaGraphicsPlatform, probe_returns_supported_when_EGL_supports_gbm_platform_but_fails_to_get_EGL_display)
+{
+    using namespace testing;
+
+    mtf::UdevEnvironment udev_environment;
+    boost::program_options::options_description po;
+    mir::options::ProgramOption options;
+    auto const stub_vt = std::make_shared<mtd::StubConsoleServices>();
+
+    udev_environment.add_standard_device("standard-drm-devices");
+
+    ON_CALL(mock_egl, eglGetPlatformDisplayEXT(_,_,_))
+        .WillByDefault(Return(EGL_NO_DISPLAY));
+
+    mir::SharedLibrary platform_lib{mtf::server_platform("graphics-gbm-kms")};
+    auto probe = platform_lib.load_function<mg::PlatformProbe>(rendering_platform_probe_symbol);
+    EXPECT_EQ(mg::PlatformPriority::supported, probe(stub_vt, options));
+}
+
 TEST_F(MesaGraphicsPlatform, probe_returns_unsupported_when_modesetting_is_not_supported)
 {
     using namespace testing;


### PR DESCRIPTION
The libmali EGL implementation requires that the `gbm_device` passed in to
`eglGetPlatformDisplay` be created from a DRM master fd.

We can't guarantee this in the rendering probe, as the display platform may
have already claimed DRM master.

Instead, assume that an EGL platform which claims to support the GBM platform
will be at least minimally usable with GBM.