### PR TITLE
Add fatal_error if unable to bind Wayland socket

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -597,7 +597,9 @@ mf::WaylandConnector::WaylandConnector(
         };
 
         this->wayland_display = wayland_display;
-    } else {
+    }
+    else
+    {
         fatal_error("Unable to bind Wayland socket");
     }
 

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -597,6 +597,8 @@ mf::WaylandConnector::WaylandConnector(
         };
 
         this->wayland_display = wayland_display;
+    } else {
+        fatal_error("Unable to bind Wayland socket");
     }
 
     auto wayland_loop = wl_display_get_event_loop(display.get());


### PR DESCRIPTION
Fixes #2191 by adding a `fatal_error` if WaylandConnector cannot bind Wayland socket.