### PR TITLE
platform: Add DRMFormat descriptor

### DIFF
--- a/include/platform/mir/graphics/drm_formats.h
+++ b/include/platform/mir/graphics/drm_formats.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef MIR_PLATFORM_GRAPHICS_DRM_FORMATS_H_
+#define MIR_PLATFORM_GRAPHICS_DRM_FORMATS_H_
+
+#include <cstdint>
+#include <string>
+#include <optional>
+
+namespace mir::graphics
+{
+class DRMFormat
+{
+public:
+    struct RGBComponentInfo
+    {
+        uint32_t red_bits;
+        uint32_t green_bits;
+        uint32_t blue_bits;
+        std::optional<uint32_t> alpha_bits;
+    };
+
+    constexpr explicit DRMFormat(uint32_t fourcc_format)
+        : format{fourcc_format}
+    {
+    }
+
+    auto name() const -> char const*;
+
+    auto opaque_equivalent() const -> std::optional<DRMFormat> const;
+    auto alpha_equivalent() const -> std::optional<DRMFormat> const;
+
+    bool has_alpha() const;
+
+    auto components() const -> std::optional<RGBComponentInfo> const&;
+
+    operator uint32_t() const;
+private:
+    uint32_t const format;
+};
+
+auto drm_modifier_to_string(uint64_t modifier) -> std::string;
+}
+
+#endif //MIR_PLATFORM_GRAPHICS_DRM_FORMATS_H_

--- a/include/platform/mir/graphics/drm_formats.h
+++ b/include/platform/mir/graphics/drm_formats.h
@@ -52,7 +52,7 @@ public:
 
     struct FormatInfo;
 private:
-    FormatInfo const& info;
+    FormatInfo const* info;
 };
 
 auto drm_modifier_to_string(uint64_t modifier) -> std::string;

--- a/include/platform/mir/graphics/drm_formats.h
+++ b/include/platform/mir/graphics/drm_formats.h
@@ -36,10 +36,8 @@ public:
         std::optional<uint32_t> alpha_bits;
     };
 
-    constexpr explicit DRMFormat(uint32_t fourcc_format)
-        : format{fourcc_format}
-    {
-    }
+    // This could be constexpr, at the cost of moving a bunch of implementation into the header
+    explicit DRMFormat(uint32_t fourcc_format);
 
     auto name() const -> char const*;
 
@@ -51,8 +49,10 @@ public:
     auto components() const -> std::optional<RGBComponentInfo> const&;
 
     operator uint32_t() const;
+
+    struct FormatInfo;
 private:
-    uint32_t const format;
+    FormatInfo const& info;
 };
 
 auto drm_modifier_to_string(uint64_t modifier) -> std::string;

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -30,7 +30,7 @@ function(add_object_library_to_target TARGET OBJECT_LIB)
     endif()
 
     if (LIBS)
-        target_link_libraries(${TARGET} INTERFACE ${LIBS})
+        target_link_libraries(${TARGET} PUBLIC ${LIBS})
     endif()
 
     target_sources(${TARGET} PRIVATE $<TARGET_OBJECTS:${OBJECT_LIB}>)

