### PR TITLE
Rename SystemExecutor to ThreadPoolExecutor

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -114,7 +114,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmircommon8 (= ${binary:Version}),
+Depends: libmircommon9 (= ${binary:Version}),
          libmircore-dev (= ${binary:Version}),
          libprotobuf-dev (>= 2.4.1),
          libxkbcommon-dev,
@@ -247,7 +247,7 @@ Description: Display server for Ubuntu - shared library
  .
  Contains the shared libraries required for the Mir server and client.
 
-Package: libmircommon8
+Package: libmircommon9
 Section: libs
 Architecture: linux-any
 Multi-Arch: same

--- a/debian/libmircommon8.install
+++ b/debian/libmircommon8.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmircommon.so.8

--- a/debian/libmircommon9.install
+++ b/debian/libmircommon9.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmircommon.so.9

--- a/include/common/mir/thread_pool_executor.h
+++ b/include/common/mir/thread_pool_executor.h
@@ -29,9 +29,9 @@ public:
     void spawn(std::function<void()>&& work) override;
 
     /**
-     * Set a handler to be called should an unhandled exception occur on the SystemExecutor
+     * Set a handler to be called should an unhandled exception occur on the ThreadPoolExecutor
      *
-     * By default the SystemExecutor will allow exceptions to propagate, resulting in process termination.
+     * By default the ThreadPoolExecutor will allow exceptions to propagate, resulting in process termination.
      *
      * \param handler [in]  A handler that will be called in exception context should an exception escape
      *                      any functor executed by \ref spawn.

--- a/include/common/mir/thread_pool_executor.h
+++ b/include/common/mir/thread_pool_executor.h
@@ -16,14 +16,14 @@
  * Authored By: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
  */
 
-#ifndef MIR_SYSTEM_EXECUTOR_H_
-#define MIR_SYSTEM_EXECUTOR_H_
+#ifndef MIR_THREAD_POOL_EXECUTOR_H_
+#define MIR_THREAD_POOL_EXECUTOR_H_
 
 #include "mir/executor.h"
 
 namespace mir
 {
-class SystemExecutor : public NonBlockingExecutor
+class ThreadPoolExecutor : public NonBlockingExecutor
 {
 public:
     void spawn(std::function<void()>&& work) override;
@@ -44,10 +44,10 @@ public:
      */
     static void quiesce();
 protected:
-    SystemExecutor() = default;
+    ThreadPoolExecutor() = default;
 };
 
-extern NonBlockingExecutor& system_executor;
+extern NonBlockingExecutor& thread_pool_executor;
 }
 
-#endif //MIR_SYSTEM_EXECUTOR_H_
+#endif // MIR_THREAD_POOL_EXECUTOR_H_

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -44,7 +44,7 @@ set(
   PARENT_SCOPE)
 
 # TODO we need a place to manage ABI and related versioning but use this as placeholder
