### PR TITLE
Refactor Wayland keyboard input

### DIFF
--- a/include/test/mir/test/doubles/stub_session.h
+++ b/include/test/mir/test/doubles/stub_session.h
@@ -58,6 +58,7 @@ struct StubSession : scene::Session
 
     auto create_surface(
         std::shared_ptr<Session> const& session,
+        wayland::Weak<frontend::WlSurface> const& wayland_surface,
         shell::SurfaceSpecification const& params,
         std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<scene::Surface> override;
 

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -64,6 +64,7 @@ struct StubSurface : scene::Surface
     void set_cursor_image(std::shared_ptr<graphics::CursorImage> const&) override {}
     std::shared_ptr<graphics::CursorImage> cursor_image() const override { return nullptr; }
     void set_cursor_stream(std::shared_ptr<frontend::BufferStream> const&, geometry::Displacement const&) override {}
+    auto wayland_surface() -> wayland::Weak<frontend::WlSurface> const& override { abort(); }
     void request_client_surface_close() override {}
     std::shared_ptr<Surface> parent() const override { return nullptr; }
     void add_observer(std::shared_ptr<scene::SurfaceObserver> const&) override {}

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -115,6 +115,7 @@ class InputReport;
 class SeatObserver;
 class Scene;
 class InputManager;
+class KeyboardObserver;
 class SurfaceInputDispatcher;
 class InputDeviceRegistry;
 class InputDeviceHub;
@@ -310,6 +311,7 @@ public:
     virtual std::shared_ptr<input::EventFilterChainDispatcher> the_event_filter_chain_dispatcher();
 
     virtual std::shared_ptr<shell::InputTargeter> the_input_targeter();
+    virtual std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> the_keyboard_observer_registrar();
     virtual std::shared_ptr<input::Scene>  the_input_scene();
     virtual std::shared_ptr<input::CursorListener> the_cursor_listener();
     virtual std::shared_ptr<input::TouchVisualizer> the_touch_visualizer();

--- a/src/include/server/mir/frontend/surface.h
+++ b/src/include/server/mir/frontend/surface.h
@@ -35,10 +35,15 @@ namespace graphics
 class Buffer;
 class CursorImage;
 }
