### PR TITLE
WlKeyboard: use WlSeat::FocusListener for focus tracking

### DIFF
--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -53,10 +53,6 @@ void mf::WaylandInputDispatcher::set_focus(bool has_focus)
 
     auto const surface = &wl_surface.value();
     seat->notify_focus(*surface, has_focus);
-    seat->for_each_listener(client, [&](WlKeyboard* keyboard)
-        {
-            keyboard->focussed(*surface, has_focus);
-        });
 }
 
 void mf::WaylandInputDispatcher::handle_event(MirInputEvent const* event)

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -21,16 +21,17 @@
 
 #include "wayland_wrapper.h"
 #include "keyboard_helper.h"
+#include "wl_seat.h"
 
 namespace mir
 {
 namespace frontend
 {
 class WlSurface;
-class WlSeat;
 
 class WlKeyboard
     : public wayland::Keyboard,
+      private WlSeat::FocusListener,
       private KeyboardCallbacks
 {
 public:
@@ -39,12 +40,14 @@ public:
     ~WlKeyboard();
 
     void handle_event(MirInputEvent const* event, WlSurface& surface);
-    void focussed(WlSurface& surface, bool should_be_focused);
 
 private:
+    WlSeat& seat;
     std::unique_ptr<KeyboardHelper> const helper;
     wayland::Weak<WlSurface> focused_surface;
-    wayland::DestroyListenerId destroy_listener_id;
+
+    /// WlSeat::FocusListener override
+    void focus_on(WlSurface* surface) override;
 
     /// KeyboardCallbacks overrides
     /// @{


### PR DESCRIPTION
It seems at some point we made `WlSeat` expose a generic focus tracking API, but never ported `WlKeyboard` to use it. This PR removes that code duplication, and because `WlSeat::FocusListener` gets notified of the focus state when initially added, it fixes #2272 for free.