### PR TITLE
Give keyboard focus to menus (grabbing popups)

### DIFF
--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -416,14 +416,13 @@ void msh::AbstractShell::notify_focus_locked(
 {
     auto const current_focus = notified_keyboard_focus_surface.lock();
 
-    // Don't give keyboard focus to popups
+    // Don't give keyboard focus to non-grabbing popups
     auto new_keyboard_focus = new_active_surface;
     while (new_keyboard_focus)
     {
         auto const type = new_keyboard_focus->type();
         if (type != mir_window_type_gloss &&
-            type != mir_window_type_tip &&
-            type != mir_window_type_menu)
+            type != mir_window_type_tip)
         {
             break;
         }

--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -97,6 +97,10 @@ set(EXPECTED_FAILURES
   LayerShellPopup/XdgPopupTest.grabbed_popup_gets_done_event_when_new_toplevel_created/0
 
   ForeignToplevelHandleTest.can_maximize_foreign_while_fullscreen # https://github.com/MirServer/mir/issues/2164
+
+  # Fixed by https://github.com/MirServer/wlcs/pull/216
+  XdgPopupStable/XdgPopupTest.grabbed_popup_does_not_get_keyboard_focus/0
+  XdgPopupUnstableV6/XdgPopupTest.grabbed_popup_does_not_get_keyboard_focus/0
 )
 
 if (MIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN)


### PR DESCRIPTION
According to XDG Shell, grabbing popups should be given keyboard focus and non-grabbing ones should not. This PR brings our keyboard focus logic in line with that.

Fixes #2241. Tested by the recently-updated https://github.com/MirServer/wlcs/pull/216.