### PR TITLE
Don't enable zwp_text_input_v2 by default

### DIFF
--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -237,7 +237,6 @@ auto mf::get_standard_extensions() -> std::vector<std::string>
         mw::XdgWmBase::interface_name,
         mw::XdgShellV6::interface_name,
         mw::XdgOutputManagerV1::interface_name,
-        mw::TextInputManagerV2::interface_name,
         mw::TextInputManagerV3::interface_name};
 }
 


### PR DESCRIPTION
The zwp_text_input_v2 implementation needs further work.

Fixes https://github.com/MirServer/mir/issues/2334