### PR TITLE
Include ldflags for umockdev

### DIFF
--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -99,7 +99,7 @@ target_link_libraries(mir-test-framework-static
   ${Boost_LIBRARIES}
   ${GTEST_BOTH_LIBRARIES}
   ${GMOCK_LIBRARIES}
-  ${UMOCKDEV_LDFLAGS} ${UMOCKDEV_LIBRARIES}
+  ${UMOCKDEV_LDFLAGS}
   ${CMAKE_THREAD_LIBS_INIT} # Link in pthread.
 )
 

--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -99,7 +99,7 @@ target_link_libraries(mir-test-framework-static
   ${Boost_LIBRARIES}
   ${GTEST_BOTH_LIBRARIES}
   ${GMOCK_LIBRARIES}
-  ${UMOCKDEV_LIBRARIES}
+  ${UMOCKDEV_LDFLAGS} ${UMOCKDEV_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT} # Link in pthread.
 )
 

--- a/tests/umock-acceptance-tests/CMakeLists.txt
+++ b/tests/umock-acceptance-tests/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(mir_umock_acceptance_tests
   mir-test-framework-static
   mir-test-doubles-static
 
-  ${UMOCKDEV_LIBRARIES}
+  ${UMOCKDEV_LDFLAGS} ${UMOCKDEV_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT} # Link in pthread.
 )
 

--- a/tests/umock-acceptance-tests/CMakeLists.txt
+++ b/tests/umock-acceptance-tests/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(mir_umock_acceptance_tests
   mir-test-framework-static
   mir-test-doubles-static
 
-  ${UMOCKDEV_LDFLAGS} ${UMOCKDEV_LIBRARIES}
+  ${UMOCKDEV_LDFLAGS}
   ${CMAKE_THREAD_LIBS_INIT} # Link in pthread.
 )
 

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -203,7 +203,7 @@ target_link_libraries(
   mir-test-framework-static
 
   ${Boost_LIBRARIES}
-  ${UMOCKDEV_LDFLAGS} ${UMOCKDEV_LIBRARIES}
+  ${UMOCKDEV_LDFLAGS}
   ${LIBINPUT_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT} # Link in pthread.
 )

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -203,7 +203,7 @@ target_link_libraries(
   mir-test-framework-static
 
   ${Boost_LIBRARIES}
-  ${UMOCKDEV_LIBRARIES}
+  ${UMOCKDEV_LDFLAGS} ${UMOCKDEV_LIBRARIES}
   ${LIBINPUT_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT} # Link in pthread.
 )


### PR DESCRIPTION
This was required for Mir to use a umockdev built from source.