### PR TITLE
Deactivate text input when the Wayland object is deleted

### DIFF
--- a/src/server/frontend_wayland/text_input_v3.cpp
+++ b/src/server/frontend_wayland/text_input_v3.cpp
@@ -282,6 +282,7 @@ mf::TextInputV3::TextInputV3(
 mf::TextInputV3::~TextInputV3()
 {
     seat.remove_focus_listener(client, this);
+    ctx->text_input_hub->deactivate_handler(handler);
 }
 
 void mf::TextInputV3::send_text_change(ms::TextInputChange const& change)


### PR DESCRIPTION
That was easy.

Fixes #2269.

Tested by https://github.com/MirServer/wlcs/pull/217.