### PR TITLE
Add a mir::linearising_executor

### DIFF
--- a/include/common/mir/linearising_executor.h
+++ b/include/common/mir/linearising_executor.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef MIR_LINEARISING_EXECUTOR_H_
+#define MIR_LINEARISING_EXECUTOR_H_
+
+#include "executor.h"
+
+namespace mir
+{
+/**
+ * An Executor that makes the following concurrency guarantees:
+ *
+ * 1.   If linearising_executor.spawn(A) happens-before linearising_executor.spawn(B) then
+ *      A() happens-before B(). That is, the entire execution of A is completed before B is started.
+ * 2.   No work is performed concurrently. For any two calls linearising_executor.spawn(A)
+ *      linearising_executor.spawn(B) either A() happens-before B() or B() happens-before A().
+ * 3.   Work is executed on a separate thread of execution to the call to spawn().
+ */
+extern Executor& linearising_executor;
+}
+
+
+#endif //MIR_LINEARISING_EXECUTOR_H_

--- a/include/common/mir/linearising_executor.h
+++ b/include/common/mir/linearising_executor.h
@@ -30,7 +30,7 @@ namespace mir
  *      A() happens-before B(). That is, the entire execution of A is completed before B is started.
  * 2.   No work is performed concurrently. For any two calls linearising_executor.spawn(A)
  *      linearising_executor.spawn(B) either A() happens-before B() or B() happens-before A().
- * 3.   Work is executed on a separate thread of execution to the call to spawn().
+ * 3.   Work is deferred; linearising_executor.spawn(A) will not block on the execution of A
  */
 extern Executor& linearising_executor;
 }

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -34,6 +34,8 @@ list(APPEND MIR_COMMON_SOURCES
   mir_cursor_api.cpp
   system_executor.cpp
   ${PROJECT_SOURCE_DIR}/include/common/mir/system_executor.h
+  linearising_executor.cpp
+  ${PROJECT_SOURCE_DIR}/include/common/mir/linearising_executor.h
 )
 
 set(

--- a/src/common/linearising_executor.cpp
+++ b/src/common/linearising_executor.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#include "mir/linearising_executor.h"
+#include "mir/system_executor.h"
+
+#include <deque>
+#include <mutex>
+#include <thread>
+
+namespace
+{
+class LinearisingAdaptor : public mir::Executor
+{
+public:
+    LinearisingAdaptor() noexcept = default;
+
+    ~LinearisingAdaptor() noexcept
+    {
+        std::unique_lock<decltype(mutex)> lock{mutex};
+        while (!workqueue.empty())
+        {
+            lock.unlock();
+            std::this_thread::sleep_for(std::chrono::milliseconds{1});
+            lock.lock();
+        }
+    }
+
+    void spawn(std::function<void()>&& work) override
+    {
+        std::lock_guard<decltype(mutex)> lock{mutex};
+        workqueue.push_back(std::move(work));
+        if (workqueue.size() == 1)
+        {
+            // If the workqueue now contains 1 item, then previously it contained 0, which means
+            // any previous work_loop() invocation has finished and we need to spawn a new one.
+            mir::system_executor.spawn([this]() { work_loop(); });
+        }
+    }
+
+private:
+    // Execute items from the queue one at a time, until none are left
+    void work_loop()
+    {
+        std::unique_lock<decltype(mutex)> lock{mutex};
+        while (!workqueue.empty())
+        {
+            {
+                auto work = std::move(workqueue.front());
+                lock.unlock();
+                work();
+            }
+            lock.lock();
+            workqueue.pop_front();
+        }
+    }
+
+    std::mutex mutex;
+    std::deque<std::function<void()>> workqueue;
+} adaptor;
+}
+
+mir::Executor& mir::linearising_executor = adaptor;

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -503,5 +503,6 @@ MIR_COMMON_2.7 {
     typeinfo?for?mir::SystemExecutor;
     vtable?for?mir::SystemExecutor;
     mir::system_executor;
+    mir::linearising_executor;
   };
 } MIR_COMMON_2.5;

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -73,6 +73,7 @@ set(
   test_edid.cpp
   test_report_exception.cpp
   test_system_executor.cpp
+  test_linearising_executor.cpp
 )
 
 if (HAVE_PTHREAD_GETNAME_NP)

