### PR TITLE
Simplify keyboard focus targeting

### DIFF
--- a/src/include/server/mir/shell/abstract_shell.h
+++ b/src/include/server/mir/shell/abstract_shell.h
@@ -170,8 +170,6 @@ private:
     std::weak_ptr<scene::Surface> focus_surface;
     std::weak_ptr<scene::Session> focus_session;
     std::vector<std::weak_ptr<scene::Surface>> notified_active_surfaces;
-    std::weak_ptr<scene::Surface> notified_keyboard_focus_surface;
-    std::weak_ptr<scene::Surface> notified_topmost_active_surface;
     std::shared_ptr<scene::SurfaceObserver> focus_surface_observer;
 
     void notify_focus_locked(

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -412,35 +412,20 @@ void msh::AbstractShell::set_focus_to(
 
 void msh::AbstractShell::notify_focus_locked(
     std::unique_lock<std::mutex> const& /*lock*/,
-    std::shared_ptr<ms::Surface> const& new_active_surface)
+    std::shared_ptr<ms::Surface> const& new_focus_surface)
 {
-    auto const current_focus = notified_keyboard_focus_surface.lock();
+    auto const current_focus = focus_surface.lock();
 
-    // Don't give keyboard focus to non-grabbing popups
-    auto new_keyboard_focus = new_active_surface;
-    while (new_keyboard_focus)
-    {
-        auto const type = new_keyboard_focus->type();
-        if (type != mir_window_type_gloss &&
-            type != mir_window_type_tip)
-        {
-            break;
-        }
-        new_keyboard_focus = new_keyboard_focus->parent();
-    }
-
-    if (current_focus != new_keyboard_focus || notified_topmost_active_surface.lock() != new_active_surface)
+    if (current_focus != new_focus_surface)
     {
         std::vector<std::shared_ptr<ms::Surface>> new_active_surfaces;
-        for (auto item = new_active_surface; item; item = item->parent())
+        for (auto item = new_focus_surface; item; item = item->parent())
         {
             new_active_surfaces.insert(begin(new_active_surfaces), item);
         }
 
         std::vector<std::shared_ptr<ms::Surface>> current_focus_tree;
 
-        notified_keyboard_focus_surface = new_keyboard_focus;
-        notified_topmost_active_surface = new_active_surface;
         seat->reset_confinement_regions();
 
         for (auto const& item : notified_active_surfaces)
@@ -489,19 +474,19 @@ void msh::AbstractShell::notify_focus_locked(
             notified_active_surfaces.shrink_to_fit();
         }
 
-        if (new_active_surface)
+        if (new_focus_surface)
         {
-            update_confinement_for(new_active_surface);
+            update_confinement_for(new_focus_surface);
 
             // Ensure the surface has really taken the focus before notifying it that it is focused
-            input_targeter->set_focus(new_active_surface);
-            new_active_surface->consume(seat->create_device_state().get());
-            new_active_surface->add_observer(focus_surface_observer);
+            input_targeter->set_focus(new_focus_surface);
+            new_focus_surface->consume(seat->create_device_state().get());
+            new_focus_surface->add_observer(focus_surface_observer);
 
             for (auto const& item : new_active_surfaces)
             {
                 notified_active_surfaces.push_back(item);
-                if (item == new_keyboard_focus)
+                if (item == new_focus_surface)
                 {
                     item->set_focus_state(mir_window_focus_state_focused);
                 }


### PR DESCRIPTION
The window manager already has logic that prevents `gloss` and `tip` windows from getting focus, so that doesn't need to be duplicated here.

The problem that this was solving is that sometimes the topmost active surface and the keyboard input surface are different, however this is not the case. XDG popups never need to become active (their active state is not reported to the client), so the only XDG popups we make active are those that also have keyboard focus (grabbing popups, aka `mir_window_type_menu`). This is handled in the window manager, so the shell does not need to worry about window types at all.