--- a/src/platform/graphics/CMakeLists.txt
+++ b/src/platform/graphics/CMakeLists.txt
@@ -34,6 +34,8 @@ add_library(mirplatformgraphicscommon OBJECT
   linux_dmabuf.cpp
   ${DRM_FORMATS_FILE}
   ${DRM_FORMATS_BIG_ENDIAN_FILE}
+  drm_formats.cpp
+  ${PROJECT_SOURCE_DIR}/include/platform/mir/graphics/drm_formats.h
 )
 
 set(LINUX_DMABUF_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/protocol/linux-dmabuf-unstable-v1.xml")

--- a/src/platform/graphics/CMakeLists.txt
+++ b/src/platform/graphics/CMakeLists.txt
@@ -38,6 +38,17 @@ add_library(mirplatformgraphicscommon OBJECT
   ${PROJECT_SOURCE_DIR}/include/platform/mir/graphics/drm_formats.h
 )
 
+if (DRM_VERSION VERSION_GREATER 2.4.107)
+  target_compile_definitions(
+    mirplatformgraphicscommon
+    PRIVATE
+      MIR_HAVE_DRM_GET_MODIFIER_NAME)
+  target_link_libraries(
+    mirplatformgraphicscommon
+    PUBLIC
+      ${DRM_LDFLAGS} ${DRM_LIBRARIES})
+endif()
+
 set(LINUX_DMABUF_PROTO "${CMAKE_CURRENT_SOURCE_DIR}/protocol/linux-dmabuf-unstable-v1.xml")
 set(WAYLAND_GENERATOR "${CMAKE_BINARY_DIR}/bin/mir_wayland_generator")
 

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -1,0 +1,697 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#include "mir/graphics/drm_formats.h"
+
+#include <cstdint>
+#include <xf86drm.h>
+#include <drm_fourcc.h>
+#include <unordered_map>
+#include <stdexcept>
+
+namespace mg = mir::graphics;
+
+namespace
+{
+constexpr auto drm_format_to_string(uint32_t format) -> char const*
+{
+#define STRINGIFY(val) \
+    case val:          \
+        return #val;
+
+    if (!(format & DRM_FORMAT_BIG_ENDIAN))
+    {
+        switch (format)
+        {
+#include "drm-formats"
+
+            default:
+                return "Unknown DRM format; rebuild Mir against newer DRM headers?";
+        }
+
+    }
+#undef STRINGIFY
+
+#define STRINGIFY_BIG_ENDIAN(val) \
+    case val:                    \
+        return #val " (big endian)";
+
+    switch (format & (~DRM_FORMAT_BIG_ENDIAN))
+    {
+#include "drm-formats-big-endian"
+
+        default:
+            return "Unknown DRM format; rebuild Mir against newer DRM headers?";
+    }
+#undef STRINGIFY_BIGENDIAN
+}
+
+
+struct FormatInfo
+{
+    uint32_t format;
+    bool has_alpha;
+    uint32_t opaque_equivalent;
+    uint32_t alpha_equivalent;
+    std::optional<mg::DRMFormat::RGBComponentInfo> components;
+};
+
+std::unordered_map<uint32_t, FormatInfo const> const formats = {
+    {
+        DRM_FORMAT_XRGB4444,
+        {
+            DRM_FORMAT_XRGB4444,
+            false,
+            DRM_FORMAT_XRGB4444,
+            DRM_FORMAT_ARGB4444,
+            mg::DRMFormat::RGBComponentInfo{
+                4, 4, 4, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_XBGR4444,
+        {
+            DRM_FORMAT_XBGR4444,
+            false,
+            DRM_FORMAT_XBGR4444,
+            DRM_FORMAT_ABGR4444,
+            mg::DRMFormat::RGBComponentInfo{
+                4, 4, 4, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_RGBX4444,
+        {
+            DRM_FORMAT_RGBX4444,
+            false,
+            DRM_FORMAT_RGBX4444,
+            DRM_FORMAT_RGBA4444,
+            mg::DRMFormat::RGBComponentInfo{
+                4, 4, 4, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_BGRX4444,
+        {
+            DRM_FORMAT_BGRX4444,
+            false,
+            DRM_FORMAT_BGRX4444,
+            DRM_FORMAT_BGRA4444,
+            mg::DRMFormat::RGBComponentInfo{
+                4, 4, 4, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_ARGB4444,
+        {
+            DRM_FORMAT_ARGB4444,
+            true,
+            DRM_FORMAT_XRGB4444,
+            DRM_FORMAT_ARGB4444,
+            mg::DRMFormat::RGBComponentInfo{
+                4, 4, 4, 4
+            },
+        }
+    },
+    {
+        DRM_FORMAT_ABGR4444,
+        {
+            DRM_FORMAT_ABGR4444,
+            true,
+            DRM_FORMAT_XBGR4444,
+            DRM_FORMAT_ABGR4444,
+            mg::DRMFormat::RGBComponentInfo{
+                4, 4, 4, 4
+            },
+        }
+    },
+    {
+        DRM_FORMAT_RGBA4444,
+        {
+            DRM_FORMAT_RGBA4444,
+            true,
+            DRM_FORMAT_RGBX4444,
+            DRM_FORMAT_RGBA4444,
+            mg::DRMFormat::RGBComponentInfo{
+                4, 4, 4, 4
+            },
+        }
+    },
+    {
+        DRM_FORMAT_BGRA4444,
+        {
+            DRM_FORMAT_BGRA4444,
+            true,
+            DRM_FORMAT_BGRX4444,
+            DRM_FORMAT_BGRA4444,
+            mg::DRMFormat::RGBComponentInfo{
+                4, 4, 4, 4
+            },
+        }
+    },
+    {
+        DRM_FORMAT_XRGB1555,
+        {
+            DRM_FORMAT_XRGB1555,
+            false,
+            DRM_FORMAT_XRGB1555,
+            DRM_FORMAT_ARGB1555,
+            mg::DRMFormat::RGBComponentInfo{
+                5, 5, 5, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_XBGR1555,
+        {
+            DRM_FORMAT_XBGR1555,
+            false,
+            DRM_FORMAT_XBGR1555,
+            DRM_FORMAT_ABGR1555,
+            mg::DRMFormat::RGBComponentInfo{
+                5, 5, 5, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_RGBX5551,
+        {
+            DRM_FORMAT_RGBX5551,
+            false,
+            DRM_FORMAT_RGBX5551,
+            DRM_FORMAT_RGBA5551,
+            mg::DRMFormat::RGBComponentInfo{
+                5, 5, 5, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_BGRX5551,
+        {
+            DRM_FORMAT_BGRX5551,
+            false,
+            DRM_FORMAT_BGRX5551,
+            DRM_FORMAT_BGRA5551,
+            mg::DRMFormat::RGBComponentInfo{
+                5, 5, 5, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_ARGB1555,
+        {
+            DRM_FORMAT_ARGB1555,
+            true,
+            DRM_FORMAT_XRGB1555,
+            DRM_FORMAT_ARGB1555,
+            mg::DRMFormat::RGBComponentInfo{
+                5, 5, 5, 1
+            },
+        }
+    },
+    {
+        DRM_FORMAT_ABGR1555,
+        {
+            DRM_FORMAT_ABGR1555,
+            true,
+            DRM_FORMAT_XBGR1555,
+            DRM_FORMAT_ABGR1555,
+            mg::DRMFormat::RGBComponentInfo{
+                5, 5, 5, 1
+            },
+        }
+    },
+    {
+        DRM_FORMAT_RGBA5551,
+        {
+            DRM_FORMAT_RGBA5551,
+            true,
+            DRM_FORMAT_RGBX5551,
+            DRM_FORMAT_RGBA5551,
+            mg::DRMFormat::RGBComponentInfo{
+                5, 5, 5, 1
+            },
+        }
+    },
+    {
+        DRM_FORMAT_BGRA5551,
+        {
+            DRM_FORMAT_BGRA5551,
+            true,
+            DRM_FORMAT_BGRX5551,
+            DRM_FORMAT_BGRA5551,
+            mg::DRMFormat::RGBComponentInfo{
+                5, 5, 5, 1
+            },
+        }
+    },
+    {
+        DRM_FORMAT_RGB565,
+        {
+            DRM_FORMAT_RGB565,
+            false,
+            DRM_FORMAT_RGB565,
+            DRM_FORMAT_INVALID,
+            mg::DRMFormat::RGBComponentInfo{
+                5, 6, 5, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_BGR565,
+        {
+            DRM_FORMAT_BGR565,
+            false,
+            DRM_FORMAT_BGR565,
+            DRM_FORMAT_INVALID,
+            mg::DRMFormat::RGBComponentInfo{
+                5, 6, 5, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_RGB888,
+        {
+            DRM_FORMAT_RGB888,
+            false,
+            DRM_FORMAT_RGB888,
+            DRM_FORMAT_INVALID,
+            mg::DRMFormat::RGBComponentInfo{
+                8, 8, 8, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_BGR888,
+        {
+            DRM_FORMAT_BGR888,
+            false,
+            DRM_FORMAT_BGR888,
+            DRM_FORMAT_INVALID,
+            mg::DRMFormat::RGBComponentInfo{
+                8, 8, 8, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_XRGB8888,
+        {
+            DRM_FORMAT_XRGB8888,
+            false,
+            DRM_FORMAT_XRGB8888,
+            DRM_FORMAT_ARGB8888,
+            mg::DRMFormat::RGBComponentInfo{
+                8, 8, 8, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_XBGR8888,
+        {
+            DRM_FORMAT_XBGR8888,
+            false,
+            DRM_FORMAT_XBGR8888,
+            DRM_FORMAT_ABGR8888,
+            mg::DRMFormat::RGBComponentInfo{
+                8, 8, 8, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_RGBX8888,
+        {
+            DRM_FORMAT_RGBX8888,
+            false,
+            DRM_FORMAT_RGBX8888,
+            DRM_FORMAT_RGBA8888,
+            mg::DRMFormat::RGBComponentInfo{
+                8, 8, 8, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_BGRX8888,
+        {
+            DRM_FORMAT_BGRX8888,
+            false,
+            DRM_FORMAT_BGRX8888,
+            DRM_FORMAT_BGRA8888,
+            mg::DRMFormat::RGBComponentInfo{
+                8, 8, 8, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_ARGB8888,
+        {
+            DRM_FORMAT_ARGB8888,
+            true,
+            DRM_FORMAT_XRGB8888,
+            DRM_FORMAT_ARGB8888,
+            mg::DRMFormat::RGBComponentInfo{
+                8, 8, 8, 8
+            },
+        }
+    },
+    {
+        DRM_FORMAT_ABGR8888,
+        {
+            DRM_FORMAT_ABGR8888,
+            true,
+            DRM_FORMAT_XBGR8888,
+            DRM_FORMAT_ABGR8888,
+            mg::DRMFormat::RGBComponentInfo{
+                8, 8, 8, 8
+            },
+        }
+    },
+    {
+        DRM_FORMAT_RGBA8888,
+        {
+            DRM_FORMAT_RGBA8888,
+            true,
+            DRM_FORMAT_RGBX8888,
+            DRM_FORMAT_RGBA8888,
+            mg::DRMFormat::RGBComponentInfo{
+                8, 8, 8, 8
+            },
+        }
+    },
+    {
+        DRM_FORMAT_BGRA8888,
+        {
+            DRM_FORMAT_BGRA8888,
+            true,
+            DRM_FORMAT_BGRX8888,
+            DRM_FORMAT_BGRA8888,
+            mg::DRMFormat::RGBComponentInfo{
+                8, 8, 8, 8
+            },
+        }
+    },
+    {
+        DRM_FORMAT_XRGB2101010,
+        {
+            DRM_FORMAT_XRGB2101010,
+            false,
+            DRM_FORMAT_XRGB2101010,
+            DRM_FORMAT_ARGB2101010,
+            mg::DRMFormat::RGBComponentInfo{
+                10, 10, 10, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_XBGR2101010,
+        {
+            DRM_FORMAT_XBGR2101010,
+            false,
+            DRM_FORMAT_XBGR2101010,
+            DRM_FORMAT_ABGR2101010,
+            mg::DRMFormat::RGBComponentInfo{
+                10, 10, 10, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_RGBX1010102,
+        {
+            DRM_FORMAT_RGBX1010102,
+            false,
+            DRM_FORMAT_RGBX1010102,
+            DRM_FORMAT_RGBA1010102,
+            mg::DRMFormat::RGBComponentInfo{
+                10, 10, 10, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_BGRX1010102,
+        {
+            DRM_FORMAT_BGRX1010102,
+            false,
+            DRM_FORMAT_BGRX1010102,
+            DRM_FORMAT_BGRA1010102,
+            mg::DRMFormat::RGBComponentInfo{
+                10, 10, 10, {}
+            },
+        }
+    },
+    {
+        DRM_FORMAT_ARGB2101010,
+        {
+            DRM_FORMAT_ARGB2101010,
+            true,
+            DRM_FORMAT_XRGB2101010,
+            DRM_FORMAT_ARGB2101010,
+            mg::DRMFormat::RGBComponentInfo{
+                10, 10, 10, 2
+            },
+        }
+    },
+    {
+        DRM_FORMAT_ABGR2101010,
+        {
+            DRM_FORMAT_ABGR2101010,
+            true,
+            DRM_FORMAT_XBGR2101010,
+            DRM_FORMAT_ABGR2101010,
+            mg::DRMFormat::RGBComponentInfo{
+                10, 10, 10, 2
+            },
+        }
+    },
+    {
+        DRM_FORMAT_RGBA1010102,
+        {
+            DRM_FORMAT_RGBA1010102,
+            true,
+            DRM_FORMAT_RGBX1010102,
+            DRM_FORMAT_RGBA1010102,
+            mg::DRMFormat::RGBComponentInfo{
+                10, 10, 10, 2
+            },
+        }
+    },
+    {
+        DRM_FORMAT_BGRA1010102,
+        {
+            DRM_FORMAT_BGRA1010102,
+            true,
+            DRM_FORMAT_BGRX1010102,
+            DRM_FORMAT_BGRA1010102,
+            mg::DRMFormat::RGBComponentInfo{
+                10, 10, 10, 2
+            },
+        }
+    },
+};
+}
+
+auto mg::DRMFormat::name() const -> const char*
+{
+    return drm_format_to_string(format);
+}
+
+auto mg::DRMFormat::opaque_equivalent() const -> const std::optional<DRMFormat>
+{
+    auto const opaque_format = formats.at(format).opaque_equivalent;
+    if (opaque_format != DRM_FORMAT_INVALID)
+    {
+        return DRMFormat{opaque_format};
+    }
+    return {};
+}
+
+auto mg::DRMFormat::alpha_equivalent() const -> const std::optional<DRMFormat>
+{
+    auto const opaque_format = formats.at(format).alpha_equivalent;
+    if (opaque_format != DRM_FORMAT_INVALID)
+    {
+        return DRMFormat{opaque_format};
+    }
+    return {};
+}
+
+bool mg::DRMFormat::has_alpha() const
+{
+    return formats.at(format).has_alpha;
+}
+
+auto mg::DRMFormat::components() const -> std::optional<RGBComponentInfo> const&
+{
+    return formats.at(format).components;
+}
+
+mg::DRMFormat::operator uint32_t() const
+{
+    return format;
+}
+
+auto mg::drm_modifier_to_string(uint64_t modifier) -> std::string
+{
+#ifdef HAVE_DRM_GET_MODIFIER_NAME
+    struct CStrDeleter
+    {
+    public:
+        void operator()(char* c_str)
+        {
+            if (c_str)
+            {
+                free (c_str);
+            }
+        }
+    };
+
+    auto const vendor =
+        [&]() -> std::string
+        {
+            std::unique_ptr<char[], CStrDeleter> vendor{drmGetFormatModifierVendor(modifier)};
+            if (vendor)
+            {
+                return vendor.get();
+            }
+            return "(UNKNOWN VENDOR)";
+        }();
+
+    auto const name =
+        [&]() -> std::string
+        {
+            std::unique_ptr<char[], CStrDeleter> name{drmGetFormatModifierName(modifier)};
+            if (name)
+            {
+                return name.get();
+            }
+            return "(UNKNOWN MODIFIER)";
+        }();
+
+    return vendor + ":" + name;
+}
+#else
+#define STRINGIFY(val) \
+    case val:          \
+        return #val;
+
+    switch (modifier)
+    {
+#ifdef DRM_FORMAT_MOD_INVALID
+        STRINGIFY(DRM_FORMAT_MOD_INVALID)
+#endif
+#ifdef DRM_FORMAT_MOD_LINEAR
+        STRINGIFY(DRM_FORMAT_MOD_LINEAR)
+#endif
+#ifdef I915_FORMAT_MOD_X_TILED
+        STRINGIFY(I915_FORMAT_MOD_X_TILED)
+#endif
+#ifdef I915_FORMAT_MOD_Y_TILED
+        STRINGIFY(I915_FORMAT_MOD_Y_TILED)
+#endif
+#ifdef I915_FORMAT_MOD_Yf_TILED
+        STRINGIFY(I915_FORMAT_MOD_Yf_TILED)
+#endif
+#ifdef I915_FORMAT_MOD_Y_TILED_CCS
+        STRINGIFY(I915_FORMAT_MOD_Y_TILED_CCS)
+#endif
+#ifdef I915_FORMAT_MOD_Yf_TILED_CCS
+        STRINGIFY(I915_FORMAT_MOD_Yf_TILED_CCS)
+#endif
+#ifdef I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS
+        STRINGIFY(I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS)
+#endif
+#ifdef I915_FORMAT_MOD_Y_TILED_GEN12_MC_CCS
+        STRINGIFY(I915_FORMAT_MOD_Y_TILED_GEN12_MC_CCS)
+#endif
+#ifdef DRM_FORMAT_MOD_SAMSUNG_64_32_TILE
+        STRINGIFY(DRM_FORMAT_MOD_SAMSUNG_64_32_TILE)
+#endif
+#ifdef DRM_FORMAT_MOD_SAMSUNG_16_16_TILE
+        STRINGIFY(DRM_FORMAT_MOD_SAMSUNG_16_16_TILE)
+#endif
+#ifdef DRM_FORMAT_MOD_QCOM_COMPRESSED
+        STRINGIFY(DRM_FORMAT_MOD_QCOM_COMPRESSED)
+#endif
+#ifdef DRM_FORMAT_MOD_VIVANTE_TILED
+        STRINGIFY(DRM_FORMAT_MOD_VIVANTE_TILED)
+#endif
+#ifdef DRM_FORMAT_MOD_VIVANTE_SUPER_TILED
+        STRINGIFY(DRM_FORMAT_MOD_VIVANTE_SUPER_TILED)
+#endif
+#ifdef DRM_FORMAT_MOD_VIVANTE_SPLIT_TILED
+        STRINGIFY(DRM_FORMAT_MOD_VIVANTE_SPLIT_TILED)
+#endif
+#ifdef DRM_FORMAT_MOD_VIVANTE_SPLIT_SUPER_TILED
+        STRINGIFY(DRM_FORMAT_MOD_VIVANTE_SPLIT_SUPER_TILED)
+#endif
+#ifdef DRM_FORMAT_MOD_NVIDIA_TEGRA_TILED
+        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_TEGRA_TILED)
+#endif
+#ifdef DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_ONE_GOB
+        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_ONE_GOB)
+#endif
+#ifdef DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_TWO_GOB
+        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_TWO_GOB)
+#endif
+#ifdef DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_FOUR_GOB
+        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_FOUR_GOB)
+#endif
+#ifdef DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_EIGHT_GOB
+        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_EIGHT_GOB)
+#endif
+#ifdef DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_SIXTEEN_GOB
+        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_SIXTEEN_GOB)
+#endif
+#ifdef DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_THIRTYTWO_GOB
+        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_THIRTYTWO_GOB)
+#endif
+#ifdef DRM_FORMAT_MOD_BROADCOM_VC4_T_TILED
+        STRINGIFY(DRM_FORMAT_MOD_BROADCOM_VC4_T_TILED)
+#endif
+#ifdef DRM_FORMAT_MOD_BROADCOM_SAND32
+        STRINGIFY(DRM_FORMAT_MOD_BROADCOM_SAND32)
+#endif
+#ifdef DRM_FORMAT_MOD_BROADCOM_SAND64
+        STRINGIFY(DRM_FORMAT_MOD_BROADCOM_SAND64)
+#endif
+#ifdef DRM_FORMAT_MOD_BROADCOM_SAND128
+        STRINGIFY(DRM_FORMAT_MOD_BROADCOM_SAND128)
+#endif
+#ifdef DRM_FORMAT_MOD_BROADCOM_SAND256
+        STRINGIFY(DRM_FORMAT_MOD_BROADCOM_SAND256)
+#endif
+#ifdef DRM_FORMAT_MOD_BROADCOM_UIF
+        STRINGIFY(DRM_FORMAT_MOD_BROADCOM_UIF)
+#endif
+#ifdef DRM_FORMAT_MOD_ARM_16X16_BLOCK_U_INTERLEAVED
+        STRINGIFY(DRM_FORMAT_MOD_ARM_16X16_BLOCK_U_INTERLEAVED)
+#endif
+#ifdef DRM_FORMAT_MOD_ALLWINNER_TILED
+        STRINGIFY(DRM_FORMAT_MOD_ALLWINNER_TILED)
+#endif
+
+        default:
+            return "(unknown)";
+    }
+
+#undef STRINGIFY
+}
+#endif
+

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -428,24 +428,29 @@ constexpr auto find_format_info(uint32_t fourcc) -> mg::DRMFormat::FormatInfo co
 
 #undef STRINGIFY
 
-constexpr auto info_for_format(uint32_t fourcc_format) -> mg::DRMFormat::FormatInfo const&
+constexpr auto maybe_info_for_format(uint32_t fourcc_format) -> mg::DRMFormat::FormatInfo const*
 {
-    mg::DRMFormat::FormatInfo const* info;
     switch (fourcc_format)
     {
 #define STRINGIFY(format) \
     case format: \
-        info = format_info_##format; \
-        break;
+        return format_info_##format; \
 
 #include "drm-formats"
 
+#undef STRINGIFY
         default:
             BOOST_THROW_EXCEPTION((
                 std::runtime_error{
                     std::string{"Unknown DRM format "} + std::to_string(fourcc_format) +
                     " (may need to rebuild Mir against newer DRM headers?)"}));
     }
+
+}
+
+constexpr auto info_for_format(uint32_t fourcc_format) -> mg::DRMFormat::FormatInfo const&
+{
+    auto const info = maybe_info_for_format(fourcc_format);
 
     if (info)
     {

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -483,7 +483,7 @@ mg::DRMFormat::operator uint32_t() const
 
 auto mg::drm_modifier_to_string(uint64_t modifier) -> std::string
 {
-#ifdef HAVE_DRM_GET_MODIFIER_NAME
+#ifdef MIR_HAVE_DRM_GET_MODIFIER_NAME
     struct CStrDeleter
     {
     public:

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -464,46 +464,46 @@ constexpr auto info_for_format(uint32_t fourcc_format) -> mg::DRMFormat::FormatI
 }
 
 mg::DRMFormat::DRMFormat(uint32_t fourcc_format)
-    : info{info_for_format(fourcc_format)}
+    : info{&info_for_format(fourcc_format)}
 {
 }
 
 auto mg::DRMFormat::name() const -> const char*
 {
-    return drm_format_to_string(info.format);
+    return drm_format_to_string(info->format);
 }
 
 auto mg::DRMFormat::opaque_equivalent() const -> const std::optional<DRMFormat>
 {
-    if (info.opaque_equivalent != DRM_FORMAT_INVALID)
+    if (info->opaque_equivalent != DRM_FORMAT_INVALID)
     {
-        return DRMFormat{info.opaque_equivalent};
+        return DRMFormat{info->opaque_equivalent};
     }
     return {};
 }
 
 auto mg::DRMFormat::alpha_equivalent() const -> const std::optional<DRMFormat>
 {
-    if (info.alpha_equivalent != DRM_FORMAT_INVALID)
+    if (info->alpha_equivalent != DRM_FORMAT_INVALID)
     {
-        return DRMFormat{info.alpha_equivalent};
+        return DRMFormat{info->alpha_equivalent};
     }
     return {};
 }
 
 bool mg::DRMFormat::has_alpha() const
 {
-    return info.has_alpha;
+    return info->has_alpha;
 }
 
 auto mg::DRMFormat::components() const -> std::optional<RGBComponentInfo> const&
 {
-    return info.components;
+    return info->components;
 }
 
 mg::DRMFormat::operator uint32_t() const
 {
-    return info.format;
+    return info->format;
 }
 
 auto mg::drm_modifier_to_string(uint64_t modifier) -> std::string

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -79,363 +79,383 @@ struct mg::DRMFormat::FormatInfo
 
 namespace
 {
-constexpr auto make_sorted_formats_list()
-{
-    std::array local_formats = {
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_XRGB4444,
-            false,
-            DRM_FORMAT_XRGB4444,
-            DRM_FORMAT_ARGB4444,
-            mg::DRMFormat::RGBComponentInfo{
-                4, 4, 4, {}
-            },
+constexpr std::array const formats = {
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_XRGB4444,
+        false,
+        DRM_FORMAT_XRGB4444,
+        DRM_FORMAT_ARGB4444,
+        mg::DRMFormat::RGBComponentInfo{
+            4, 4, 4, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_XBGR4444,
-            false,
-            DRM_FORMAT_XBGR4444,
-            DRM_FORMAT_ABGR4444,
-            mg::DRMFormat::RGBComponentInfo{
-                4, 4, 4, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_XBGR4444,
+        false,
+        DRM_FORMAT_XBGR4444,
+        DRM_FORMAT_ABGR4444,
+        mg::DRMFormat::RGBComponentInfo{
+            4, 4, 4, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_RGBX4444,
-            false,
-            DRM_FORMAT_RGBX4444,
-            DRM_FORMAT_RGBA4444,
-            mg::DRMFormat::RGBComponentInfo{
-                4, 4, 4, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_RGBX4444,
+        false,
+        DRM_FORMAT_RGBX4444,
+        DRM_FORMAT_RGBA4444,
+        mg::DRMFormat::RGBComponentInfo{
+            4, 4, 4, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_BGRX4444,
-            false,
-            DRM_FORMAT_BGRX4444,
-            DRM_FORMAT_BGRA4444,
-            mg::DRMFormat::RGBComponentInfo{
-                4, 4, 4, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_BGRX4444,
+        false,
+        DRM_FORMAT_BGRX4444,
+        DRM_FORMAT_BGRA4444,
+        mg::DRMFormat::RGBComponentInfo{
+            4, 4, 4, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_ARGB4444,
-            true,
-            DRM_FORMAT_XRGB4444,
-            DRM_FORMAT_ARGB4444,
-            mg::DRMFormat::RGBComponentInfo{
-                4, 4, 4, 4
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_ARGB4444,
+        true,
+        DRM_FORMAT_XRGB4444,
+        DRM_FORMAT_ARGB4444,
+        mg::DRMFormat::RGBComponentInfo{
+            4, 4, 4, 4
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_ABGR4444,
-            true,
-            DRM_FORMAT_XBGR4444,
-            DRM_FORMAT_ABGR4444,
-            mg::DRMFormat::RGBComponentInfo{
-                4, 4, 4, 4
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_ABGR4444,
+        true,
+        DRM_FORMAT_XBGR4444,
+        DRM_FORMAT_ABGR4444,
+        mg::DRMFormat::RGBComponentInfo{
+            4, 4, 4, 4
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_RGBA4444,
-            true,
-            DRM_FORMAT_RGBX4444,
-            DRM_FORMAT_RGBA4444,
-            mg::DRMFormat::RGBComponentInfo{
-                4, 4, 4, 4
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_RGBA4444,
+        true,
+        DRM_FORMAT_RGBX4444,
+        DRM_FORMAT_RGBA4444,
+        mg::DRMFormat::RGBComponentInfo{
+            4, 4, 4, 4
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_BGRA4444,
-            true,
-            DRM_FORMAT_BGRX4444,
-            DRM_FORMAT_BGRA4444,
-            mg::DRMFormat::RGBComponentInfo{
-                4, 4, 4, 4
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_BGRA4444,
+        true,
+        DRM_FORMAT_BGRX4444,
+        DRM_FORMAT_BGRA4444,
+        mg::DRMFormat::RGBComponentInfo{
+            4, 4, 4, 4
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_XRGB1555,
-            false,
-            DRM_FORMAT_XRGB1555,
-            DRM_FORMAT_ARGB1555,
-            mg::DRMFormat::RGBComponentInfo{
-                5, 5, 5, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_XRGB1555,
+        false,
+        DRM_FORMAT_XRGB1555,
+        DRM_FORMAT_ARGB1555,
+        mg::DRMFormat::RGBComponentInfo{
+            5, 5, 5, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_XBGR1555,
-            false,
-            DRM_FORMAT_XBGR1555,
-            DRM_FORMAT_ABGR1555,
-            mg::DRMFormat::RGBComponentInfo{
-                5, 5, 5, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_XBGR1555,
+        false,
+        DRM_FORMAT_XBGR1555,
+        DRM_FORMAT_ABGR1555,
+        mg::DRMFormat::RGBComponentInfo{
+            5, 5, 5, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_RGBX5551,
-            false,
-            DRM_FORMAT_RGBX5551,
-            DRM_FORMAT_RGBA5551,
-            mg::DRMFormat::RGBComponentInfo{
-                5, 5, 5, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_RGBX5551,
+        false,
+        DRM_FORMAT_RGBX5551,
+        DRM_FORMAT_RGBA5551,
+        mg::DRMFormat::RGBComponentInfo{
+            5, 5, 5, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_BGRX5551,
-            false,
-            DRM_FORMAT_BGRX5551,
-            DRM_FORMAT_BGRA5551,
-            mg::DRMFormat::RGBComponentInfo{
-                5, 5, 5, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_BGRX5551,
+        false,
+        DRM_FORMAT_BGRX5551,
+        DRM_FORMAT_BGRA5551,
+        mg::DRMFormat::RGBComponentInfo{
+            5, 5, 5, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_ARGB1555,
-            true,
-            DRM_FORMAT_XRGB1555,
-            DRM_FORMAT_ARGB1555,
-            mg::DRMFormat::RGBComponentInfo{
-                5, 5, 5, 1
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_ARGB1555,
+        true,
+        DRM_FORMAT_XRGB1555,
+        DRM_FORMAT_ARGB1555,
+        mg::DRMFormat::RGBComponentInfo{
+            5, 5, 5, 1
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_ABGR1555,
-            true,
-            DRM_FORMAT_XBGR1555,
-            DRM_FORMAT_ABGR1555,
-            mg::DRMFormat::RGBComponentInfo{
-                5, 5, 5, 1
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_ABGR1555,
+        true,
+        DRM_FORMAT_XBGR1555,
+        DRM_FORMAT_ABGR1555,
+        mg::DRMFormat::RGBComponentInfo{
+            5, 5, 5, 1
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_RGBA5551,
-            true,
-            DRM_FORMAT_RGBX5551,
-            DRM_FORMAT_RGBA5551,
-            mg::DRMFormat::RGBComponentInfo{
-                5, 5, 5, 1
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_RGBA5551,
+        true,
+        DRM_FORMAT_RGBX5551,
+        DRM_FORMAT_RGBA5551,
+        mg::DRMFormat::RGBComponentInfo{
+            5, 5, 5, 1
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_BGRA5551,
-            true,
-            DRM_FORMAT_BGRX5551,
-            DRM_FORMAT_BGRA5551,
-            mg::DRMFormat::RGBComponentInfo{
-                5, 5, 5, 1
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_BGRA5551,
+        true,
+        DRM_FORMAT_BGRX5551,
+        DRM_FORMAT_BGRA5551,
+        mg::DRMFormat::RGBComponentInfo{
+            5, 5, 5, 1
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_RGB565,
-            false,
-            DRM_FORMAT_RGB565,
-            DRM_FORMAT_INVALID,
-            mg::DRMFormat::RGBComponentInfo{
-                5, 6, 5, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_RGB565,
+        false,
+        DRM_FORMAT_RGB565,
+        DRM_FORMAT_INVALID,
+        mg::DRMFormat::RGBComponentInfo{
+            5, 6, 5, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_BGR565,
-            false,
-            DRM_FORMAT_BGR565,
-            DRM_FORMAT_INVALID,
-            mg::DRMFormat::RGBComponentInfo{
-                5, 6, 5, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_BGR565,
+        false,
+        DRM_FORMAT_BGR565,
+        DRM_FORMAT_INVALID,
+        mg::DRMFormat::RGBComponentInfo{
+            5, 6, 5, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_RGB888,
-            false,
-            DRM_FORMAT_RGB888,
-            DRM_FORMAT_INVALID,
-            mg::DRMFormat::RGBComponentInfo{
-                8, 8, 8, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_RGB888,
+        false,
+        DRM_FORMAT_RGB888,
+        DRM_FORMAT_INVALID,
+        mg::DRMFormat::RGBComponentInfo{
+            8, 8, 8, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_BGR888,
-            false,
-            DRM_FORMAT_BGR888,
-            DRM_FORMAT_INVALID,
-            mg::DRMFormat::RGBComponentInfo{
-                8, 8, 8, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_BGR888,
+        false,
+        DRM_FORMAT_BGR888,
+        DRM_FORMAT_INVALID,
+        mg::DRMFormat::RGBComponentInfo{
+            8, 8, 8, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_XRGB8888,
-            false,
-            DRM_FORMAT_XRGB8888,
-            DRM_FORMAT_ARGB8888,
-            mg::DRMFormat::RGBComponentInfo{
-                8, 8, 8, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_XRGB8888,
+        false,
+        DRM_FORMAT_XRGB8888,
+        DRM_FORMAT_ARGB8888,
+        mg::DRMFormat::RGBComponentInfo{
+            8, 8, 8, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_XBGR8888,
-            false,
-            DRM_FORMAT_XBGR8888,
-            DRM_FORMAT_ABGR8888,
-            mg::DRMFormat::RGBComponentInfo{
-                8, 8, 8, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_XBGR8888,
+        false,
+        DRM_FORMAT_XBGR8888,
+        DRM_FORMAT_ABGR8888,
+        mg::DRMFormat::RGBComponentInfo{
+            8, 8, 8, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_RGBX8888,
-            false,
-            DRM_FORMAT_RGBX8888,
-            DRM_FORMAT_RGBA8888,
-            mg::DRMFormat::RGBComponentInfo{
-                8, 8, 8, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_RGBX8888,
+        false,
+        DRM_FORMAT_RGBX8888,
+        DRM_FORMAT_RGBA8888,
+        mg::DRMFormat::RGBComponentInfo{
+            8, 8, 8, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_BGRX8888,
-            false,
-            DRM_FORMAT_BGRX8888,
-            DRM_FORMAT_BGRA8888,
-            mg::DRMFormat::RGBComponentInfo{
-                8, 8, 8, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_BGRX8888,
+        false,
+        DRM_FORMAT_BGRX8888,
+        DRM_FORMAT_BGRA8888,
+        mg::DRMFormat::RGBComponentInfo{
+            8, 8, 8, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_ARGB8888,
-            true,
-            DRM_FORMAT_XRGB8888,
-            DRM_FORMAT_ARGB8888,
-            mg::DRMFormat::RGBComponentInfo{
-                8, 8, 8, 8
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_ARGB8888,
+        true,
+        DRM_FORMAT_XRGB8888,
+        DRM_FORMAT_ARGB8888,
+        mg::DRMFormat::RGBComponentInfo{
+            8, 8, 8, 8
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_ABGR8888,
-            true,
-            DRM_FORMAT_XBGR8888,
-            DRM_FORMAT_ABGR8888,
-            mg::DRMFormat::RGBComponentInfo{
-                8, 8, 8, 8
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_ABGR8888,
+        true,
+        DRM_FORMAT_XBGR8888,
+        DRM_FORMAT_ABGR8888,
+        mg::DRMFormat::RGBComponentInfo{
+            8, 8, 8, 8
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_RGBA8888,
-            true,
-            DRM_FORMAT_RGBX8888,
-            DRM_FORMAT_RGBA8888,
-            mg::DRMFormat::RGBComponentInfo{
-                8, 8, 8, 8
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_RGBA8888,
+        true,
+        DRM_FORMAT_RGBX8888,
+        DRM_FORMAT_RGBA8888,
+        mg::DRMFormat::RGBComponentInfo{
+            8, 8, 8, 8
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_BGRA8888,
-            true,
-            DRM_FORMAT_BGRX8888,
-            DRM_FORMAT_BGRA8888,
-            mg::DRMFormat::RGBComponentInfo{
-                8, 8, 8, 8
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_BGRA8888,
+        true,
+        DRM_FORMAT_BGRX8888,
+        DRM_FORMAT_BGRA8888,
+        mg::DRMFormat::RGBComponentInfo{
+            8, 8, 8, 8
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_XRGB2101010,
-            false,
-            DRM_FORMAT_XRGB2101010,
-            DRM_FORMAT_ARGB2101010,
-            mg::DRMFormat::RGBComponentInfo{
-                10, 10, 10, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_XRGB2101010,
+        false,
+        DRM_FORMAT_XRGB2101010,
+        DRM_FORMAT_ARGB2101010,
+        mg::DRMFormat::RGBComponentInfo{
+            10, 10, 10, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_XBGR2101010,
-            false,
-            DRM_FORMAT_XBGR2101010,
-            DRM_FORMAT_ABGR2101010,
-            mg::DRMFormat::RGBComponentInfo{
-                10, 10, 10, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_XBGR2101010,
+        false,
+        DRM_FORMAT_XBGR2101010,
+        DRM_FORMAT_ABGR2101010,
+        mg::DRMFormat::RGBComponentInfo{
+            10, 10, 10, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_RGBX1010102,
-            false,
-            DRM_FORMAT_RGBX1010102,
-            DRM_FORMAT_RGBA1010102,
-            mg::DRMFormat::RGBComponentInfo{
-                10, 10, 10, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_RGBX1010102,
+        false,
+        DRM_FORMAT_RGBX1010102,
+        DRM_FORMAT_RGBA1010102,
+        mg::DRMFormat::RGBComponentInfo{
+            10, 10, 10, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_BGRX1010102,
-            false,
-            DRM_FORMAT_BGRX1010102,
-            DRM_FORMAT_BGRA1010102,
-            mg::DRMFormat::RGBComponentInfo{
-                10, 10, 10, {}
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_BGRX1010102,
+        false,
+        DRM_FORMAT_BGRX1010102,
+        DRM_FORMAT_BGRA1010102,
+        mg::DRMFormat::RGBComponentInfo{
+            10, 10, 10, {}
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_ARGB2101010,
-            true,
-            DRM_FORMAT_XRGB2101010,
-            DRM_FORMAT_ARGB2101010,
-            mg::DRMFormat::RGBComponentInfo{
-                10, 10, 10, 2
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_ARGB2101010,
+        true,
+        DRM_FORMAT_XRGB2101010,
+        DRM_FORMAT_ARGB2101010,
+        mg::DRMFormat::RGBComponentInfo{
+            10, 10, 10, 2
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_ABGR2101010,
-            true,
-            DRM_FORMAT_XBGR2101010,
-            DRM_FORMAT_ABGR2101010,
-            mg::DRMFormat::RGBComponentInfo{
-                10, 10, 10, 2
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_ABGR2101010,
+        true,
+        DRM_FORMAT_XBGR2101010,
+        DRM_FORMAT_ABGR2101010,
+        mg::DRMFormat::RGBComponentInfo{
+            10, 10, 10, 2
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_RGBA1010102,
-            true,
-            DRM_FORMAT_RGBX1010102,
-            DRM_FORMAT_RGBA1010102,
-            mg::DRMFormat::RGBComponentInfo{
-                10, 10, 10, 2
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_RGBA1010102,
+        true,
+        DRM_FORMAT_RGBX1010102,
+        DRM_FORMAT_RGBA1010102,
+        mg::DRMFormat::RGBComponentInfo{
+            10, 10, 10, 2
         },
-        mg::DRMFormat::FormatInfo{
-            DRM_FORMAT_BGRA1010102,
-            true,
-            DRM_FORMAT_BGRX1010102,
-            DRM_FORMAT_BGRA1010102,
-            mg::DRMFormat::RGBComponentInfo{
-                10, 10, 10, 2
-            },
+    },
+    mg::DRMFormat::FormatInfo{
+        DRM_FORMAT_BGRA1010102,
+        true,
+        DRM_FORMAT_BGRX1010102,
+        DRM_FORMAT_BGRA1010102,
+        mg::DRMFormat::RGBComponentInfo{
+            10, 10, 10, 2
         },
-    };
-    std::sort(
-        local_formats.begin(), local_formats.end(),
-        [](auto const& a, auto const& b)
-        {
-            return a.format < b.format;
-        });
-    return local_formats;
+    },
 };
 
-constexpr std::array const formats = make_sorted_formats_list();
-
-constexpr auto info_for_format(uint32_t fourcc) -> mg::DRMFormat::FormatInfo const&
+constexpr auto find_format_info(uint32_t fourcc) -> mg::DRMFormat::FormatInfo const*
 {
-    auto const candidate = std::lower_bound(
-        formats.begin(), formats.end(),
-        fourcc,
-        [](auto const& format, uint32_t fourcc)
-        {
-            return format.format < fourcc;
-        });
-
-    if (candidate != formats.end() && candidate->format == fourcc)
+    for (auto const& format: formats)
     {
-        return *candidate;
+        if (format.format == fourcc)
+            return &format;
+    }
+    /* The format array doesn't cover all DRM_FORMAT_*, only the ones relevant to Mir
+     * (and not all of them, yet: eg YUV formats), so we must have a sentinel value
+     * for the missing ones
+     */
+    return nullptr;
+}
+
+/* Generate a bunch of variables named format_info_DRM_FORMAT_FOO pointing to associated FormatInfo */
+#define STRINGIFY(format) \
+    constexpr mg::DRMFormat::FormatInfo const* format_info_##format = find_format_info(format);
+
+#include "drm-formats"
+
+#undef STRINGIFY
+
+constexpr auto info_for_format(uint32_t fourcc_format) -> mg::DRMFormat::FormatInfo const&
+{
+    mg::DRMFormat::FormatInfo const* info;
+    switch (fourcc_format)
+    {
+#define STRINGIFY(format) \
+    case format: \
+        info = format_info_##format; \
+        break;
+
+#include "drm-formats"
+
+        default:
+            BOOST_THROW_EXCEPTION((
+                std::runtime_error{
+                    std::string{"Unknown DRM format "} + std::to_string(fourcc_format) +
+                    " (may need to rebuild Mir against newer DRM headers?)"}));
     }
 
-    BOOST_THROW_EXCEPTION(std::runtime_error{
-        std::string{"Failed to find descriptor for format " + std::to_string(fourcc)}}); // TODO: Print fourcc as four characters.
+    if (info)
+    {
+        return *info;
+    }
+    BOOST_THROW_EXCEPTION((
+        std::runtime_error{
+            std::string{"Unsupported DRM format: "} + drm_format_to_string(fourcc_format)}));
 }
+
 }
 
 mg::DRMFormat::DRMFormat(uint32_t fourcc_format)

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -19,10 +19,16 @@
 #include "mir/graphics/drm_formats.h"
 
 #include <cstdint>
-#include <xf86drm.h>
 #include <drm_fourcc.h>
-#include <unordered_map>
 #include <stdexcept>
+#include <memory>
+#include <array>
+#include <algorithm>
+#include <boost/throw_exception.hpp>
+
+#ifdef MIR_HAVE_DRM_GET_MODIFIER_NAME
+#include <xf86drm.h>
+#endif
 
 namespace mg = mir::graphics;
 
@@ -61,8 +67,8 @@ constexpr auto drm_format_to_string(uint32_t format) -> char const*
 #undef STRINGIFY_BIGENDIAN
 }
 
-
-struct FormatInfo
+}
+struct mg::DRMFormat::FormatInfo
 {
     uint32_t format;
     bool has_alpha;
@@ -71,10 +77,12 @@ struct FormatInfo
     std::optional<mg::DRMFormat::RGBComponentInfo> components;
 };
 
-std::unordered_map<uint32_t, FormatInfo const> const formats = {
-    {
-        DRM_FORMAT_XRGB4444,
-        {
+namespace
+{
+constexpr auto make_sorted_formats_list()
+{
+    std::array local_formats = {
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_XRGB4444,
             false,
             DRM_FORMAT_XRGB4444,
@@ -82,11 +90,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 4, 4, 4, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_XBGR4444,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_XBGR4444,
             false,
             DRM_FORMAT_XBGR4444,
@@ -94,11 +99,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 4, 4, 4, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_RGBX4444,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_RGBX4444,
             false,
             DRM_FORMAT_RGBX4444,
@@ -106,11 +108,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 4, 4, 4, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_BGRX4444,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_BGRX4444,
             false,
             DRM_FORMAT_BGRX4444,
@@ -118,11 +117,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 4, 4, 4, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_ARGB4444,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_ARGB4444,
             true,
             DRM_FORMAT_XRGB4444,
@@ -130,11 +126,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 4, 4, 4, 4
             },
-        }
-    },
-    {
-        DRM_FORMAT_ABGR4444,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_ABGR4444,
             true,
             DRM_FORMAT_XBGR4444,
@@ -142,11 +135,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 4, 4, 4, 4
             },
-        }
-    },
-    {
-        DRM_FORMAT_RGBA4444,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_RGBA4444,
             true,
             DRM_FORMAT_RGBX4444,
@@ -154,11 +144,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 4, 4, 4, 4
             },
-        }
-    },
-    {
-        DRM_FORMAT_BGRA4444,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_BGRA4444,
             true,
             DRM_FORMAT_BGRX4444,
@@ -166,11 +153,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 4, 4, 4, 4
             },
-        }
-    },
-    {
-        DRM_FORMAT_XRGB1555,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_XRGB1555,
             false,
             DRM_FORMAT_XRGB1555,
@@ -178,11 +162,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 5, 5, 5, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_XBGR1555,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_XBGR1555,
             false,
             DRM_FORMAT_XBGR1555,
@@ -190,11 +171,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 5, 5, 5, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_RGBX5551,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_RGBX5551,
             false,
             DRM_FORMAT_RGBX5551,
@@ -202,11 +180,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 5, 5, 5, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_BGRX5551,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_BGRX5551,
             false,
             DRM_FORMAT_BGRX5551,
@@ -214,11 +189,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 5, 5, 5, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_ARGB1555,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_ARGB1555,
             true,
             DRM_FORMAT_XRGB1555,
@@ -226,11 +198,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 5, 5, 5, 1
             },
-        }
-    },
-    {
-        DRM_FORMAT_ABGR1555,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_ABGR1555,
             true,
             DRM_FORMAT_XBGR1555,
@@ -238,11 +207,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 5, 5, 5, 1
             },
-        }
-    },
-    {
-        DRM_FORMAT_RGBA5551,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_RGBA5551,
             true,
             DRM_FORMAT_RGBX5551,
@@ -250,11 +216,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 5, 5, 5, 1
             },
-        }
-    },
-    {
-        DRM_FORMAT_BGRA5551,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_BGRA5551,
             true,
             DRM_FORMAT_BGRX5551,
@@ -262,11 +225,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 5, 5, 5, 1
             },
-        }
-    },
-    {
-        DRM_FORMAT_RGB565,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_RGB565,
             false,
             DRM_FORMAT_RGB565,
@@ -274,11 +234,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 5, 6, 5, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_BGR565,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_BGR565,
             false,
             DRM_FORMAT_BGR565,
@@ -286,11 +243,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 5, 6, 5, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_RGB888,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_RGB888,
             false,
             DRM_FORMAT_RGB888,
@@ -298,11 +252,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 8, 8, 8, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_BGR888,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_BGR888,
             false,
             DRM_FORMAT_BGR888,
@@ -310,11 +261,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 8, 8, 8, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_XRGB8888,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_XRGB8888,
             false,
             DRM_FORMAT_XRGB8888,
@@ -322,11 +270,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 8, 8, 8, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_XBGR8888,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_XBGR8888,
             false,
             DRM_FORMAT_XBGR8888,
@@ -334,11 +279,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 8, 8, 8, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_RGBX8888,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_RGBX8888,
             false,
             DRM_FORMAT_RGBX8888,
@@ -346,11 +288,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 8, 8, 8, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_BGRX8888,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_BGRX8888,
             false,
             DRM_FORMAT_BGRX8888,
@@ -358,11 +297,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 8, 8, 8, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_ARGB8888,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_ARGB8888,
             true,
             DRM_FORMAT_XRGB8888,
@@ -370,11 +306,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 8, 8, 8, 8
             },
-        }
-    },
-    {
-        DRM_FORMAT_ABGR8888,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_ABGR8888,
             true,
             DRM_FORMAT_XBGR8888,
@@ -382,11 +315,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 8, 8, 8, 8
             },
-        }
-    },
-    {
-        DRM_FORMAT_RGBA8888,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_RGBA8888,
             true,
             DRM_FORMAT_RGBX8888,
@@ -394,11 +324,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 8, 8, 8, 8
             },
-        }
-    },
-    {
-        DRM_FORMAT_BGRA8888,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_BGRA8888,
             true,
             DRM_FORMAT_BGRX8888,
@@ -406,11 +333,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 8, 8, 8, 8
             },
-        }
-    },
-    {
-        DRM_FORMAT_XRGB2101010,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_XRGB2101010,
             false,
             DRM_FORMAT_XRGB2101010,
@@ -418,11 +342,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 10, 10, 10, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_XBGR2101010,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_XBGR2101010,
             false,
             DRM_FORMAT_XBGR2101010,
@@ -430,11 +351,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 10, 10, 10, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_RGBX1010102,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_RGBX1010102,
             false,
             DRM_FORMAT_RGBX1010102,
@@ -442,11 +360,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 10, 10, 10, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_BGRX1010102,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_BGRX1010102,
             false,
             DRM_FORMAT_BGRX1010102,
@@ -454,11 +369,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 10, 10, 10, {}
             },
-        }
-    },
-    {
-        DRM_FORMAT_ARGB2101010,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_ARGB2101010,
             true,
             DRM_FORMAT_XRGB2101010,
@@ -466,11 +378,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 10, 10, 10, 2
             },
-        }
-    },
-    {
-        DRM_FORMAT_ABGR2101010,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_ABGR2101010,
             true,
             DRM_FORMAT_XBGR2101010,
@@ -478,11 +387,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 10, 10, 10, 2
             },
-        }
-    },
-    {
-        DRM_FORMAT_RGBA1010102,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_RGBA1010102,
             true,
             DRM_FORMAT_RGBX1010102,
@@ -490,11 +396,8 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 10, 10, 10, 2
             },
-        }
-    },
-    {
-        DRM_FORMAT_BGRA1010102,
-        {
+        },
+        mg::DRMFormat::FormatInfo{
             DRM_FORMAT_BGRA1010102,
             true,
             DRM_FORMAT_BGRX1010102,
@@ -502,49 +405,80 @@ std::unordered_map<uint32_t, FormatInfo const> const formats = {
             mg::DRMFormat::RGBComponentInfo{
                 10, 10, 10, 2
             },
-        }
-    },
+        },
+    };
+    std::sort(
+        local_formats.begin(), local_formats.end(),
+        [](auto const& a, auto const& b)
+        {
+            return a.format < b.format;
+        });
+    return local_formats;
 };
+
+constexpr std::array const formats = make_sorted_formats_list();
+
+constexpr auto info_for_format(uint32_t fourcc) -> mg::DRMFormat::FormatInfo const&
+{
+    auto const candidate = std::lower_bound(
+        formats.begin(), formats.end(),
+        fourcc,
+        [](auto const& format, uint32_t fourcc)
+        {
+            return format.format < fourcc;
+        });
+
+    if (candidate != formats.end() && candidate->format == fourcc)
+    {
+        return *candidate;
+    }
+
+    BOOST_THROW_EXCEPTION(std::runtime_error{
+        std::string{"Failed to find descriptor for format " + std::to_string(fourcc)}}); // TODO: Print fourcc as four characters.
+}
+}
+
+mg::DRMFormat::DRMFormat(uint32_t fourcc_format)
+    : info{info_for_format(fourcc_format)}
+{
 }
 
 auto mg::DRMFormat::name() const -> const char*
 {
-    return drm_format_to_string(format);
+    return drm_format_to_string(info.format);
 }
 
 auto mg::DRMFormat::opaque_equivalent() const -> const std::optional<DRMFormat>
 {
-    auto const opaque_format = formats.at(format).opaque_equivalent;
-    if (opaque_format != DRM_FORMAT_INVALID)
+    if (info.opaque_equivalent != DRM_FORMAT_INVALID)
     {
-        return DRMFormat{opaque_format};
+        return DRMFormat{info.opaque_equivalent};
     }
     return {};
 }
 
 auto mg::DRMFormat::alpha_equivalent() const -> const std::optional<DRMFormat>
 {
-    auto const opaque_format = formats.at(format).alpha_equivalent;
-    if (opaque_format != DRM_FORMAT_INVALID)
+    if (info.alpha_equivalent != DRM_FORMAT_INVALID)
     {
-        return DRMFormat{opaque_format};
+        return DRMFormat{info.alpha_equivalent};
     }
     return {};
 }
 
 bool mg::DRMFormat::has_alpha() const
 {
-    return formats.at(format).has_alpha;
+    return info.has_alpha;
 }
 
 auto mg::DRMFormat::components() const -> std::optional<RGBComponentInfo> const&
 {
-    return formats.at(format).components;
+    return info.components;
 }
 
 mg::DRMFormat::operator uint32_t() const
 {
-    return format;
+    return info.format;
 }
 
 auto mg::drm_modifier_to_string(uint64_t modifier) -> std::string

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -18,6 +18,7 @@
 
 
 #include "mir/graphics/linux_dmabuf.h"
+#include "mir/graphics/drm_formats.h"
 
 
 #include "wayland_wrapper.h"
@@ -48,149 +49,6 @@ namespace mg = mir::graphics;
 namespace mw = mir::wayland;
 namespace geom = mir::geometry;
 
-namespace
-{
-constexpr auto drm_format_to_string(uint32_t format) -> char const*
-{
-#define STRINGIFY(val) \
-    case val:          \
-        return #val;
-
-    if (!(format & DRM_FORMAT_BIG_ENDIAN))
-    {
-        switch (format)
-        {
-#include "drm-formats"
-            default:
-                return "Unknown DRM format; rebuild Mir against newer DRM headers?";
-        }
-
-    }
-#undef STRINGIFY
-
-#define STRINGIFY_BIG_ENDIAN(val) \
-    case val:                    \
-        return #val " (big endian)";
-
-    switch (format & (~DRM_FORMAT_BIG_ENDIAN))
-    {
-#include "drm-formats-big-endian"
-        default:
-            return "Unknown DRM format; rebuild Mir against newer DRM headers?";
-    }
-#undef STRINGIFY_BIGENDIAN
-}
-
-constexpr auto drm_modifier_to_string(uint64_t modifier) -> char const*
-{
-#define STRINGIFY(val) \
-    case val:          \
-        return #val;
-
-    switch (modifier)
-    {
-#ifdef DRM_FORMAT_MOD_INVALID
-        STRINGIFY(DRM_FORMAT_MOD_INVALID)
-#endif
-#ifdef DRM_FORMAT_MOD_LINEAR
-        STRINGIFY(DRM_FORMAT_MOD_LINEAR)
-#endif
-#ifdef I915_FORMAT_MOD_X_TILED
-        STRINGIFY(I915_FORMAT_MOD_X_TILED)
-#endif
-#ifdef I915_FORMAT_MOD_Y_TILED
-        STRINGIFY(I915_FORMAT_MOD_Y_TILED)
-#endif
-#ifdef I915_FORMAT_MOD_Yf_TILED
-        STRINGIFY(I915_FORMAT_MOD_Yf_TILED)
-#endif
-#ifdef I915_FORMAT_MOD_Y_TILED_CCS
-        STRINGIFY(I915_FORMAT_MOD_Y_TILED_CCS)
-#endif
-#ifdef I915_FORMAT_MOD_Yf_TILED_CCS
-        STRINGIFY(I915_FORMAT_MOD_Yf_TILED_CCS)
-#endif
-#ifdef I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS
-        STRINGIFY(I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS)
-#endif
-#ifdef I915_FORMAT_MOD_Y_TILED_GEN12_MC_CCS
-        STRINGIFY(I915_FORMAT_MOD_Y_TILED_GEN12_MC_CCS)
-#endif
-#ifdef DRM_FORMAT_MOD_SAMSUNG_64_32_TILE
-        STRINGIFY(DRM_FORMAT_MOD_SAMSUNG_64_32_TILE)
-#endif
-#ifdef DRM_FORMAT_MOD_SAMSUNG_16_16_TILE
-        STRINGIFY(DRM_FORMAT_MOD_SAMSUNG_16_16_TILE)
-#endif
-#ifdef DRM_FORMAT_MOD_QCOM_COMPRESSED
-        STRINGIFY(DRM_FORMAT_MOD_QCOM_COMPRESSED)
-#endif
-#ifdef DRM_FORMAT_MOD_VIVANTE_TILED
-        STRINGIFY(DRM_FORMAT_MOD_VIVANTE_TILED)
-#endif
-#ifdef DRM_FORMAT_MOD_VIVANTE_SUPER_TILED
-        STRINGIFY(DRM_FORMAT_MOD_VIVANTE_SUPER_TILED)
-#endif
-#ifdef DRM_FORMAT_MOD_VIVANTE_SPLIT_TILED
-        STRINGIFY(DRM_FORMAT_MOD_VIVANTE_SPLIT_TILED)
-#endif
-#ifdef DRM_FORMAT_MOD_VIVANTE_SPLIT_SUPER_TILED
-        STRINGIFY(DRM_FORMAT_MOD_VIVANTE_SPLIT_SUPER_TILED)
-#endif
-#ifdef DRM_FORMAT_MOD_NVIDIA_TEGRA_TILED
-        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_TEGRA_TILED)
-#endif
-#ifdef DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_ONE_GOB
-        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_ONE_GOB)
-#endif
-#ifdef DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_TWO_GOB
-        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_TWO_GOB)
-#endif
-#ifdef DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_FOUR_GOB
-        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_FOUR_GOB)
-#endif
-#ifdef DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_EIGHT_GOB
-        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_EIGHT_GOB)
-#endif
-#ifdef DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_SIXTEEN_GOB
-        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_SIXTEEN_GOB)
-#endif
-#ifdef DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_THIRTYTWO_GOB
-        STRINGIFY(DRM_FORMAT_MOD_NVIDIA_16BX2_BLOCK_THIRTYTWO_GOB)
-#endif
-#ifdef DRM_FORMAT_MOD_BROADCOM_VC4_T_TILED
-        STRINGIFY(DRM_FORMAT_MOD_BROADCOM_VC4_T_TILED)
-#endif
-#ifdef DRM_FORMAT_MOD_BROADCOM_SAND32
-        STRINGIFY(DRM_FORMAT_MOD_BROADCOM_SAND32)
-#endif
-#ifdef DRM_FORMAT_MOD_BROADCOM_SAND64
-        STRINGIFY(DRM_FORMAT_MOD_BROADCOM_SAND64)
-#endif
-#ifdef DRM_FORMAT_MOD_BROADCOM_SAND128
-        STRINGIFY(DRM_FORMAT_MOD_BROADCOM_SAND128)
-#endif
-#ifdef DRM_FORMAT_MOD_BROADCOM_SAND256
-        STRINGIFY(DRM_FORMAT_MOD_BROADCOM_SAND256)
-#endif
-#ifdef DRM_FORMAT_MOD_BROADCOM_UIF
-        STRINGIFY(DRM_FORMAT_MOD_BROADCOM_UIF)
-#endif
-#ifdef DRM_FORMAT_MOD_ARM_16X16_BLOCK_U_INTERLEAVED
-        STRINGIFY(DRM_FORMAT_MOD_ARM_16X16_BLOCK_U_INTERLEAVED)
-#endif
-#ifdef DRM_FORMAT_MOD_ALLWINNER_TILED
-        STRINGIFY(DRM_FORMAT_MOD_ALLWINNER_TILED)
-#endif
-
-        default:
-            return "(unknown)";
-    }
-
-#undef STRINGIFY
-}
-
-}
 
 class mg::DmaBufFormatDescriptors
 {
@@ -384,7 +242,7 @@ public:
         wl_resource* wl_buffer,
         int32_t width,
         int32_t height,
-        uint32_t format,
+        mg::DRMFormat format,
         uint32_t flags,
         uint64_t modifier,
         std::vector<PlaneInfo> plane_params)
@@ -518,7 +376,7 @@ private:
     std::shared_ptr<mg::EGLExtensions> const egl_extensions;
     BufferGLDescription const& desc;
     int32_t const width, height;
-    uint32_t const format_;
+    mg::DRMFormat const format_;
     uint32_t const flags;
     uint64_t const modifier_;
     std::vector<PlaneInfo> const planes_;
@@ -712,7 +570,7 @@ private:
         }
     }
 
-    BufferGLDescription const& descriptor_for_format_and_modifiers(uint32_t format)
+    BufferGLDescription const& descriptor_for_format_and_modifiers(mg::DRMFormat format)
     {
         /* The optional<uint64_t> modifier is guaranteed to be engaged here,
          * as the add() call fills it if it is unset, and validate_and_count_planes()
@@ -757,9 +615,9 @@ private:
                 resource,
                 Error::invalid_format,
                 "Client requested unsupported format/modifier combination %s/%s (%u/%u,%u)",
-                drm_format_to_string(format),
-                drm_modifier_to_string(requested_modifier),
-                format,
+                format.name(),
+                mg::drm_modifier_to_string(requested_modifier).c_str(),
+                static_cast<uint32_t>(format),
                 static_cast<uint32_t>(requested_modifier >> 32),
                 static_cast<uint32_t>(requested_modifier & 0xFFFFFFFF)}));
     }
@@ -778,14 +636,16 @@ private:
             }
 
             auto const last_valid_plane = validate_and_count_planes();
+
+            mg::DRMFormat const drm_format{format};
             new WlDmaBufBuffer{
                 dpy,
                 egl_extensions,
-                descriptor_for_format_and_modifiers(format),
+                descriptor_for_format_and_modifiers(drm_format),
                 buffer_resource,
                 width,
                 height,
-                format,
+                drm_format,
                 flags,
                 modifier.value(),
                 {planes.cbegin(), last_valid_plane}};
@@ -820,14 +680,15 @@ private:
         {
             auto const last_valid_plane = validate_and_count_planes();
 
+            mg::DRMFormat const drm_format{format};
             new WlDmaBufBuffer{
                 dpy,
                 egl_extensions,
-                descriptor_for_format_and_modifiers(format),
+                descriptor_for_format_and_modifiers(drm_format),
                 buffer_id,
                 width,
                 height,
-                format,
+                drm_format,
                 flags,
                 modifier.value(),
                 {planes.cbegin(), last_valid_plane}};

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -189,3 +189,18 @@ MIRPLATFORM_2.7 {
     mir::options::idle_timeout_opt;
   };
 } MIRPLATFORM_2.5;
+
+MIR_PLATFORM_2.8 {
+ global:
+  extern "C++" {
+    mir::graphics::DRMFormat::DRMFormat*;
+    mir::graphics::DRMFormat::name*;
+    mir::graphics::DRMFormat::alpha_equivalent*;
+    mir::graphics::DRMFormat::opaque_equivalent*;
+    mir::graphics::DRMFormat::has_alpha*;
+    mir::graphics::DRMFormat::components*;
+    mir::graphics::DRMFormat::operator?unsigned?int*; /* Is actually operator uint32_t(), but 🤷 */
+
+    mir::graphics::drm_modifier_to_string*;
+  };
+} MIRPLATFORM_2.7;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ check_cxx_compiler_flag(-Winconsistent-missing-override HAS_W_INCONSISTENT_MISSI
 check_cxx_compiler_flag(-Wgnu-zero-variadic-macro-arguments HAS_W_GNU_ZERO_VARIADIC_MACRO_ARGUMENTS)
 check_cxx_compiler_flag(-Wno-sign-compare HAS_W_GNU_SIGN_COMPARE)
 check_cxx_compiler_flag(-Wmaybe-uninitialized HAS_W_MAYBE_UNINITIALIZED)
+check_cxx_compiler_flag(-Winfinite-recursion HAS_W_INFINITE_RECURSION)
 
 if (HAS_W_NULL_DEREFERENCE)
   # Avoid clang complaints about poor quality gmock/gtest headers
@@ -105,6 +106,11 @@ endif()
 if (HAS_W_MAYBE_UNINITIALIZED)
   # Avoid g++ complaints about gmock/gtest headers
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=maybe-uninitialized")
+endif()
+if (HAS_W_INFINITE_RECURSION)
+  # g++-12 doesn't notice that Abort() is going to call a [[noreturn]] function
+  # before Invalid<T>() tries to return itself.
+  add_compile_options(-Wno-error=infinite-recursion)
 endif()
 
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-lto")


### PR DESCRIPTION
Various parts of Mir code want to know various things about
pixel formats. The DRM fourcc format specifiers are reasonably
well described, in common use through Linux subsystems,
both kernel and userspace, and we already need to use them
in various parts of the codebase.

This adds some infrastructure for describing DRM formats.