### PR TITLE
release/1.8: Stop forcing systemtap integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,9 +308,13 @@ check_cxx_symbol_exists("drmIsMaster" "xf86drm.h" MIR_LIBDRM_HAS_IS_MASTER)
 # USDT integration. The integration only involves #include-ing a
 # SystemTap header and calling a macro from it in the LTTNG macro,
 # but there aren't guarantees this won't change in future.
-add_definitions(  # Drop in favour of add_compile_definitions when we drop 16.04
-  -DLTTNG_UST_HAVE_SDT_INTEGRATION
-)
+include(CheckIncludeFile)
+CHECK_INCLUDE_FILE(sys/sdt.h HAVE_SYS_SDT_H)
+if (HAVE_SYS_SDT_H)
+  add_definitions(  # Drop in favour of add_compile_definitions when we drop 16.04
+    -DLTTNG_UST_HAVE_SDT_INTEGRATION
+  )
+endif()
 
 #
 # Full OpenGL support is possibly complete but not yet perfect. So is


### PR DESCRIPTION
```
This isn't available on Alpine (and other distros)

/usr/include/lttng/tracepoint.h:39:10: fatal error: sys/sdt.h: No such file or directory
   39 | #include <sys/sdt.h>
      |          ^~~~~~~~~~~

(cherry picked from commit 77920fb7ac5b734b696769fb25acb9e25206060d)
```

Original pull request: #1957