### PR TITLE
Revert "Do not give menus keyboard focus (again) (#2330)"

### DIFF
--- a/src/include/server/mir/shell/abstract_shell.h
+++ b/src/include/server/mir/shell/abstract_shell.h
@@ -170,18 +170,12 @@ private:
     std::weak_ptr<scene::Surface> focus_surface;
     std::weak_ptr<scene::Session> focus_session;
     std::vector<std::weak_ptr<scene::Surface>> notified_active_surfaces;
-    std::weak_ptr<scene::Surface> last_requested_focus_surface;
-    std::weak_ptr<scene::Surface> notified_keyboard_focus_surface;
-    std::shared_ptr<scene::SurfaceObserver> const focus_surface_observer;
+    std::weak_ptr<scene::Surface> notified_focus_surface;
+    std::shared_ptr<scene::SurfaceObserver> focus_surface_observer;
 
-    void notify_active_surfaces(
-        std::unique_lock<std::mutex> const&,
-        std::shared_ptr<scene::Surface> const& new_keyboard_focus_surface,
-        std::vector<std::shared_ptr<scene::Surface>> new_active_surfaces);
-
-    void set_keyboard_focus_surface(
+    void notify_focus_locked(
         std::unique_lock<std::mutex> const& lock,
-        std::shared_ptr<scene::Surface> const& new_keyboard_focus_surface);
+        std::shared_ptr<scene::Surface> const& focus_surface);
 
     void update_focus_locked(
         std::unique_lock<std::mutex> const& lock,

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -32,7 +32,6 @@
 #include "decoration/manager.h"
 
 #include <algorithm>
-#include <iterator>
 #include <vector>
 
 namespace mf = mir::frontend;
@@ -69,33 +68,6 @@ private:
 
     msh::AbstractShell* shell;
 };
