### PR TITLE
Do not give menus keyboard focus (again)

### DIFF
--- a/src/include/server/mir/shell/abstract_shell.h
+++ b/src/include/server/mir/shell/abstract_shell.h
@@ -175,9 +175,9 @@ private:
     std::shared_ptr<scene::SurfaceObserver> const focus_surface_observer;
 
     void notify_active_surfaces(
-        std::unique_lock<std::mutex> const& lock,
+        std::unique_lock<std::mutex> const&,
         std::shared_ptr<scene::Surface> const& new_keyboard_focus_surface,
-        std::vector<std::shared_ptr<scene::Surface>> const& new_active_surfaces);
+        std::vector<std::shared_ptr<scene::Surface>> new_active_surfaces);
 
     void set_keyboard_focus_surface(
         std::unique_lock<std::mutex> const& lock,

--- a/src/include/server/mir/shell/abstract_shell.h
+++ b/src/include/server/mir/shell/abstract_shell.h
@@ -170,12 +170,18 @@ private:
     std::weak_ptr<scene::Surface> focus_surface;
     std::weak_ptr<scene::Session> focus_session;
     std::vector<std::weak_ptr<scene::Surface>> notified_active_surfaces;
-    std::weak_ptr<scene::Surface> notified_focus_surface;
-    std::shared_ptr<scene::SurfaceObserver> focus_surface_observer;
+    std::weak_ptr<scene::Surface> last_requested_focus_surface;
+    std::weak_ptr<scene::Surface> notified_keyboard_focus_surface;
+    std::shared_ptr<scene::SurfaceObserver> const focus_surface_observer;
 
-    void notify_focus_locked(
+    void notify_active_surfaces(
         std::unique_lock<std::mutex> const& lock,
-        std::shared_ptr<scene::Surface> const& focus_surface);
+        std::shared_ptr<scene::Surface> const& new_keyboard_focus_surface,
+        std::vector<std::shared_ptr<scene::Surface>> const& new_active_surfaces);
+
+    void set_keyboard_focus_surface(
+        std::unique_lock<std::mutex> const& lock,
+        std::shared_ptr<scene::Surface> const& new_keyboard_focus_surface);
 
     void update_focus_locked(
         std::unique_lock<std::mutex> const& lock,

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -85,12 +85,13 @@ auto get_non_popup_parent(std::shared_ptr<ms::Surface> surface) -> std::shared_p
     return surface;
 }
 
-auto get_active_surfaces(std::shared_ptr<ms::Surface> surface) -> std::vector<std::shared_ptr<ms::Surface>>
+// Returns a vector comprising the supplied surface (if not null), parent, grandparent, etc. in order
+auto get_ancestry(std::shared_ptr<ms::Surface> surface) -> std::vector<std::shared_ptr<ms::Surface>>
 {
     std::vector<std::shared_ptr<ms::Surface>> result;
-    for (auto item = surface; item; item = item->parent())
+    for (auto item = std::move(surface); item; item = item->parent())
     {
-        result.insert(begin(result), item);
+        result.push_back(item);
     }
     return result;
 }
@@ -435,7 +436,7 @@ void msh::AbstractShell::set_focus_to(
     if (last_requested_focus_surface.lock() != focus_surface)
     {
         last_requested_focus_surface = focus_surface;
-        auto new_active_surfaces = get_active_surfaces(focus_surface);
+        auto new_active_surfaces = get_ancestry(focus_surface);
 
         /// HACK: Grabbing popups (menus, in Mir terminology) should be given keyboard focus according to xdg-shell,
         /// however, giving menus keyboard focus breaks Qt submenus. As of February 2022 Weston and other compositors

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -468,20 +468,22 @@ void msh::AbstractShell::notify_active_surfaces(
         auto const found = old_active_surfaces.find(new_active);
         if (found == end(old_active_surfaces))
         {
+            // If the new active surface was not already active, add it to new_activations
             new_activations.push_back(new_active);
         }
         else
         {
+            // If the new active surface was already active, remove it from old_active_surfaces so it's not deactivated
             old_active_surfaces.erase(found);
         }
     }
 
-    for (auto const& old_active: notified_active_surfaces)
+    for (auto const& current_active_weak: notified_active_surfaces)
     {
-        if (auto const current_active = old_active.lock())
+        if (auto const current_active = current_active_weak.lock())
         {
-            // old_active_surfaces has only surfaces that are no longer active
-            if (old_active_surfaces.find(old_active) != end(old_active_surfaces))
+            // old_active_surfaces has only surfaces that should no longer be active
+            if (old_active_surfaces.find(current_active_weak) != end(old_active_surfaces))
             {
                 // If a surface that was previously active is not in the set of new active surfaces, notify it
                 current_active->set_focus_state(mir_window_focus_state_unfocused);

--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -98,9 +98,12 @@ set(EXPECTED_FAILURES
 
   ForeignToplevelHandleTest.can_maximize_foreign_while_fullscreen # https://github.com/MirServer/mir/issues/2164
 
-  # Fixed by https://github.com/MirServer/wlcs/pull/216
-  XdgPopupStable/XdgPopupTest.grabbed_popup_does_not_get_keyboard_focus/0
-  XdgPopupUnstableV6/XdgPopupTest.grabbed_popup_does_not_get_keyboard_focus/0
+  # See https://github.com/MirServer/mir/issues/2324
+  TextInputV3WithInputMethodV2Test.text_input_enters_parent_surface_after_child_destroyed
+  TextInputV3WithInputMethodV2Test.text_input_enters_grabbing_popup
+  XdgPopupUnstableV6/XdgPopupTest.grabbed_popup_gets_keyboard_focus/0
+  XdgPopupStable/XdgPopupTest.grabbed_popup_gets_keyboard_focus/0
+  LayerShellPopup/XdgPopupTest.grabbed_popup_gets_keyboard_focus/0
 )
 
 if (MIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN)

--- a/tests/include/mir/test/doubles/mock_surface.h
+++ b/tests/include/mir/test/doubles/mock_surface.h
@@ -49,10 +49,16 @@ struct MockSurface : public scene::BasicSurface
                 { return scene::BasicSurface::primary_buffer_stream(); }));
         ON_CALL(*this, parent())
             .WillByDefault(testing::Return(nullptr));
+        ON_CALL(*this, set_focus_state(testing::_))
+            .WillByDefault(testing::Invoke([this](MirWindowFocusState focus_state)
+                {
+                    BasicSurface::set_focus_state(focus_state);
+                }));
     }
 
     ~MockSurface() noexcept {}
 
+    MOCK_CONST_METHOD0(type, MirWindowType());
     MOCK_METHOD0(hide, void());
     MOCK_METHOD0(show, void());
     MOCK_CONST_METHOD0(visible, bool());
@@ -63,6 +69,7 @@ struct MockSurface : public scene::BasicSurface
     MOCK_CONST_METHOD0(size, geometry::Size());
     MOCK_CONST_METHOD0(pixel_format, MirPixelFormat());
 
+    MOCK_METHOD0(request_client_surface_close, void());
     MOCK_CONST_METHOD0(parent, std::shared_ptr<scene::Surface>());
     MOCK_METHOD2(configure, int(MirWindowAttrib, int));
     MOCK_METHOD1(add_observer, void(std::shared_ptr<scene::SurfaceObserver> const&));
@@ -71,6 +78,8 @@ struct MockSurface : public scene::BasicSurface
 
     MOCK_CONST_METHOD0(primary_buffer_stream, std::shared_ptr<frontend::BufferStream>());
     MOCK_METHOD1(set_streams, void(std::list<scene::StreamInfo> const&));
+
+    MOCK_METHOD1(set_focus_state, void(MirWindowFocusState));
 
     std::shared_ptr<MockBufferStream> const stream;
 };


### PR DESCRIPTION
Fixes #2324, and refactors `AbstractShell::notify_focus_locked()` in an attempt to make future changes easier to understand.