### PR TITLE
SystemExecutor: Quiesce before exiting `run_mir()`

### DIFF
--- a/include/common/mir/system_executor.h
+++ b/include/common/mir/system_executor.h
@@ -39,6 +39,10 @@ public:
      */
     static void set_unhandled_exception_handler(void (*handler)());
 
+    /**
+     * Wait for all current work to finish and terminate all worker threads
+     */
+    static void quiesce();
 protected:
     SystemExecutor() = default;
 };

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -500,6 +500,7 @@ MIR_COMMON_2.7 {
     mir::events::make_pointer_axis_with_stop_event*;
     mir::SystemExecutor::spawn*;
     mir::SystemExecutor::set_unhandled_exception_handler*;
+    mir::SystemExecutor::quiesce*;
     typeinfo?for?mir::SystemExecutor;
     vtable?for?mir::SystemExecutor;
     mir::system_executor;

--- a/src/common/system_executor.cpp
+++ b/src/common/system_executor.cpp
@@ -239,6 +239,7 @@ public:
         std::lock_guard<decltype(workers_mutex)> lock{workers_mutex};
         free_workers.clear();
         workers.clear();
+        num_workers_free = 0;
     }
 
     void spawn(std::function<void()>&& work)

--- a/src/server/run_mir.cpp
+++ b/src/server/run_mir.cpp
@@ -112,5 +112,6 @@ void mir::run_mir(
     init(server);
     server.run();
 
+    mir::SystemExecutor::quiesce();
     check_for_termination_exception();
 }

--- a/tests/unit-tests/test_system_executor.cpp
+++ b/tests/unit-tests/test_system_executor.cpp
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 
 #include <boost/throw_exception.hpp>
+#include <chrono>
 #include <thread>
 #include <future>
 
@@ -199,4 +200,20 @@ TEST(SystemExecutor, new_work_can_be_submitted_after_quiesce)
             });
     }
     EXPECT_TRUE(done->wait_for(60s));
+}
+
+TEST(SystemExecutor, quiesce_waits_until_work_completes)
+{
+    constexpr auto const delay = 500ms;
+
+    auto const expected_end = std::chrono::steady_clock::now() + delay;
+
+    mir::system_executor.spawn(
+        [delay]()
+        {
+            std::this_thread::sleep_for(delay);
+        });
+
+    mir::SystemExecutor::quiesce();
+    EXPECT_THAT(std::chrono::steady_clock::now(), Gt(expected_end));
 }


### PR DESCRIPTION
Global destruction order is not specified (or specifiable), *and* code
we use may register its own global destructors. In an ideal world we
could ensure the SystemExecutor gets destroyed before any other global,
and hence guarantee that none of its threads access state which may
have already been destroyed. Sadly, attempting that is *at best*
non-portable and fragile, at worst impossible.

Do the next best thing by explicitly waiting in `run_mir()` for
work to finish.

Fixes: #2313 - double free on shutdown.

Mesa EGL registers some thread-local storage and frees it during
global teardown. If this teardown is done before all threads which
access that storage have exited then a double-free will occur when
thread termination triggers deallocation of the TLS object.