--- a/tests/unit-tests/test_linearising_executor.cpp
+++ b/tests/unit-tests/test_linearising_executor.cpp
@@ -18,10 +18,10 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <thread>
 
 #include "mir/linearising_executor.h"
 #include "mir/test/signal.h"
-#include "mir/test/current_thread_name.h"
 
 using namespace std::literals::chrono_literals;
 using namespace testing;

--- a/tests/unit-tests/test_linearising_executor.cpp
+++ b/tests/unit-tests/test_linearising_executor.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "mir/linearising_executor.h"
+#include "mir/test/signal.h"
+#include "mir/test/current_thread_name.h"
+
+using namespace std::literals::chrono_literals;
+using namespace testing;
+
+namespace mt = mir::test;
+
+TEST(LinearisingExecutor, executes_work)
+{
+    auto done = std::make_shared<mt::Signal>();
+    mir::linearising_executor.spawn([done]() { done->raise(); });
+
+    EXPECT_TRUE(done->wait_for(60s));
+}
+
+TEST(LinearisingExecutor, does_not_execute_concurrently)
+{
+    std::atomic<int> counter{0};
+    std::atomic<int> which_thread{0};
+
+    // Should be make_shared<mt::Signal[2]>, but as of 22.04 g++/libstdc++ don't implement that bit of C++20
+    std::shared_ptr<mt::Signal[2]> done{new mt::Signal[2]};
+
+    auto counter_check =
+        [&counter, &which_thread, done]()
+        {
+            EXPECT_THAT(counter, Eq(0));
+            counter++;
+            std::this_thread::sleep_for(1s);
+            EXPECT_THAT(counter, Eq(1));
+            counter--;
+            done[which_thread++].raise();
+        };
+
+    mir::linearising_executor.spawn(counter_check);
+    mir::linearising_executor.spawn(counter_check);
+
+    done[0].wait_for(60s);
+    done[1].wait_for(60s);
+}
+
+TEST(LinearisingExecutor, happens_before_is_executed_before)
+{
+    std::atomic<int> counter{0};
+    constexpr int expected_count = 2;
+    auto done = std::make_shared<mt::Signal>();
+
+    for (int i = 0; i < expected_count; ++i)
+    {
+        mir::linearising_executor.spawn(
+            [&counter]()
+            {
+                std::this_thread::sleep_for(1s);
+                ++counter;
+            });
+    }
+    mir::linearising_executor.spawn([done]() { done->raise(); });
+
+    ASSERT_TRUE(done->wait_for(60s));
+    EXPECT_THAT(counter, Eq(expected_count));
+}
+
+TEST(LinearisingExecutor, spawns_work_on_different_thread)
+{
+    auto this_thread_done = std::make_shared<mt::Signal>();
+    auto work_done = std::make_shared<mt::Signal>();
+
+    mir::linearising_executor.spawn(
+        [this_thread_done, work_done]()
+        {
+            EXPECT_TRUE(this_thread_done->wait_for(60s));
+            work_done->raise();
+        });
+
+    this_thread_done->raise();
+    EXPECT_TRUE(work_done->wait_for(60s));
+}

--- a/tests/unit-tests/test_linearising_executor.cpp
+++ b/tests/unit-tests/test_linearising_executor.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <thread>
+#include <atomic>
 
 #include "mir/linearising_executor.h"
 #include "mir/test/signal.h"


### PR DESCRIPTION
This can be used to ensure work is executed in the order it is `spawn()`ed.