-
-auto get_non_popup_parent(std::shared_ptr<ms::Surface> surface) -> std::shared_ptr<ms::Surface>
-{
-    while (surface)
-    {
-        auto const type = surface->type();
-        if (type != mir_window_type_gloss &&
-            type != mir_window_type_tip &&
-            type != mir_window_type_menu)
-        {
-            break;
-        }
-        surface = surface->parent();
-    }
-    return surface;
-}
-
-// Returns a vector comprising the supplied surface (if not null), parent, grandparent, etc. in order
-auto get_ancestry(std::shared_ptr<ms::Surface> surface) -> std::vector<std::shared_ptr<ms::Surface>>
-{
-    std::vector<std::shared_ptr<ms::Surface>> result;
-    for (auto item = std::move(surface); item; item = item->parent())
-    {
-        result.push_back(item);
-    }
-    return result;
-}
 }
 
 msh::AbstractShell::AbstractShell(
@@ -434,127 +406,102 @@ void msh::AbstractShell::set_focus_to(
 {
     std::unique_lock<std::mutex> lock(focus_mutex);
 
-    if (last_requested_focus_surface.lock() != focus_surface)
-    {
-        last_requested_focus_surface = focus_surface;
-        auto new_active_surfaces = get_ancestry(focus_surface);
-
-        /// HACK: Grabbing popups (menus, in Mir terminology) should be given keyboard focus according to xdg-shell,
-        /// however, giving menus keyboard focus breaks Qt submenus. As of February 2022 Weston and other compositors
-        /// disobey the protocol by not giving keyboard focus to grabbing popups, so we do the same thing. The behavior
-        /// is subject change. See: https://github.com/MirServer/mir/issues/2324.
-        auto const new_keyboard_focus_surface = get_non_popup_parent(focus_surface);
-
-        notify_active_surfaces(lock, new_keyboard_focus_surface, std::move(new_active_surfaces));
-        set_keyboard_focus_surface(lock, new_keyboard_focus_surface);
-    }
-
+    notify_focus_locked(lock, focus_surface);
     update_focus_locked(lock, focus_session, focus_surface);
 }
 
-void msh::AbstractShell::notify_active_surfaces(
-    std::unique_lock<std::mutex> const&,
-    std::shared_ptr<ms::Surface> const& new_keyboard_focus_surface,
-    std::vector<std::shared_ptr<ms::Surface>> new_active_surfaces)
+void msh::AbstractShell::notify_focus_locked(
+    std::unique_lock<std::mutex> const& /*lock*/,
+    std::shared_ptr<ms::Surface> const& new_focus_surface)
 {
-    // Initially populate old_active_surfaces with all surfaces that were already active,
-    // but we will discard any that remain active (below)
-    SurfaceSet old_active_surfaces{begin(notified_active_surfaces), end(notified_active_surfaces)};
+    auto const current_focus = notified_focus_surface.lock();
 
-    decltype(new_active_surfaces) new_activations;
-
-    for (auto const& new_active: new_active_surfaces)
+    if (current_focus != new_focus_surface)
     {
-        auto const found = old_active_surfaces.find(new_active);
-        if (found == end(old_active_surfaces))
+        std::vector<std::shared_ptr<ms::Surface>> new_active_surfaces;
+        for (auto item = new_focus_surface; item; item = item->parent())
         {
-            // If the new active surface was not already active, add it to new_activations
-            new_activations.push_back(new_active);
+            new_active_surfaces.insert(begin(new_active_surfaces), item);
         }
-        else
-        {
-            // If the new active surface was already active, remove it from old_active_surfaces so it's not deactivated
-            old_active_surfaces.erase(found);
-        }
-    }
 
-    for (auto const& current_active_weak: notified_active_surfaces)
-    {
-        if (auto const current_active = current_active_weak.lock())
+        std::vector<std::shared_ptr<ms::Surface>> current_focus_tree;
+
+        notified_focus_surface = new_focus_surface;
+        seat->reset_confinement_regions();
+
+        for (auto const& item : notified_active_surfaces)
         {
-            // old_active_surfaces has only surfaces that should no longer be active
-            if (old_active_surfaces.find(current_active_weak) != end(old_active_surfaces))
+            if (auto const active = item.lock())
             {
-                // If a surface that was previously active is not in the set of new active surfaces, notify it
-                current_active->set_focus_state(mir_window_focus_state_unfocused);
-
-                // When a menu loses focus we should close and unmap it
-                if (current_active->type() == mir_window_type_menu || current_active->type() == mir_window_type_gloss)
+                current_focus_tree.push_back(active);
+                if (find(begin(new_active_surfaces), end(new_active_surfaces), active) == end(new_active_surfaces))
                 {
-                    current_active->request_client_surface_close();
-                    current_active->hide();
+                    active->set_focus_state(mir_window_focus_state_unfocused);
+
+                    // When a menu loses focus we should close and unmap it
+                    if (active->type() == mir_window_type_menu || active->type() == mir_window_type_gloss)
+                    {
+                        active->request_client_surface_close();
+                        active->hide();
+                    }
+                }
+                else if (active == current_focus)
+                {
+                    active->set_focus_state(mir_window_focus_state_active);
                 }
             }
         }
-    }
 
-    for (auto const& new_active: new_activations)
-    {
-        if (new_active == new_keyboard_focus_surface)
+        if (current_focus)
         {
-            new_active->set_focus_state(mir_window_focus_state_focused);
+            current_focus->remove_observer(focus_surface_observer);
+
+            switch (current_focus->confine_pointer_state())
+            {
+            case mir_pointer_confined_oneshot:
+            case mir_pointer_locked_oneshot:
+                seat->reset_confinement_regions();
+                current_focus->set_confine_pointer_state(mir_pointer_unconfined);
+                break;
+
+            default:
+                break;
+            }
+        }
+
+        notified_active_surfaces.clear();
+        if (notified_active_surfaces.capacity() > 100)
+        {
+            notified_active_surfaces.shrink_to_fit();
+        }
+
+        if (new_focus_surface)
+        {
+            update_confinement_for(new_focus_surface);
+
+            // Ensure the surface has really taken the focus before notifying it that it is focused
+            input_targeter->set_focus(new_focus_surface);
+            new_focus_surface->consume(seat->create_device_state().get());
+            new_focus_surface->add_observer(focus_surface_observer);
+
+            for (auto const& item : new_active_surfaces)
+            {
+                notified_active_surfaces.push_back(item);
+                if (item == new_focus_surface)
+                {
+                    item->set_focus_state(mir_window_focus_state_focused);
+                }
+                else if (find(begin(current_focus_tree), end(current_focus_tree), item) == end(current_focus_tree))
+                {
+                    item->set_focus_state(mir_window_focus_state_active);
+                }
+            }
         }
         else
         {
-            new_active->set_focus_state(mir_window_focus_state_active);
+            input_targeter->clear_focus();
         }
     }
-
-    notified_active_surfaces = {begin(new_active_surfaces), end(new_active_surfaces)};
-}
-
-void msh::AbstractShell::set_keyboard_focus_surface(
-    std::unique_lock<std::mutex> const&,
-    std::shared_ptr<ms::Surface> const& new_keyboard_focus_surface)
-{
-    auto const current_keyboard_focus = notified_keyboard_focus_surface.lock();
-    if (current_keyboard_focus == new_keyboard_focus_surface)
-    {
-        return;
-    }
-
-    seat->reset_confinement_regions();
-
-    if (current_keyboard_focus)
-    {
-        current_keyboard_focus->remove_observer(focus_surface_observer);
-
-        switch (current_keyboard_focus->confine_pointer_state())
-        {
-        case mir_pointer_confined_oneshot:
-        case mir_pointer_locked_oneshot:
-            current_keyboard_focus->set_confine_pointer_state(mir_pointer_unconfined);
-            break;
-
-        default:
-            break;
-        }
-    }
-
-    if (new_keyboard_focus_surface)
-    {
-        update_confinement_for(new_keyboard_focus_surface);
-
-        input_targeter->set_focus(new_keyboard_focus_surface);
-        new_keyboard_focus_surface->consume(seat->create_device_state().get());
-        new_keyboard_focus_surface->add_observer(focus_surface_observer);
-    }
-    else
-    {
-        input_targeter->clear_focus();
-    }
-
-    notified_keyboard_focus_surface = new_keyboard_focus_surface;
 }
 
 void msh::AbstractShell::update_confinement_for(std::shared_ptr<ms::Surface> const& surface) const

--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -98,12 +98,9 @@ set(EXPECTED_FAILURES
 
   ForeignToplevelHandleTest.can_maximize_foreign_while_fullscreen # https://github.com/MirServer/mir/issues/2164
 
-  # See https://github.com/MirServer/mir/issues/2324
-  TextInputV3WithInputMethodV2Test.text_input_enters_parent_surface_after_child_destroyed
-  TextInputV3WithInputMethodV2Test.text_input_enters_grabbing_popup
-  XdgPopupUnstableV6/XdgPopupTest.grabbed_popup_gets_keyboard_focus/0
-  XdgPopupStable/XdgPopupTest.grabbed_popup_gets_keyboard_focus/0
-  LayerShellPopup/XdgPopupTest.grabbed_popup_gets_keyboard_focus/0
+  # Fixed by https://github.com/MirServer/wlcs/pull/216
+  XdgPopupStable/XdgPopupTest.grabbed_popup_does_not_get_keyboard_focus/0
+  XdgPopupUnstableV6/XdgPopupTest.grabbed_popup_does_not_get_keyboard_focus/0
 )
 
 if (MIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN)

--- a/tests/include/mir/test/doubles/mock_surface.h
+++ b/tests/include/mir/test/doubles/mock_surface.h
@@ -49,16 +49,10 @@ struct MockSurface : public scene::BasicSurface
                 { return scene::BasicSurface::primary_buffer_stream(); }));
         ON_CALL(*this, parent())
             .WillByDefault(testing::Return(nullptr));