-set(MIRCOMMON_ABI 8)
+set(MIRCOMMON_ABI 9)
 set(symbol_map ${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)
 
 add_library(mircommon SHARED

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -32,8 +32,8 @@ list(APPEND MIR_COMMON_SOURCES
   event_printer.cpp
   mir_cookie.cpp
   mir_cursor_api.cpp
-  system_executor.cpp
-  ${PROJECT_SOURCE_DIR}/include/common/mir/system_executor.h
+  thread_pool_executor.cpp
+  ${PROJECT_SOURCE_DIR}/include/common/mir/thread_pool_executor.h
   linearising_executor.cpp
   ${PROJECT_SOURCE_DIR}/include/common/mir/linearising_executor.h
 )

--- a/src/common/linearising_executor.cpp
+++ b/src/common/linearising_executor.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "mir/linearising_executor.h"
-#include "mir/system_executor.h"
+#include "mir/thread_pool_executor.h"
 
 #include <deque>
 #include <mutex>
@@ -51,7 +51,7 @@ public:
         if (idle)
         {
             idle = false;
-            mir::system_executor.spawn([this]() { work_loop(); });
+            mir::thread_pool_executor.spawn([this]() { work_loop(); });
         }
     }
 

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -1,4 +1,4 @@
-MIR_COMMON_2.5 {
+MIR_COMMON_2.8 {
   global:
   mir_arrow_cursor_name;
   mir_busy_cursor_name;
@@ -65,6 +65,7 @@ MIR_COMMON_2.5 {
   mir_vsplit_resize_cursor_name;
   mir_window_event_get_attribute;
   mir_window_event_get_attribute_value;
+  mir_pointer_event_axis_stop;
 
   extern "C++" {
     mir::events::add_touch*;
@@ -488,15 +489,6 @@ MIR_COMMON_2.5 {
     mir::input::BufferKeymap::matches*;
     typeinfo?for?mir::input::BufferKeymap;
     vtable?for?mir::input::BufferKeymap;
-  };
-  local: *;
-};
-
-MIR_COMMON_2.7 {
-  global:
-  mir_pointer_event_axis_stop;
-
-  extern "C++" {
     mir::events::make_pointer_axis_with_stop_event*;
     mir::SystemExecutor::spawn*;
     mir::SystemExecutor::set_unhandled_exception_handler*;
@@ -505,14 +497,6 @@ MIR_COMMON_2.7 {
     vtable?for?mir::SystemExecutor;
     mir::system_executor;
     mir::linearising_executor;
-  };
-} MIR_COMMON_2.5;
-
-MIR_COMMON_2.8 {
-  global:
-  mir_pointer_event_axis_stop;
-
-  extern "C++" {
     mir::ThreadPoolExecutor::spawn*;
     mir::ThreadPoolExecutor::set_unhandled_exception_handler*;
     mir::ThreadPoolExecutor::quiesce*;
@@ -520,4 +504,5 @@ MIR_COMMON_2.8 {
     vtable?for?mir::ThreadPoolExecutor;
     mir::thread_pool_executor;
   };
-} MIR_COMMON_2.7;
+  local: *;
+};

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -507,3 +507,17 @@ MIR_COMMON_2.7 {
     mir::linearising_executor;
   };
 } MIR_COMMON_2.5;
+
+MIR_COMMON_2.8 {
+  global:
+  mir_pointer_event_axis_stop;
+
+  extern "C++" {
+    mir::ThreadPoolExecutor::spawn*;
+    mir::ThreadPoolExecutor::set_unhandled_exception_handler*;
+    mir::ThreadPoolExecutor::quiesce*;
+    typeinfo?for?mir::ThreadPoolExecutor;
+    vtable?for?mir::ThreadPoolExecutor;
+    mir::thread_pool_executor;
+  };
+} MIR_COMMON_2.7;

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -490,12 +490,6 @@ MIR_COMMON_2.8 {
     typeinfo?for?mir::input::BufferKeymap;
     vtable?for?mir::input::BufferKeymap;
     mir::events::make_pointer_axis_with_stop_event*;
-    mir::SystemExecutor::spawn*;
-    mir::SystemExecutor::set_unhandled_exception_handler*;
-    mir::SystemExecutor::quiesce*;
-    typeinfo?for?mir::SystemExecutor;
-    vtable?for?mir::SystemExecutor;
-    mir::system_executor;
     mir::linearising_executor;
     mir::ThreadPoolExecutor::spawn*;
     mir::ThreadPoolExecutor::set_unhandled_exception_handler*;

--- a/src/common/thread_pool_executor.cpp
+++ b/src/common/thread_pool_executor.cpp
@@ -16,7 +16,7 @@
  * Authored By: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
  */
 
-#include "mir/system_executor.h"
+#include "mir/thread_pool_executor.h"
 
 #include "mir/thread_name.h"
 
@@ -327,23 +327,23 @@ private:
     std::list<std::shared_ptr<Worker>> workers;
 };
 
-ThreadPool system_threadpool;
+ThreadPool thread_pool;
 
 }
 
-mir::NonBlockingExecutor& mir::system_executor = system_threadpool;
+mir::NonBlockingExecutor& mir::thread_pool_executor = thread_pool;
 
-void mir::SystemExecutor::spawn(std::function<void()>&& work)
+void mir::ThreadPoolExecutor::spawn(std::function<void()>&& work)
 {
-    system_threadpool.spawn(std::move(work));
+    thread_pool.spawn(std::move(work));
 }
 
-void mir::SystemExecutor::set_unhandled_exception_handler(void (*handler)())
+void mir::ThreadPoolExecutor::set_unhandled_exception_handler(void (*handler)())
 {
     exception_handler = handler;
 }
 
-void mir::SystemExecutor::quiesce()
+void mir::ThreadPoolExecutor::quiesce()
 {
-    system_threadpool.quiesce();
+    thread_pool.quiesce();
 }

--- a/src/server/compositor/default_configuration.cpp
+++ b/src/server/compositor/default_configuration.cpp
@@ -27,7 +27,7 @@
 #include "null_screen_shooter.h"
 #include "mir/main_loop.h"
 #include "mir/graphics/display.h"
-#include "mir/system_executor.h"
+#include "mir/thread_pool_executor.h"
 #include "mir/renderer/gl/basic_buffer_render_target.h"
 #include "mir/renderer/gl/context.h"
 #include "mir/renderer/renderer.h"
@@ -109,7 +109,7 @@ auto mir::DefaultServerConfiguration::the_screen_shooter() -> std::shared_ptr<co
                 return std::make_shared<compositor::BasicScreenShooter>(
                     the_scene(),
                     the_clock(),
-                    system_executor,
+                    thread_pool_executor,
                     std::move(render_target),
                     std::move(renderer));
             }
@@ -120,7 +120,7 @@ auto mir::DefaultServerConfiguration::the_screen_shooter() -> std::shared_ptr<co
                     "",
                     std::current_exception(),
                     "failed to create BasicScreenShooter");
-                return std::make_shared<compositor::NullScreenShooter>(system_executor);
+                return std::make_shared<compositor::NullScreenShooter>(thread_pool_executor);
             }
         });
 }

