### PR TITLE
[debian] disable LTO on jammy, and in dpkg, too

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -45,9 +45,9 @@ jobs:
                     "google:ubuntu-20.04-64:spread/build/ubuntu:rpi"
                     "google:ubuntu-20.04-64:spread/build/ubuntu:clang"
                     "google:fedora-34-64:spread/build/fedora:amd64"
-                    "google:fedora-35-64:spread/build/fedora:amd64"'
-            FAILING_TASKS='"google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_devel"
-                           "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_proposed"
+                    "google:fedora-35-64:spread/build/fedora:amd64"
+                    "google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_devel"'
+            FAILING_TASKS='"google:ubuntu-20.04-64:spread/build/sbuild:ubuntu_proposed"
                            "google:fedora-rawhide-64:spread/build/fedora:amd64"'
           fi
         fi

--- a/debian/rules
+++ b/debian/rules
@@ -24,16 +24,18 @@ endif
 COMMON_CONFIGURE_OPTIONS = \
   -DCMAKE_INSTALL_LIBEXECDIR="lib/$(DEB_HOST_MULTIARCH)/mir"\
   -DMIR_BUILD_INTERPROCESS_TESTS=OFF\
+  -DMIR_LINK_TIME_OPTIMIZATION=ON\
 
+# Disable LTO if optimizations are off
 ifeq ($(filter noopt,$(DEB_BUILD_OPTIONS)),noopt)
 	COMMON_CONFIGURE_OPTIONS += -DMIR_LINK_TIME_OPTIMIZATION=OFF
-else
-	COMMON_CONFIGURE_OPTIONS += -DMIR_LINK_TIME_OPTIMIZATION=ON
+	DEB_BUILD_MAINT_OPTIONS += optimize=-lto
 endif
 
-# Disable LTO on s390x, armhf, ppc64el & arm64 due to failing to build
-ifeq ($(filter amd64 i386,$(DEB_HOST_ARCH)),)
+# Disable LTO on jammy due to failing to build
+ifneq ($(filter jammy,$(DEB_DISTRIBUTION)),)
 	COMMON_CONFIGURE_OPTIONS += -DMIR_LINK_TIME_OPTIMIZATION=OFF
+	DEB_BUILD_MAINT_OPTIONS += optimize=-lto
 endif
 
 # We can't guarantee non-Ubuntu builds will build against WLCS packages we
@@ -42,8 +44,10 @@ ifeq ($(filter Ubuntu,$(DEB_VENDOR)),)
 	COMMON_CONFIGURE_OPTIONS += -DMIR_RUN_WLCS_TESTS=OFF
 endif
 
+export DEB_BUILD_MAINT_OPTIONS
 
 $(info COMMON_CONFIGURE_OPTIONS: ${COMMON_CONFIGURE_OPTIONS})
+$(info DEB_BUILD_MAINT_OPTIONS: ${DEB_BUILD_MAINT_OPTIONS})
 
 AVAILABLE_PLATFORMS=gbm-kms\;x11\;wayland\;eglstream-kms
 


### PR DESCRIPTION
Filed an Ubuntu bug at:

https://bugs.launchpad.net/ubuntu/+source/gcc-defaults/+bug/1958984