-        ON_CALL(*this, set_focus_state(testing::_))
-            .WillByDefault(testing::Invoke([this](MirWindowFocusState focus_state)
-                {
-                    BasicSurface::set_focus_state(focus_state);
-                }));
     }
 
     ~MockSurface() noexcept {}
 
-    MOCK_CONST_METHOD0(type, MirWindowType());
     MOCK_METHOD0(hide, void());
     MOCK_METHOD0(show, void());
     MOCK_CONST_METHOD0(visible, bool());
@@ -69,7 +63,6 @@ struct MockSurface : public scene::BasicSurface
     MOCK_CONST_METHOD0(size, geometry::Size());
     MOCK_CONST_METHOD0(pixel_format, MirPixelFormat());
 
-    MOCK_METHOD0(request_client_surface_close, void());
     MOCK_CONST_METHOD0(parent, std::shared_ptr<scene::Surface>());
     MOCK_METHOD2(configure, int(MirWindowAttrib, int));
     MOCK_METHOD1(add_observer, void(std::shared_ptr<scene::SurfaceObserver> const&));
@@ -78,8 +71,6 @@ struct MockSurface : public scene::BasicSurface
 
     MOCK_CONST_METHOD0(primary_buffer_stream, std::shared_ptr<frontend::BufferStream>());
     MOCK_METHOD1(set_streams, void(std::list<scene::StreamInfo> const&));
-
-    MOCK_METHOD1(set_focus_state, void(MirWindowFocusState));
 
     std::shared_ptr<MockBufferStream> const stream;
 };

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -184,21 +184,6 @@ struct AbstractShell : Test
                     }));
     }
 
