### PR TITLE
Add missing stdexcept include to mirserverhooks

### DIFF
--- a/src/miroil/mir_server_hooks.cpp
+++ b/src/miroil/mir_server_hooks.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <miroil/mir_server_hooks.h>
+#include <stdexcept>
 
 // mir
 #include <mir/server.h>


### PR DESCRIPTION
This fixes a bunch of errors like the following while building against musl libc:
```
  ../src/miroil/mir_server_hooks.cpp: In member function 'std::shared_ptr<mir::scene::PromptSessionManager> miroil::MirServerHooks::the_prompt_session_manager() const':
  ../src/miroil/mir_server_hooks.cpp:164:16: error: 'logic_error' is not a member of 'std'
    164 |     throw std::logic_error("No prompt session manager available. Server not running?");
        |                ^~~~~~~~~~~
```