### PR TITLE
release/1.8: Fix Alpine/edge (by not using internal GTEST macros for trivial stuff)

### DIFF
--- a/tests/include/mir/test/input_config_matchers.h
+++ b/tests/include/mir/test/input_config_matchers.h
@@ -116,7 +116,7 @@ private:
 
     MatcherVec matchers_;
 
-    GTEST_DISALLOW_ASSIGN_(InputConfigElementsMatcher);
+    void operator=(InputConfigElementsMatcher const&) = delete;
 };
 
 // Multiple specializations because gmock does not decay the parameter type to the


### PR DESCRIPTION
(cherry picked from commit 08671a33714b6dc196d093e962a473730bd8bb5a)