### PR TITLE
Fix 22.04 FTBFS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 XSBC-Original-Maintainer: Thomas Voß <thomas.voss@canonical.com>
 Build-Depends: cmake,
+               lld, # Workaround for lp:1958984 (ld broken on 22.04)
                pkg-config,
                debhelper (>= 9),
                doxygen,

--- a/debian/rules
+++ b/debian/rules
@@ -32,6 +32,11 @@ ifeq ($(filter noopt,$(DEB_BUILD_OPTIONS)),noopt)
 	DEB_BUILD_MAINT_OPTIONS += optimize=-lto
 endif
 
+# Use ldd on jammy due to failing to build with ld
+ifneq ($(filter jammy,$(DEB_DISTRIBUTION)),)
+	COMMON_CONFIGURE_OPTIONS += -DMIR_USE_LD=ldd
+endif
+
 # We can't guarantee non-Ubuntu builds will build against WLCS packages we
 # control, so disable it on non-Ubuntu builds
 ifeq ($(filter Ubuntu,$(DEB_VENDOR)),)

--- a/debian/rules
+++ b/debian/rules
@@ -32,12 +32,6 @@ ifeq ($(filter noopt,$(DEB_BUILD_OPTIONS)),noopt)
 	DEB_BUILD_MAINT_OPTIONS += optimize=-lto
 endif
 
-# Disable LTO on jammy due to failing to build
-ifneq ($(filter jammy,$(DEB_DISTRIBUTION)),)
-	COMMON_CONFIGURE_OPTIONS += -DMIR_LINK_TIME_OPTIMIZATION=OFF
-	DEB_BUILD_MAINT_OPTIONS += optimize=-lto
-endif
-
 # We can't guarantee non-Ubuntu builds will build against WLCS packages we
 # control, so disable it on non-Ubuntu builds
 ifeq ($(filter Ubuntu,$(DEB_VENDOR)),)

--- a/debian/rules
+++ b/debian/rules
@@ -32,9 +32,9 @@ ifeq ($(filter noopt,$(DEB_BUILD_OPTIONS)),noopt)
 	DEB_BUILD_MAINT_OPTIONS += optimize=-lto
 endif
 
-# Use ldd on jammy due to failing to build with ld
+# Use lld on jammy due to failing to build with ld
 ifneq ($(filter jammy,$(DEB_DISTRIBUTION)),)
-	COMMON_CONFIGURE_OPTIONS += -DMIR_USE_LD=ldd
+	COMMON_CONFIGURE_OPTIONS += -DMIR_USE_LD=lld
 endif
 
 # We can't guarantee non-Ubuntu builds will build against WLCS packages we

--- a/src/miral/CMakeLists.txt
+++ b/src/miral/CMakeLists.txt
@@ -125,6 +125,7 @@ set_target_properties(miral
 
 find_program(MIR_DPKG_GENSYMBOLS dpkg-gensymbols)
 if (CMAKE_COMPILER_IS_GNUCXX   AND  # clang generates slightly different symbols (but we don't care)
+    MIR_USE_LD EQUAL "ld"      AND  # lld on 22.04 generates slightly different symbols (but we don't care)
     MIR_LINK_TIME_OPTIMIZATION AND  # g++ generates slightly different symbols without LTO (but we don't care)
     MIR_DPKG_GENSYMBOLS)
 

--- a/src/miroil/CMakeLists.txt
+++ b/src/miroil/CMakeLists.txt
@@ -61,6 +61,7 @@ set_target_properties(miroil
 
 find_program(MIR_DPKG_GENSYMBOLS dpkg-gensymbols)
 if (CMAKE_COMPILER_IS_GNUCXX   AND  # clang generates slightly different symbols (but we don't care)
+    MIR_USE_LD EQUAL "ld"      AND  # lld on 22.04 generates slightly different symbols (but we don't care)
     MIR_LINK_TIME_OPTIMIZATION AND  # g++ generates slightly different symbols without LTO (but we don't care)
     MIR_DPKG_GENSYMBOLS)            # Using dpkg-gensymbols only makes sense on Debian based distros
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,7 +104,7 @@ if (HAS_W_GNU_SIGN_COMPARE)
 endif()
 if (HAS_W_MAYBE_UNINITIALIZED)
   # Avoid g++ complaints about gmock/gtest headers
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=maybe-uninitialized")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
 endif()
 
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-lto")


### PR DESCRIPTION
* Don't use ld, use ldd;
* Don't check .symbols unless using ld; and
* Working incantation for gmock/gtest headers