### PR TITLE
[x11-platform] Make window title a configuration option

### DIFF
--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -79,11 +79,12 @@ private:
 }
 
 mgx::X11Window::X11Window(mx::X11Resources* x11_resources,
+                          std::string* title,
                           EGLDisplay egl_dpy,
                           geom::Size const size,
-                          EGLConfig const egl_cfg,
-                          std::string title)
-    : x11_resources{x11_resources}
+                          EGLConfig const egl_cfg)
+    : x11_resources{x11_resources},
+      title{title}
 {
     auto const conn = x11_resources->conn.get();
 
@@ -118,12 +119,12 @@ mgx::X11Window::X11Window(mx::X11Resources* x11_resources,
         char buffer[128] = { '\0' };
         if (gethostname(buffer, sizeof buffer - 1) == 0)
         {
-            title += " - ";
-            title += buffer;
+            *title += " - ";
+            *title += buffer;
         }
     }
 
-    conn->change_property(win, x11_resources->_NET_WM_NAME, x11_resources->UTF8_STRING, 8, title.size(), title.c_str());
+    conn->change_property(win, x11_resources->_NET_WM_NAME, x11_resources->UTF8_STRING, 8, title->size(), title->c_str());
 
     conn->map_window(win);
 }

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -144,6 +144,7 @@ unsigned long mgx::X11Window::red_mask() const
 }
 
 mgx::Display::Display(std::shared_ptr<mir::X::X11Resources> const& x11_resources,
+                      std::shared_ptr<std::string> const& title,
                       std::vector<X11OutputConfig> const& requested_sizes,
                       std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
                       std::shared_ptr<GLConfig> const& gl_config,
@@ -162,10 +163,10 @@ mgx::Display::Display(std::shared_ptr<mir::X::X11Resources> const& x11_resources
         auto actual_size = requested_size.size;
         auto window = std::make_unique<X11Window>(
             x11_resources.get(),
+            title.get(),
             shared_egl.display(),
             actual_size,
-            shared_egl.config(),
-            "Mir On X");
+            shared_egl.config());
         auto red_mask = window->red_mask();
         auto pf = (red_mask == 0xFF0000 ?
             mir_pixel_format_argb_8888 :

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -112,10 +112,6 @@ mgx::X11Window::X11Window(mx::X11Resources* x11_resources,
     // Enable the WM_DELETE_WINDOW protocol for the window (causes a client message to be sent when window is closed)
     conn->change_property(win, x11_resources->WM_PROTOCOLS, XCB_ATOM_ATOM, 32, 1, &x11_resources->WM_DELETE_WINDOW);
 
-    // Set the window title if null
-    if (title.empty())
-        title = "Mir on X";
-
     // Include hostname in title when X-forwarding
     if (getenv("SSH_CONNECTION"))
     {

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -83,8 +83,7 @@ mgx::X11Window::X11Window(mx::X11Resources* x11_resources,
                           EGLDisplay egl_dpy,
                           geom::Size const size,
                           EGLConfig const egl_cfg)
-    : x11_resources{x11_resources},
-      title{title}
+    : x11_resources{x11_resources}
 {
     auto const conn = x11_resources->conn.get();
 

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -81,7 +81,8 @@ private:
 mgx::X11Window::X11Window(mx::X11Resources* x11_resources,
                           EGLDisplay egl_dpy,
                           geom::Size const size,
-                          EGLConfig const egl_cfg)
+                          EGLConfig const egl_cfg,
+                          std::string title)
     : x11_resources{x11_resources}
 {
     auto const conn = x11_resources->conn.get();
@@ -111,8 +112,9 @@ mgx::X11Window::X11Window(mx::X11Resources* x11_resources,
     // Enable the WM_DELETE_WINDOW protocol for the window (causes a client message to be sent when window is closed)
     conn->change_property(win, x11_resources->WM_PROTOCOLS, XCB_ATOM_ATOM, 32, 1, &x11_resources->WM_DELETE_WINDOW);
 
-    // Set the window title
-    std::string title{"Mir on X"};
+    // Set the window title if null
+    if (title.empty())
+        title = "Mir on X";
 
     // Include hostname in title when X-forwarding
     if (getenv("SSH_CONNECTION"))
@@ -166,7 +168,8 @@ mgx::Display::Display(std::shared_ptr<mir::X::X11Resources> const& x11_resources
             x11_resources.get(),
             shared_egl.display(),
             actual_size,
-            shared_egl.config());
+            shared_egl.config(),
+            "Mir On X");
         auto red_mask = window->red_mask();
         auto pf = (red_mask == 0xFF0000 ?
             mir_pixel_format_argb_8888 :

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -79,7 +79,7 @@ private:
 }
 
 mgx::X11Window::X11Window(mx::X11Resources* x11_resources,
-                          std::string* title,
+                          std::string title,
                           EGLDisplay egl_dpy,
                           geom::Size const size,
                           EGLConfig const egl_cfg)
@@ -119,12 +119,12 @@ mgx::X11Window::X11Window(mx::X11Resources* x11_resources,
         char buffer[128] = { '\0' };
         if (gethostname(buffer, sizeof buffer - 1) == 0)
         {
-            *title += " - ";
-            *title += buffer;
+            title += " - ";
+            title += buffer;
         }
     }
 
-    conn->change_property(win, x11_resources->_NET_WM_NAME, x11_resources->UTF8_STRING, 8, title->size(), title->c_str());
+    conn->change_property(win, x11_resources->_NET_WM_NAME, x11_resources->UTF8_STRING, 8, title.size(), title.c_str());
 
     conn->map_window(win);
 }
@@ -145,7 +145,7 @@ unsigned long mgx::X11Window::red_mask() const
 }
 
 mgx::Display::Display(std::shared_ptr<mir::X::X11Resources> const& x11_resources,
-                      std::shared_ptr<std::string> const& title,
+                      std::string const title,
                       std::vector<X11OutputConfig> const& requested_sizes,
                       std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
                       std::shared_ptr<GLConfig> const& gl_config,
@@ -164,7 +164,7 @@ mgx::Display::Display(std::shared_ptr<mir::X::X11Resources> const& x11_resources
         auto actual_size = requested_size.size;
         auto window = std::make_unique<X11Window>(
             x11_resources.get(),
-            title.get(),
+            title,
             shared_egl.display(),
             actual_size,
             shared_egl.config());

--- a/src/platforms/x11/graphics/display.h
+++ b/src/platforms/x11/graphics/display.h
@@ -53,7 +53,7 @@ class X11Window
 {
 public:
     X11Window(mir::X::X11Resources* x11_resources,
-              std::string* title,
+              std::string title,
               EGLDisplay egl_dpy,
               geometry::Size const size,
               EGLConfig const egl_cfg);
@@ -64,7 +64,7 @@ public:
 
 private:
     mir::X::X11Resources* const x11_resources;
-    std::string* const title;
+    std::string const title;
     xcb_window_t win;
     unsigned long r_mask;
 };
@@ -73,7 +73,7 @@ class Display : public graphics::Display
 {
 public:
     explicit Display(std::shared_ptr<mir::X::X11Resources> const& x11_resources,
-                     std::shared_ptr<std::string> const& title,
+                     std::string const title,
                      std::vector<X11OutputConfig> const& requested_size,
                      std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
                      std::shared_ptr<GLConfig> const& gl_config,

--- a/src/platforms/x11/graphics/display.h
+++ b/src/platforms/x11/graphics/display.h
@@ -73,6 +73,7 @@ class Display : public graphics::Display
 {
 public:
     explicit Display(std::shared_ptr<mir::X::X11Resources> const& x11_resources,
+                     std::shared_ptr<std::string> const& title,
                      std::vector<X11OutputConfig> const& requested_size,
                      std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
                      std::shared_ptr<GLConfig> const& gl_config,

--- a/src/platforms/x11/graphics/display.h
+++ b/src/platforms/x11/graphics/display.h
@@ -55,7 +55,8 @@ public:
     X11Window(mir::X::X11Resources* x11_resources,
               EGLDisplay egl_dpy,
               geometry::Size const size,
-              EGLConfig const egl_cfg);
+              EGLConfig const egl_cfg,
+              std::string title);
     ~X11Window();
 
     operator xcb_window_t() const;

--- a/src/platforms/x11/graphics/display.h
+++ b/src/platforms/x11/graphics/display.h
@@ -53,10 +53,10 @@ class X11Window
 {
 public:
     X11Window(mir::X::X11Resources* x11_resources,
+              std::string* title,
               EGLDisplay egl_dpy,
               geometry::Size const size,
-              EGLConfig const egl_cfg,
-              std::string title);
+              EGLConfig const egl_cfg);
     ~X11Window();
 
     operator xcb_window_t() const;
@@ -64,6 +64,7 @@ public:
 
 private:
     mir::X::X11Resources* const x11_resources;
+    std::string* const title;
     xcb_window_t win;
     unsigned long r_mask;
 };

--- a/src/platforms/x11/graphics/display.h
+++ b/src/platforms/x11/graphics/display.h
@@ -64,7 +64,6 @@ public:
 
 private:
     mir::X::X11Resources* const x11_resources;
-    std::string const title;
     xcb_window_t win;
     unsigned long r_mask;
 };

--- a/src/platforms/x11/graphics/graphics.cpp
+++ b/src/platforms/x11/graphics/graphics.cpp
@@ -38,6 +38,7 @@ namespace geom = mir::geometry;
 namespace
 {
 char const* x11_displays_option_name{"x11-output"};
+char const* x11_window_title_option_name{"x11-window-title"};
 }
 
 mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
@@ -57,9 +58,11 @@ mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
     }
 
     auto output_sizes = mgx::Platform::parse_output_sizes(options->get<std::string>(x11_displays_option_name));
+    auto const title = options->get<std::string>(x11_window_title_option_name);
 
     return mir::make_module_ptr<mgx::Platform>(
         std::move(x11_resources),
+        std::move(std::make_shared<std::string>(title)),
         move(output_sizes),
         report
     );
@@ -82,6 +85,12 @@ void add_graphics_platform_options(boost::program_options::options_description& 
          boost::program_options::value<std::string>()->default_value("1280x1024"),
          "[mir-on-X specific] Colon separated list of WIDTHxHEIGHT sizes for \"output\" windows."
          " ^SCALE may also be appended to any output");
+
+    mir::assert_entry_point_signature<mg::AddPlatformOptions>(&add_graphics_platform_options);
+    config.add_options()
+        (x11_window_title_option_name,
+         boost::program_options::value<std::string>()->default_value("Mir on X"),
+         "[mir-on-X specific] Title for the banner of the generated X11 window");
 }
 
 mg::PlatformPriority probe_graphics_platform()

--- a/src/platforms/x11/graphics/graphics.cpp
+++ b/src/platforms/x11/graphics/graphics.cpp
@@ -62,7 +62,7 @@ mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
 
     return mir::make_module_ptr<mgx::Platform>(
         std::move(x11_resources),
-        std::move(std::make_shared<std::string>(title)),
+        std::move(title),
         move(output_sizes),
         report
     );

--- a/src/platforms/x11/graphics/graphics.cpp
+++ b/src/platforms/x11/graphics/graphics.cpp
@@ -86,7 +86,6 @@ void add_graphics_platform_options(boost::program_options::options_description& 
          "[mir-on-X specific] Colon separated list of WIDTHxHEIGHT sizes for \"output\" windows."
          " ^SCALE may also be appended to any output");
 
-    mir::assert_entry_point_signature<mg::AddPlatformOptions>(&add_graphics_platform_options);
     config.add_options()
         (x11_window_title_option_name,
          boost::program_options::value<std::string>()->default_value("Mir on X"),

--- a/src/platforms/x11/graphics/platform.cpp
+++ b/src/platforms/x11/graphics/platform.cpp
@@ -108,7 +108,7 @@ auto mgx::Platform::parse_output_sizes(std::string output_sizes) -> std::vector<
 }
 
 mgx::Platform::Platform(std::shared_ptr<mir::X::X11Resources> const& x11_resources,
-                        std::shared_ptr<std::string> const& title,
+                        std::string const title,
                         std::vector<X11OutputConfig> output_sizes,
                         std::shared_ptr<mg::DisplayReport> const& report)
     : x11_resources{x11_resources},

--- a/src/platforms/x11/graphics/platform.cpp
+++ b/src/platforms/x11/graphics/platform.cpp
@@ -108,11 +108,11 @@ auto mgx::Platform::parse_output_sizes(std::string output_sizes) -> std::vector<
 }
 
 mgx::Platform::Platform(std::shared_ptr<mir::X::X11Resources> const& x11_resources,
-                        std::string const title,
+                        std::string title,
                         std::vector<X11OutputConfig> output_sizes,
                         std::shared_ptr<mg::DisplayReport> const& report)
     : x11_resources{x11_resources},
-      title{title},
+      title{std::move(title)},
       report{report},
       output_sizes{move(output_sizes)}
 {

--- a/src/platforms/x11/graphics/platform.cpp
+++ b/src/platforms/x11/graphics/platform.cpp
@@ -108,9 +108,11 @@ auto mgx::Platform::parse_output_sizes(std::string output_sizes) -> std::vector<
 }
 
 mgx::Platform::Platform(std::shared_ptr<mir::X::X11Resources> const& x11_resources,
+                        std::shared_ptr<std::string> const& title,
                         std::vector<X11OutputConfig> output_sizes,
                         std::shared_ptr<mg::DisplayReport> const& report)
     : x11_resources{x11_resources},
+      title{title},
       report{report},
       output_sizes{move(output_sizes)}
 {
@@ -128,5 +130,5 @@ mir::UniqueModulePtr<mg::Display> mgx::Platform::create_display(
     std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
     std::shared_ptr<GLConfig> const& gl_config)
 {
-    return make_module_ptr<mgx::Display>(x11_resources, output_sizes, initial_conf_policy, gl_config, report);
+    return make_module_ptr<mgx::Display>(x11_resources, title, output_sizes, initial_conf_policy, gl_config, report);
 }

--- a/src/platforms/x11/graphics/platform.h
+++ b/src/platforms/x11/graphics/platform.h
@@ -61,7 +61,7 @@ public:
     static auto parse_output_sizes(std::string output_sizes) -> std::vector<X11OutputConfig>;
 
     explicit Platform(std::shared_ptr<mir::X::X11Resources> const& x11_resources,
-                      std::shared_ptr<std::string> const& title,
+                      std::string const title,
                       std::vector<X11OutputConfig> output_sizes,
                       std::shared_ptr<DisplayReport> const& report);
     ~Platform() = default;
@@ -72,7 +72,7 @@ public:
         std::shared_ptr<GLConfig> const& gl_config) override;
 private:
     std::shared_ptr<mir::X::X11Resources> const x11_resources;
-    std::shared_ptr<std::string> const title;
+    std::string const title;
     std::shared_ptr<DisplayReport> const report;
     std::vector<X11OutputConfig> const output_sizes;
 };

--- a/src/platforms/x11/graphics/platform.h
+++ b/src/platforms/x11/graphics/platform.h
@@ -61,6 +61,7 @@ public:
     static auto parse_output_sizes(std::string output_sizes) -> std::vector<X11OutputConfig>;
 
     explicit Platform(std::shared_ptr<mir::X::X11Resources> const& x11_resources,
+                      std::shared_ptr<std::string> const& title,
                       std::vector<X11OutputConfig> output_sizes,
                       std::shared_ptr<DisplayReport> const& report);
     ~Platform() = default;
@@ -71,6 +72,7 @@ public:
         std::shared_ptr<GLConfig> const& gl_config) override;
 private:
     std::shared_ptr<mir::X::X11Resources> const x11_resources;
+    std::shared_ptr<std::string> const title;
     std::shared_ptr<DisplayReport> const report;
     std::vector<X11OutputConfig> const output_sizes;
 };