-
+namespace wayland
+{
+template<typename T>
+class Weak;
+}
 namespace frontend
 {
 class BufferStream;
+class WlSurface;
 
 class Surface
 {
@@ -58,6 +63,9 @@ public:
     virtual void set_cursor_stream(
         std::shared_ptr<frontend::BufferStream> const& image,
         geometry::Displacement const& hotspot) = 0;
+
+    /// Returned value is only safe to use on the Wayland thread
+    virtual auto wayland_surface() -> wayland::Weak<WlSurface> const& = 0;
 
 protected:
     Surface() = default;

--- a/src/include/server/mir/input/keyboard_observer.h
+++ b/src/include/server/mir/input/keyboard_observer.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_INPUT_KEYBOARD_OBSERVER_H_
+#define MIR_INPUT_KEYBOARD_OBSERVER_H_
+
+#include "mir/events/input_event.h"
+#include <memory>
+
+namespace mir
+{
+namespace input
+{
+class Surface;
+
+class KeyboardObserver
+{
+public:
+    KeyboardObserver() = default;
+    virtual ~KeyboardObserver() = default;
+
+    /// A keyboard or keyboard resync event has been triggered
+    virtual void keyboard_event(std::shared_ptr<MirEvent const> const& event) = 0;
+    /// The keyboard is now focused on the given surface (or nothing if surface is null)
+    virtual void keyboard_focus_set(std::shared_ptr<Surface> const& surface) = 0;
+
+protected:
+    KeyboardObserver(const KeyboardObserver&) = delete;
+    KeyboardObserver& operator=(const KeyboardObserver&) = delete;
+};
+
+}
+}
+
+#endif // MIR_INPUT_KEYBOARD_OBSERVER_H_

--- a/src/include/server/mir/scene/session.h
+++ b/src/include/server/mir/scene/session.h
@@ -37,8 +37,14 @@ namespace compositor
 {
 class BufferStream;
 }
+namespace wayland
+{
+template<typename>
+class Weak;
+}
 namespace frontend
 {
+class WlSurface;
 class EventSink;
 class Surface;
 class BufferStream;
@@ -90,6 +96,7 @@ public:
     /// \return a newly created surface
     virtual auto create_surface(
         std::shared_ptr<Session> const& session,
+        wayland::Weak<frontend::WlSurface> const& wayland_surface,
         shell::SurfaceSpecification const& params,
         std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<Surface> = 0;
     virtual void destroy_surface(std::shared_ptr<Surface> const& surface) = 0;

--- a/src/include/server/mir/scene/surface_factory.h
+++ b/src/include/server/mir/scene/surface_factory.h
@@ -26,6 +26,15 @@ namespace mir
 {
 namespace compositor { class BufferStream; }
 namespace shell { class SurfaceSpecification; }
+namespace wayland
+{
+template<typename>
+class Weak;
+}
+namespace frontend
+{
+class WlSurface;
+}
 namespace scene
 {
 class Surface;
@@ -40,6 +49,7 @@ public:
 
     virtual std::shared_ptr<Surface> create_surface(
         std::shared_ptr<Session> const& session,
+        wayland::Weak<frontend::WlSurface> const& wayland_surface,
         std::list<scene::StreamInfo> const& streams,
         shell::SurfaceSpecification const& params) = 0;
 

--- a/src/include/server/mir/shell/abstract_shell.h
+++ b/src/include/server/mir/shell/abstract_shell.h
@@ -66,6 +66,7 @@ public:
 
     auto create_surface(
         std::shared_ptr<scene::Session> const& session,
+        wayland::Weak<frontend::WlSurface> const& wayland_surface,
         SurfaceSpecification const& params,
         std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<scene::Surface> override;
 

--- a/src/include/server/mir/shell/shell.h
+++ b/src/include/server/mir/shell/shell.h
@@ -30,7 +30,16 @@
 
 namespace mir
 {
-namespace frontend { class EventSink; }
+namespace wayland
+{
+template<typename>
+class Weak;
+}
+namespace frontend
+{
+class WlSurface;
+class EventSink;
+}
 namespace geometry { struct Rectangle; }
 namespace scene
 {
@@ -76,6 +85,7 @@ public:
 
     virtual auto create_surface(
         std::shared_ptr<scene::Session> const& session,
+        wayland::Weak<frontend::WlSurface> const& wayland_surface,
         SurfaceSpecification const& params,
         std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<scene::Surface> = 0;
 

--- a/src/include/server/mir/shell/shell_wrapper.h
+++ b/src/include/server/mir/shell/shell_wrapper.h
@@ -65,6 +65,7 @@ public:
 
     auto create_surface(
         std::shared_ptr<scene::Session> const& session,
+        wayland::Weak<frontend::WlSurface> const& wayland_surface,
         SurfaceSpecification const& params,
         std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<scene::Surface> override;
 

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -493,6 +493,7 @@ mf::WaylandConnector::WaylandConnector(
     std::shared_ptr<time::Clock> const& clock,
     std::shared_ptr<mi::InputDeviceHub> const& input_hub,
     std::shared_ptr<mi::Seat> const& seat,
+    std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> const& keyboard_observer_registrar,
     std::shared_ptr<mi::InputDeviceRegistry> const& input_device_registry,
     std::shared_ptr<mi::CompositeEventFilter> const& composite_event_filter,
     std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
@@ -548,7 +549,14 @@ mf::WaylandConnector::WaylandConnector(
         std::make_shared<FrameExecutor>(*main_loop),
         this->allocator);
     subcompositor_global = std::make_unique<mf::WlSubcompositor>(display.get());
-    seat_global = std::make_unique<mf::WlSeat>(display.get(), clock, input_hub, seat, enable_key_repeat);
+    seat_global = std::make_unique<mf::WlSeat>(
+        display.get(),
+        *executor,
+        clock,
+        input_hub,
+        keyboard_observer_registrar,
+        seat,
+        enable_key_repeat);
     output_manager = std::make_unique<mf::OutputManager>(
         display.get(),
         display_config,

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -34,6 +34,8 @@
 namespace mir
 {
 class Executor;
+template<typename>
+class ObserverRegistrar;
 
 namespace input
 {
@@ -41,6 +43,7 @@ class InputDeviceHub;
 class InputDeviceRegistry;
 class Seat;
 class CompositeEventFilter;
+class KeyboardObserver;
 }
 namespace graphics
 {
@@ -124,6 +127,7 @@ public:
         std::shared_ptr<time::Clock> const& clock,
         std::shared_ptr<input::InputDeviceHub> const& input_hub,
         std::shared_ptr<input::Seat> const& seat,
+        std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> const& keyboard_observer_registrar,
         std::shared_ptr<input::InputDeviceRegistry> const& input_device_registry,
         std::shared_ptr<input::CompositeEventFilter> const& composite_event_filter,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -276,6 +276,7 @@ std::shared_ptr<mf::Connector>
                 the_clock(),
                 the_input_device_hub(),
                 the_seat(),
+                the_keyboard_observer_registrar(),
                 the_input_device_registry(),
                 the_composite_event_filter(),
                 the_buffer_allocator(),

--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -66,14 +66,6 @@ void mf::WaylandInputDispatcher::handle_event(MirInputEvent const* event)
 
     switch (mir_input_event_get_type(event))
     {
-    case mir_input_event_type_key:
-    case mir_input_event_type_keyboard_resync:
-    {
-        seat->for_each_listener(client, [&](WlKeyboard* keyboard)
-            {
-                keyboard->handle_event(event, wl_surface.value());
-            });
-    }   break;
 
     case mir_input_event_type_pointer:
     {
@@ -92,6 +84,8 @@ void mf::WaylandInputDispatcher::handle_event(MirInputEvent const* event)
                 touch->event(touch_event, wl_surface.value());
             });
     }   break;
+
+    // Keyboard events are sent to the WlSeat via it's KeyboardObserver
 
     default:
         break;

--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -40,17 +40,6 @@ mf::WaylandInputDispatcher::WaylandInputDispatcher(
 {
 }
 
-void mf::WaylandInputDispatcher::set_focus(bool has_focus)
-{
-    if (!wl_surface)
-    {
-        return;
-    }
-
-    auto const surface = &wl_surface.value();
-    seat->notify_focus(*surface, has_focus);
-}
-
 void mf::WaylandInputDispatcher::handle_event(MirInputEvent const* event)
 {
     if (!wl_surface)

--- a/src/server/frontend_wayland/wayland_input_dispatcher.h
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.h
@@ -50,7 +50,6 @@ public:
         WlSurface* wl_surface);
     ~WaylandInputDispatcher() = default;
 
-    void set_focus(bool has_focus);
     void handle_event(MirInputEvent const* event);
 
     auto latest_timestamp() const -> std::chrono::nanoseconds { return timestamp; }

--- a/src/server/frontend_wayland/wayland_surface_observer.cpp
+++ b/src/server/frontend_wayland/wayland_surface_observer.cpp
@@ -54,10 +54,9 @@ void mf::WaylandSurfaceObserver::attrib_changed(ms::Surface const*, MirWindowAtt
     {
     case mir_window_attrib_focus:
         run_on_wayland_thread_unless_window_destroyed(
-            [value](Impl* impl, WindowWlSurfaceRole* window)
+            [value](Impl* /*impl*/, WindowWlSurfaceRole* window)
             {
-                auto state = static_cast<MirWindowFocusState>(value);
-                impl->input_dispatcher->set_focus(state == mir_window_focus_state_focused);
+                auto const state = static_cast<MirWindowFocusState>(value);
                 window->handle_active_change(state != mir_window_focus_state_unfocused);
             });
         break;

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -441,7 +441,7 @@ void mf::WindowWlSurfaceRole::create_scene_surface()
     mods.input_shape = std::vector<geom::Rectangle>{};
     surface.value().populate_surface_data(mods.streams.value(), mods.input_shape.value(), {});
 
-    auto const scene_surface = shell->create_surface(session, mods, observer);
+    auto const scene_surface = shell->create_surface(session, surface, mods, observer);
     weak_scene_surface = scene_surface;
 
     if (mods.min_width)  committed_min_size.width  = mods.min_width.value();

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -43,15 +43,8 @@ mf::WlKeyboard::~WlKeyboard()
     seat.remove_focus_listener(client, this);
 }
 
-void mf::WlKeyboard::handle_event(MirInputEvent const* event, WlSurface& surface)
+void mf::WlKeyboard::handle_event(MirInputEvent const* event)
 {
-    if (!focused_surface.is(surface))
-    {
-        fatal_error(
-            "Attempt to send keyboard event to wl_surface@%u even though it was not given keyboard focus",
-            wl_resource_get_id(surface.resource));
-    }
-
     helper->handle_event(event);
 }
 

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -39,7 +39,7 @@ public:
 
     ~WlKeyboard();
 
-    void handle_event(MirInputEvent const* event, WlSurface& surface);
+    void handle_event(MirInputEvent const* event);
 
 private:
     WlSeat& seat;

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -255,20 +255,6 @@ auto mf::WlSeat::make_keyboard_helper(KeyboardCallbacks* callbacks) -> std::uniq
     return std::make_unique<KeyboardHelper>(callbacks, keymap, seat, enable_key_repeat);
 }
 
-void mf::WlSeat::notify_focus(WlSurface& surface, bool has_focus)
-{
-    if (has_focus && !focused_surface.is(surface))
-    {
-        // give focus to any surface other than the current one
-        set_focus_to(&surface);
-    }
-    else if (!has_focus && focused_surface.is(surface))
-    {
-        // only take focus away if the newly unfocused surface is the current one
-        set_focus_to(nullptr);
-    }
-}
-
 void mf::WlSeat::bind(wl_resource* new_wl_seat)
 {
     new Instance{new_wl_seat, this};

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -153,7 +153,7 @@ public:
         {
             seat.for_each_listener(seat.focused_surface.value().client, [&](WlKeyboard* keyboard)
                 {
-                    keyboard->handle_event(mir_event_get_input_event(event.get()), seat.focused_surface.value());
+                    keyboard->handle_event(mir_event_get_input_event(event.get()));
                 });
         }
     }

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -27,11 +27,15 @@
 
 namespace mir
 {
+class Executor;
+template<typename T>
+class ObserverRegistrar;
 namespace input
 {
 class InputDeviceHub;
 class Seat;
 class Keymap;
+class KeyboardObserver;
 }
 namespace time
 {
@@ -51,8 +55,10 @@ class WlSeat : public wayland::Seat::Global
 public:
     WlSeat(
         wl_display* display,
+        Executor& wayland_executor,
         std::shared_ptr<time::Clock> const& clock,
         std::shared_ptr<mir::input::InputDeviceHub> const& input_hub,
+        std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> const& keyboard_observer_registrar,
         std::shared_ptr<mir::input::Seat> const& seat,
         bool enable_key_repeat);
 
@@ -96,9 +102,12 @@ private:
 
     class ConfigObserver;
     class Instance;
+    class KeyboardObserver;
 
     std::shared_ptr<mir::input::Keymap> keymap;
     std::shared_ptr<ConfigObserver> const config_observer;
+    std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> const keyboard_observer_registrar;
+    std::shared_ptr<KeyboardObserver> const keyboard_observer;
 
     // listener list are shared pointers so devices can keep them around long enough to remove themselves
     std::shared_ptr<ListenerList<FocusListener>> const focus_listeners;

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -88,7 +88,6 @@ public:
     /// Adds the listener for future use, and makes a call into it to inform of initial state
     void add_focus_listener(wl_client* client, FocusListener* listener);
     void remove_focus_listener(wl_client* client, FocusListener* listener);
-    void notify_focus(WlSurface& surface, bool has_focus);
 
 private:
     void set_focus_to(WlSurface* surface);

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -35,6 +35,7 @@
 namespace mf = mir::frontend;
 namespace msh = mir::shell;
 namespace ms = mir::scene;
+namespace mw = mir::wayland;
 namespace geom = mir::geometry;
 
 namespace
@@ -784,7 +785,7 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
         prep_surface_spec(lock, spec);
     }
 
-    auto const surface = shell->create_surface(session, spec, observer);
+    auto const surface = shell->create_surface(session, mw::make_weak(wl_surface), spec, observer);
     inform_client_of_window_state(state);
     auto const top_left = scaled_top_left_of(*surface) + scaled_content_offset_of(*surface);
     auto const size = scaled_content_size_of(*surface);

--- a/src/server/frontend_xwayland/xwayland_surface_observer.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.cpp
@@ -63,11 +63,6 @@ void mf::XWaylandSurfaceObserver::attrib_changed(ms::Surface const*, MirWindowAt
     {
         auto state = static_cast<MirWindowFocusState>(value);
         wm_surface->scene_surface_focus_set(state != mir_window_focus_state_unfocused);
-        aquire_input_dispatcher(
-            [state](auto input_dispatcher)
-            {
-                input_dispatcher->set_focus(state == mir_window_focus_state_focused);
-            });
     }   break;
 
     case mir_window_attrib_state:

--- a/src/server/input/default_configuration.cpp
+++ b/src/server/input/default_configuration.cpp
@@ -52,7 +52,6 @@
 #include "mir/shared_library.h"
 #include "mir/dispatch/action_queue.h"
 #include "mir/console_services.h"
-#include "mir/log.h"
 
 #include "mir_toolkit/cursors.h"
 
@@ -116,6 +115,12 @@ mir::DefaultServerConfiguration::the_input_targeter()
             else
                 return the_surface_input_dispatcher();
         });
+}
+
+std::shared_ptr<mir::ObserverRegistrar<mi::KeyboardObserver>>
+mir::DefaultServerConfiguration::the_keyboard_observer_registrar()
+{
+    return the_surface_input_dispatcher();
 }
 
 std::shared_ptr<mi::SurfaceInputDispatcher>

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -81,6 +81,7 @@ ms::ApplicationSession::~ApplicationSession()
 
 auto ms::ApplicationSession::create_surface(
     std::shared_ptr<Session> const& session,
+    wayland::Weak<frontend::WlSurface> const& wayland_surface,
     shell::SurfaceSpecification const& the_params,
     std::shared_ptr<ms::SurfaceObserver> const& observer) -> std::shared_ptr<Surface>
 {
@@ -105,7 +106,7 @@ auto ms::ApplicationSession::create_surface(
         streams.push_back({std::dynamic_pointer_cast<mc::BufferStream>(stream.stream.lock()), stream.displacement, stream.size});
     }
 
-    auto surface = surface_factory->create_surface(session, streams, params);
+    auto surface = surface_factory->create_surface(session, wayland_surface, streams, params);
 
     auto const input_mode = params.input_mode.is_set() ? params.input_mode.value() : input::InputReceptionMode::normal;
     surface_stack->add_surface(surface, input_mode);

--- a/src/server/scene/application_session.h
+++ b/src/server/scene/application_session.h
@@ -60,6 +60,7 @@ public:
 
     auto create_surface(
         std::shared_ptr<Session> const& session,
+        wayland::Weak<frontend::WlSurface> const& wayland_surface,
         shell::SurfaceSpecification const& params,
         std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<Surface> override;
     void destroy_surface(std::shared_ptr<Surface> const& surface) override;

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -44,6 +44,7 @@ namespace msh = mir::shell;
 namespace mg = mir::graphics;
 namespace mi = mir::input;
 namespace mf = mir::frontend;
+namespace mw = mir::wayland;
 namespace geom = mir::geometry;
 namespace mrs = mir::renderer::software;
 
@@ -244,6 +245,7 @@ auto weak(std::shared_ptr<ms::SurfaceObservers>& observers) -> std::weak_ptr<ms:
 
 ms::BasicSurface::BasicSurface(
     std::shared_ptr<Session> const& session,
+    mw::Weak<frontend::WlSurface> wayland_surface,
     std::string const& name,
     geometry::Rectangle rect,
     std::weak_ptr<Surface> const& parent,
@@ -262,6 +264,7 @@ ms::BasicSurface::BasicSurface(
     cursor_image_(cursor_image),
     report(report),
     parent_(parent),
+    wayland_surface_{wayland_surface},
     layers(layers),
     confine_pointer_state_(state),
     cursor_stream_adapter{std::make_unique<ms::CursorStreamImageAdapter>(*this)},
@@ -282,14 +285,23 @@ ms::BasicSurface::BasicSurface(
 
 ms::BasicSurface::BasicSurface(
     std::shared_ptr<Session> const& session,
+    mw::Weak<frontend::WlSurface> wayland_surface,
     std::string const& name,
     geometry::Rectangle rect,
     MirPointerConfinementState state,
     std::list<StreamInfo> const& layers,
     std::shared_ptr<mg::CursorImage> const& cursor_image,
     std::shared_ptr<SceneReport> const& report) :
-    BasicSurface(session, name, rect, std::shared_ptr<Surface>{nullptr}, state, layers,
-                 cursor_image, report)
+    BasicSurface(
+        session,
+        wayland_surface,
+        name,
+        rect,
+        std::shared_ptr<Surface>{nullptr},
+        state,
+        layers,
+        cursor_image,
+        report)
 {
 }
 
@@ -709,6 +721,11 @@ void ms::BasicSurface::set_cursor_stream(std::shared_ptr<mf::BufferStream> const
                                          geom::Displacement const& hotspot)
 {
     cursor_stream_adapter->update(stream, hotspot);
+}
+
+auto ms::BasicSurface::wayland_surface() -> mw::Weak<mf::WlSurface> const&
+{
+    return wayland_surface_;
 }
 
 void ms::BasicSurface::request_client_surface_close()

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -23,9 +23,8 @@
 #include "mir/basic_observers.h"
 #include "mir/proof_of_mutex_lock.h"
 #include "mir/scene/surface_observers.h"
-
+#include "mir/wayland/wayland_base.h"
 #include "mir/geometry/rectangle.h"
-
 #include "mir_toolkit/common.h"
 
 #include <glm/glm.hpp>
@@ -60,6 +59,7 @@ class BasicSurface : public Surface
 public:
     BasicSurface(
         std::shared_ptr<Session> const& session,
+        wayland::Weak<frontend::WlSurface> wayland_surface,
         std::string const& name,
         geometry::Rectangle rect,
         MirPointerConfinementState state,
@@ -69,6 +69,7 @@ public:
 
     BasicSurface(
         std::shared_ptr<Session> const& session,
+        wayland::Weak<frontend::WlSurface> wayland_surface,
         std::string const& name,
         geometry::Rectangle rect,
         std::weak_ptr<Surface> const& parent,
@@ -128,6 +129,8 @@ public:
                            geometry::Displacement const& hotspot) override;
     void set_cursor_from_buffer(std::shared_ptr<graphics::Buffer> buffer,
                                 geometry::Displacement const& hotspot);
+
+    auto wayland_surface() -> wayland::Weak<frontend::WlSurface> const& override;
 
     void request_client_surface_close() override;
 
@@ -192,6 +195,7 @@ private:
     std::shared_ptr<graphics::CursorImage> cursor_image_;
     std::shared_ptr<SceneReport> const report;
     std::weak_ptr<Surface> const parent_;
+    wayland::Weak<frontend::WlSurface> const wayland_surface_;
 
     std::list<StreamInfo> layers;
     // Surface attributes:

--- a/src/server/scene/surface_allocator.cpp
+++ b/src/server/scene/surface_allocator.cpp
@@ -39,6 +39,7 @@ ms::SurfaceAllocator::SurfaceAllocator(
 
 std::shared_ptr<ms::Surface> ms::SurfaceAllocator::create_surface(
     std::shared_ptr<Session> const& session,
+    wayland::Weak<frontend::WlSurface> const& wayland_surface,
     std::list<ms::StreamInfo> const& streams,
     shell::SurfaceSpecification const& params)
 {
@@ -51,6 +52,7 @@ std::shared_ptr<ms::Surface> ms::SurfaceAllocator::create_surface(
     auto const parent = params.parent.is_set() ? params.parent.value() : std::weak_ptr<scene::Surface>{};
     auto const surface = std::make_shared<BasicSurface>(
         session,
+        wayland_surface,
         name,
         rect,
         parent,

--- a/src/server/scene/surface_allocator.h
+++ b/src/server/scene/surface_allocator.h
@@ -41,6 +41,7 @@ public:
 
     std::shared_ptr<Surface> create_surface(
         std::shared_ptr<Session> const& session,
+        wayland::Weak<frontend::WlSurface> const& wayland_surface,
         std::list<scene::StreamInfo> const& streams,
         shell::SurfaceSpecification const& params) override;
 

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -29,6 +29,7 @@
 #include "mir/scene/session.h"
 #include "mir/scene/surface.h"
 #include "mir/input/seat.h"
+#include "mir/wayland/wayland_base.h"
 #include "decoration/manager.h"
 
 #include <algorithm>
@@ -180,13 +181,14 @@ void msh::AbstractShell::close_session(
 
 auto msh::AbstractShell::create_surface(
     std::shared_ptr<ms::Session> const& session,
+    wayland::Weak<frontend::WlSurface> const& wayland_surface,
     SurfaceSpecification const& spec,
     std::shared_ptr<ms::SurfaceObserver> const& observer) -> std::shared_ptr<ms::Surface>
 {
     // Instead of a shared pointer, a local variable could be used and the lambda could capture a reference to it
     // This should be safe, but could be the source of nasty bugs and crashes if the wm did something unexpected
     auto const should_decorate = std::make_shared<bool>(false);
-    auto const build = [observer, should_decorate](
+    auto const build = [observer, should_decorate, wayland_surface](
             std::shared_ptr<ms::Session> const& session,
             msh::SurfaceSpecification const& placed_params)
         {
@@ -194,7 +196,7 @@ auto msh::AbstractShell::create_surface(
             {
                 *should_decorate = true;
             }
-            return session->create_surface(session, placed_params, observer);
+            return session->create_surface(session, wayland_surface, placed_params, observer);
         };
 
     auto const result = window_manager->add_surface(session, spec, build);

--- a/src/server/shell/decoration/basic_decoration.cpp
+++ b/src/server/shell/decoration/basic_decoration.cpp
@@ -31,6 +31,7 @@
 #include "mir/graphics/buffer_properties.h"
 #include "mir/compositor/buffer_stream.h"
 #include "mir/input/cursor_images.h"
+#include "mir/wayland/wayland_base.h"
 #include "mir/log.h"
 
 #include <boost/throw_exception.hpp>
@@ -292,7 +293,7 @@ auto msd::BasicDecoration::create_surface() const -> std::shared_ptr<scene::Surf
             mg::BufferUsage::software}),
         {},
         {}}};
-    return shell->create_surface(session, params, nullptr);
+    return shell->create_surface(session, {}, params, nullptr);
 }
 
 void msd::BasicDecoration::update(

--- a/src/server/shell/shell_wrapper.cpp
+++ b/src/server/shell/shell_wrapper.cpp
@@ -86,10 +86,11 @@ void msh::ShellWrapper::stop_prompt_session(std::shared_ptr<ms::PromptSession> c
 
 auto msh::ShellWrapper::create_surface(
     std::shared_ptr<ms::Session> const& session,
+    wayland::Weak<frontend::WlSurface> const& wayland_surface,
     SurfaceSpecification const& params,
     std::shared_ptr<ms::SurfaceObserver> const& observer) -> std::shared_ptr<ms::Surface>
 {
-    return wrapped->create_surface(session, params, observer);
+    return wrapped->create_surface(session, wayland_surface, params, observer);
 }
 
 void msh::ShellWrapper::modify_surface(

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -916,3 +916,10 @@ MIR_SERVER_2.6 {
   };
  local: *;
 };
+
+MIR_SERVER_2.8 {
+ global:
+  extern "C++" {
+    mir::DefaultServerConfiguration::the_keyboard_observer_registrar*;
+  };
+} MIR_SERVER_2.6;

--- a/tests/include/mir/test/doubles/mock_scene_session.h
+++ b/tests/include/mir/test/doubles/mock_scene_session.h
@@ -25,6 +25,7 @@
 #include "mir/input/mir_input_config.h"
 #include "mir/client_visible_error.h"
 #include "mir/shell/surface_specification.h"
+#include "mir/wayland/wayland_base.h"
 
 #include <gmock/gmock.h>
 
@@ -37,9 +38,10 @@ namespace doubles
 
 struct MockSceneSession : public scene::Session
 {
-    MOCK_METHOD3(create_surface,
+    MOCK_METHOD4(create_surface,
         std::shared_ptr<scene::Surface>(
             std::shared_ptr<Session> const&,
+            wayland::Weak<frontend::WlSurface> const&,
             shell::SurfaceSpecification const&,
             std::shared_ptr<scene::SurfaceObserver> const&));
     MOCK_METHOD1(destroy_surface, void(std::shared_ptr<scene::Surface> const&));

--- a/tests/include/mir/test/doubles/mock_surface.h
+++ b/tests/include/mir/test/doubles/mock_surface.h
@@ -38,6 +38,7 @@ struct MockSurface : public scene::BasicSurface
         scene::BasicSurface(
             {},
             {},
+            {},
             {{},{}},
             mir_pointer_unconfined,
             { { std::make_shared<testing::NiceMock<MockBufferStream>>(), {0, 0}, {} } },

--- a/tests/include/mir/test/doubles/stub_shell.h
+++ b/tests/include/mir/test/doubles/stub_shell.h
@@ -129,6 +129,7 @@ struct StubShell : public shell::Shell
 
     auto create_surface(
         std::shared_ptr<scene::Session> const& /*session*/,
+        wayland::Weak<frontend::WlSurface> const& /*wayland_surface*/,
         shell::SurfaceSpecification const& /*params*/,
         std::shared_ptr<scene::SurfaceObserver> const& /*observer*/) -> std::shared_ptr<scene::Surface> override
     {

--- a/tests/include/mir/test/doubles/stub_surface_factory.h
+++ b/tests/include/mir/test/doubles/stub_surface_factory.h
@@ -36,6 +36,7 @@ class StubSurfaceFactory : public scene::SurfaceFactory
 public:
     std::shared_ptr<scene::Surface> create_surface(
         std::shared_ptr<scene::Session> const&,
+        wayland::Weak<frontend::WlSurface> const&,
         std::list<scene::StreamInfo> const&,
         shell::SurfaceSpecification const& params) override
     {

--- a/tests/integration-tests/input/test_single_seat_setup.cpp
+++ b/tests/integration-tests/input/test_single_seat_setup.cpp
@@ -50,6 +50,7 @@
 #include "mir/input/touch_visualizer.h"
 #include "mir/input/input_device_info.h"
 #include "mir/geometry/rectangles.h"
+#include "mir/wayland/wayland_base.h"
 #include "mir/test/input_config_matchers.h"
 #include "mir/test/fd_utils.h"
 

--- a/tests/integration-tests/test_surface_stack_with_compositor.cpp
+++ b/tests/integration-tests/test_surface_stack_with_compositor.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "mir/compositor/display_listener.h"
+#include "mir/wayland/wayland_base.h"
 #include "mir/renderer/renderer_factory.h"
 #include "src/server/report/null_report_factory.h"
 #include "src/server/scene/surface_stack.h"
@@ -46,6 +47,7 @@ namespace mr = mir::report;
 namespace mc = mir::compositor;
 namespace mg = mir::graphics;
 namespace mf = mir::frontend;
+namespace mw = mir::wayland;
 namespace mi = mir::input;
 namespace geom = mir::geometry;
 using namespace testing;
@@ -128,6 +130,7 @@ struct SurfaceStackCompositor : public Test
         streams({ { stream, {0,0}, {} } }),
         stub_surface{std::make_shared<ms::BasicSurface>(
             nullptr /* session */,
+            mw::Weak<mf::WlSurface>{},
             std::string("stub"),
             geom::Rectangle{{0,0},{1,1}},
             mir_pointer_unconfined,

--- a/tests/mir_test_framework/stub_session.cpp
+++ b/tests/mir_test_framework/stub_session.cpp
@@ -82,6 +82,7 @@ void mtd::StubSession::resume_prompt_session()
 
 auto mtd::StubSession::create_surface(
     std::shared_ptr<Session> const& /*session*/,
+    wayland::Weak<frontend::WlSurface> const& /*wayland_surface*/,
     mir::shell::SurfaceSpecification const& /*params*/,
     std::shared_ptr<scene::SurfaceObserver> const& /*observer*/) -> std::shared_ptr<ms::Surface>
 {

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -27,6 +27,7 @@
 #include <mir/shell/focus_controller.h>
 #include <mir/shell/persistent_surface_store.h>
 #include "mir/graphics/display_configuration_observer.h"
+#include <mir/wayland/wayland_base.h>
 
 #include <mir/test/doubles/stub_session.h>
 #include <mir/test/doubles/stub_surface.h>
@@ -152,6 +153,7 @@ struct StubStubSession : mir::test::doubles::StubSession
 {
     auto create_surface(
         std::shared_ptr<mir::scene::Session> const& /*session*/,
+        mir::wayland::Weak<mir::frontend::WlSurface> const& /*wayland_surface*/,
         mir::shell::SurfaceSpecification const& params,
         std::shared_ptr<mir::scene::SurfaceObserver> const& /*observer*/) -> std::shared_ptr<mir::scene::Surface> override
     {
@@ -316,7 +318,7 @@ auto mt::TestWindowManagerTools::create_surface(
 {
     // This type is Mir-internal, I hope we don't need to create it here
     std::shared_ptr<mir::scene::SurfaceObserver> const observer;
-    return session->create_surface(nullptr, params, observer);
+    return session->create_surface(nullptr, {}, params, observer);
 }
 
 auto mt::TestWindowManagerTools::create_fake_display_configuration(std::vector<miral::Rectangle> const& outputs)

--- a/tests/unit-tests/input/test_config_changer.cpp
+++ b/tests/unit-tests/input/test_config_changer.cpp
@@ -24,6 +24,7 @@
 #include "mir/scene/session_event_handler_register.h"
 #include "mir/input/input_device_observer.h"
 #include "mir/input/mir_touchscreen_config.h"
+#include "mir/wayland/wayland_base.h"
 
 #include "mir/test/doubles/mock_input_device_hub.h"
 #include "mir/test/doubles/mock_input_manager.h"

--- a/tests/unit-tests/input/test_surface_input_dispatcher.cpp
+++ b/tests/unit-tests/input/test_surface_input_dispatcher.cpp
@@ -27,6 +27,7 @@
 #include "mir/test/fake_shared.h"
 #include "mir/test/doubles/stub_input_scene.h"
 #include "mir/test/doubles/mock_surface.h"
+#include "mir/test/doubles/explicit_executor.h"
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
@@ -70,7 +71,7 @@ struct StubInputScene : public mtd::StubInputScene
 {
     std::shared_ptr<mtd::MockSurface> add_surface(geom::Rectangle const& geometry)
     {
-        auto surface = std::make_shared<MockSurfaceWithGeometry>(geometry);
+        auto surface = std::make_shared<NiceMock<MockSurfaceWithGeometry>>(geometry);
         surfaces.add(surface);
 
         observer->surface_added(surface);
@@ -260,6 +261,12 @@ struct FakeToucher
     MirInputDeviceId const id;
 };
 
+struct MockKeyboardObserver: mi::KeyboardObserver
+{
+    MOCK_METHOD1(keyboard_event, void(std::shared_ptr<MirEvent const> const& event));
+    MOCK_METHOD1(keyboard_focus_set, void(std::shared_ptr<mi::Surface> const& surface));
+};
+
 }
 
 TEST_F(SurfaceInputDispatcher, key_event_not_delivered_to_surface)
@@ -275,6 +282,54 @@ TEST_F(SurfaceInputDispatcher, key_event_not_delivered_to_surface)
 
     dispatcher.set_focus(surface);
     dispatcher.dispatch(std::move(event));
+}
+
+TEST_F(SurfaceInputDispatcher, key_event_delivered_to_keyboard_observer)
+{
+    auto surface = scene.add_surface();
+    mtd::ExplicitExectutor executor;
+
+    FakeKeyboard keyboard;
+    auto event = keyboard.press();
+
+    auto const kb_observer = std::make_shared<MockKeyboardObserver>();
+    EXPECT_CALL(*kb_observer, keyboard_event(mt::MirKeyboardEventMatches(event.get())));
+
+    dispatcher.start();
+    dispatcher.register_interest(kb_observer, executor);
+    dispatcher.dispatch(std::move(event));
+    executor.execute();
+}
+
+TEST_F(SurfaceInputDispatcher, keyboard_focus_delivered_to_keyboard_observer)
+{
+    auto surface = scene.add_surface();
+    mtd::ExplicitExectutor executor;
+
+    auto const kb_observer = std::make_shared<MockKeyboardObserver>();
+    EXPECT_CALL(*kb_observer, keyboard_focus_set(Eq(surface)));
+
+    dispatcher.start();
+    dispatcher.register_interest(kb_observer, executor);
+    dispatcher.set_focus(surface);
+    executor.execute();
+}
+
+TEST_F(SurfaceInputDispatcher, keyboard_focus_clear_delivered_to_keyboard_observer)
+{
+    auto surface = scene.add_surface();
+    mtd::ExplicitExectutor executor;
+
+    auto const kb_observer = std::make_shared<NiceMock<MockKeyboardObserver>>();
+
+    dispatcher.start();
+    dispatcher.register_interest(kb_observer, executor);
+    dispatcher.set_focus(surface);
+    executor.execute();
+
+    EXPECT_CALL(*kb_observer, keyboard_focus_set(Eq(nullptr)));
+    dispatcher.set_focus(nullptr);
+    executor.execute();
 }
 
 TEST_F(SurfaceInputDispatcher, pointer_motion_delivered_to_client_under_pointer)

--- a/tests/unit-tests/input/test_surface_input_dispatcher.cpp
+++ b/tests/unit-tests/input/test_surface_input_dispatcher.cpp
@@ -262,31 +262,19 @@ struct FakeToucher
 
 }
 
-TEST_F(SurfaceInputDispatcher, key_event_delivered_to_focused_surface)
+TEST_F(SurfaceInputDispatcher, key_event_not_delivered_to_surface)
 {
     auto surface = scene.add_surface();
 
     FakeKeyboard keyboard;
     auto event = keyboard.press();
 
-    EXPECT_CALL(*surface, consume(mt::MirKeyboardEventMatches(event.get()))).Times(1);
-
-    dispatcher.start();
-
-    dispatcher.set_focus(surface);
-    EXPECT_TRUE(dispatcher.dispatch(std::move(event)));
-}
-
-TEST_F(SurfaceInputDispatcher, key_event_dropped_if_no_surface_focused)
-{
-    auto surface = scene.add_surface();
-    
     EXPECT_CALL(*surface, consume(_)).Times(0);
 
     dispatcher.start();
 
-    FakeKeyboard keyboard;
-    EXPECT_FALSE(dispatcher.dispatch(keyboard.press()));
+    dispatcher.set_focus(surface);
+    dispatcher.dispatch(std::move(event));
 }
 
 TEST_F(SurfaceInputDispatcher, pointer_motion_delivered_to_client_under_pointer)

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -42,6 +42,7 @@
 
 namespace mc = mir::compositor;
 namespace mf = mir::frontend;
+namespace mw = mir::wayland;
 namespace mi = mir::input;
 namespace mr = mir::report;
 namespace ms = mir::scene;
@@ -92,6 +93,7 @@ struct BasicSurfaceTest : public testing::Test
 
     ms::BasicSurface surface{
         nullptr /* session */,
+        {} /* wayland_surface */,
         name,
         rect,
         mir_pointer_unconfined,
@@ -126,6 +128,7 @@ TEST_F(BasicSurfaceTest, can_be_created_with_session)
     auto const session = std::make_shared<mtd::StubSession>();
     ms::BasicSurface surface{
         session,
+        {} /* wayland_surface */,
         name,
         geom::Rectangle{{0,0}, {100,100}},
         mir_pointer_unconfined,
@@ -146,6 +149,7 @@ TEST_F(BasicSurfaceTest, buffer_stream_ids_always_unique)
     {
         surface = std::make_unique<ms::BasicSurface>(
                 nullptr /* session */,
+                mw::Weak<mf::WlSurface>{},
                 name,
                 rect,
                 mir_pointer_unconfined,
@@ -170,6 +174,7 @@ TEST_F(BasicSurfaceTest, id_never_invalid)
     {
         surface = std::make_unique<ms::BasicSurface>(
                 nullptr /* session */,
+                mw::Weak<mf::WlSurface>{},
                 name,
                 rect,
                 mir_pointer_unconfined,
@@ -435,6 +440,7 @@ TEST_F(BasicSurfaceTest, test_surface_visibility)
     // Must be a fresh surface to guarantee no frames posted yet...
     ms::BasicSurface surface{
         nullptr /* session */,
+        {} /* wayland_surface */,
         name,
         rect,
         mir_pointer_unconfined,
@@ -474,6 +480,7 @@ TEST_F(BasicSurfaceTest, default_region_is_surface_rectangle)
     geom::Size one_by_one{geom::Width{1}, geom::Height{1}};
     ms::BasicSurface surface{
         nullptr /* session */,
+        {} /* wayland_surface */,
         name,
         geom::Rectangle{pt, one_by_one},
         mir_pointer_unconfined,
@@ -510,6 +517,7 @@ TEST_F(BasicSurfaceTest, default_invisible_surface_doesnt_get_input)
 {
     ms::BasicSurface surface{
         nullptr /* session */,
+        {} /* wayland_surface */,
         name,
         geom::Rectangle{{0,0}, {100,100}},
         mir_pointer_unconfined,
@@ -529,6 +537,7 @@ TEST_F(BasicSurfaceTest, surface_doesnt_get_input_outside_clip_area)
 {
     ms::BasicSurface surface{
         nullptr /* session */,
+        {} /* wayland_surface */,
         name,
         geom::Rectangle{{0,0}, {100,100}},
         mir_pointer_unconfined,
@@ -752,6 +761,7 @@ TEST_F(BasicSurfaceTest, stores_parent)
     auto parent = mt::fake_shared(surface);
     ms::BasicSurface child{
         nullptr /* session */,
+        {} /* wayland_surface */,
         name,
         geom::Rectangle{{0,0}, {100,100}},
         parent,
@@ -1326,6 +1336,7 @@ TEST_F(BasicSurfaceTest, registers_frame_callbacks_on_construction)
 
     ms::BasicSurface child{
         nullptr /* session */,
+        {} /* wayland_surface */,
         name,
         geom::Rectangle{{0,0}, {100,100}},
         std::weak_ptr<ms::Surface>{},
@@ -1601,6 +1612,7 @@ TEST_F(BasicSurfaceTest, buffer_can_be_submitted_to_original_stream_after_surfac
 
     auto surface = std::make_unique<ms::BasicSurface>(
         nullptr, // session
+        mw::Weak<mf::WlSurface>{},
         name,
         rect,
         mir_pointer_unconfined,
@@ -1626,6 +1638,7 @@ TEST_F(BasicSurfaceTest, buffer_can_be_submitted_to_set_stream_after_surface_des
 
     auto surface = std::make_unique<ms::BasicSurface>(
         nullptr, // session
+        mw::Weak<mf::WlSurface>{},
         name,
         rect,
         mir_pointer_unconfined,

--- a/tests/unit-tests/scene/test_mediating_display_changer.cpp
+++ b/tests/unit-tests/scene/test_mediating_display_changer.cpp
@@ -21,6 +21,7 @@
 #include "mir/graphics/display_configuration_policy.h"
 #include "src/server/scene/broadcasting_session_event_sink.h"
 #include "mir/server_action_queue.h"
+#include "mir/wayland/wayland_base.h"
 
 #include "mir/test/doubles/mock_display.h"
 #include "mir/test/doubles/mock_compositor.h"

--- a/tests/unit-tests/scene/test_session_manager.cpp
+++ b/tests/unit-tests/scene/test_session_manager.cpp
@@ -24,7 +24,7 @@
 #include "mir/graphics/display_configuration_observer.h"
 #include "mir/compositor/buffer_stream.h"
 #include "mir/scene/null_surface_observer.h"
-
+#include "mir/wayland/wayland_base.h"
 #include "src/server/scene/basic_surface.h"
 #include "src/include/server/mir/scene/session_event_sink.h"
 #include "src/server/report/null_report_factory.h"
@@ -48,6 +48,7 @@
 #include <gtest/gtest.h>
 
 namespace mf = mir::frontend;
+namespace mw = mir::wayland;
 namespace mi = mir::input;
 namespace ms = mir::scene;
 namespace mg = mir::graphics;
@@ -69,6 +70,7 @@ struct SessionManagerSetup : public testing::Test
 {
     std::shared_ptr<ms::Surface> dummy_surface = std::make_shared<ms::BasicSurface>(
         nullptr /* session */,
+        mw::Weak<mf::WlSurface>{},
         std::string("stub"),
         geom::Rectangle{{},{}},
         mir_pointer_unconfined,
@@ -176,7 +178,7 @@ TEST_F(SessionManagerSessionListenerSetup, additional_listeners_receive_surface_
     auto session = session_manager.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
     auto bs = std::dynamic_pointer_cast<mc::BufferStream>(session->create_buffer_stream(
         mg::BufferProperties{{640, 480}, mir_pixel_format_abgr_8888, mg::BufferUsage::hardware}));
-    session->create_surface(nullptr, mt::make_surface_spec(bs), mt::fake_shared(observer));
+    session->create_surface(nullptr, {}, mt::make_surface_spec(bs), mt::fake_shared(observer));
 }
 
 namespace

--- a/tests/unit-tests/scene/test_surface.cpp
+++ b/tests/unit-tests/scene/test_surface.cpp
@@ -51,6 +51,7 @@ struct SurfaceCreation : public ::testing::Test
     SurfaceCreation()
         : surface(
             nullptr /* session */,
+            {} /* wayland_surface */,
             surface_name,
             rect,
             mir_pointer_unconfined,
@@ -188,6 +189,7 @@ TEST_F(SurfaceCreation, consume_calls_send_event)
     using namespace testing;
     ms::BasicSurface surface(
         nullptr /* session */,
+        {} /* wayland_surface */,
         surface_name,
         rect,
         mir_pointer_unconfined,

--- a/tests/unit-tests/scene/test_surface_impl.cpp
+++ b/tests/unit-tests/scene/test_surface_impl.cpp
@@ -35,6 +35,7 @@
 namespace ms = mir::scene;
 namespace msh = mir::shell;
 namespace mf = mir::frontend;
+namespace mw = mir::wayland;
 namespace mc = mir::compositor;
 namespace mg = mir::graphics;
 namespace mi = mir::input;
@@ -77,6 +78,7 @@ struct Surface : testing::Test
         
         surface = std::make_shared<ms::BasicSurface>(
             nullptr /* session */,
+            mw::Weak<mf::WlSurface>{},
             std::string("stub"),
             geom::Rectangle{{},{}},
             mir_pointer_unconfined,
@@ -272,6 +274,7 @@ TEST_F(Surface, preferred_orientation_mode_defaults_to_any)
 
     ms::BasicSurface surf(
         nullptr /* session */,
+        {} /* wayland_surface */,
         std::string("stub"),
         geom::Rectangle{{},{}},
         mir_pointer_unconfined,

--- a/tests/unit-tests/scene/test_surface_stack.cpp
+++ b/tests/unit-tests/scene/test_surface_stack.cpp
@@ -46,6 +46,8 @@ namespace geom = mir::geometry;
 namespace mt = mir::test;
 namespace mtd = mir::test::doubles;
 namespace mr = mir::report;
+namespace mf = mir::frontend;
+namespace mw = mir::wayland;
 
 namespace
 {
@@ -94,6 +96,7 @@ struct SurfaceStack : public ::testing::Test
 
         stub_surface1 = std::make_shared<ms::BasicSurface>(
             nullptr /* session */,
+            mw::Weak<mf::WlSurface>{},
             std::string("stub"),
             geom::Rectangle{{},{}},
             mir_pointer_unconfined,
@@ -103,6 +106,7 @@ struct SurfaceStack : public ::testing::Test
 
         stub_surface2 = std::make_shared<ms::BasicSurface>(
             nullptr /* session */,
+            mw::Weak<mf::WlSurface>{},
             std::string("stub"),
             geom::Rectangle{{},{}},
             mir_pointer_unconfined,
@@ -113,6 +117,7 @@ struct SurfaceStack : public ::testing::Test
         
         stub_surface3 = std::make_shared<ms::BasicSurface>(
             nullptr /* session */,
+            mw::Weak<mf::WlSurface>{},
             std::string("stub"),
             geom::Rectangle{{},{}},
             mir_pointer_unconfined,
@@ -123,6 +128,7 @@ struct SurfaceStack : public ::testing::Test
         
         invisible_stub_surface = std::make_shared<ms::BasicSurface>(
             nullptr /* session */,
+            mw::Weak<mf::WlSurface>{},
             std::string("stub"),
             geom::Rectangle{{},{}},
             mir_pointer_unconfined,
@@ -239,6 +245,7 @@ TEST_F(SurfaceStack, scene_counts_pending_accurately)
 
     auto surface = std::make_shared<ms::BasicSurface>(
         nullptr /* session */,
+        mw::Weak<mf::WlSurface>{},
         std::string("stub"),
         geom::Rectangle{{},{}},
         mir_pointer_unconfined,
@@ -273,6 +280,7 @@ TEST_F(SurfaceStack, scene_doesnt_count_pending_frames_from_occluded_surfaces)
     auto stream = std::make_shared<mtd::StubBufferStream>();
     auto surface = std::make_shared<ms::BasicSurface>(
         nullptr /* session */,
+        mw::Weak<mf::WlSurface>{},
         std::string("stub"),
         geom::Rectangle{{},{}},
         mir_pointer_unconfined,
@@ -306,6 +314,7 @@ TEST_F(SurfaceStack, scene_doesnt_count_pending_frames_from_partially_exposed_su
     auto stream = std::make_shared<mtd::StubBufferStream>();
     auto surface = std::make_shared<ms::BasicSurface>(
         nullptr /* session */,
+        mw::Weak<mf::WlSurface>{},
         std::string("stub"),
         geom::Rectangle{{},{}},
         mir_pointer_unconfined,
@@ -418,6 +427,7 @@ TEST_F(SurfaceStack, generate_elementelements)
     {
         auto const surface = std::make_shared<ms::BasicSurface>(
             nullptr /* session */,
+            mw::Weak<mf::WlSurface>{},
             std::string("stub"),
             geom::Rectangle{geom::Point{3 * i, 4 * i},geom::Size{1 * i, 2 * i}},
             mir_pointer_unconfined,
@@ -619,6 +629,7 @@ TEST_F(SurfaceStack, scene_elements_hold_snapshot_of_positioning_info)
     {
         auto const surface = std::make_shared<ms::BasicSurface>(
             nullptr /* session */,
+            mw::Weak<mf::WlSurface>{},
             std::string("stub"),
             geom::Rectangle{geom::Point{3 * i, 4 * i},geom::Size{1 * i, 2 * i}},
             mir_pointer_unconfined,
@@ -651,6 +662,7 @@ TEST_F(SurfaceStack, generates_scene_elements_that_delay_buffer_acquisition)
 
     auto const surface = std::make_shared<ms::BasicSurface>(
         nullptr /* session */,
+        mw::Weak<mf::WlSurface>{},
         std::string("stub"),
         geom::Rectangle{geom::Point{3, 4},geom::Size{1, 2}},
         mir_pointer_unconfined,
@@ -680,6 +692,7 @@ TEST_F(SurfaceStack, generates_scene_elements_that_allow_only_one_buffer_acquisi
 
     auto const surface = std::make_shared<ms::BasicSurface>(
         nullptr /* session */,
+        mw::Weak<mf::WlSurface>{},
         std::string("stub"),
         geom::Rectangle{geom::Point{3, 4},geom::Size{1, 2}},
         mir_pointer_unconfined,
@@ -701,6 +714,7 @@ struct MockConfigureSurface : public ms::BasicSurface
 {
     MockConfigureSurface() :
         ms::BasicSurface(
+            {},
             {},
             {},
             {{},{}},

--- a/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
+++ b/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
@@ -79,6 +79,7 @@ struct MockSurface
         : ms::BasicSurface{
               session,
               {},
+              {},
               {{},{}},
               mir_pointer_unconfined,
               { { std::make_shared<testing::NiceMock<mtd::MockBufferStream>>(), {0, 0}, {} } },

--- a/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
+++ b/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
@@ -41,6 +41,8 @@ namespace mc = mir::compositor;
 namespace msh = mir::shell;
 namespace geom = mir::geometry;
 namespace mev = mir::events;
+namespace mf = mir::frontend;
+namespace mw = mir::wayland;
 namespace msd = mir::shell::decoration;
 namespace mt = mir::test;
 namespace mtd = mir::test::doubles;
@@ -133,8 +135,9 @@ struct MockShell
         uint64_t,
         MirResizeEdge));
 
-    MOCK_METHOD3(create_surface, std::shared_ptr<ms::Surface>(
+    MOCK_METHOD4(create_surface, std::shared_ptr<ms::Surface>(
         std::shared_ptr<ms::Session> const&,
+        mw::Weak<mf::WlSurface> const&,
         msh::SurfaceSpecification const&,
         std::shared_ptr<ms::SurfaceObserver> const&));
 
@@ -148,9 +151,10 @@ struct DecorationBasicDecoration
 {
     void SetUp() override
     {
-        ON_CALL(shell, create_surface(_, _, _))
+        ON_CALL(shell, create_surface(_, _, _, _))
             .WillByDefault(Invoke([this](
                     std::shared_ptr<ms::Session> const&,
+                    mw::Weak<mf::WlSurface> const&,
                     msh::SurfaceSpecification const& params,
                     std::shared_ptr<ms::SurfaceObserver> const& observer) -> std::shared_ptr<ms::Surface>
                 {


### PR DESCRIPTION
#2331, and related issues caused us some trouble last release. This PR refactors the way keyboard input is processed internally to make it better match up with how events need to be delivered to Wayland clients.

A new observer is introduced through which both keyboard focus and keyboard events flow. Assuming the executor used preserves ordering of events, this prevents race conditions from causing input to go to non-focused surfaces. It also removes the need for the slightly complex system we previously had where we watched the state of all surfaces to determine the currently focused surface.

Fixes #2331.

~~Marked as draft initially because I still have tests to write.~~ done