-    auto create_surface(ms::Surface& surface) -> std::shared_ptr<ms::Surface>
-    {
-        auto const session = shell.open_session(
-            __LINE__,
-            mir::Fd{mir::Fd::invalid},
-            "Foo",
-            std::shared_ptr<mf::EventSink>());
-        EXPECT_CALL(surface_factory, create_surface(_, _, _))
-            .WillOnce(Return(mt::fake_shared(surface)));
-        return shell.create_surface(
-            session,
-            mt::make_surface_spec(session->create_buffer_stream(properties)),
-            nullptr);
-    }
-
     std::chrono::nanoseconds const event_timestamp = std::chrono::nanoseconds(0);
     std::vector<uint8_t> const cookie{};
     mg::BufferProperties properties { geom::Size{1,1}, mir_pixel_format_abgr_8888, mg::BufferUsage::software};
@@ -849,81 +834,6 @@ TEST_F(AbstractShell, setting_focus_to_child_makes_parent_active)
     focus_controller.set_focus_to(session, child_surface);
     EXPECT_THAT(child_surface->focus_state(), Eq(mir_window_focus_state_focused));
     EXPECT_THAT(parent_surface->focus_state(), Eq(mir_window_focus_state_active));
-}
-
-TEST_F(AbstractShell, does_not_give_keyboard_focus_to_menu)
-{
-    auto const surface_parent = create_surface(mock_surface);
-
-    NiceMock<mtd::MockSurface> mock_surface_child;
-    auto const surface_child = create_surface(mock_surface_child);
-    ON_CALL(mock_surface_child, parent())
-        .WillByDefault(Return(surface_parent));
-    ON_CALL(mock_surface_child, type())
-        .WillByDefault(Return(mir_window_type_menu));
-
-    msh::FocusController& focus_controller = shell;
-
-    EXPECT_CALL(mock_surface_child, set_focus_state(mir_window_focus_state_active));
-    EXPECT_CALL(mock_surface, set_focus_state(mir_window_focus_state_focused));
-    focus_controller.set_focus_to(surface_child->session().lock(), surface_child);
-}
-
-TEST_F(AbstractShell, does_not_give_keyboard_focus_to_tip)
-{
-    auto const surface_parent = create_surface(mock_surface);
-
-    NiceMock<mtd::MockSurface> mock_surface_child;
-    auto const surface_child = create_surface(mock_surface_child);
-    ON_CALL(mock_surface_child, parent())
-        .WillByDefault(Return(surface_parent));
-    ON_CALL(mock_surface_child, type())
-        .WillByDefault(Return(mir_window_type_tip));
-
-    msh::FocusController& focus_controller = shell;
-
-    EXPECT_CALL(mock_surface_child, set_focus_state(mir_window_focus_state_active));
-    EXPECT_CALL(mock_surface, set_focus_state(mir_window_focus_state_focused));
-    focus_controller.set_focus_to(surface_child->session().lock(), surface_child);
-}
-
-TEST_F(AbstractShell, does_not_deactivate_parent_when_switching_children)
-{
-    auto const surface_parent = create_surface(mock_surface);
-
-    NiceMock<mtd::MockSurface> mock_surface_child_a;
-    auto const surface_child_a = create_surface(mock_surface_child_a);
-    ON_CALL(mock_surface_child_a, parent())
-        .WillByDefault(Return(surface_parent));
-
-    NiceMock<mtd::MockSurface> mock_surface_child_b;
-    auto const surface_child_b = create_surface(mock_surface_child_b);
-    ON_CALL(mock_surface_child_b, parent())
-        .WillByDefault(Return(surface_parent));
-
-    msh::FocusController& focus_controller = shell;
-    focus_controller.set_focus_to(surface_child_a->session().lock(), surface_child_a);
-
-    EXPECT_CALL(mock_surface, set_focus_state(_)).Times(0);
-    focus_controller.set_focus_to(surface_child_b->session().lock(), surface_child_b);
-}
-
-TEST_F(AbstractShell, removing_focus_from_menu_closes_it)
-{
-    auto const surface_parent = create_surface(mock_surface);
-
-    NiceMock<mtd::MockSurface> mock_surface_menu;
-    auto const surface_menu = create_surface(mock_surface_menu);
-    ON_CALL(mock_surface_menu, parent())
-        .WillByDefault(Return(surface_parent));
-    ON_CALL(mock_surface_menu, type())
-        .WillByDefault(Return(mir_window_type_menu));
-
-    msh::FocusController& focus_controller = shell;
-    focus_controller.set_focus_to(surface_menu->session().lock(), surface_menu);
-
-    EXPECT_CALL(mock_surface_menu, request_client_surface_close());
-    focus_controller.set_focus_to(surface_parent->session().lock(), surface_parent);
 }
 
 // Regression test for https://github.com/MirServer/mir/issues/2279


### PR DESCRIPTION
This reverts commit 7c287ea1a0e020af722b2c48e7eff0c0b5549e2b.

Fixes: #2334 at the cost of reintroducing the bug #2330 fixed.