--- a/src/server/compositor/multi_threaded_compositor.cpp
+++ b/src/server/compositor/multi_threaded_compositor.cpp
@@ -31,7 +31,7 @@
 #include "mir/raii.h"
 #include "mir/unwind_helpers.h"
 #include "mir/thread_name.h"
-#include "mir/system_executor.h"
+#include "mir/thread_pool_executor.h"
 
 #include <thread>
 #include <chrono>
@@ -383,7 +383,7 @@ void mc::MultiThreadedCompositor::create_compositing_threads()
             display_buffer_compositor_factory, group, scene, display_listener,
             fixed_composite_delay, report);
 
-        mir::system_executor.spawn(std::ref(*thread_functor));
+        mir::thread_pool_executor.spawn(std::ref(*thread_functor));
         thread_functors.push_back(std::move(thread_functor));
     });
 

--- a/src/server/run_mir.cpp
+++ b/src/server/run_mir.cpp
@@ -25,7 +25,7 @@
 #include "mir/frontend/connector.h"
 #include "mir/raii.h"
 #include "mir/emergency_cleanup.h"
-#include "mir/system_executor.h"
+#include "mir/thread_pool_executor.h"
 
 #include <atomic>
 #include <mutex>
@@ -329,11 +329,11 @@ void mir::run_mir(
             }
         });
 
-    mir::SystemExecutor::set_unhandled_exception_handler(&terminate_with_current_exception);
+    mir::ThreadPoolExecutor::set_unhandled_exception_handler(&terminate_with_current_exception);
 
     init(server);
     server.run();
 
-    mir::SystemExecutor::quiesce();
+    mir::ThreadPoolExecutor::quiesce();
     check_for_termination_exception();
 }

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -111,7 +111,7 @@ if (NOT HAVE_PTHREAD_GETNAME_NP)
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/test_threaded_dispatcher.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/frontend/test_basic_connector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compositor/test_multi_threaded_compositor.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_system_executor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_thread_pool_executor.cpp
 
     PROPERTIES COMPILE_DEFINITIONS MIR_DONT_USE_PTHREAD_GETNAME_NP
   )
@@ -119,7 +119,7 @@ if (NOT HAVE_PTHREAD_GETNAME_NP)
   message(WARNING "pthread_getname_np() not supported: Disabling test_basic_connector.cpp tests that rely on it")
   message(WARNING "pthread_getname_np() not supported: Disabling test_multi_threaded_compositor.cpp tests that rely on it")
   message(WARNING "pthread_getname_np() not supported: Disabling test_threaded_snapshot_strategy.cpp tests that rely on it")
-  message(WARNING "pthread_getname_np() not supported: Disabling test_system_executor.cpp tests that rely on it")
+  message(WARNING "pthread_getname_np() not supported: Disabling test_thread_pool_executor.cpp tests that rely on it")
 endif()
 
 link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -72,7 +72,7 @@ set(
   test_observer_multiplexer.cpp
   test_edid.cpp
   test_report_exception.cpp
-  test_system_executor.cpp
+  test_thread_pool_executor.cpp
   test_linearising_executor.cpp
 )
 


### PR DESCRIPTION
I've previously discussed this with @RAOF. I think thread pool is a more obvious name. I don't think external code is using `SystemExecutor` but might be a no-go because of ABI stability?