### PR TITLE
Further simplify and correct keyboard focus setting

### DIFF
--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -919,9 +919,20 @@ TEST_F(AbstractShell, makes_parent_active_when_switching_to_child)
 
     msh::FocusController& focus_controller = shell;
     focus_controller.set_focus_to(surface_parent->session().lock(), surface_parent);
+    /* window         | expected focus state
+     * -----------------------------------------------
+     * surface_parent | mir_window_focus_state_focused 
+     * surface_child  | <don't care>
+    */
 
     EXPECT_CALL(mock_surface, set_focus_state(mir_window_focus_state_active));
     focus_controller.set_focus_to(surface_child->session().lock(), surface_child);
+    /* window         | expected focus state
+     * -----------------------------------------------
+     * surface_parent | mir_window_focus_state_active
+     * surface_child  | mir_window_focus_state_focused
+    */
+
 }
 
 TEST_F(AbstractShell, makes_parent_focused_when_switching_back_from_child)
@@ -935,9 +946,19 @@ TEST_F(AbstractShell, makes_parent_focused_when_switching_back_from_child)
 
     msh::FocusController& focus_controller = shell;
     focus_controller.set_focus_to(surface_child->session().lock(), surface_child);
+    /* window         | expected focus state
+     * -----------------------------------------------
+     * surface_parent | mir_window_focus_state_active
+     * surface_child  | mir_window_focus_state_focused
+    */
 
     EXPECT_CALL(mock_surface, set_focus_state(mir_window_focus_state_focused));
     focus_controller.set_focus_to(surface_parent->session().lock(), surface_parent);
+    /* window         | expected focus state
+     * -----------------------------------------------
+     * surface_parent | mir_window_focus_state_focused
+     * surface_child  | <don't care>
+    */
 }
 
 TEST_F(AbstractShell, removing_focus_from_menu_closes_it)

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -904,8 +904,40 @@ TEST_F(AbstractShell, does_not_deactivate_parent_when_switching_children)
     msh::FocusController& focus_controller = shell;
     focus_controller.set_focus_to(surface_child_a->session().lock(), surface_child_a);
 
-    EXPECT_CALL(mock_surface, set_focus_state(_)).Times(0);
+    EXPECT_CALL(mock_surface, set_focus_state(mir_window_focus_state_active)).Times(AnyNumber());
     focus_controller.set_focus_to(surface_child_b->session().lock(), surface_child_b);
+}
+
+TEST_F(AbstractShell, makes_parent_active_when_switching_to_child)
+{
+    auto const surface_parent = create_surface(mock_surface);
+
+    NiceMock<mtd::MockSurface> mock_surface_child;
+    auto const surface_child = create_surface(mock_surface_child);
+    ON_CALL(mock_surface_child, parent())
+        .WillByDefault(Return(surface_parent));
+
+    msh::FocusController& focus_controller = shell;
+    focus_controller.set_focus_to(surface_parent->session().lock(), surface_parent);
+
+    EXPECT_CALL(mock_surface, set_focus_state(mir_window_focus_state_active));
+    focus_controller.set_focus_to(surface_child->session().lock(), surface_child);
+}
+
+TEST_F(AbstractShell, makes_parent_focused_when_switching_back_from_child)
+{
+    auto const surface_parent = create_surface(mock_surface);
+
+    NiceMock<mtd::MockSurface> mock_surface_child;
+    auto const surface_child = create_surface(mock_surface_child);
+    ON_CALL(mock_surface_child, parent())
+        .WillByDefault(Return(surface_parent));
+
+    msh::FocusController& focus_controller = shell;
+    focus_controller.set_focus_to(surface_child->session().lock(), surface_child);
+
+    EXPECT_CALL(mock_surface, set_focus_state(mir_window_focus_state_focused));
+    focus_controller.set_focus_to(surface_parent->session().lock(), surface_parent);
 }
 
 TEST_F(AbstractShell, removing_focus_from_menu_closes_it)


### PR DESCRIPTION
This PR corrects a behavior where Mir would fail to set the requested surface as focused if it was already active. Instead of adding additional error-prone logic I simply gave up on our previous strategy of only notifying surfaces when necessary.

`BasicSurface` already returns immediately if `focus_state` is set to the same value multiple times. The only additional performance cost is that of locking all surfaces that were active both before and after, which will never be never be the majority of the cost of changing focus because we already lock all surfaces in the new focus tree once anyway to get their parent.

Fixes #2338