### PR TITLE
Send wl_pointer.axis_stop

### DIFF
--- a/include/common/mir/events/event_builders.h
+++ b/include/common/mir/events/event_builders.h
@@ -125,6 +125,8 @@ EventUPtr make_pointer_axis_event(
     float y_axis_value,
     float hscroll_value,
     float vscroll_value,
+    bool hscroll_stop,
+    bool vscroll_stop,
     float relative_x_value,
     float relative_y_value);
 

--- a/include/common/mir/events/event_builders.h
+++ b/include/common/mir/events/event_builders.h
@@ -125,6 +125,22 @@ EventUPtr make_pointer_axis_event(
     float y_axis_value,
     float hscroll_value,
     float vscroll_value,
+    float relative_x_value,
+    float relative_y_value);
+
+// Pointer axis with stop event
+EventUPtr make_pointer_axis_with_stop_event(
+    MirPointerAxisSource axis_source,
+    MirInputDeviceId device_id,
+    std::chrono::nanoseconds timestamp,
+    std::vector<uint8_t> const& mac,
+    MirInputEventModifiers modifiers,
+    MirPointerAction action,
+    MirPointerButtons buttons_pressed,
+    float x_axis_value,
+    float y_axis_value,
+    float hscroll_value,
+    float vscroll_value,
     bool hscroll_stop,
     bool vscroll_stop,
     float relative_x_value,

--- a/include/common/mir_toolkit/events/input/pointer_event.h
+++ b/include/common/mir_toolkit/events/input/pointer_event.h
@@ -85,6 +85,19 @@ float mir_pointer_event_axis_value(MirPointerEvent const* event,
     MirPointerAxis axis);
 
 /**
+ * Retrieve if this is a stop event for the given scroll axis. When scroll
+ * events are generated with a source of finger they always end in an axis
+ * stop when the finger is raised. Other scroll events may in with an axis
+ * stop. Any axis other than vscroll and hscroll always returns false.
+ *
+ *  \param [in] event       The pointer event
+ *  \param [in] axis        The axis to check
+ *  \return                 If this is an axis stop event for the given axis
+ */
+bool mir_pointer_event_axis_stop(MirPointerEvent const* event,
+    MirPointerAxis axis);
+
+/**
  * Retrieve the corresponding input event.
  *
  * \param [in] event The pointer event

--- a/include/platform/mir/input/event_builder.h
+++ b/include/platform/mir/input/event_builder.h
@@ -73,6 +73,16 @@ public:
         float hscroll_value, float vscroll_value,
         float relative_x_value, float relative_y_value) = 0;
 
+    virtual EventUPtr pointer_axis_with_stop_event(
+        MirPointerAxisSource axis_source,
+        std::optional<Timestamp> timestamp,
+        MirPointerAction action,
+        MirPointerButtons buttons_pressed,
+        float x_position, float y_position,
+        float hscroll_value, float vscroll_value,
+        bool hscroll_stop, bool vscroll_stop,
+        float relative_x_value, float relative_y_value) = 0;
+
     virtual EventUPtr pointer_axis_discrete_scroll_event(
         MirPointerAxisSource axis_source,
         std::optional<Timestamp> timestamp,

--- a/include/platform/mir/input/event_builder.h
+++ b/include/platform/mir/input/event_builder.h
@@ -73,16 +73,6 @@ public:
         float hscroll_value, float vscroll_value,
         float relative_x_value, float relative_y_value) = 0;
 
-    virtual EventUPtr pointer_axis_with_stop_event(
-        MirPointerAxisSource axis_source,
-        std::optional<Timestamp> timestamp,
-        MirPointerAction action,
-        MirPointerButtons buttons_pressed,
-        float x_position, float y_position,
-        float hscroll_value, float vscroll_value,
-        bool hscroll_stop, bool vscroll_stop,
-        float relative_x_value, float relative_y_value) = 0;
-
     virtual EventUPtr pointer_axis_discrete_scroll_event(
         MirPointerAxisSource axis_source,
         std::optional<Timestamp> timestamp,
@@ -94,6 +84,16 @@ public:
     virtual EventUPtr touch_event(
         std::optional<Timestamp> timestamp,
         std::vector<mir::events::ContactState> const& contacts) = 0;
+
+    virtual EventUPtr pointer_axis_with_stop_event(
+        MirPointerAxisSource axis_source,
+        std::optional<Timestamp> timestamp,
+        MirPointerAction action,
+        MirPointerButtons buttons_pressed,
+        float x_position, float y_position,
+        float hscroll_value, float vscroll_value,
+        bool hscroll_stop, bool vscroll_stop,
+        float relative_x_value, float relative_y_value) = 0;
 protected:
     EventBuilder(EventBuilder const&) = delete;
     EventBuilder& operator=(EventBuilder const&) = delete;

--- a/src/common/events/event_builders.cpp
+++ b/src/common/events/event_builders.cpp
@@ -279,6 +279,29 @@ mir::EventUPtr mir::events::make_pointer_axis_event(
     float y_axis_value,
     float hscroll_value,
     float vscroll_value,
+    float relative_x_value,
+    float relative_y_value)
+{
+    auto const e = new_event<MirPointerEvent>(
+        device_id, timestamp, modifiers, cookie, action, buttons_pressed, x_axis_value,
+        y_axis_value, relative_x_value, relative_y_value, vscroll_value, hscroll_value);
+    e->set_axis_source(axis_source);
+
+    return make_uptr_event(e);
+}
+
+mir::EventUPtr mir::events::make_pointer_axis_with_stop_event(
+    MirPointerAxisSource axis_source,
+    MirInputDeviceId device_id,
+    std::chrono::nanoseconds timestamp,
+    std::vector<uint8_t> const& cookie,
+    MirInputEventModifiers modifiers,
+    MirPointerAction action,
+    MirPointerButtons buttons_pressed,
+    float x_axis_value,
+    float y_axis_value,
+    float hscroll_value,
+    float vscroll_value,
     bool hscroll_stop,
     bool vscroll_stop,
     float relative_x_value,

--- a/src/common/events/event_builders.cpp
+++ b/src/common/events/event_builders.cpp
@@ -279,6 +279,8 @@ mir::EventUPtr mir::events::make_pointer_axis_event(
     float y_axis_value,
     float hscroll_value,
     float vscroll_value,
+    bool hscroll_stop,
+    bool vscroll_stop,
     float relative_x_value,
     float relative_y_value)
 {
@@ -286,6 +288,8 @@ mir::EventUPtr mir::events::make_pointer_axis_event(
         device_id, timestamp, modifiers, cookie, action, buttons_pressed, x_axis_value,
         y_axis_value, relative_x_value, relative_y_value, vscroll_value, hscroll_value);
     e->set_axis_source(axis_source);
+    e->set_hscroll_stop(hscroll_stop);
+    e->set_vscroll_stop(vscroll_stop);
 
     return make_uptr_event(e);
 }

--- a/src/common/events/pointer_event.cpp
+++ b/src/common/events/pointer_event.cpp
@@ -125,6 +125,26 @@ void MirPointerEvent::set_hscroll(float hs)
     hscroll_ = hs;
 }
 
+bool MirPointerEvent::vscroll_stop() const
+{
+    return vscroll_stop_;
+}
+
+void MirPointerEvent::set_vscroll_stop(bool stop)
+{
+    vscroll_stop_ = stop;
+}
+
+bool MirPointerEvent::hscroll_stop() const
+{
+    return hscroll_stop_;
+}
+
+void MirPointerEvent::set_hscroll_stop(bool stop)
+{
+    hscroll_stop_ = stop;
+}
+
 MirPointerAction MirPointerEvent::action() const
 {
     return action_;

--- a/src/common/input/input_event.cpp
+++ b/src/common/input/input_event.cpp
@@ -311,6 +311,27 @@ float mir_pointer_event_axis_value(MirPointerEvent const* pev, MirPointerAxis ax
    }
 })
 
+bool mir_pointer_event_axis_stop(MirPointerEvent const* pev, MirPointerAxis axis) MIR_HANDLE_EVENT_EXCEPTION(
+{
+   switch (axis)
+   {
+   case mir_pointer_axis_vscroll:
+       return pev->vscroll_stop();
+   case mir_pointer_axis_hscroll:
+       return pev->hscroll_stop();
+   case mir_pointer_axis_x:
+   case mir_pointer_axis_y:
+   case mir_pointer_axis_relative_x:
+   case mir_pointer_axis_relative_y:
+   case mir_pointer_axis_vscroll_discrete:
+   case mir_pointer_axis_hscroll_discrete:
+       return false;
+   default:
+       mir::log_critical("Invalid axis enumeration " + std::to_string(axis));
+       abort();
+   }
+})
+
 bool mir_input_event_has_cookie(MirInputEvent const* ev) MIR_HANDLE_EVENT_EXCEPTION(
 {
     switch (ev->input_type())

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -49,7 +49,6 @@ MIR_COMMON_2.5 {
   mir_pointer_event_action;
   mir_pointer_event_axis_source;
   mir_pointer_event_axis_value;
-  mir_pointer_event_axis_stop;
   mir_pointer_event_buttons;
   mir_pointer_event_button_state;
   mir_pointer_event_input_event;
@@ -492,3 +491,12 @@ MIR_COMMON_2.5 {
   };
   local: *;
 };
+
+MIR_COMMON_2.7 {
+  global:
+  mir_pointer_event_axis_stop;
+
+  extern "C++" {
+    mir::events::make_pointer_axis_with_stop_event*;
+  };
+} MIR_COMMON_2.5;

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -49,6 +49,7 @@ MIR_COMMON_2.5 {
   mir_pointer_event_action;
   mir_pointer_event_axis_source;
   mir_pointer_event_axis_value;
+  mir_pointer_event_axis_stop;
   mir_pointer_event_buttons;
   mir_pointer_event_button_state;
   mir_pointer_event_input_event;

--- a/src/include/common/mir/events/pointer_event.h
+++ b/src/include/common/mir/events/pointer_event.h
@@ -64,6 +64,12 @@ struct MirPointerEvent : MirInputEvent
     float hscroll() const;
     void set_hscroll(float h);
 
+    bool vscroll_stop() const;
+    void set_vscroll_stop(bool stop);
+
+    bool hscroll_stop() const;
+    void set_hscroll_stop(bool stop);
+
     float vscroll_discrete() const;
     void set_vscroll_discrete(float v);
 
@@ -87,6 +93,8 @@ private:
     float dy_ = 0.0;
     float vscroll_ = 0.0;
     float hscroll_ = 0.0;
+    bool hscroll_stop_ = false;
+    bool vscroll_stop_ = false;
     float hscroll_discrete_ = 0.0;
     float vscroll_discrete_ = 0.0;
 

--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -272,25 +272,29 @@ mir::EventUPtr mie::LibInputDevice::convert_axis_event(libinput_event_pointer* p
 
     auto hscroll_value = 0.0f;
     auto vscroll_value = 0.0f;
+    auto hscroll_stop = false;
+    auto vscroll_stop = false;
     if (libinput_event_pointer_has_axis(pointer, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
     {
         hscroll_value = horizontal_scroll_scale *
                         libinput_event_pointer_get_axis_value(pointer, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL);
+        hscroll_stop = hscroll_value == 0;
     }
 
     if (libinput_event_pointer_has_axis(pointer, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
     {
         vscroll_value = vertical_scroll_scale *
                         libinput_event_pointer_get_axis_value(pointer, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL);
+        vscroll_stop = vscroll_value == 0;
     }
 
     report->received_event_from_kernel(time.count(), EV_REL, 0, 0);
 
     auto builder_pointer_axis_event = [&, this](MirPointerAxisSource axis_source)
         {
-            return builder->pointer_axis_event(
+            return builder->pointer_axis_with_stop_event(
                 axis_source, time, action, button_state, 0, 0, hscroll_value, vscroll_value,
-                relative_x_value, relative_y_value);
+                hscroll_stop, vscroll_stop, relative_x_value, relative_y_value);
         };
 
     switch (libinput_event_pointer_get_axis_source(pointer))

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -249,12 +249,15 @@ void mf::WlPointer::axis(MirPointerEvent const* event)
 {
     auto const h_scroll = mir_pointer_event_axis_value(event, mir_pointer_axis_hscroll);
     auto const v_scroll = mir_pointer_event_axis_value(event, mir_pointer_axis_vscroll);
+    auto const h_scroll_stop = mir_pointer_event_axis_stop(event, mir_pointer_axis_hscroll);
+    auto const v_scroll_stop = mir_pointer_event_axis_stop(event, mir_pointer_axis_vscroll);
     auto const h_scroll_discrete = mir_pointer_event_axis_value(event, mir_pointer_axis_hscroll_discrete);
     auto const v_scroll_discrete = mir_pointer_event_axis_value(event, mir_pointer_axis_vscroll_discrete);
     auto const axis_source = wayland_axis_source(mir_pointer_event_axis_source(event));
 
     // Don't send an axis source unless we have one and we're also sending some sort of axis event.
-    if (axis_source && (h_scroll || v_scroll || h_scroll_discrete || v_scroll_discrete))
+    if (axis_source &&
+        (h_scroll || v_scroll || h_scroll_stop || v_scroll_stop || h_scroll_discrete || v_scroll_discrete))
     {
         send_axis_source_event(axis_source.value());
         needs_frame = true;
@@ -290,6 +293,18 @@ void mf::WlPointer::axis(MirPointerEvent const* event)
             timestamp_of(event),
             Axis::vertical_scroll,
             v_scroll);
+        needs_frame = true;
+    }
+
+    if (h_scroll_stop)
+    {
+        send_axis_stop_event(timestamp_of(event), Axis::horizontal_scroll);
+        needs_frame = true;
+    }
+
+    if (v_scroll_stop)
+    {
+        send_axis_stop_event(timestamp_of(event), Axis::vertical_scroll);
         needs_frame = true;
     }
 }

--- a/src/server/input/default_event_builder.cpp
+++ b/src/server/input/default_event_builder.cpp
@@ -113,7 +113,7 @@ mir::EventUPtr mi::DefaultEventBuilder::pointer_axis_event(
     }
     return me::make_pointer_axis_event(
         axis_source, device_id, timestamp, vec_cookie, mir_input_event_modifier_none, action, buttons_pressed, x_axis,
-        y_axis, hscroll_value, vscroll_value, false, false, relative_x_value, relative_y_value);
+        y_axis, hscroll_value, vscroll_value, relative_x_value, relative_y_value);
 }
 
 mir::EventUPtr mi::DefaultEventBuilder::pointer_axis_with_stop_event(
@@ -133,7 +133,7 @@ mir::EventUPtr mi::DefaultEventBuilder::pointer_axis_with_stop_event(
         auto const cookie = cookie_authority->make_cookie(timestamp.count());
         vec_cookie = cookie->serialize();
     }
-    return me::make_pointer_axis_event(
+    return me::make_pointer_axis_with_stop_event(
         axis_source, device_id, timestamp, vec_cookie, mir_input_event_modifier_none, action, buttons_pressed, x_axis,
         y_axis, hscroll_value, vscroll_value, hscroll_stop, vscroll_stop, relative_x_value, relative_y_value);
 }

--- a/src/server/input/default_event_builder.cpp
+++ b/src/server/input/default_event_builder.cpp
@@ -113,9 +113,30 @@ mir::EventUPtr mi::DefaultEventBuilder::pointer_axis_event(
     }
     return me::make_pointer_axis_event(
         axis_source, device_id, timestamp, vec_cookie, mir_input_event_modifier_none, action, buttons_pressed, x_axis,
-        y_axis, hscroll_value, vscroll_value, relative_x_value, relative_y_value);
+        y_axis, hscroll_value, vscroll_value, false, false, relative_x_value, relative_y_value);
 }
 
+mir::EventUPtr mi::DefaultEventBuilder::pointer_axis_with_stop_event(
+    MirPointerAxisSource axis_source,
+    std::optional<Timestamp> source_timestamp,
+    MirPointerAction action,
+    MirPointerButtons buttons_pressed,
+    float x_axis, float y_axis,
+    float hscroll_value, float vscroll_value,
+    bool hscroll_stop, bool vscroll_stop,
+    float relative_x_value, float relative_y_value)
+{
+    std::vector<uint8_t> vec_cookie{};
+    auto const timestamp = calibrate_timestamp(source_timestamp);
+    if (action == mir_pointer_action_button_up || action == mir_pointer_action_button_down)
+    {
+        auto const cookie = cookie_authority->make_cookie(timestamp.count());
+        vec_cookie = cookie->serialize();
+    }
+    return me::make_pointer_axis_event(
+        axis_source, device_id, timestamp, vec_cookie, mir_input_event_modifier_none, action, buttons_pressed, x_axis,
+        y_axis, hscroll_value, vscroll_value, hscroll_stop, vscroll_stop, relative_x_value, relative_y_value);
+}
 
 mir::EventUPtr mir::input::DefaultEventBuilder::pointer_axis_discrete_scroll_event(
     MirPointerAxisSource axis_source, std::optional<Timestamp> source_timestamp, MirPointerAction action,

--- a/src/server/input/default_event_builder.h
+++ b/src/server/input/default_event_builder.h
@@ -81,6 +81,16 @@ public:
         float hscroll_value, float vscroll_value,
         float relative_x_value, float relative_y_value) override;
 
+    EventUPtr pointer_axis_with_stop_event(
+        MirPointerAxisSource axis_source,
+        std::optional<Timestamp> source_timestamp,
+        MirPointerAction action,
+        MirPointerButtons buttons_pressed,
+        float x, float y,
+        float hscroll_value, float vscroll_value,
+        bool hscroll_stop, bool vscroll_stop,
+        float relative_x_value, float relative_y_value) override;
+
     EventUPtr pointer_axis_discrete_scroll_event(
         MirPointerAxisSource axis_source, std::optional<Timestamp> timestamp, MirPointerAction action,
         MirPointerButtons buttons_pressed, float hscroll_value, float vscroll_value, float hscroll_discrete,

--- a/tests/include/mir/test/doubles/mock_libinput.h
+++ b/tests/include/mir/test/doubles/mock_libinput.h
@@ -50,9 +50,12 @@ public:
     libinput_event* setup_absolute_pointer_event(libinput_device* dev, uint64_t event_time, float x, float y);
     libinput_event* setup_button_event(libinput_device* dev, uint64_t event_time, int button, libinput_button_state state);
     libinput_event* setup_axis_event(
-        libinput_device* dev, uint64_t event_time, double horizontal, double vertical,
+        libinput_device* dev, uint64_t event_time,
+        std::optional<double> horizontal, std::optional<double> vertical,
         double horizontal_discrete = 0.0, double vertical_discrete = 0.0);
-    libinput_event* setup_finger_axis_event(libinput_device* dev, uint64_t event_time, double horizontal, double vertical);
+    libinput_event* setup_finger_axis_event(
+        libinput_device* dev, uint64_t event_time,
+        std::optional<double> horizontal, std::optional<double> vertical);
     libinput_event* setup_device_add_event(libinput_device* dev);
     libinput_event* setup_device_remove_event(libinput_device* dev);
 

--- a/tests/include/mir/test/doubles/mock_libinput.h
+++ b/tests/include/mir/test/doubles/mock_libinput.h
@@ -21,8 +21,8 @@
 
 #include "mir/dispatch/action_queue.h"
 
+#include <optional>
 #include <gmock/gmock.h>
-
 #include <libinput.h>
 
 namespace mir

--- a/tests/mir_test_doubles/mock_libinput.cpp
+++ b/tests/mir_test_doubles/mock_libinput.cpp
@@ -801,7 +801,8 @@ libinput_event* mtd::MockLibInput::setup_button_event(libinput_device* dev, uint
 
 libinput_event* mtd::MockLibInput::setup_axis_event(
     libinput_device* dev, uint64_t event_time,
-    double horizontal, double vertical, double horizontal_discrete, double vertical_discrete)
+    std::optional<double> horizontal, std::optional<double> vertical,
+    double horizontal_discrete, double vertical_discrete)
 {
     auto event = get_next_fake_ptr<libinput_event*>();
     auto pointer_event = reinterpret_cast<libinput_event_pointer*>(event);
@@ -818,21 +819,25 @@ libinput_event* mtd::MockLibInput::setup_axis_event(
     ON_CALL(*this, libinput_event_pointer_get_axis_source(pointer_event))
         .WillByDefault(Return(LIBINPUT_POINTER_AXIS_SOURCE_WHEEL));
     ON_CALL(*this, libinput_event_pointer_has_axis(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
-        .WillByDefault(Return(horizontal!=0.0));
+        .WillByDefault(Return(horizontal.operator bool()));
     ON_CALL(*this, libinput_event_pointer_has_axis(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-        .WillByDefault(Return(vertical!=0.0));
+        .WillByDefault(Return(vertical.operator bool()));
     ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
         .WillByDefault(Return(vertical_discrete));
     ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
         .WillByDefault(Return(horizontal_discrete));
     ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-        .WillByDefault(Return(vertical));
+        .WillByDefault(Return(vertical.value_or(0.0)));
     ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
-        .WillByDefault(Return(horizontal));
+        .WillByDefault(Return(horizontal.value_or(0.0)));
     return event;
 }
 
-libinput_event* mtd::MockLibInput::setup_finger_axis_event(libinput_device* dev, uint64_t event_time, double horizontal, double vertical)
+libinput_event* mtd::MockLibInput::setup_finger_axis_event(
+    libinput_device* dev,
+    uint64_t event_time,
+    std::optional<double> horizontal,
+    std::optional<double> vertical)
 {
     auto event = get_next_fake_ptr<libinput_event*>();
     auto pointer_event = reinterpret_cast<libinput_event_pointer*>(event);
@@ -849,13 +854,13 @@ libinput_event* mtd::MockLibInput::setup_finger_axis_event(libinput_device* dev,
     ON_CALL(*this, libinput_event_pointer_get_axis_source(pointer_event))
         .WillByDefault(Return(LIBINPUT_POINTER_AXIS_SOURCE_FINGER));
     ON_CALL(*this, libinput_event_pointer_has_axis(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
-        .WillByDefault(Return(horizontal!=0.0));
+        .WillByDefault(Return(horizontal.operator bool()));
     ON_CALL(*this, libinput_event_pointer_has_axis(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-        .WillByDefault(Return(vertical!=0.0));
+        .WillByDefault(Return(vertical.operator bool()));
     ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-        .WillByDefault(Return(vertical));
+        .WillByDefault(Return(vertical.value_or(0.0)));
     ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
-        .WillByDefault(Return(horizontal));
+        .WillByDefault(Return(horizontal.value_or(0.0)));
     return event;
 }
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -549,8 +549,8 @@ TEST_F(LibInputDeviceOnMouse, process_event_handles_scroll)
     EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_hscroll, 5.0f)));
 
     mouse.start(&mock_sink, &mock_builder);
-    env.mock_libinput.setup_axis_event(fake_device, event_time_1, 0.0, -20.0, 0, 2);
-    env.mock_libinput.setup_axis_event(fake_device, event_time_2, 5.0, 0.0, 1, 0);
+    env.mock_libinput.setup_axis_event(fake_device, event_time_1, {}, -20.0, 0, 2);
+    env.mock_libinput.setup_axis_event(fake_device, event_time_2, 5.0, {}, 1, 0);
     process_events(mouse);
 }
 
@@ -747,8 +747,8 @@ TEST_F(LibInputDeviceOnMouse, scroll_speed_scales_scroll_events)
     settings.horizontal_scroll_scale = 5.0;
     mouse.apply_settings(settings);
 
-    env.mock_libinput.setup_axis_event(fake_device, event_time_1, 0.0, -3.0);
-    env.mock_libinput.setup_axis_event(fake_device, event_time_2, -2.0, 0.0);
+    env.mock_libinput.setup_axis_event(fake_device, event_time_1, {}, -3.0);
+    env.mock_libinput.setup_axis_event(fake_device, event_time_2, -2.0, {});
 
     mouse.start(&mock_sink, &mock_builder);
     process_events(mouse);
@@ -775,11 +775,10 @@ TEST_F(LibInputDeviceOnTouchpad, process_event_handles_scroll)
         0, 0, 1.0f, 0.0f, false, false, 0.0f, 0.0f));
     EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_hscroll, 1.0f)));
 
-    env.mock_libinput.setup_finger_axis_event(fake_device, event_time_1, 0.0, -10.0);
-    env.mock_libinput.setup_finger_axis_event(fake_device, event_time_2, 1.0, 0.0);
+    env.mock_libinput.setup_finger_axis_event(fake_device, event_time_1, {}, -10.0);
+    env.mock_libinput.setup_finger_axis_event(fake_device, event_time_2, 1.0, {});
     touchpad.start(&mock_sink, &mock_builder);
     process_events(touchpad);
-
 }
 
 TEST_F(LibInputDeviceOnTouchpad, reads_touchpad_settings_from_libinput)

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -781,6 +781,25 @@ TEST_F(LibInputDeviceOnTouchpad, process_event_handles_scroll)
     process_events(touchpad);
 }
 
+TEST_F(LibInputDeviceOnTouchpad, process_event_handles_stop)
+{
+    InSequence seq;
+    // expect two scroll events..
+    EXPECT_CALL(mock_builder, pointer_axis_with_stop_event(
+        mir_pointer_axis_source_finger, {time_stamp_1}, mir_pointer_action_motion, 0,
+        0, 0, 0.0f, -10.0f, false, false, 0.0f, 0.0f));
+    EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_vscroll, -10.0f)));
+    EXPECT_CALL(mock_builder, pointer_axis_with_stop_event(
+        mir_pointer_axis_source_finger, {time_stamp_2}, mir_pointer_action_motion, 0,
+        0, 0, 0.0f, 0.0f, false, true, 0.0f, 0.0f));
+    EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_vscroll, 0.0f)));
+
+    env.mock_libinput.setup_finger_axis_event(fake_device, event_time_1, {}, -10.0);
+    env.mock_libinput.setup_finger_axis_event(fake_device, event_time_2, {}, 0.0);
+    touchpad.start(&mock_sink, &mock_builder);
+    process_events(touchpad);
+}
+
 TEST_F(LibInputDeviceOnTouchpad, reads_touchpad_settings_from_libinput)
 {
     setup_touchpad_configuration(fake_device, mir_touchpad_click_mode_finger_count,

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -766,11 +766,13 @@ TEST_F(LibInputDeviceOnTouchpad, process_event_handles_scroll)
 {
     InSequence seq;
     // expect two scroll events..
-    EXPECT_CALL(mock_builder,
-                pointer_axis_event(mir_pointer_axis_source_finger, {time_stamp_1}, mir_pointer_action_motion, 0, 0, 0, 0.0f, -10.0f, 0.0f, 0.0f));
+    EXPECT_CALL(mock_builder, pointer_axis_with_stop_event(
+        mir_pointer_axis_source_finger, {time_stamp_1}, mir_pointer_action_motion, 0,
+        0, 0, 0.0f, -10.0f, false, false, 0.0f, 0.0f));
     EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_vscroll, -10.0f)));
-    EXPECT_CALL(mock_builder,
-                pointer_axis_event(mir_pointer_axis_source_finger, {time_stamp_2}, mir_pointer_action_motion, 0, 0, 0, 1.0f, 0.0f, 0.0f, 0.0f));
+    EXPECT_CALL(mock_builder, pointer_axis_with_stop_event(
+        mir_pointer_axis_source_finger, {time_stamp_2}, mir_pointer_action_motion, 0,
+        0, 0, 1.0f, 0.0f, false, false, 0.0f, 0.0f));
     EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_hscroll, 1.0f)));
 
     env.mock_libinput.setup_finger_axis_event(fake_device, event_time_1, 0.0, -10.0);

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -105,6 +105,16 @@ struct MockEventBuilder : mi::EventBuilder
                     axis_source, time, action, buttons, x, y, hscroll, vscroll, relative_x, relative_y);
             });
 
+        ON_CALL(*this, pointer_axis_with_stop_event(_, _, _, _, _, _, _, _, _, _, _, _)).WillByDefault(
+            [this](MirPointerAxisSource axis_source, std::optional<Timestamp> time, MirPointerAction action,
+                   MirPointerButtons buttons, float x, float y, float hscroll, float vscroll,
+                   bool hscroll_stop, bool vscroll_stop, float relative_x, float relative_y)
+            {
+                return builder.pointer_axis_with_stop_event(
+                    axis_source, time, action, buttons, x, y, hscroll, vscroll, vscroll_stop, hscroll_stop,
+                    relative_x, relative_y);
+            });
+
         ON_CALL(*this, pointer_axis_discrete_scroll_event(_, _, _, _, _, _, _, _)).WillByDefault(
             [this](MirPointerAxisSource axis_source, std::optional<Timestamp> timestamp, MirPointerAction action,
                    MirPointerButtons buttons_pressed, float hscroll_value, float vscroll_value,
@@ -127,6 +137,11 @@ struct MockEventBuilder : mi::EventBuilder
                 (MirPointerAxisSource axis_source, std::optional<Timestamp> timestamp, MirPointerAction action,
                  MirPointerButtons buttons_pressed, float x_position, float y_position,
                  float hscroll_value, float vscroll_value, float relative_x_value, float relative_y_value));
+    MOCK_METHOD(mir::EventUPtr, pointer_axis_with_stop_event,
+                (MirPointerAxisSource axis_source, std::optional<Timestamp> timestamp, MirPointerAction action,
+                 MirPointerButtons buttons_pressed, float x_position, float y_position,
+                 float hscroll_value, float vscroll_value, bool hscroll_stop, bool vscroll_stop,
+                 float relative_x_value, float relative_y_value));
     MOCK_METHOD(mir::EventUPtr, pointer_axis_discrete_scroll_event,
                 (MirPointerAxisSource axis_source, std::optional<Timestamp> timestamp, MirPointerAction action,
                  MirPointerButtons buttons_pressed, float hscroll_value, float vscroll_value, float hscroll_discrete,


### PR DESCRIPTION
This sends a `wl_pointer.axis_stop` event when we get a libinput scroll event that has an axis with value 0. Reading the llibinput and Wayland docs it seems to be correct behavior, is consistent with both Weston and wlroots and works with Firefox.

I've quite possibly screwed up the symbols, so double check them.

Fixes #2247, fixes #2276