--- a/tests/unit-tests/platforms/x11/test_display.cpp
+++ b/tests/unit-tests/platforms/x11/test_display.cpp
@@ -103,7 +103,7 @@ public:
     {
         return std::make_shared<mgx::Display>(
                    mt::fake_shared(x11_resources),
-                   std::make_shared<std::string>("Mir on X"),
+                   std::string("Mir on X"),
                    sizes,
                    mt::fake_shared(null_display_configuration_policy),
                    mt::fake_shared(mock_gl_config),

--- a/tests/unit-tests/platforms/x11/test_display.cpp
+++ b/tests/unit-tests/platforms/x11/test_display.cpp
@@ -103,7 +103,7 @@ public:
     {
         return std::make_shared<mgx::Display>(
                    mt::fake_shared(x11_resources),
-                   std::string("Mir on X"),
+                   "Mir on X",
                    sizes,
                    mt::fake_shared(null_display_configuration_policy),
                    mt::fake_shared(mock_gl_config),

--- a/tests/unit-tests/platforms/x11/test_display.cpp
+++ b/tests/unit-tests/platforms/x11/test_display.cpp
@@ -103,6 +103,7 @@ public:
     {
         return std::make_shared<mgx::Display>(
                    mt::fake_shared(x11_resources),
+                   std::make_shared<std::string>("Mir on X"),
                    sizes,
                    mt::fake_shared(null_display_configuration_policy),
                    mt::fake_shared(mock_gl_config),

--- a/tests/unit-tests/platforms/x11/test_display_generic.cpp
+++ b/tests/unit-tests/platforms/x11/test_display_generic.cpp
@@ -91,7 +91,7 @@ public:
     {
         auto const platform = std::make_shared<mg::X::Platform>(
             std::make_shared<mtd::MockX11Resources>(),
-            std::make_shared<std::string>("Mir on X"),
+            std::string("Mir on X"),
             std::vector<mg::X::X11OutputConfig>{{{1280, 1024}}},
             std::make_shared<mir::report::null::DisplayReport>());
         return platform->create_display(

--- a/tests/unit-tests/platforms/x11/test_display_generic.cpp
+++ b/tests/unit-tests/platforms/x11/test_display_generic.cpp
@@ -91,6 +91,7 @@ public:
     {
         auto const platform = std::make_shared<mg::X::Platform>(
             std::make_shared<mtd::MockX11Resources>(),
+            std::make_shared<std::string>("Mir on X"),
             std::vector<mg::X::X11OutputConfig>{{{1280, 1024}}},
             std::make_shared<mir::report::null::DisplayReport>());
         return platform->create_display(

--- a/tests/unit-tests/platforms/x11/test_display_generic.cpp
+++ b/tests/unit-tests/platforms/x11/test_display_generic.cpp
@@ -91,7 +91,7 @@ public:
     {
         auto const platform = std::make_shared<mg::X::Platform>(
             std::make_shared<mtd::MockX11Resources>(),
-            std::string("Mir on X"),
+            "Mir on X",
             std::vector<mg::X::X11OutputConfig>{{{1280, 1024}}},
             std::make_shared<mir::report::null::DisplayReport>());
         return platform->create_display(

--- a/tests/unit-tests/platforms/x11/test_platform.cpp
+++ b/tests/unit-tests/platforms/x11/test_platform.cpp
@@ -69,7 +69,7 @@ public:
     {
         return std::make_shared<mg::X::Platform>(
             std::make_shared<mtd::MockX11Resources>(),
-            std::make_shared<std::string>("Mir on X"),
+            std::string("Mir on X"),
             std::vector<mg::X::X11OutputConfig>{{{1280, 1024}}},
             std::make_shared<mir::report::null::DisplayReport>());
     }
@@ -89,7 +89,7 @@ TEST_F(X11GraphicsPlatformTest, failure_to_open_x11_display_results_in_an_error)
         {
             std::make_shared<mg::X::Platform>(
                 nullptr,
-                std::make_shared<std::string>("Mir on X"),
+                std::string("Mir on X"),
                 std::vector<mg::X::X11OutputConfig>{{{1280, 1024}}},
                 std::make_shared<mir::report::null::DisplayReport>());
         }, std::exception);

--- a/tests/unit-tests/platforms/x11/test_platform.cpp
+++ b/tests/unit-tests/platforms/x11/test_platform.cpp
@@ -69,6 +69,7 @@ public:
     {
         return std::make_shared<mg::X::Platform>(
             std::make_shared<mtd::MockX11Resources>(),
+            std::make_shared<std::string>("Mir on X"),
             std::vector<mg::X::X11OutputConfig>{{{1280, 1024}}},
             std::make_shared<mir::report::null::DisplayReport>());
     }
@@ -88,6 +89,7 @@ TEST_F(X11GraphicsPlatformTest, failure_to_open_x11_display_results_in_an_error)
         {
             std::make_shared<mg::X::Platform>(
                 nullptr,
+                std::make_shared<std::string>("Mir on X"),
                 std::vector<mg::X::X11OutputConfig>{{{1280, 1024}}},
                 std::make_shared<mir::report::null::DisplayReport>());
         }, std::exception);

--- a/tests/unit-tests/platforms/x11/test_platform.cpp
+++ b/tests/unit-tests/platforms/x11/test_platform.cpp
@@ -69,7 +69,7 @@ public:
     {
         return std::make_shared<mg::X::Platform>(
             std::make_shared<mtd::MockX11Resources>(),
-            std::string("Mir on X"),
+            "Mir on X",
             std::vector<mg::X::X11OutputConfig>{{{1280, 1024}}},
             std::make_shared<mir::report::null::DisplayReport>());
     }
@@ -89,7 +89,7 @@ TEST_F(X11GraphicsPlatformTest, failure_to_open_x11_display_results_in_an_error)
         {
             std::make_shared<mg::X::Platform>(
                 nullptr,
-                std::string("Mir on X"),
+                "Mir on X",
                 std::vector<mg::X::X11OutputConfig>{{{1280, 1024}}},
                 std::make_shared<mir::report::null::DisplayReport>());
         }, std::exception);


### PR DESCRIPTION
Fixes #2219 by making the initialized title an argument in X11Window, and if the argument is an empty string, sets it to the previous default, "Mir on X".