### PR TITLE
Restore the "fatal_error" when focus is screwed

### DIFF
--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -47,11 +47,9 @@ void mf::WlKeyboard::handle_event(MirInputEvent const* event, WlSurface& surface
 {
     if (!focused_surface.is(surface))
     {
-        log_warning(
-            "Sending keyboard event to wl_surface@%u even though it was not explicitly given keyboard focus",
+        fatal_error(
+            "Attempt to send keyboard event to wl_surface@%u even though it was not given keyboard focus",
             wl_resource_get_id(surface.resource));
-
-        focus_on(&surface);
     }
 
     helper->handle_event(event);


### PR DESCRIPTION
While we're not ready for release with this, it has been useful identifying and fixing genuine problems in development.