### PR TITLE
Modernize surface observer

### DIFF
--- a/include/test/mir/test/doubles/stub_session.h
+++ b/include/test/mir/test/doubles/stub_session.h
@@ -58,7 +58,8 @@ struct StubSession : scene::Session
         std::shared_ptr<Session> const& session,
         wayland::Weak<frontend::WlSurface> const& wayland_surface,
         shell::SurfaceSpecification const& params,
-        std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<scene::Surface> override;
+        std::shared_ptr<scene::SurfaceObserver> const& observer,
+        Executor* observer_executor) -> std::shared_ptr<scene::Surface> override;
 
     void destroy_surface(std::shared_ptr<scene::Surface> const& surface) override;
 

--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -64,8 +64,9 @@ struct StubSurface : scene::Surface
     auto wayland_surface() -> wayland::Weak<frontend::WlSurface> const& override { abort(); }
     void request_client_surface_close() override {}
     std::shared_ptr<Surface> parent() const override { return nullptr; }
-    void add_observer(std::shared_ptr<scene::SurfaceObserver> const&) override {}
-    void remove_observer(std::weak_ptr<scene::SurfaceObserver> const&) override {}
+    void register_interest(std::weak_ptr<scene::SurfaceObserver> const&) override {}
+    void register_interest(std::weak_ptr<scene::SurfaceObserver> const&, Executor&) override {}
+    void unregister_interest(scene::SurfaceObserver const&) override {}
     void rename(std::string const&) override {}
     void set_confine_pointer_state(MirPointerConfinementState) override {}
     MirPointerConfinementState confine_pointer_state() const override { return mir_pointer_unconfined; }

--- a/src/include/server/mir/scene/scene_change_notification.h
+++ b/src/include/server/mir/scene/scene_change_notification.h
@@ -56,7 +56,7 @@ private:
     std::function<void(int frames, mir::geometry::Rectangle const& damage)> const damage_notify_change;
 
     std::mutex surface_observers_guard;
-    std::map<Surface*, std::weak_ptr<SurfaceObserver>> surface_observers;
+    std::map<Surface*, std::shared_ptr<SurfaceObserver>> surface_observers;
     
     void add_surface_observer(Surface* surface);
 };

--- a/src/include/server/mir/scene/session.h
+++ b/src/include/server/mir/scene/session.h
@@ -31,6 +31,7 @@
 namespace mir
 {
 class ClientVisibleError;
+class Executor;
 namespace compositor
 {
 class BufferStream;
@@ -96,7 +97,8 @@ public:
         std::shared_ptr<Session> const& session,
         wayland::Weak<frontend::WlSurface> const& wayland_surface,
         shell::SurfaceSpecification const& params,
-        std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<Surface> = 0;
+        std::shared_ptr<scene::SurfaceObserver> const& observer,
+        Executor* observer_executor) -> std::shared_ptr<Surface> = 0;
     virtual void destroy_surface(std::shared_ptr<Surface> const& surface) = 0;
     virtual auto surface_after(std::shared_ptr<Surface> const& surface) const -> std::shared_ptr<Surface> = 0;
 

--- a/src/include/server/mir/scene/surface.h
+++ b/src/include/server/mir/scene/surface.h
@@ -22,6 +22,7 @@
 #include "mir/frontend/surface.h"
 #include "mir/compositor/compositor_id.h"
 #include "mir/optional_value.h"
+#include "mir/observer_registrar.h"
 #include "surface_state_tracker.h"
 
 #include <vector>
@@ -46,7 +47,8 @@ class Session;
 
 class Surface :
     public input::Surface,
-    public frontend::Surface
+    public frontend::Surface,
+    public ObserverRegistrar<SurfaceObserver>
 {
 public:
     // resolve ambiguous member function names
@@ -94,9 +96,6 @@ public:
     
     virtual void set_cursor_image(std::shared_ptr<graphics::CursorImage> const& image) override = 0;
     virtual std::shared_ptr<graphics::CursorImage> cursor_image() const override = 0;
-
-    virtual void add_observer(std::shared_ptr<SurfaceObserver> const& observer) = 0;
-    virtual void remove_observer(std::weak_ptr<SurfaceObserver> const& observer) = 0;
 
     virtual void set_reception_mode(input::InputReceptionMode mode) = 0;
 

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -17,7 +17,7 @@
 #ifndef MIR_SCENE_SURFACE_OBSERVERS_H_
 #define MIR_SCENE_SURFACE_OBSERVERS_H_
 
-#include "mir/basic_observers.h"
+#include "mir/observer_multiplexer.h"
 #include "mir/scene/surface_observer.h"
 
 namespace mir
@@ -25,12 +25,13 @@ namespace mir
 namespace scene
 {
 
-class SurfaceObservers : public SurfaceObserver, BasicObservers<SurfaceObserver>
+class SurfaceObservers : public ObserverMultiplexer<SurfaceObserver>
 {
 public:
-    using BasicObservers<SurfaceObserver>::add;
-    using BasicObservers<SurfaceObserver>::remove;
-    using BasicObservers<SurfaceObserver>::for_each;
+    SurfaceObservers()
+        : ObserverMultiplexer{immediate_executor}
+    {
+    }
 
     void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) override;
     void window_resized_to(Surface const* surf, geometry::Size const& window_size) override;

--- a/src/include/server/mir/shell/abstract_shell.h
+++ b/src/include/server/mir/shell/abstract_shell.h
@@ -66,7 +66,8 @@ public:
         std::shared_ptr<scene::Session> const& session,
         wayland::Weak<frontend::WlSurface> const& wayland_surface,
         SurfaceSpecification const& params,
-        std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<scene::Surface> override;
+        std::shared_ptr<scene::SurfaceObserver> const& observer,
+        Executor* observer_executor) -> std::shared_ptr<scene::Surface> override;
 
     void surface_ready(std::shared_ptr<scene::Surface> const& surface) override;
 

--- a/src/include/server/mir/shell/shell.h
+++ b/src/include/server/mir/shell/shell.h
@@ -28,6 +28,7 @@
 
 namespace mir
 {
+class Executor;
 namespace wayland
 {
 template<typename>
@@ -84,7 +85,8 @@ public:
         std::shared_ptr<scene::Session> const& session,
         wayland::Weak<frontend::WlSurface> const& wayland_surface,
         SurfaceSpecification const& params,
-        std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<scene::Surface> = 0;
+        std::shared_ptr<scene::SurfaceObserver> const& observer,
+        Executor* observer_executor) -> std::shared_ptr<scene::Surface> = 0;
 
     virtual void surface_ready(std::shared_ptr<scene::Surface> const& surface) = 0;
 

--- a/src/include/server/mir/shell/shell_wrapper.h
+++ b/src/include/server/mir/shell/shell_wrapper.h
@@ -65,7 +65,8 @@ public:
         std::shared_ptr<scene::Session> const& session,
         wayland::Weak<frontend::WlSurface> const& wayland_surface,
         SurfaceSpecification const& params,
-        std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<scene::Surface> override;
+        std::shared_ptr<scene::SurfaceObserver> const& observer,
+        Executor* observer_executor) -> std::shared_ptr<scene::Surface> override;
 
     void surface_ready(std::shared_ptr<scene::Surface> const& surface) override;
 

--- a/src/miroil/surface.cpp
+++ b/src/miroil/surface.cpp
@@ -18,6 +18,7 @@
 #include "mir/scene/surface.h"
 #include "mir/scene/surface_observer.h"
 #include "mir/log.h"
+#include "mir/executor.h"
 
 class miroil::SurfaceObserverImpl : public mir::scene::SurfaceObserver
 {
@@ -175,7 +176,7 @@ void miroil::Surface::add_observer(std::shared_ptr<SurfaceObserver> const& obser
     if (it == observers.end()) {
         std::shared_ptr<SurfaceObserverImpl> impl = std::make_shared<SurfaceObserverImpl>(observer);
         
-        wrapped->register_interest(impl);
+        wrapped->register_interest(impl, mir::immediate_executor);
         observers.insert({observer, impl});
     }
 }

--- a/src/miroil/surface.cpp
+++ b/src/miroil/surface.cpp
@@ -175,7 +175,7 @@ void miroil::Surface::add_observer(std::shared_ptr<SurfaceObserver> const& obser
     if (it == observers.end()) {
         std::shared_ptr<SurfaceObserverImpl> impl = std::make_shared<SurfaceObserverImpl>(observer);
         
-        wrapped->add_observer(impl);
+        wrapped->register_interest(impl);
         observers.insert({observer, impl});
     }
 }
@@ -190,7 +190,7 @@ void miroil::Surface::remove_observer(std::shared_ptr<miroil::SurfaceObserver> c
 {
     auto it = observers.find(observer);
     if (it != observers.end()) {        
-        wrapped->remove_observer(it->second);
+        wrapped->unregister_interest(*it->second);
         observers.erase(it);        
     }
 }

--- a/src/server/compositor/stream.cpp
+++ b/src/server/compositor/stream.cpp
@@ -19,6 +19,7 @@
 #include "dropping_schedule.h"
 #include "mir/graphics/buffer.h"
 #include <boost/throw_exception.hpp>
+#include <math.h>
 
 #include <cmath>
 

--- a/src/server/compositor/stream.h
+++ b/src/server/compositor/stream.h
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <memory>
 #include <set>
+#include <atomic>
 
 namespace mir
 {

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -100,7 +100,6 @@ class ForeignSurfaceObserver
 {
 public:
     ForeignSurfaceObserver(
-        std::shared_ptr<Executor> const& wayland_executor,
         wayland::Weak<ForeignToplevelManagerV1> manager,
         std::shared_ptr<scene::Surface> const& surface);
     ~ForeignSurfaceObserver();
@@ -119,7 +118,6 @@ private:
     void application_id_set_to(scene::Surface const*, std::string const& application_id) override;
     ///@}
 
-    std::shared_ptr<Executor> const wayland_executor;
     wayland::Weak<ForeignToplevelManagerV1> const manager;
 
     std::mutex mutex;
@@ -264,8 +262,8 @@ void mf::ForeignSceneObserver::end_observation()
 void mf::ForeignSceneObserver::create_surface_observer(std::shared_ptr<scene::Surface> const& surface)
 {
     std::lock_guard lock{mutex};
-    auto observer = std::make_shared<ForeignSurfaceObserver>(wayland_executor, manager, surface);
-    surface->register_interest(observer);
+    auto observer = std::make_shared<ForeignSurfaceObserver>(manager, surface);
+    surface->register_interest(observer, *wayland_executor);
     auto insert_result = surface_observers.insert(std::make_pair(surface, observer));
     if (!insert_result.second)
     {
@@ -293,11 +291,9 @@ void mf::ForeignSceneObserver::clear_surface_observers()
 // ForeignSurfaceObserver
 
 mf::ForeignSurfaceObserver::ForeignSurfaceObserver(
-    std::shared_ptr<Executor> const& wayland_executor,
     mw::Weak<ForeignToplevelManagerV1> manager,
     std::shared_ptr<scene::Surface> const& surface)
-    : wayland_executor{wayland_executor},
-      manager{manager},
+    : manager{manager},
       weak_surface{surface}
 {
     std::lock_guard lock{mutex};
@@ -320,16 +316,9 @@ void mf::ForeignSurfaceObserver::with_toplevel_handle(
     std::lock_guard<std::mutex>&,
     std::function<void(ForeignToplevelHandleV1&)>&& action)
 {
-    if (handle)
+    if (handle && *handle)
     {
-        wayland_executor->spawn(
-            [handle = handle, action = std::move(action)]()
-            {
-                if (*handle)
-                {
-                    action(handle->value());
-                }
-            });
+        action(handle->value());
     }
 }
 
@@ -383,23 +372,20 @@ void mf::ForeignSurfaceObserver::create_or_close_toplevel_handle_as_needed(std::
             auto const focused = surface->focus_state();
             auto const state = surface->state_tracker();
 
-            wayland_executor->spawn([manager = manager, handle = handle, surface, name, app_id, focused, state]()
-                {
-                    // If the manager has been destroyed we can't create a toplevel handle
-                    if (!manager)
-                        return;
+            // If the manager has been destroyed we can't create a toplevel handle
+            if (!manager)
+                return;
 
-                    // Remember Wayland objects manage their own lifetime
-                    auto const handle_ptr = new ForeignToplevelHandleV1{manager.value(), surface};
-                    *handle = mw::make_weak(handle_ptr);
+            // Remember Wayland objects manage their own lifetime
+            auto const handle_ptr = new ForeignToplevelHandleV1{manager.value(), surface};
+            *handle = mw::make_weak(handle_ptr);
 
-                    if (!name.empty())
-                        handle->value().send_title_event(name);
-                    if (!app_id.empty())
-                        handle->value().send_app_id_event(app_id);
-                    handle->value().send_state(focused, state);
-                    handle->value().send_done_event();
-                });
+            if (!name.empty())
+                handle->value().send_title_event(name);
+            if (!app_id.empty())
+                handle->value().send_app_id_event(app_id);
+            handle->value().send_state(focused, state);
+            handle->value().send_done_event();
         }
         else
         {

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -265,7 +265,7 @@ void mf::ForeignSceneObserver::create_surface_observer(std::shared_ptr<scene::Su
 {
     std::lock_guard lock{mutex};
     auto observer = std::make_shared<ForeignSurfaceObserver>(wayland_executor, manager, surface);
-    surface->add_observer(observer);
+    surface->register_interest(observer);
     auto insert_result = surface_observers.insert(std::make_pair(surface, observer));
     if (!insert_result.second)
     {
@@ -284,7 +284,7 @@ void mf::ForeignSceneObserver::clear_surface_observers()
         pair.second->cease_and_desist();
         if (auto const surface = pair.first.lock())
         {
-            surface->remove_observer(pair.second);
+            surface->unregister_interest(*pair.second);
         }
     }
     surface_observers.clear();

--- a/src/server/frontend_wayland/pointer_constraints_unstable_v1.cpp
+++ b/src/server/frontend_wayland/pointer_constraints_unstable_v1.cpp
@@ -297,7 +297,7 @@ mir::frontend::LockedPointerV1::LockedPointerV1(
     weak_scene_surface{scene_surface},
     my_surface_observer{std::make_shared<MyWaylandSurfaceObserver>(this, wayland_executor)}
 {
-    scene_surface->add_observer(my_surface_observer);
+    scene_surface->register_interest(my_surface_observer);
 
     shell::SurfaceSpecification mods;
 
@@ -337,7 +337,7 @@ mir::frontend::LockedPointerV1::~LockedPointerV1()
     mark_destroyed();
     if (auto const scene_surface = weak_scene_surface.lock())
     {
-        scene_surface->remove_observer(my_surface_observer);
+        scene_surface->unregister_interest(*my_surface_observer);
         shell::SurfaceSpecification mods;
         mods.confine_pointer = MirPointerConfinementState::mir_pointer_unconfined;
         shell->modify_surface(scene_surface->session().lock(), scene_surface, mods);
@@ -364,7 +364,7 @@ mir::frontend::ConfinedPointerV1::ConfinedPointerV1(
     weak_scene_surface(scene_surface),
     my_surface_observer{std::make_shared<SurfaceObserver>(this, wayland_executor)}
 {
-    scene_surface->add_observer(my_surface_observer);
+    scene_surface->register_interest(my_surface_observer);
 
     shell::SurfaceSpecification mods;
 
@@ -403,7 +403,7 @@ mir::frontend::ConfinedPointerV1::~ConfinedPointerV1()
     mark_destroyed();
     if (auto const scene_surface = weak_scene_surface.lock())
     {
-        scene_surface->remove_observer(my_surface_observer);
+        scene_surface->unregister_interest(*my_surface_observer);
         shell::SurfaceSpecification mods;
         mods.confine_pointer = MirPointerConfinementState::mir_pointer_unconfined;
         shell->modify_surface(scene_surface->session().lock(), scene_surface, mods);

--- a/src/server/frontend_wayland/pointer_constraints_unstable_v1.cpp
+++ b/src/server/frontend_wayland/pointer_constraints_unstable_v1.cpp
@@ -121,11 +121,9 @@ private:
 
 struct LockedPointerV1::MyWaylandSurfaceObserver : ms::NullSurfaceObserver
 {
-    MyWaylandSurfaceObserver(LockedPointerV1* const self, Executor& wayland_executor) :
-        wayland_executor{wayland_executor}, self{self} {}
+    MyWaylandSurfaceObserver(LockedPointerV1* const self) : self{self} {}
 
     void attrib_changed(const scene::Surface* surf, MirWindowAttrib attrib, int value) override;
-    Executor& wayland_executor;
     mw::Weak<LockedPointerV1> const self;
 };
 
@@ -140,27 +138,17 @@ void LockedPointerV1::MyWaylandSurfaceObserver::attrib_changed(
         {
         case mir_pointer_locked_persistent:
         case mir_pointer_locked_oneshot:
-            if (value != mir_window_focus_state_unfocused)
+            if (self)
             {
-                wayland_executor.spawn([self=self]()
-                    {
-                        if (self)
-                        {
-                            self.value().send_locked_event();
-                        }
-                    });
+                if (value == mir_window_focus_state_unfocused)
+                {
+                    self.value().send_unlocked_event();
+                }
+                else
+                {
+                    self.value().send_locked_event();
+                }
             }
-            else
-            {
-                wayland_executor.spawn([self=self]()
-                    {
-                        if (self)
-                        {
-                            self.value().send_unlocked_event();
-                        }
-                    });
-            }
-
             break;
 
         default:
@@ -172,11 +160,9 @@ void LockedPointerV1::MyWaylandSurfaceObserver::attrib_changed(
 
 struct ConfinedPointerV1::SurfaceObserver : ms::NullSurfaceObserver
 {
-    SurfaceObserver(ConfinedPointerV1* const self, Executor& wayland_executor) :
-        wayland_executor{wayland_executor}, self{self} {}
+    SurfaceObserver(ConfinedPointerV1* const self) : self{self} {}
 
     void attrib_changed(const scene::Surface* surf, MirWindowAttrib attrib, int value) override;
-    Executor& wayland_executor;
     mw::Weak<ConfinedPointerV1> const self;
 };
 
@@ -191,27 +177,17 @@ void ConfinedPointerV1::SurfaceObserver::attrib_changed(
         {
         case mir_pointer_confined_persistent:
         case mir_pointer_confined_oneshot:
-            if (value != mir_window_focus_state_unfocused)
+            if (self)
             {
-                wayland_executor.spawn([self=self]()
-                    {
-                        if (self)
-                        {
-                            self.value().send_confined_event();
-                        }
-                    });
+                if (value == mir_window_focus_state_unfocused)
+                {
+                    self.value().send_unconfined_event();
+                }
+                else
+                {
+                    self.value().send_confined_event();
+                }
             }
-            else
-            {
-                wayland_executor.spawn([self=self]()
-                    {
-                        if (self)
-                        {
-                            self.value().send_unconfined_event();
-                        }
-                    });
-            }
-
             break;
 
         default:
@@ -295,9 +271,9 @@ mir::frontend::LockedPointerV1::LockedPointerV1(
     wayland::LockedPointerV1{id, Version<1>{}},
     shell{std::move(shell)},
     weak_scene_surface{scene_surface},
-    my_surface_observer{std::make_shared<MyWaylandSurfaceObserver>(this, wayland_executor)}
+    my_surface_observer{std::make_shared<MyWaylandSurfaceObserver>(this)}
 {
-    scene_surface->register_interest(my_surface_observer);
+    scene_surface->register_interest(my_surface_observer, wayland_executor);
 
     shell::SurfaceSpecification mods;
 
@@ -362,9 +338,9 @@ mir::frontend::ConfinedPointerV1::ConfinedPointerV1(
     wayland::ConfinedPointerV1{id, Version<1>{}},
     shell{std::move(shell)},
     weak_scene_surface(scene_surface),
-    my_surface_observer{std::make_shared<SurfaceObserver>(this, wayland_executor)}
+    my_surface_observer{std::make_shared<SurfaceObserver>(this)}
 {
-    scene_surface->register_interest(my_surface_observer);
+    scene_surface->register_interest(my_surface_observer, wayland_executor);
 
     shell::SurfaceSpecification mods;
 

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -72,6 +72,7 @@ mf::WindowWlSurfaceRole::WindowWlSurfaceRole(
       shell{shell},
       session{weak_client.value().client_session()},
       output_manager{output_manager},
+      wayland_executor{wayland_executor},
       observer{std::make_shared<WaylandSurfaceObserver>(wayland_executor, seat, surface, this)},
       committed_min_size{0, 0},
       committed_max_size{max_possible_size}
@@ -443,7 +444,7 @@ void mf::WindowWlSurfaceRole::create_scene_surface()
     mods.input_shape = std::vector<geom::Rectangle>{};
     surface.value().populate_surface_data(mods.streams.value(), mods.input_shape.value(), {});
 
-    auto const scene_surface = shell->create_surface(session, surface, mods, observer);
+    auto const scene_surface = shell->create_surface(session, surface, mods, observer, &wayland_executor);
     weak_scene_surface = scene_surface;
 
     if (mods.min_width)  committed_min_size.width  = mods.min_width.value();

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -126,6 +126,7 @@ private:
     std::shared_ptr<shell::Shell> const shell;
     std::shared_ptr<scene::Session> const session;
     OutputManager* output_manager;
+    Executor& wayland_executor;
     std::shared_ptr<WaylandSurfaceObserver> const observer;
     bool scene_surface_marked_ready{false};
     std::weak_ptr<scene::Surface> weak_scene_surface;

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -490,7 +490,7 @@ void mf::XWaylandSurface::close()
 
     if (scene_surface && observer)
     {
-        scene_surface->remove_observer(observer);
+        scene_surface->unregister_interest(*observer);
     }
 
     if (scene_surface)

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -785,7 +785,7 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
         prep_surface_spec(lock, spec);
     }
 
-    auto const surface = shell->create_surface(session, mw::make_weak(wl_surface), spec, observer);
+    auto const surface = shell->create_surface(session, mw::make_weak(wl_surface), spec, observer, nullptr);
     inform_client_of_window_state(state);
     auto const top_left = scaled_top_left_of(*surface) + scaled_content_offset_of(*surface);
     auto const size = scaled_content_size_of(*surface);

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -53,7 +53,7 @@ struct InputDispatcherSceneObserver :
 
     void surface_added(std::shared_ptr<ms::Surface> const& surface) override
     {
-        surface->add_observer(shared_from_this());
+        surface->register_interest(shared_from_this());
     }
 
     void surface_removed(std::shared_ptr<ms::Surface> const& surface) override
@@ -63,7 +63,7 @@ struct InputDispatcherSceneObserver :
 
     void surface_exists(std::shared_ptr<ms::Surface> const& surface) override
     {
-        surface->add_observer(shared_from_this());
+        surface->register_interest(shared_from_this());
     }
 
     void attrib_changed(ms::Surface const*, MirWindowAttrib /*attrib*/, int /*value*/) override
@@ -159,17 +159,8 @@ mi::SurfaceInputDispatcher::SurfaceInputDispatcher(std::shared_ptr<mi::Scene> co
 mi::SurfaceInputDispatcher::~SurfaceInputDispatcher()
 {
     scene->remove_observer(scene_observer);
-    scene->for_each(
-        [this](auto surface)
-        {
-            // Everything *should* be a scene::Surface, but let's not crash if it isn't.
-            if (auto scene_surf = std::dynamic_pointer_cast<ms::Surface>(surface))
-            {
-                // We *know* scene_observer is an InputDispatcherSceneObserver
-                scene_surf->remove_observer(
-                    std::static_pointer_cast<InputDispatcherSceneObserver>(scene_observer));
-            }
-        });
+
+    // It's safe to destroy a surface observer without unregistering it
 }
 
 namespace

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -53,7 +53,7 @@ struct InputDispatcherSceneObserver :
 
     void surface_added(std::shared_ptr<ms::Surface> const& surface) override
     {
-        surface->register_interest(shared_from_this());
+        surface->register_interest(shared_from_this(), mir::immediate_executor);
     }
 
     void surface_removed(std::shared_ptr<ms::Surface> const& surface) override

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -110,7 +110,7 @@ auto ms::ApplicationSession::create_surface(
     surface_stack->add_surface(surface, input_mode);
 
     if (observer)
-        surface->add_observer(observer);
+        surface->register_interest(observer);
 
     {
         std::unique_lock lock(surfaces_and_streams_mutex);

--- a/src/server/scene/application_session.cpp
+++ b/src/server/scene/application_session.cpp
@@ -81,7 +81,8 @@ auto ms::ApplicationSession::create_surface(
     std::shared_ptr<Session> const& session,
     wayland::Weak<frontend::WlSurface> const& wayland_surface,
     shell::SurfaceSpecification const& the_params,
-    std::shared_ptr<ms::SurfaceObserver> const& observer) -> std::shared_ptr<Surface>
+    std::shared_ptr<ms::SurfaceObserver> const& observer,
+    Executor* observer_executor) -> std::shared_ptr<Surface>
 {
     if (session && session.get() != this)
         fatal_error("Incorrect session");
@@ -109,8 +110,14 @@ auto ms::ApplicationSession::create_surface(
     auto const input_mode = params.input_mode.is_set() ? params.input_mode.value() : input::InputReceptionMode::normal;
     surface_stack->add_surface(surface, input_mode);
 
-    if (observer)
+    if (observer && observer_executor)
+    {
+        surface->register_interest(observer, *observer_executor);
+    }
+    else if (observer)
+    {
         surface->register_interest(observer);
+    }
 
     {
         std::unique_lock lock(surfaces_and_streams_mutex);

--- a/src/server/scene/application_session.h
+++ b/src/server/scene/application_session.h
@@ -60,7 +60,8 @@ public:
         std::shared_ptr<Session> const& session,
         wayland::Weak<frontend::WlSurface> const& wayland_surface,
         shell::SurfaceSpecification const& params,
-        std::shared_ptr<scene::SurfaceObserver> const& observer) -> std::shared_ptr<Surface> override;
+        std::shared_ptr<scene::SurfaceObserver> const& observer,
+        Executor* observer_executor) -> std::shared_ptr<Surface> override;
     void destroy_surface(std::shared_ptr<Surface> const& surface) override;
     auto surface_after(std::shared_ptr<Surface> const& sruface) const -> std::shared_ptr<Surface> override;
 

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -46,7 +46,7 @@ class ms::BasicSurface::Multiplexer : public ObserverMultiplexer<SurfaceObserver
 {
 public:
     Multiplexer()
-        : ObserverMultiplexer{immediate_executor}
+        : ObserverMultiplexer{linearising_executor}
     {
     }
 

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -43,118 +43,99 @@ namespace mrs = mir::renderer::software;
 
 void ms::SurfaceObservers::attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->attrib_changed(surf, attrib, value); });
+    for_each_observer(&SurfaceObserver::attrib_changed, surf, attrib, value);
 }
 
 void ms::SurfaceObservers::window_resized_to(Surface const* surf, geometry::Size const& window_size)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->window_resized_to(surf, window_size); });
+    for_each_observer(&SurfaceObserver::window_resized_to, surf, window_size);
 }
 
 void ms::SurfaceObservers::content_resized_to(Surface const* surf, geometry::Size const& content_size)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->content_resized_to(surf, content_size); });
+    for_each_observer(&SurfaceObserver::content_resized_to, surf, content_size);
 }
 
 void ms::SurfaceObservers::moved_to(Surface const* surf, geometry::Point const& top_left)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->moved_to(surf, top_left); });
+    for_each_observer(&SurfaceObserver::moved_to, surf, top_left);
 }
 
 void ms::SurfaceObservers::hidden_set_to(Surface const* surf, bool hide)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->hidden_set_to(surf, hide); });
+    for_each_observer(&SurfaceObserver::hidden_set_to, surf, hide);
 }
 
 void ms::SurfaceObservers::frame_posted(Surface const* surf, int frames_available, geometry::Rectangle const& damage)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->frame_posted(surf, frames_available, damage); });
+    for_each_observer(&SurfaceObserver::frame_posted, surf, frames_available, damage);
 }
 
 void ms::SurfaceObservers::alpha_set_to(Surface const* surf, float alpha)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->alpha_set_to(surf, alpha); });
+    for_each_observer(&SurfaceObserver::alpha_set_to, surf, alpha);
 }
 
 void ms::SurfaceObservers::orientation_set_to(Surface const* surf, MirOrientation orientation)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->orientation_set_to(surf, orientation); });
+    for_each_observer(&SurfaceObserver::orientation_set_to, surf, orientation);
 }
 
 void ms::SurfaceObservers::transformation_set_to(Surface const* surf, glm::mat4 const& t)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->transformation_set_to(surf, t); });
+    for_each_observer(&SurfaceObserver::transformation_set_to, surf, t);
 }
 
 void ms::SurfaceObservers::cursor_image_set_to(
     Surface const* surf,
     std::weak_ptr<mir::graphics::CursorImage> const& image)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->cursor_image_set_to(surf, image); });
+    for_each_observer(&SurfaceObserver::cursor_image_set_to, surf, image);
 }
 
 void ms::SurfaceObservers::reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->reception_mode_set_to(surf, mode); });
+    for_each_observer(&SurfaceObserver::reception_mode_set_to, surf, mode);
 }
 
 void ms::SurfaceObservers::client_surface_close_requested(Surface const* surf)
 {
-    for_each([&surf](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->client_surface_close_requested(surf); });
+    for_each_observer(&SurfaceObserver::client_surface_close_requested, surf);
 }
 
 void ms::SurfaceObservers::renamed(Surface const* surf, std::string const& name)
 {
-    for_each([&surf, name](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->renamed(surf, name); });
+    for_each_observer(&SurfaceObserver::renamed, surf, name);
 }
 
 void ms::SurfaceObservers::cursor_image_removed(Surface const* surf)
 {
-    for_each([&surf](std::shared_ptr<SurfaceObserver> const& observer)
-        { observer->cursor_image_removed(surf); });
+    for_each_observer(&SurfaceObserver::cursor_image_removed, surf);
 }
 
 void ms::SurfaceObservers::placed_relative(Surface const* surf, geometry::Rectangle const& placement)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-                 { observer->placed_relative(surf, placement); });
+    for_each_observer(&SurfaceObserver::placed_relative, surf, placement);
 }
 
 void ms::SurfaceObservers::input_consumed(Surface const* surf, std::shared_ptr<MirEvent const> const& event)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-                 { observer->input_consumed(surf, event); });
+    for_each_observer(&SurfaceObserver::input_consumed, surf, event);
 }
 
 void ms::SurfaceObservers::start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-                 { observer->start_drag_and_drop(surf, handle); });
+    for_each_observer(&SurfaceObserver::start_drag_and_drop, surf, handle);
 }
 
 void ms::SurfaceObservers::depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-                 { observer->depth_layer_set_to(surf, depth_layer); });
+    for_each_observer(&SurfaceObserver::depth_layer_set_to, surf, depth_layer);
 }
 
 void ms::SurfaceObservers::application_id_set_to(Surface const* surf, std::string const& application_id)
 {
-    for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
-                 { observer->application_id_set_to(surf, application_id); });
+    for_each_observer(&SurfaceObserver::application_id_set_to, surf, application_id);
 }
 
 namespace
@@ -236,6 +217,21 @@ ms::BasicSurface::~BasicSurface() noexcept
     auto state = synchronised_state.lock();
     clear_frame_posted_callbacks(*state);
     report->surface_deleted(this, state->surface_name);
+}
+
+void ms::BasicSurface::register_interest(std::weak_ptr<SurfaceObserver> const& observer)
+{
+    observers->register_interest(observer);
+}
+
+void ms::BasicSurface::register_interest(std::weak_ptr<SurfaceObserver> const& observer, Executor& executor)
+{
+    observers->register_interest(observer, executor);
+}
+
+void ms::BasicSurface::unregister_interest(SurfaceObserver const& observer)
+{
+    observers->unregister_interest(observer);
 }
 
 std::string ms::BasicSurface::name() const
@@ -662,19 +658,6 @@ MirWindowVisibility ms::BasicSurface::set_visibility(MirWindowVisibility new_vis
     }
 
     return new_visibility;
-}
-
-void ms::BasicSurface::add_observer(std::shared_ptr<SurfaceObserver> const& observer)
-{
-    observers->add(observer);
-}
-
-void ms::BasicSurface::remove_observer(std::weak_ptr<SurfaceObserver> const& observer)
-{
-    auto o = observer.lock();
-    if (!o)
-        BOOST_THROW_EXCEPTION(std::runtime_error("Invalid observer (previously destroyed)"));
-    observers->remove(o);
 }
 
 std::shared_ptr<ms::Surface> ms::BasicSurface::parent() const

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -22,6 +22,7 @@
 #include "mir/graphics/pixel_format_utils.h"
 #include "mir/geometry/displacement.h"
 #include "mir/renderer/sw/pixel_source.h"
+#include "mir/observer_multiplexer.h"
 
 #include "mir/scene/scene_report.h"
 #include "mir/scene/null_surface_observer.h"
@@ -41,102 +42,109 @@ namespace mw = mir::wayland;
 namespace geom = mir::geometry;
 namespace mrs = mir::renderer::software;
 
-void ms::SurfaceObservers::attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value)
+class ms::BasicSurface::Multiplexer : public ObserverMultiplexer<SurfaceObserver>
 {
-    for_each_observer(&SurfaceObserver::attrib_changed, surf, attrib, value);
-}
+public:
+    Multiplexer()
+        : ObserverMultiplexer{immediate_executor}
+    {
+    }
 
-void ms::SurfaceObservers::window_resized_to(Surface const* surf, geometry::Size const& window_size)
-{
-    for_each_observer(&SurfaceObserver::window_resized_to, surf, window_size);
-}
+    void attrib_changed(Surface const* surf, MirWindowAttrib attrib, int value) override
+    {
+        for_each_observer(&SurfaceObserver::attrib_changed, surf, attrib, value);
+    }
 
-void ms::SurfaceObservers::content_resized_to(Surface const* surf, geometry::Size const& content_size)
-{
-    for_each_observer(&SurfaceObserver::content_resized_to, surf, content_size);
-}
+    void window_resized_to(Surface const* surf, geometry::Size const& window_size) override
+    {
+        for_each_observer(&SurfaceObserver::window_resized_to, surf, window_size);
+    }
 
-void ms::SurfaceObservers::moved_to(Surface const* surf, geometry::Point const& top_left)
-{
-    for_each_observer(&SurfaceObserver::moved_to, surf, top_left);
-}
+    void content_resized_to(Surface const* surf, geometry::Size const& content_size) override
+    {
+        for_each_observer(&SurfaceObserver::content_resized_to, surf, content_size);
+    }
 
-void ms::SurfaceObservers::hidden_set_to(Surface const* surf, bool hide)
-{
-    for_each_observer(&SurfaceObserver::hidden_set_to, surf, hide);
-}
+    void moved_to(Surface const* surf, geometry::Point const& top_left) override
+    {
+        for_each_observer(&SurfaceObserver::moved_to, surf, top_left);
+    }
 
-void ms::SurfaceObservers::frame_posted(Surface const* surf, int frames_available, geometry::Rectangle const& damage)
-{
-    for_each_observer(&SurfaceObserver::frame_posted, surf, frames_available, damage);
-}
+    void hidden_set_to(Surface const* surf, bool hide) override
+    {
+        for_each_observer(&SurfaceObserver::hidden_set_to, surf, hide);
+    }
 
-void ms::SurfaceObservers::alpha_set_to(Surface const* surf, float alpha)
-{
-    for_each_observer(&SurfaceObserver::alpha_set_to, surf, alpha);
-}
+    void frame_posted(Surface const* surf, int frames_available, geometry::Rectangle const& damage) override
+    {
+        for_each_observer(&SurfaceObserver::frame_posted, surf, frames_available, damage);
+    }
 
-void ms::SurfaceObservers::orientation_set_to(Surface const* surf, MirOrientation orientation)
-{
-    for_each_observer(&SurfaceObserver::orientation_set_to, surf, orientation);
-}
+    void alpha_set_to(Surface const* surf, float alpha) override
+    {
+        for_each_observer(&SurfaceObserver::alpha_set_to, surf, alpha);
+    }
 
-void ms::SurfaceObservers::transformation_set_to(Surface const* surf, glm::mat4 const& t)
-{
-    for_each_observer(&SurfaceObserver::transformation_set_to, surf, t);
-}
+    void orientation_set_to(Surface const* surf, MirOrientation orientation) override
+    {
+        for_each_observer(&SurfaceObserver::orientation_set_to, surf, orientation);
+    }
 
-void ms::SurfaceObservers::cursor_image_set_to(
-    Surface const* surf,
-    std::weak_ptr<mir::graphics::CursorImage> const& image)
-{
-    for_each_observer(&SurfaceObserver::cursor_image_set_to, surf, image);
-}
+    void transformation_set_to(Surface const* surf, glm::mat4 const& t) override
+    {
+        for_each_observer(&SurfaceObserver::transformation_set_to, surf, t);
+    }
 
-void ms::SurfaceObservers::reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode)
-{
-    for_each_observer(&SurfaceObserver::reception_mode_set_to, surf, mode);
-}
+    void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) override
+    {
+        for_each_observer(&SurfaceObserver::reception_mode_set_to, surf, mode);
+    }
 
-void ms::SurfaceObservers::client_surface_close_requested(Surface const* surf)
-{
-    for_each_observer(&SurfaceObserver::client_surface_close_requested, surf);
-}
+    void cursor_image_set_to(Surface const* surf, std::weak_ptr<graphics::CursorImage> const& image) override
+    {
+        for_each_observer(&SurfaceObserver::cursor_image_set_to, surf, image);
+    }
 
-void ms::SurfaceObservers::renamed(Surface const* surf, std::string const& name)
-{
-    for_each_observer(&SurfaceObserver::renamed, surf, name);
-}
+    void client_surface_close_requested(Surface const* surf) override
+    {
+        for_each_observer(&SurfaceObserver::client_surface_close_requested, surf);
+    }
 
-void ms::SurfaceObservers::cursor_image_removed(Surface const* surf)
-{
-    for_each_observer(&SurfaceObserver::cursor_image_removed, surf);
-}
+    void renamed(Surface const* surf, std::string const& name) override
+    {
+        for_each_observer(&SurfaceObserver::renamed, surf, name);
+    }
 
-void ms::SurfaceObservers::placed_relative(Surface const* surf, geometry::Rectangle const& placement)
-{
-    for_each_observer(&SurfaceObserver::placed_relative, surf, placement);
-}
+    void cursor_image_removed(Surface const* surf) override
+    {
+        for_each_observer(&SurfaceObserver::cursor_image_removed, surf);
+    }
 
-void ms::SurfaceObservers::input_consumed(Surface const* surf, std::shared_ptr<MirEvent const> const& event)
-{
-    for_each_observer(&SurfaceObserver::input_consumed, surf, event);
-}
+    void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override
+    {
+        for_each_observer(&SurfaceObserver::placed_relative, surf, placement);
+    }
 
-void ms::SurfaceObservers::start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle)
-{
-    for_each_observer(&SurfaceObserver::start_drag_and_drop, surf, handle);
-}
+    void input_consumed(Surface const* surf, std::shared_ptr<MirEvent const> const& event) override
+    {
+        for_each_observer(&SurfaceObserver::input_consumed, surf, event);
+    }
 
-void ms::SurfaceObservers::depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer)
-{
-    for_each_observer(&SurfaceObserver::depth_layer_set_to, surf, depth_layer);
-}
+    void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override
+    {
+        for_each_observer(&SurfaceObserver::start_drag_and_drop, surf, handle);
+    }
 
-void ms::SurfaceObservers::application_id_set_to(Surface const* surf, std::string const& application_id)
-{
-    for_each_observer(&SurfaceObserver::application_id_set_to, surf, application_id);
-}
+    void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override
+    {
+        for_each_observer(&SurfaceObserver::depth_layer_set_to, surf, depth_layer);
+    }
+
+    void application_id_set_to(Surface const* surf, std::string const& application_id) override
+    {
+        for_each_observer(&SurfaceObserver::application_id_set_to, surf, application_id);
+    }
+};
 
 namespace
 {
@@ -150,10 +158,6 @@ std::shared_ptr<mc::BufferStream> default_stream(std::list<ms::StreamInfo> const
         return layers.front().stream;
 }
 
-auto weak(std::shared_ptr<ms::SurfaceObservers>& observers) -> std::weak_ptr<ms::SurfaceObservers>
-{
-    return observers;
-}
 }
 
 ms::BasicSurface::BasicSurface(
@@ -179,6 +183,7 @@ ms::BasicSurface::BasicSurface(
             .confine_pointer_state = confinement_state,
         }
     },
+    observers(std::make_shared<Multiplexer>()),
     session_{session},
     surface_buffer_stream(default_stream(layers)),
     report(report),
@@ -945,7 +950,7 @@ void mir::scene::BasicSurface::update_frame_posted_callbacks(State& state)
     {
         auto const position = geom::Point{} + state.margins.left + state.margins.top + layer.displacement;
         layer.stream->set_frame_posted_callback(
-            [this, observers=weak(observers), position, explicit_size=layer.size, stream=layer.stream.get()]
+            [this, observers=std::weak_ptr{observers}, position, explicit_size=layer.size, stream=layer.stream.get()]
                 (auto const&)
             {
                 auto const logical_size = explicit_size ? explicit_size.value() : stream->stream_size();

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -79,6 +79,10 @@ public:
 
     ~BasicSurface() noexcept;
 
+    void register_interest(std::weak_ptr<SurfaceObserver> const& observer) override;
+    void register_interest(std::weak_ptr<SurfaceObserver> const& observer, Executor& executor) override;
+    void unregister_interest(SurfaceObserver const& observer) override;
+
     std::string name() const override;
     void move_to(geometry::Point const& top_left) override;
 
@@ -131,9 +135,6 @@ public:
     void request_client_surface_close() override;
 
     std::shared_ptr<Surface> parent() const override;
-
-    void add_observer(std::shared_ptr<SurfaceObserver> const& observer) override;
-    void remove_observer(std::weak_ptr<SurfaceObserver> const& observer) override;
 
     int dpi() const;
 

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -18,9 +18,7 @@
 #define MIR_SCENE_BASIC_SURFACE_H_
 
 #include "mir/scene/surface.h"
-#include "mir/basic_observers.h"
 #include "mir/proof_of_mutex_lock.h"
-#include "mir/scene/surface_observers.h"
 #include "mir/wayland/wayland_base.h"
 #include "mir/geometry/rectangle.h"
 #include "mir_toolkit/common.h"
@@ -170,6 +168,7 @@ public:
 
 private:
     struct State;
+    class Multiplexer;
 
     bool visible(State const& state) const;
     MirWindowType set_type(MirWindowType t);  // Use configure() to make public changes
@@ -182,8 +181,6 @@ private:
     void update_frame_posted_callbacks(State& state);
     auto content_size(State const& state) const -> geometry::Size;
     auto content_top_left(State const& state) const -> geometry::Point;
-
-    std::shared_ptr<SurfaceObservers> observers = std::make_shared<SurfaceObservers>();
 
     struct State
     {
@@ -222,8 +219,8 @@ private:
     };
     mir::Synchronised<State> synchronised_state;
 
+    std::shared_ptr<Multiplexer> const observers;
     std::weak_ptr<Session> const session_;
-
     std::shared_ptr<compositor::BufferStream> const surface_buffer_stream;
     std::shared_ptr<SceneReport> const report;
     std::weak_ptr<Surface> const parent_;

--- a/src/server/scene/scene_change_notification.cpp
+++ b/src/server/scene/scene_change_notification.cpp
@@ -48,7 +48,7 @@ void ms::SceneChangeNotification::add_surface_observer(ms::Surface* surface)
         };
 
     auto observer = std::make_shared<SurfaceChangeNotification>(surface, notifier, damage_notify_change);
-    surface->add_observer(observer);
+    surface->register_interest(observer);
 
     std::unique_lock lg(surface_observers_guard);
     surface_observers[surface] = observer;
@@ -75,7 +75,7 @@ void ms::SceneChangeNotification::surface_removed(std::shared_ptr<ms::Surface> c
         auto it = surface_observers.find(surface.get());
         if (it != surface_observers.end())
         {
-            surface->remove_observer(it->second);
+            surface->unregister_interest(*it->second);
             surface_observers.erase(it);
         }
     }
@@ -101,7 +101,9 @@ void ms::SceneChangeNotification::end_observation()
     {
         auto surface = kv.first;
         if (surface)
-            surface->remove_observer(kv.second);
+        {
+            surface->unregister_interest(*kv.second);
+        }
     }
     surface_observers.clear();
 }

--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -22,6 +22,7 @@
 #include "mir/compositor/scene_element.h"
 #include "mir/graphics/renderable.h"
 #include "mir/depth_layer.h"
+#include "mir/executor.h"
 
 #include <boost/throw_exception.hpp>
 
@@ -266,7 +267,7 @@ void ms::SurfaceStack::add_surface(
         RecursiveWriteLock lg(guard);
         insert_surface_at_top_of_depth_layer(surface);
         create_rendering_tracker_for(surface);
-        surface->register_interest(surface_observer);
+        surface->register_interest(surface_observer, immediate_executor);
     }
     surface->set_reception_mode(input_mode);
     observers.surface_added(surface);

--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -141,7 +141,7 @@ ms::SurfaceStack::~SurfaceStack() noexcept(true)
     {
         for (auto const& surface : layer)
         {
-            surface->remove_observer(surface_observer);
+            surface->unregister_interest(*surface_observer);
         }
     }
 }
@@ -266,7 +266,7 @@ void ms::SurfaceStack::add_surface(
         RecursiveWriteLock lg(guard);
         insert_surface_at_top_of_depth_layer(surface);
         create_rendering_tracker_for(surface);
-        surface->add_observer(surface_observer);
+        surface->register_interest(surface_observer);
     }
     surface->set_reception_mode(input_mode);
     observers.surface_added(surface);
@@ -290,7 +290,7 @@ void ms::SurfaceStack::remove_surface(std::weak_ptr<Surface> const& surface)
             {
                 layer.erase(surface);
                 rendering_trackers.erase(keep_alive.get());
-                keep_alive->remove_observer(surface_observer);
+                keep_alive->unregister_interest(*surface_observer);
                 found_surface = true;
                 break;
             }

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -190,12 +190,13 @@ auto msh::AbstractShell::create_surface(
     std::shared_ptr<ms::Session> const& session,
     wayland::Weak<frontend::WlSurface> const& wayland_surface,
     SurfaceSpecification const& spec,
-    std::shared_ptr<ms::SurfaceObserver> const& observer) -> std::shared_ptr<ms::Surface>
+    std::shared_ptr<ms::SurfaceObserver> const& observer,
+    Executor* observer_executor) -> std::shared_ptr<ms::Surface>
 {
     // Instead of a shared pointer, a local variable could be used and the lambda could capture a reference to it
     // This should be safe, but could be the source of nasty bugs and crashes if the wm did something unexpected
     auto const should_decorate = std::make_shared<bool>(false);
-    auto const build = [observer, should_decorate, wayland_surface](
+    auto const build = [observer, observer_executor, should_decorate, wayland_surface](
             std::shared_ptr<ms::Session> const& session,
             msh::SurfaceSpecification const& placed_params)
         {
@@ -203,7 +204,7 @@ auto msh::AbstractShell::create_surface(
             {
                 *should_decorate = true;
             }
-            return session->create_surface(session, wayland_surface, placed_params, observer);
+            return session->create_surface(session, wayland_surface, placed_params, observer, observer_executor);
         };
 
     auto const result = window_manager->add_surface(session, spec, build);

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -145,7 +145,7 @@ msh::AbstractShell::~AbstractShell() noexcept
     decoration_manager->undecorate_all();
     if (auto const current_keyboard_focus = notified_keyboard_focus_surface.lock())
     {
-        current_keyboard_focus->remove_observer(surface_confinement_updater);
+        current_keyboard_focus->unregister_interest(*surface_confinement_updater);
     }
 }
 
@@ -509,7 +509,7 @@ void msh::AbstractShell::set_keyboard_focus_surface(
 
     if (current_keyboard_focus)
     {
-        current_keyboard_focus->remove_observer(surface_confinement_updater);
+        current_keyboard_focus->unregister_interest(*surface_confinement_updater);
 
         switch (current_keyboard_focus->confine_pointer_state())
         {
@@ -530,7 +530,7 @@ void msh::AbstractShell::set_keyboard_focus_surface(
         input_targeter->set_focus(new_keyboard_focus_surface);
         new_keyboard_focus_surface->consume(seat->create_device_state());
         surface_confinement_updater->set_focus_surface(new_keyboard_focus_surface);
-        new_keyboard_focus_surface->add_observer(surface_confinement_updater);
+        new_keyboard_focus_surface->register_interest(surface_confinement_updater);
     }
     else
     {

--- a/src/server/shell/decoration/basic_decoration.cpp
+++ b/src/server/shell/decoration/basic_decoration.cpp
@@ -291,7 +291,7 @@ auto msd::BasicDecoration::create_surface() const -> std::shared_ptr<scene::Surf
             mg::BufferUsage::software}),
         {},
         {}}};
-    return shell->create_surface(session, {}, params, nullptr);
+    return shell->create_surface(session, {}, params, nullptr, nullptr);
 }
 
 void msd::BasicDecoration::update(

--- a/src/server/shell/decoration/input.cpp
+++ b/src/server/shell/decoration/input.cpp
@@ -141,12 +141,12 @@ msd::InputManager::InputManager(
 {
     set_cursor(mir_resize_edge_none);
     update_window_state(window_state);
-    decoration_surface->add_observer(observer);
+    decoration_surface->register_interest(observer);
 }
 
 msd::InputManager::~InputManager()
 {
-    decoration_surface->remove_observer(observer);
+    decoration_surface->unregister_interest(*observer);
 }
 
 void msd::InputManager::update_window_state(WindowState const& window_state)

--- a/src/server/shell/decoration/window.cpp
+++ b/src/server/shell/decoration/window.cpp
@@ -285,10 +285,10 @@ msd::WindowSurfaceObserverManager::WindowSurfaceObserverManager(
     : surface_{window_surface},
       observer{std::make_shared<Observer>(decoration)}
 {
-    surface_->add_observer(observer);
+    surface_->register_interest(observer);
 }
 
 msd::WindowSurfaceObserverManager::~WindowSurfaceObserverManager()
 {
-    surface_->remove_observer(observer);
+    surface_->unregister_interest(*observer);
 }

--- a/src/server/shell/shell_wrapper.cpp
+++ b/src/server/shell/shell_wrapper.cpp
@@ -86,9 +86,10 @@ auto msh::ShellWrapper::create_surface(
     std::shared_ptr<ms::Session> const& session,
     wayland::Weak<frontend::WlSurface> const& wayland_surface,
     SurfaceSpecification const& params,
-    std::shared_ptr<ms::SurfaceObserver> const& observer) -> std::shared_ptr<ms::Surface>
+    std::shared_ptr<ms::SurfaceObserver> const& observer,
+    Executor* observer_executor) -> std::shared_ptr<ms::Surface>
 {
-    return wrapped->create_surface(session, wayland_surface, params, observer);
+    return wrapped->create_surface(session, wayland_surface, params, observer, observer_executor);
 }
 
 void msh::ShellWrapper::surface_ready(std::shared_ptr<ms::Surface> const& surface)

--- a/tests/include/mir/test/doubles/mock_scene_session.h
+++ b/tests/include/mir/test/doubles/mock_scene_session.h
@@ -40,7 +40,8 @@ struct MockSceneSession : public scene::Session
         std::shared_ptr<Session> const&,
         wayland::Weak<frontend::WlSurface> const&,
         shell::SurfaceSpecification const&,
-        std::shared_ptr<scene::SurfaceObserver> const&), (override));
+        std::shared_ptr<scene::SurfaceObserver> const&,
+        Executor*), (override));
     MOCK_METHOD(void, destroy_surface, (std::shared_ptr<scene::Surface> const&), (override));
     MOCK_METHOD(std::shared_ptr<scene::Surface>, surface_after, (
         std::shared_ptr<scene::Surface> const&), (const override));

--- a/tests/include/mir/test/doubles/mock_surface.h
+++ b/tests/include/mir/test/doubles/mock_surface.h
@@ -71,8 +71,8 @@ struct MockSurface : public scene::BasicSurface
     MOCK_METHOD0(request_client_surface_close, void());
     MOCK_CONST_METHOD0(parent, std::shared_ptr<scene::Surface>());
     MOCK_METHOD2(configure, int(MirWindowAttrib, int));
-    MOCK_METHOD1(add_observer, void(std::shared_ptr<scene::SurfaceObserver> const&));
-    MOCK_METHOD1(remove_observer, void(std::weak_ptr<scene::SurfaceObserver> const&));
+    MOCK_METHOD1(register_interest, void(std::weak_ptr<scene::SurfaceObserver> const&));
+    MOCK_METHOD1(unregister_interest, void(scene::SurfaceObserver const&));
     MOCK_METHOD1(consume, void(std::shared_ptr<MirEvent const> const& event));
 
     MOCK_CONST_METHOD0(primary_buffer_stream, std::shared_ptr<frontend::BufferStream>());

--- a/tests/include/mir/test/doubles/stub_shell.h
+++ b/tests/include/mir/test/doubles/stub_shell.h
@@ -129,7 +129,8 @@ struct StubShell : public shell::Shell
         std::shared_ptr<scene::Session> const& /*session*/,
         wayland::Weak<frontend::WlSurface> const& /*wayland_surface*/,
         shell::SurfaceSpecification const& /*params*/,
-        std::shared_ptr<scene::SurfaceObserver> const& /*observer*/) -> std::shared_ptr<scene::Surface> override
+        std::shared_ptr<scene::SurfaceObserver> const& /*observer*/,
+        Executor* /*observer_executor*/) -> std::shared_ptr<scene::Surface> override
     {
         return std::make_shared<StubSurface>();
     }

--- a/tests/mir_test_framework/stub_session.cpp
+++ b/tests/mir_test_framework/stub_session.cpp
@@ -82,7 +82,8 @@ auto mtd::StubSession::create_surface(
     std::shared_ptr<Session> const& /*session*/,
     wayland::Weak<frontend::WlSurface> const& /*wayland_surface*/,
     mir::shell::SurfaceSpecification const& /*params*/,
-    std::shared_ptr<scene::SurfaceObserver> const& /*observer*/) -> std::shared_ptr<ms::Surface>
+    std::shared_ptr<scene::SurfaceObserver> const& /*observer*/,
+    Executor* /*observer_executor*/) -> std::shared_ptr<ms::Surface>
 {
     return nullptr;
 }

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -153,7 +153,8 @@ struct StubStubSession : mir::test::doubles::StubSession
         std::shared_ptr<mir::scene::Session> const& /*session*/,
         mir::wayland::Weak<mir::frontend::WlSurface> const& /*wayland_surface*/,
         mir::shell::SurfaceSpecification const& params,
-        std::shared_ptr<mir::scene::SurfaceObserver> const& /*observer*/) -> std::shared_ptr<mir::scene::Surface> override
+        std::shared_ptr<mir::scene::SurfaceObserver> const& /*observer*/,
+        mir::Executor*) -> std::shared_ptr<mir::scene::Surface> override
     {
         auto id = mir::frontend::SurfaceId{next_surface_id.fetch_add(1)};
         auto surface = std::make_shared<StubSurface>(
@@ -311,7 +312,7 @@ auto mt::TestWindowManagerTools::create_surface(
 {
     // This type is Mir-internal, I hope we don't need to create it here
     std::shared_ptr<mir::scene::SurfaceObserver> const observer;
-    return session->create_surface(nullptr, {}, params, observer);
+    return session->create_surface(nullptr, {}, params, observer, nullptr);
 }
 
 auto mt::TestWindowManagerTools::create_fake_display_configuration(std::vector<miral::Rectangle> const& outputs)

--- a/tests/unit-tests/frontend_wayland/test_screencopy_v1_damage_tracker.cpp
+++ b/tests/unit-tests/frontend_wayland/test_screencopy_v1_damage_tracker.cpp
@@ -16,6 +16,7 @@
 
 #include "src/server/frontend_wayland/wlr_screencopy_v1.h"
 #include "mir/scene/observer.h"
+#include "mir/scene/surface_observer.h"
 #include "mir/test/doubles/mock_frontend_surface_stack.h"
 #include "mir/test/doubles/mock_surface.h"
 #include "mir/test/doubles/explicit_executor.h"

--- a/tests/unit-tests/input/test_surface_input_dispatcher.cpp
+++ b/tests/unit-tests/input/test_surface_input_dispatcher.cpp
@@ -19,6 +19,7 @@
 #include "mir/events/event_builders.h"
 #include "mir/events/event_private.h"
 #include "mir/scene/observer.h"
+#include "mir/scene/surface_observer.h"
 #include "mir/thread_safe_list.h"
 
 #include "mir/test/event_matchers.h"

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -200,6 +200,7 @@ struct AbstractShell : Test
             session,
             {},
             mt::make_surface_spec(session->create_buffer_stream(properties)),
+            nullptr,
             nullptr);
     }
 
@@ -257,11 +258,11 @@ TEST_F(AbstractShell, close_session_removes_existing_session_surfaces_from_windo
 
     auto const session = shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
     auto const created_surface1 = shell.create_surface(session, {},
-        mt::make_surface_spec(session->create_buffer_stream(properties)), nullptr);
+        mt::make_surface_spec(session->create_buffer_stream(properties)), nullptr, nullptr);
     auto const created_surface2 = shell.create_surface(session, {},
-        mt::make_surface_spec(session->create_buffer_stream(properties)), nullptr);
+        mt::make_surface_spec(session->create_buffer_stream(properties)), nullptr, nullptr);
     auto const created_surface3 = shell.create_surface(session, {},
-        mt::make_surface_spec(session->create_buffer_stream(properties)), nullptr);
+        mt::make_surface_spec(session->create_buffer_stream(properties)), nullptr, nullptr);
 
     session->destroy_surface(created_surface2);
 
@@ -282,7 +283,7 @@ TEST_F(AbstractShell, create_surface_provides_create_parameters_to_window_manage
     auto params = mt::make_surface_spec(session->create_buffer_stream(properties));
     EXPECT_CALL(*wm, add_surface(session, params, _));
 
-    shell.create_surface(session, {}, params, nullptr);
+    shell.create_surface(session, {}, params, nullptr, nullptr);
 }
 
 TEST_F(AbstractShell, create_surface_allows_window_manager_to_set_create_parameters)
@@ -302,7 +303,7 @@ TEST_F(AbstractShell, create_surface_allows_window_manager_to_set_create_paramet
             std::function<std::shared_ptr<ms::Surface>(std::shared_ptr<ms::Session> const& session, msh::SurfaceSpecification const&)> const& build)
             { return build(session, params); }));
 
-    shell.create_surface(session, {}, params, nullptr);
+    shell.create_surface(session, {}, params, nullptr, nullptr);
 }
 
 TEST_F(AbstractShell, create_surface_allows_window_manager_to_enable_ssd)
@@ -327,7 +328,7 @@ TEST_F(AbstractShell, create_surface_allows_window_manager_to_enable_ssd)
                 return build(session, modified_params);
             }));
 
-    shell.create_surface(session, {}, params, nullptr);
+    shell.create_surface(session, {}, params, nullptr, nullptr);
 }
 
 TEST_F(AbstractShell, create_surface_allows_window_manager_to_disable_ssd)
@@ -353,7 +354,7 @@ TEST_F(AbstractShell, create_surface_allows_window_manager_to_disable_ssd)
                 return build(session, modified_params);
             }));
 
-    shell.create_surface(session, {}, params, nullptr);
+    shell.create_surface(session, {}, params, nullptr, nullptr);
 }
 
 TEST_F(AbstractShell, create_surface_sets_surfaces_session)
@@ -368,7 +369,7 @@ TEST_F(AbstractShell, create_surface_sets_surfaces_session)
 
     auto params = mt::make_surface_spec(session->create_buffer_stream(properties));
 
-    shell.create_surface(session, {}, params, nullptr);
+    shell.create_surface(session, {}, params, nullptr, nullptr);
 }
 
 TEST_F(AbstractShell, destroy_surface_removes_surface_from_window_manager)
@@ -377,7 +378,7 @@ TEST_F(AbstractShell, destroy_surface_removes_surface_from_window_manager)
         shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
     auto const params = mt::make_surface_spec(session->create_buffer_stream(properties));
 
-    auto const surface = shell.create_surface(session, {}, params, nullptr);
+    auto const surface = shell.create_surface(session, {}, params, nullptr, nullptr);
 
     EXPECT_CALL(*wm, remove_surface(session, WeakPtrTo(surface)));
 
@@ -484,7 +485,7 @@ TEST_F(AbstractShell, setting_surface_state_is_handled_by_window_manager)
         shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
 
     auto const params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto const surface = shell.create_surface(session, {}, params, nullptr);
+    auto const surface = shell.create_surface(session, {}, params, nullptr, nullptr);
 
     MirWindowState const state{mir_window_state_fullscreen};
 
@@ -520,8 +521,8 @@ TEST_F(AbstractShell, as_focus_controller_focus_next_session_notifies_session_ev
     auto session1 = shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "Bla", std::shared_ptr<mf::EventSink>());
     auto const params = mt::make_surface_spec(session->create_buffer_stream(properties));
     auto const params2 = mt::make_surface_spec(session->create_buffer_stream(properties));
-    shell.create_surface(session, {}, params, nullptr);
-    shell.create_surface(session1, {}, params2, nullptr);
+    shell.create_surface(session, {}, params, nullptr, nullptr);
+    shell.create_surface(session1, {}, params2, nullptr, nullptr);
 
     focus_controller.set_focus_to(session, {});
 
@@ -536,8 +537,8 @@ TEST_F(AbstractShell, as_focus_controller_focused_session_follows_focus)
     auto session1 = shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "Bla", std::shared_ptr<mf::EventSink>());
     auto const params = mt::make_surface_spec(session->create_buffer_stream(properties));
     auto const params2 = mt::make_surface_spec(session->create_buffer_stream(properties));
-    shell.create_surface(session, {}, params, nullptr);
-    shell.create_surface(session1, {}, params2, nullptr);
+    shell.create_surface(session, {}, params, nullptr, nullptr);
+    shell.create_surface(session1, {}, params2, nullptr, nullptr);
 
     msh::FocusController& focus_controller = shell;
 
@@ -560,8 +561,8 @@ TEST_F(AbstractShell, as_focus_controller_focused_surface_follows_focus)
 
     auto const params0 = mt::make_surface_spec(session0->create_buffer_stream(properties));
     auto const params1 = mt::make_surface_spec(session1->create_buffer_stream(properties));
-    auto const surface0 = shell.create_surface(session0, {}, params0, nullptr);
-    auto const surface1 = shell.create_surface(session1, {}, params1, nullptr);
+    auto const surface0 = shell.create_surface(session0, {}, params0, nullptr, nullptr);
+    auto const surface1 = shell.create_surface(session1, {}, params1, nullptr, nullptr);
 
     msh::FocusController& focus_controller = shell;
 
@@ -598,9 +599,9 @@ TEST_F(AbstractShell, as_focus_controller_focus_next_session_skips_surfaceless_s
     auto session1 = shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "Surfaceless", std::shared_ptr<mf::EventSink>());
     auto session2 = shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "Bla", std::shared_ptr<mf::EventSink>());
     auto const params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto created_surface = shell.create_surface(session, {}, params, nullptr);
+    auto created_surface = shell.create_surface(session, {}, params, nullptr, nullptr);
     auto const params2 = mt::make_surface_spec(session2->create_buffer_stream(properties));
-    shell.create_surface(session2, {}, params2, nullptr);
+    shell.create_surface(session2, {}, params2, nullptr, nullptr);
 
     focus_controller.set_focus_to(session, created_surface);
 
@@ -616,7 +617,7 @@ TEST_F(AbstractShell,
     auto session = shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
     auto session1 = shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "Surfaceless", std::shared_ptr<mf::EventSink>());
     auto creation_params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto surface = shell.create_surface(session, {}, creation_params, nullptr);
+    auto surface = shell.create_surface(session, {}, creation_params, nullptr, nullptr);
 
     focus_controller.set_focus_to(session, surface);
 
@@ -633,7 +634,7 @@ TEST_F(AbstractShell, modify_surface_with_only_streams_doesnt_call_into_wm)
         shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
 
     auto creation_params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto surface = shell.create_surface(session, {}, creation_params, nullptr);
+    auto surface = shell.create_surface(session, {}, creation_params, nullptr, nullptr);
 
     msh::SurfaceSpecification stream_modification;
     stream_modification.streams = std::vector<msh::StreamSpecification>{};
@@ -650,7 +651,7 @@ TEST_F(AbstractShell, modify_surface_does_not_call_wm_for_empty_changes)
 
     auto creation_params = mt::make_surface_spec(session->create_buffer_stream(properties));
 
-    auto surface = shell.create_surface(session, {}, creation_params, nullptr);
+    auto surface = shell.create_surface(session, {}, creation_params, nullptr, nullptr);
 
     msh::SurfaceSpecification stream_modification;
 
@@ -673,7 +674,7 @@ TEST_F(AbstractShell, size_gets_adjusted_for_windows_with_margins)
         shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
 
     auto creation_params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto surface = shell.create_surface(session, {}, creation_params, nullptr);
+    auto surface = shell.create_surface(session, {}, creation_params, nullptr, nullptr);
     surface->resize({50, 50});
     surface->set_window_margins(top, left, bottom, right);
 
@@ -704,7 +705,7 @@ TEST_F(AbstractShell, max_size_gets_adjusted_for_windows_with_margins)
         shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
 
     auto creation_params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto surface = shell.create_surface(session, {}, creation_params, nullptr);
+    auto surface = shell.create_surface(session, {}, creation_params, nullptr, nullptr);
     surface->resize({50, 50});
     surface->set_window_margins(top, left, bottom, right);
 
@@ -735,7 +736,7 @@ TEST_F(AbstractShell, min_size_gets_adjusted_for_windows_with_margins)
         shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
 
     auto creation_params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto surface = shell.create_surface(session, {}, creation_params, nullptr);
+    auto surface = shell.create_surface(session, {}, creation_params, nullptr, nullptr);
     surface->resize({50, 50});
     surface->set_window_margins(top, left, bottom, right);
 
@@ -767,7 +768,7 @@ TEST_F(AbstractShell, aux_rect_gets_adjusted_for_windows_with_margins)
         shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
 
     auto creation_params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto surface = shell.create_surface(session, {}, creation_params, nullptr);
+    auto surface = shell.create_surface(session, {}, creation_params, nullptr, nullptr);
     surface->resize(content_size);
     surface->set_window_margins(top, left, bottom, right);
 
@@ -793,7 +794,7 @@ TEST_F(AbstractShell, when_remaining_session_has_no_surface_focus_next_session_d
             shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "another_session", std::shared_ptr<mf::EventSink>());
 
         auto creation_params = mt::make_surface_spec(another_session->create_buffer_stream(properties));
-        auto surface = shell.create_surface(another_session, {}, creation_params, nullptr);
+        auto surface = shell.create_surface(another_session, {}, creation_params, nullptr, nullptr);
 
         shell.set_focus_to(another_session, surface);
 
@@ -812,8 +813,8 @@ TEST_F(AbstractShell, focus_can_be_set)
     msh::FocusController& focus_controller = shell;
     auto const session = shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
     auto const params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto const created_surface1 = shell.create_surface(session, {}, params, nullptr);
-    auto const created_surface2 = shell.create_surface(session, {}, params, nullptr);
+    auto const created_surface1 = shell.create_surface(session, {}, params, nullptr, nullptr);
+    auto const created_surface2 = shell.create_surface(session, {}, params, nullptr, nullptr);
 
     focus_controller.set_focus_to(session, created_surface2);
     EXPECT_THAT(created_surface1->focus_state(), Eq(mir_window_focus_state_unfocused));
@@ -836,9 +837,9 @@ TEST_F(AbstractShell, setting_focus_to_child_makes_parent_active)
     msh::FocusController& focus_controller = shell;
     auto const session = shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
     auto const params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto const parent_surface = shell.create_surface(session, {}, params, nullptr);
-    auto const child_surface = shell.create_surface(session, {}, params, nullptr);
-    auto const other_surface = shell.create_surface(session, {}, params, nullptr);
+    auto const parent_surface = shell.create_surface(session, {}, params, nullptr, nullptr);
+    auto const child_surface = shell.create_surface(session, {}, params, nullptr, nullptr);
+    auto const other_surface = shell.create_surface(session, {}, params, nullptr, nullptr);
 
     ASSERT_THAT(child_surface->parent(), Eq(parent_surface));
 
@@ -983,9 +984,9 @@ TEST_F(AbstractShell, focus_next_session_allows_later_focusing_same_window)
     auto session1 = shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
     auto session2 = shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "Bla", std::shared_ptr<mf::EventSink>());
     auto const params1 = mt::make_surface_spec(session1->create_buffer_stream(properties));
-    auto created_surface1 = shell.create_surface(session1, {}, params1, nullptr);
+    auto created_surface1 = shell.create_surface(session1, {}, params1, nullptr, nullptr);
     auto const params2 = mt::make_surface_spec(session2->create_buffer_stream(properties));
-    auto created_surface2 = shell.create_surface(session2, {}, params2, nullptr);
+    auto created_surface2 = shell.create_surface(session2, {}, params2, nullptr, nullptr);
 
     focus_controller.set_focus_to(session1, created_surface1);
     focus_controller.focus_next_session();
@@ -1026,7 +1027,7 @@ TEST_F(AbstractShell, as_focus_controller_emits_input_device_state_event_on_focu
 
     auto session = shell.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "some", std::shared_ptr<mf::EventSink>());
     auto creation_params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto surface = shell.create_surface(session, {}, creation_params, nullptr);
+    auto surface = shell.create_surface(session, {}, creation_params, nullptr, nullptr);
 
     msh::FocusController& focus_controller = shell;
     focus_controller.set_focus_to(session, surface);

--- a/tests/unit-tests/scene/test_application_session.cpp
+++ b/tests/unit-tests/scene/test_application_session.cpp
@@ -244,7 +244,7 @@ TEST_F(ApplicationSession, adds_created_surface_to_coordinator)
         mt::fake_shared(surface_stack), mt::fake_shared(mock_surface_factory));
 
     auto const params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto surf = session->create_surface(nullptr, {}, params, surface_observer);
+    auto surf = session->create_surface(nullptr, {}, params, surface_observer, nullptr);
 
     session->destroy_surface(surf);
 }
@@ -279,7 +279,7 @@ TEST_F(ApplicationSession, can_destroy_buffer_stream_after_destroying_surface)
 
     auto buffer_stream = session->create_buffer_stream(properties);
     auto const params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto surf = session->create_surface(nullptr, {}, params, surface_observer);
+    auto surf = session->create_surface(nullptr, {}, params, surface_observer, nullptr);
 
     session->destroy_surface(surf);
     session->destroy_buffer_stream(buffer_stream);
@@ -298,7 +298,7 @@ TEST_F(ApplicationSession, notifies_listener_of_create_and_destroy_surface)
     auto session = make_application_session_with_listener(mt::fake_shared(listener));
 
     auto const params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto surf = session->create_surface(nullptr, {}, params, surface_observer);
+    auto surf = session->create_surface(nullptr, {}, params, surface_observer, nullptr);
 
     session->destroy_surface(surf);
 }
@@ -317,7 +317,7 @@ TEST_F(ApplicationSession, notifies_listener_of_surface_destruction_via_session_
         auto session = make_application_session_with_listener(mt::fake_shared(listener));
 
         auto const params = mt::make_surface_spec(session->create_buffer_stream(properties));
-        session->create_surface(nullptr, {}, params, surface_observer);
+        session->create_surface(nullptr, {}, params, surface_observer, nullptr);
     }
 }
 
@@ -341,9 +341,9 @@ TEST_F(ApplicationSession, default_surface_is_first_surface)
     auto app_session = make_application_session_with_stubs();
 
     auto const params = mt::make_surface_spec(app_session->create_buffer_stream(properties));
-    auto surface1 = app_session->create_surface(nullptr, {}, params, nullptr);
-    auto surface2 = app_session->create_surface(nullptr, {}, params, nullptr);
-    auto surface3 = app_session->create_surface(nullptr, {}, params, nullptr);
+    auto surface1 = app_session->create_surface(nullptr, {}, params, nullptr, nullptr);
+    auto surface2 = app_session->create_surface(nullptr, {}, params, nullptr, nullptr);
+    auto surface3 = app_session->create_surface(nullptr, {}, params, nullptr, nullptr);
 
     auto default_surf = app_session->default_surface();
     EXPECT_EQ(surface1, default_surf);
@@ -362,8 +362,8 @@ TEST_F(ApplicationSession, foreign_surface_has_no_successor)
 {
     auto session1 = make_application_session_with_stubs();
     auto const params = mt::make_surface_spec(session1->create_buffer_stream(properties));
-    auto surf1 = session1->create_surface(nullptr, {}, params, nullptr);
-    auto surf2 = session1->create_surface(nullptr, {}, params, nullptr);
+    auto surf1 = session1->create_surface(nullptr, {}, params, nullptr, nullptr);
+    auto surf2 = session1->create_surface(nullptr, {}, params, nullptr, nullptr);
 
     auto session2 = make_application_session_with_stubs();
 
@@ -378,7 +378,7 @@ TEST_F(ApplicationSession, surface_after_one_is_self)
 {
     auto session = make_application_session_with_stubs();
     auto const params = mt::make_surface_spec(session->create_buffer_stream(properties));
-    auto surf = session->create_surface(nullptr, {}, params, nullptr);
+    auto surf = session->create_surface(nullptr, {}, params, nullptr, nullptr);
 
     EXPECT_EQ(surf, session->surface_after(surf));
 
@@ -396,7 +396,7 @@ TEST_F(ApplicationSession, surface_after_cycles_through_all)
 
     for (int i = 0; i < N; ++i)
     {
-        surf[i] = app_session->create_surface(nullptr, {}, params, nullptr);
+        surf[i] = app_session->create_surface(nullptr, {}, params, nullptr, nullptr);
 
         if (i > 0)
         {
@@ -431,7 +431,7 @@ TEST_F(ApplicationSession, session_visbility_propagates_to_surfaces)
     }
 
     auto const params = mt::make_surface_spec(app_session->create_buffer_stream(properties));
-    auto surf = app_session->create_surface(nullptr, {}, params, surface_observer);
+    auto surf = app_session->create_surface(nullptr, {}, params, surface_observer, nullptr);
 
     app_session->hide();
     app_session->show();
@@ -464,7 +464,7 @@ TEST_F(ApplicationSession, can_destroy_surface_bstream)
     auto session = make_application_session_with_stubs();
     auto const stream = session->create_buffer_stream(properties);
     auto const params = mt::make_surface_spec(stream);
-    auto id = session->create_surface(nullptr, {}, params, surface_observer);
+    auto id = session->create_surface(nullptr, {}, params, surface_observer, nullptr);
     session->destroy_buffer_stream(stream);
     EXPECT_FALSE(session->has_buffer_stream(stream));
     session->destroy_surface(id);
@@ -515,7 +515,7 @@ TEST_F(ApplicationSession, sets_and_looks_up_surface_streams)
         {streams[1], geom::Displacement{0,2}, {}}
     };
 
-    session->create_surface(nullptr, {}, mt::make_surface_spec(stream0), surface_observer);
+    session->create_surface(nullptr, {}, mt::make_surface_spec(stream0), surface_observer, nullptr);
 
     EXPECT_CALL(*mock_surface, set_streams(Pointwise(StreamEq(), info)));
     session->configure_streams(*mock_surface, {
@@ -603,7 +603,7 @@ TEST_F(ApplicationSession, surface_uses_prexisting_buffer_stream_if_set)
     params.name = "Aardavks";
     params.type = mir_window_type_normal;
 
-    session->create_surface(nullptr, {}, params, surface_observer);
+    session->create_surface(nullptr, {}, params, surface_observer, nullptr);
 }
 
 namespace

--- a/tests/unit-tests/scene/test_application_session.cpp
+++ b/tests/unit-tests/scene/test_application_session.cpp
@@ -688,14 +688,14 @@ namespace
 class ObserverPreservingSurface : public mtd::MockSurface
 {
 public:
-    void add_observer(std::shared_ptr<mir::scene::SurfaceObserver> const &observer) override
+    void register_interest(std::weak_ptr<mir::scene::SurfaceObserver> const& observer) override
     {
-        return BasicSurface::add_observer(observer);
+        return BasicSurface::register_interest(observer);
     }
 
-    void remove_observer(std::weak_ptr<mir::scene::SurfaceObserver> const &observer) override
+    void unregister_interest(mir::scene::SurfaceObserver const& observer) override
     {
-        return BasicSurface::remove_observer(observer);
+        return BasicSurface::unregister_interest(observer);
     }
 };
 

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -196,7 +196,7 @@ TEST_F(BasicSurfaceTest, update_top_left)
     EXPECT_CALL(mock_callback, call())
         .Times(1);
 
-    surface.add_observer(observer);
+    surface.register_interest(observer);
 
     EXPECT_EQ(rect.top_left, surface.top_left());
 
@@ -212,7 +212,7 @@ TEST_F(BasicSurfaceTest, update_size)
     EXPECT_CALL(mock_callback, call())
         .Times(1);
 
-    surface.add_observer(observer);
+    surface.register_interest(observer);
 
     EXPECT_EQ(rect.size, surface.window_size());
     EXPECT_NE(new_size, surface.window_size());
@@ -241,7 +241,7 @@ TEST_F(BasicSurfaceTest, observer_notified_of_window_resize)
     EXPECT_CALL(mock_surface_observer, window_resized_to(_, new_size))
         .Times(1);
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
     surface.resize(new_size);
 }
 
@@ -257,7 +257,7 @@ TEST_F(BasicSurfaceTest, observer_notified_of_content_resize)
     EXPECT_CALL(mock_surface_observer, content_resized_to(_, new_size))
         .Times(1);
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
     surface.resize(new_size);
 }
 
@@ -277,7 +277,7 @@ TEST_F(BasicSurfaceTest, resize_notifications_only_sent_when_size_changed)
     EXPECT_CALL(mock_surface_observer, content_resized_to(_, _))
         .Times(1);
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
     surface.resize(rect.size);
     surface.resize(new_size);
     surface.resize(new_size);
@@ -301,7 +301,7 @@ TEST_F(BasicSurfaceTest, only_content_is_notified_of_resize_when_frame_geometry_
     EXPECT_CALL(mock_surface_observer, content_resized_to(_, new_content_size))
         .Times(1);
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
     surface.set_window_margins(top, left, bottom, right);
 }
 
@@ -406,7 +406,7 @@ TEST_F(BasicSurfaceTest, test_surface_set_transformation_updates_transform)
     EXPECT_CALL(mock_callback, call())
         .Times(1);
 
-    surface.add_observer(observer);
+    surface.register_interest(observer);
 
     auto renderables = surface.generate_renderables(compositor_id);
     ASSERT_THAT(renderables.size(), testing::Eq(1));
@@ -472,7 +472,7 @@ TEST_F(BasicSurfaceTest, test_surface_hidden_notifies_changes)
     EXPECT_CALL(mock_callback, call())
         .Times(1);
 
-    surface.add_observer(observer);
+    surface.register_interest(observer);
 
     surface.set_hidden(true);
 }
@@ -492,7 +492,7 @@ TEST_F(BasicSurfaceTest, default_region_is_surface_rectangle)
         std::shared_ptr<mg::CursorImage>(),
         report};
 
-    surface.add_observer(observer);
+    surface.register_interest(observer);
 
     std::vector<geom::Point> contained_pt
     {
@@ -566,7 +566,7 @@ TEST_F(BasicSurfaceTest, set_input_region)
         {{geom::X{1}, geom::Y{1}}, {geom::Width{1}, geom::Height{1}}}  //region1
     };
 
-    surface.add_observer(observer);
+    surface.register_interest(observer);
 
     surface.set_input_region(rectangles);
 
@@ -870,7 +870,7 @@ TEST_P(BasicSurfaceAttributeTest, notifies_about_attrib_changes)
     EXPECT_CALL(mock_surface_observer, attrib_changed(_, attribute, value2))
         .Times(1);
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
 
     surface.configure(attribute, value1);
     surface.configure(attribute, value2);
@@ -890,7 +890,7 @@ TEST_P(BasicSurfaceAttributeTest, does_not_notify_if_attrib_is_unchanged)
     EXPECT_CALL(mock_surface_observer, attrib_changed(_, attribute, another_value))
         .Times(1);
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
 
     surface.configure(attribute, default_value);
     surface.configure(attribute, another_value);
@@ -953,7 +953,7 @@ TEST_F(BasicSurfaceTest, notifies_about_focus_state_changes)
     EXPECT_CALL(mock_surface_observer, attrib_changed(_, mir_window_attrib_focus, mir_window_focus_state_unfocused))
         .Times(1);
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
 
     surface.set_focus_state(mir_window_focus_state_focused);
     surface.set_focus_state(mir_window_focus_state_unfocused);
@@ -968,7 +968,7 @@ TEST_F(BasicSurfaceTest, does_not_notify_if_focus_state_is_unchanged)
     EXPECT_CALL(mock_surface_observer, attrib_changed(_, mir_window_attrib_focus, mir_window_focus_state_focused))
         .Times(1);
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
 
     surface.set_focus_state(mir_window_focus_state_unfocused); // will not notify, since it is default
     surface.set_focus_state(mir_window_focus_state_focused);
@@ -995,7 +995,7 @@ TEST_F(BasicSurfaceTest, notifies_about_cursor_image_change)
     auto cursor_image = std::make_shared<mtd::StubCursorImage>();
     EXPECT_CALL(mock_surface_observer, cursor_image_set_to(_, _));
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
     surface.set_cursor_image(cursor_image);
 }
 
@@ -1008,7 +1008,7 @@ TEST_F(BasicSurfaceTest, notifies_about_cursor_image_removal)
     EXPECT_CALL(mock_surface_observer, cursor_image_set_to(_, _)).Times(0);
     EXPECT_CALL(mock_surface_observer, cursor_image_removed(_));
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
     surface.set_cursor_image({});
 }
 
@@ -1020,7 +1020,7 @@ TEST_F(BasicSurfaceTest, when_frame_is_posted_an_observer_is_notified_of_frame_w
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
 
     surface.resize({100, 150}); // should not affect frame_posted notification
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, {}}});
     ON_CALL(*buffer_stream, stream_size())
         .WillByDefault(Return(rect.size));
@@ -1040,7 +1040,7 @@ TEST_F(BasicSurfaceTest, when_stream_size_differs_from_buffer_size_an_observer_i
     ON_CALL(*buffer_stream, stream_size())
         .WillByDefault(Return(stream_size));
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, {}}});
 
     EXPECT_CALL(mock_surface_observer, frame_posted(_, _, mt::RectSizeEq(stream_size)));
@@ -1059,7 +1059,7 @@ TEST_F(BasicSurfaceTest, when_stream_info_has_explicit_size_an_observer_is_notif
     ON_CALL(*buffer_stream, stream_size())
         .WillByDefault(Return(stream_size));
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, stream_info_size}});
 
     EXPECT_CALL(mock_surface_observer, frame_posted(_, _, mt::RectSizeEq(stream_info_size)));
@@ -1073,7 +1073,7 @@ TEST_F(BasicSurfaceTest, when_frame_is_posted_an_observer_is_notified_of_frame_a
     NiceMock<MockSurfaceObserver> mock_surface_observer;
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, {}}});
 
     EXPECT_CALL(mock_surface_observer, frame_posted(_, _, mt::RectTopLeftEq(geom::Point{})));
@@ -1089,7 +1089,7 @@ TEST_F(BasicSurfaceTest, when_stream_info_has_offset_an_observer_is_notified_of_
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
     std::function<void(geom::Size const&)> frame_posted_callback;
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
     surface.set_streams({ms::StreamInfo{buffer_stream, stream_info_offset, {}}});
 
     EXPECT_CALL(mock_surface_observer, frame_posted(_, _, mt::RectTopLeftEq(geom::Point{} + stream_info_offset)));
@@ -1106,7 +1106,7 @@ TEST_F(BasicSurfaceTest, when_surface_has_margins_an_observer_is_notified_of_fra
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
     std::function<void(geom::Size const&)> frame_posted_callback;
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, {}}});
 
     EXPECT_CALL(mock_surface_observer, frame_posted(_, _, mt::RectTopLeftEq(geom::Point{} + margin_top + margin_left)));
@@ -1132,7 +1132,7 @@ TEST_F(BasicSurfaceTest, observer_can_trigger_state_change_within_notification)
         .WillOnce(InvokeWithoutArgs(async_state_changer))
         .WillOnce(Return());
 
-    surface.add_observer(observer);
+    surface.register_interest(observer);
 
     surface.set_hidden(true);
 }
@@ -1160,7 +1160,7 @@ TEST_F(BasicSurfaceTest, notifies_about_application_id_changes)
     EXPECT_CALL(mock_surface_observer, application_id_set_to(_, id))
         .Times(1);
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
 
     surface.set_application_id(id);
 }
@@ -1175,7 +1175,7 @@ TEST_F(BasicSurfaceTest, does_not_notify_if_application_id_is_unchanged)
     EXPECT_CALL(mock_surface_observer, application_id_set_to(_, id))
         .Times(1);
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
 
     surface.set_application_id("");
     surface.set_application_id(id);
@@ -1195,15 +1195,15 @@ TEST_F(BasicSurfaceTest, observer_can_remove_itself_within_notification)
     EXPECT_CALL(observer3, hidden_set_to(_, true)).Times(2);
 
     auto const remove_observer = [&]{
-        surface.remove_observer(mt::fake_shared(observer2));
+        surface.unregister_interest(observer2);
     };
 
     EXPECT_CALL(observer2, hidden_set_to(_, true)).Times(1)
         .WillOnce(InvokeWithoutArgs(remove_observer));
 
-    surface.add_observer(mt::fake_shared(observer1));
-    surface.add_observer(mt::fake_shared(observer2));
-    surface.add_observer(mt::fake_shared(observer3));
+    surface.register_interest(mt::fake_shared(observer1));
+    surface.register_interest(mt::fake_shared(observer2));
+    surface.register_interest(mt::fake_shared(observer3));
 
     surface.set_hidden(true);
     surface.set_hidden(true);
@@ -1217,7 +1217,7 @@ TEST_F(BasicSurfaceTest, notifies_of_client_close_request)
 
     EXPECT_CALL(mock_surface_observer, client_surface_close_requested(_)).Times(1);
 
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
 
     surface.request_client_surface_close();
 }
@@ -1227,7 +1227,7 @@ TEST_F(BasicSurfaceTest, notifies_of_rename)
     using namespace testing;
 
     MockSurfaceObserver mock_surface_observer;
-    surface.add_observer(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mt::fake_shared(mock_surface_observer));
 
     EXPECT_CALL(mock_surface_observer, renamed(_, StrEq("Steve")));
 
@@ -1625,7 +1625,7 @@ TEST_F(BasicSurfaceTest, notifies_when_first_visible)
 {
     using namespace testing;
     auto observer = std::make_shared<VisibilityObserver>();
-    surface.add_observer(observer);
+    surface.register_interest(observer);
 
     EXPECT_THAT(observer->exposes(), Eq(0));
     EXPECT_THAT(observer->hides(), Eq(0));

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -29,6 +29,7 @@
 #include "mir/test/doubles/mock_buffer_stream.h"
 #include "mir/test/doubles/stub_buffer.h"
 #include "mir/test/doubles/stub_session.h"
+#include "mir/test/doubles/explicit_executor.h"
 #include "mir/test/fake_shared.h"
 #include "mir/test/geometry_matchers.h"
 
@@ -88,6 +89,9 @@ struct BasicSurfaceTest : public testing::Test
     std::shared_ptr<ms::SceneReport> const report = mr::null_scene_report();
     void const* compositor_id{nullptr};
     std::list<ms::StreamInfo> streams { { mock_buffer_stream, {}, {} } };
+    std::shared_ptr<testing::NiceMock<MockSurfaceObserver>> mock_surface_observer =
+        std::make_shared<testing::NiceMock<MockSurfaceObserver>>();
+    mtd::ExplicitExecutor executor;
 
     ms::BasicSurface surface{
         nullptr /* session */,
@@ -110,6 +114,11 @@ struct BasicSurfaceTest : public testing::Test
         // use an opaque pixel format by default
         ON_CALL(*mock_buffer_stream, pixel_format())
             .WillByDefault(testing::Return(mir_pixel_format_xrgb_8888));
+    }
+
+    void TearDown() override
+    {
+        executor.execute();
     }
 };
 
@@ -196,7 +205,7 @@ TEST_F(BasicSurfaceTest, update_top_left)
     EXPECT_CALL(mock_callback, call())
         .Times(1);
 
-    surface.register_interest(observer);
+    surface.register_interest(observer, executor);
 
     EXPECT_EQ(rect.top_left, surface.top_left());
 
@@ -212,7 +221,7 @@ TEST_F(BasicSurfaceTest, update_size)
     EXPECT_CALL(mock_callback, call())
         .Times(1);
 
-    surface.register_interest(observer);
+    surface.register_interest(observer, executor);
 
     EXPECT_EQ(rect.size, surface.window_size());
     EXPECT_NE(new_size, surface.window_size());
@@ -234,14 +243,13 @@ TEST_F(BasicSurfaceTest, observer_notified_of_window_resize)
     using namespace testing;
 
     geom::Size const new_size{34, 56};
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
 
     ASSERT_THAT(new_size, Ne(surface.window_size())) << "Precondition failed";
 
-    EXPECT_CALL(mock_surface_observer, window_resized_to(_, new_size))
+    EXPECT_CALL(*mock_surface_observer, window_resized_to(_, new_size))
         .Times(1);
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
     surface.resize(new_size);
 }
 
@@ -250,14 +258,13 @@ TEST_F(BasicSurfaceTest, observer_notified_of_content_resize)
     using namespace testing;
 
     geom::Size const new_size{34, 56};
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
 
     ASSERT_THAT(new_size, Ne(surface.content_size())) << "Precondition failed";
 
-    EXPECT_CALL(mock_surface_observer, content_resized_to(_, new_size))
+    EXPECT_CALL(*mock_surface_observer, content_resized_to(_, new_size))
         .Times(1);
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
     surface.resize(new_size);
 }
 
@@ -266,18 +273,17 @@ TEST_F(BasicSurfaceTest, resize_notifications_only_sent_when_size_changed)
     using namespace testing;
 
     geom::Size const new_size{34, 56};
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
 
     ASSERT_THAT(rect.size, Eq(surface.window_size())) << "Precondition failed";
     ASSERT_THAT(rect.size, Eq(surface.content_size())) << "Precondition failed";
     ASSERT_THAT(new_size, Ne(surface.content_size())) << "Precondition failed";
 
-    EXPECT_CALL(mock_surface_observer, window_resized_to(_, _))
+    EXPECT_CALL(*mock_surface_observer, window_resized_to(_, _))
         .Times(1);
-    EXPECT_CALL(mock_surface_observer, content_resized_to(_, _))
+    EXPECT_CALL(*mock_surface_observer, content_resized_to(_, _))
         .Times(1);
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
     surface.resize(rect.size);
     surface.resize(new_size);
     surface.resize(new_size);
@@ -294,14 +300,13 @@ TEST_F(BasicSurfaceTest, only_content_is_notified_of_resize_when_frame_geometry_
     geom::Size const new_content_size{
         rect.size.width - left - right,
         rect.size.height - top - bottom};
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
 
-    EXPECT_CALL(mock_surface_observer, window_resized_to(_, _))
+    EXPECT_CALL(*mock_surface_observer, window_resized_to(_, _))
         .Times(0);
-    EXPECT_CALL(mock_surface_observer, content_resized_to(_, new_content_size))
+    EXPECT_CALL(*mock_surface_observer, content_resized_to(_, new_content_size))
         .Times(1);
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
     surface.set_window_margins(top, left, bottom, right);
 }
 
@@ -406,7 +411,7 @@ TEST_F(BasicSurfaceTest, test_surface_set_transformation_updates_transform)
     EXPECT_CALL(mock_callback, call())
         .Times(1);
 
-    surface.register_interest(observer);
+    surface.register_interest(observer, executor);
 
     auto renderables = surface.generate_renderables(compositor_id);
     ASSERT_THAT(renderables.size(), testing::Eq(1));
@@ -472,7 +477,7 @@ TEST_F(BasicSurfaceTest, test_surface_hidden_notifies_changes)
     EXPECT_CALL(mock_callback, call())
         .Times(1);
 
-    surface.register_interest(observer);
+    surface.register_interest(observer, executor);
 
     surface.set_hidden(true);
 }
@@ -492,7 +497,7 @@ TEST_F(BasicSurfaceTest, default_region_is_surface_rectangle)
         std::shared_ptr<mg::CursorImage>(),
         report};
 
-    surface.register_interest(observer);
+    surface.register_interest(observer, executor);
 
     std::vector<geom::Point> contained_pt
     {
@@ -566,7 +571,7 @@ TEST_F(BasicSurfaceTest, set_input_region)
         {{geom::X{1}, geom::Y{1}}, {geom::Width{1}, geom::Height{1}}}  //region1
     };
 
-    surface.register_interest(observer);
+    surface.register_interest(observer, executor);
 
     surface.set_input_region(rectangles);
 
@@ -862,15 +867,13 @@ TEST_P(BasicSurfaceAttributeTest, notifies_about_attrib_changes)
     auto const& value1 = params.a_valid_value;
     auto const& value2 = params.default_value;
 
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
-
     InSequence s;
-    EXPECT_CALL(mock_surface_observer, attrib_changed(_, attribute, value1))
+    EXPECT_CALL(*mock_surface_observer, attrib_changed(_, attribute, value1))
         .Times(1);
-    EXPECT_CALL(mock_surface_observer, attrib_changed(_, attribute, value2))
+    EXPECT_CALL(*mock_surface_observer, attrib_changed(_, attribute, value2))
         .Times(1);
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
 
     surface.configure(attribute, value1);
     surface.configure(attribute, value2);
@@ -885,12 +888,10 @@ TEST_P(BasicSurfaceAttributeTest, does_not_notify_if_attrib_is_unchanged)
     auto const& default_value = params.default_value;
     auto const& another_value = params.a_valid_value;
 
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
-
-    EXPECT_CALL(mock_surface_observer, attrib_changed(_, attribute, another_value))
+    EXPECT_CALL(*mock_surface_observer, attrib_changed(_, attribute, another_value))
         .Times(1);
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
 
     surface.configure(attribute, default_value);
     surface.configure(attribute, another_value);
@@ -946,14 +947,12 @@ TEST_F(BasicSurfaceTest, notifies_about_focus_state_changes)
 {
     using namespace testing;
 
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
-
-    EXPECT_CALL(mock_surface_observer, attrib_changed(_, mir_window_attrib_focus, mir_window_focus_state_focused))
+    EXPECT_CALL(*mock_surface_observer, attrib_changed(_, mir_window_attrib_focus, mir_window_focus_state_focused))
         .Times(1);
-    EXPECT_CALL(mock_surface_observer, attrib_changed(_, mir_window_attrib_focus, mir_window_focus_state_unfocused))
+    EXPECT_CALL(*mock_surface_observer, attrib_changed(_, mir_window_attrib_focus, mir_window_focus_state_unfocused))
         .Times(1);
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
 
     surface.set_focus_state(mir_window_focus_state_focused);
     surface.set_focus_state(mir_window_focus_state_unfocused);
@@ -963,12 +962,10 @@ TEST_F(BasicSurfaceTest, does_not_notify_if_focus_state_is_unchanged)
 {
     using namespace testing;
 
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
-
-    EXPECT_CALL(mock_surface_observer, attrib_changed(_, mir_window_attrib_focus, mir_window_focus_state_focused))
+    EXPECT_CALL(*mock_surface_observer, attrib_changed(_, mir_window_attrib_focus, mir_window_focus_state_focused))
         .Times(1);
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
 
     surface.set_focus_state(mir_window_focus_state_unfocused); // will not notify, since it is default
     surface.set_focus_state(mir_window_focus_state_focused);
@@ -990,12 +987,10 @@ TEST_F(BasicSurfaceTest, notifies_about_cursor_image_change)
 {
     using namespace testing;
 
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
-
     auto cursor_image = std::make_shared<mtd::StubCursorImage>();
-    EXPECT_CALL(mock_surface_observer, cursor_image_set_to(_, _));
+    EXPECT_CALL(*mock_surface_observer, cursor_image_set_to(_, _));
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
     surface.set_cursor_image(cursor_image);
 }
 
@@ -1003,12 +998,10 @@ TEST_F(BasicSurfaceTest, notifies_about_cursor_image_removal)
 {
     using namespace testing;
 
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
+    EXPECT_CALL(*mock_surface_observer, cursor_image_set_to(_, _)).Times(0);
+    EXPECT_CALL(*mock_surface_observer, cursor_image_removed(_));
 
-    EXPECT_CALL(mock_surface_observer, cursor_image_set_to(_, _)).Times(0);
-    EXPECT_CALL(mock_surface_observer, cursor_image_removed(_));
-
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
     surface.set_cursor_image({});
 }
 
@@ -1016,16 +1009,15 @@ TEST_F(BasicSurfaceTest, when_frame_is_posted_an_observer_is_notified_of_frame_w
 {
     using namespace testing;
 
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
 
     surface.resize({100, 150}); // should not affect frame_posted notification
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, {}}});
     ON_CALL(*buffer_stream, stream_size())
         .WillByDefault(Return(rect.size));
 
-    EXPECT_CALL(mock_surface_observer, frame_posted(_, _, mt::RectSizeEq(rect.size)));
+    EXPECT_CALL(*mock_surface_observer, frame_posted(_, _, mt::RectSizeEq(rect.size)));
     buffer_stream->frame_posted_callback(rect.size);
 }
 
@@ -1034,16 +1026,15 @@ TEST_F(BasicSurfaceTest, when_stream_size_differs_from_buffer_size_an_observer_i
     using namespace testing;
     geom::Size const stream_size{rect.size * 1.5};
 
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
     std::function<void(geom::Size const&)> frame_posted_callback;
     ON_CALL(*buffer_stream, stream_size())
         .WillByDefault(Return(stream_size));
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, {}}});
 
-    EXPECT_CALL(mock_surface_observer, frame_posted(_, _, mt::RectSizeEq(stream_size)));
+    EXPECT_CALL(*mock_surface_observer, frame_posted(_, _, mt::RectSizeEq(stream_size)));
     buffer_stream->frame_posted_callback(stream_size * 2);
 }
 
@@ -1053,16 +1044,15 @@ TEST_F(BasicSurfaceTest, when_stream_info_has_explicit_size_an_observer_is_notif
     geom::Size const stream_info_size{rect.size * 1.5};
     geom::Size const stream_size{stream_info_size * 2};
 
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
     std::function<void(geom::Size const&)> frame_posted_callback;
     ON_CALL(*buffer_stream, stream_size())
         .WillByDefault(Return(stream_size));
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, stream_info_size}});
 
-    EXPECT_CALL(mock_surface_observer, frame_posted(_, _, mt::RectSizeEq(stream_info_size)));
+    EXPECT_CALL(*mock_surface_observer, frame_posted(_, _, mt::RectSizeEq(stream_info_size)));
     buffer_stream->frame_posted_callback(stream_size);
 }
 
@@ -1070,13 +1060,11 @@ TEST_F(BasicSurfaceTest, when_frame_is_posted_an_observer_is_notified_of_frame_a
 {
     using namespace testing;
 
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
-
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, {}}});
 
-    EXPECT_CALL(mock_surface_observer, frame_posted(_, _, mt::RectTopLeftEq(geom::Point{})));
+    EXPECT_CALL(*mock_surface_observer, frame_posted(_, _, mt::RectTopLeftEq(geom::Point{})));
     buffer_stream->frame_posted_callback(rect.size);
 }
 
@@ -1085,14 +1073,13 @@ TEST_F(BasicSurfaceTest, when_stream_info_has_offset_an_observer_is_notified_of_
     using namespace testing;
     geom::Displacement const stream_info_offset{7, 10};
 
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
     std::function<void(geom::Size const&)> frame_posted_callback;
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
     surface.set_streams({ms::StreamInfo{buffer_stream, stream_info_offset, {}}});
 
-    EXPECT_CALL(mock_surface_observer, frame_posted(_, _, mt::RectTopLeftEq(geom::Point{} + stream_info_offset)));
+    EXPECT_CALL(*mock_surface_observer, frame_posted(_, _, mt::RectTopLeftEq(geom::Point{} + stream_info_offset)));
     buffer_stream->frame_posted_callback(rect.size);
 }
 
@@ -1102,41 +1089,16 @@ TEST_F(BasicSurfaceTest, when_surface_has_margins_an_observer_is_notified_of_fra
     geom::DeltaY const margin_top{4}, margin_bottom{6};
     geom::DeltaX const margin_left{3}, margin_right{5};
 
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
     auto buffer_stream = std::make_shared<NiceMock<mtd::MockBufferStream>>();
     std::function<void(geom::Size const&)> frame_posted_callback;
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
     surface.set_streams({ms::StreamInfo{buffer_stream, {}, {}}});
 
-    EXPECT_CALL(mock_surface_observer, frame_posted(_, _, mt::RectTopLeftEq(geom::Point{} + margin_top + margin_left)));
+    EXPECT_CALL(*mock_surface_observer, frame_posted(_, _, mt::RectTopLeftEq(geom::Point{} + margin_top + margin_left)));
     surface.set_window_margins(margin_top, margin_left, margin_bottom, margin_right);
     buffer_stream->frame_posted_callback({20, 30});
 }
-
-TEST_F(BasicSurfaceTest, observer_can_trigger_state_change_within_notification)
-{
-    using namespace testing;
-
-    auto const state_changer = [&]{
-       surface.set_hidden(false);
-    };
-
-    //Make sure another thread can also change state
-    auto const async_state_changer = [&]{
-        std::async(std::launch::async, state_changer).wait();
-    };
-
-    EXPECT_CALL(mock_callback, call()).Times(3)
-        .WillOnce(InvokeWithoutArgs(state_changer))
-        .WillOnce(InvokeWithoutArgs(async_state_changer))
-        .WillOnce(Return());
-
-    surface.register_interest(observer);
-
-    surface.set_hidden(true);
-}
-
 
 TEST_F(BasicSurfaceTest, default_application_id)
 {
@@ -1155,12 +1117,11 @@ TEST_F(BasicSurfaceTest, notifies_about_application_id_changes)
     using namespace testing;
 
     std::string const id{"test.id"};
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
 
-    EXPECT_CALL(mock_surface_observer, application_id_set_to(_, id))
+    EXPECT_CALL(*mock_surface_observer, application_id_set_to(_, id))
         .Times(1);
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
 
     surface.set_application_id(id);
 }
@@ -1170,54 +1131,24 @@ TEST_F(BasicSurfaceTest, does_not_notify_if_application_id_is_unchanged)
     using namespace testing;
 
     std::string const id{"test.id"};
-    NiceMock<MockSurfaceObserver> mock_surface_observer;
 
-    EXPECT_CALL(mock_surface_observer, application_id_set_to(_, id))
+    EXPECT_CALL(*mock_surface_observer, application_id_set_to(_, id))
         .Times(1);
 
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
 
     surface.set_application_id("");
     surface.set_application_id(id);
     surface.set_application_id(id);
 }
 
-TEST_F(BasicSurfaceTest, observer_can_remove_itself_within_notification)
-{
-    using namespace testing;
-    MockSurfaceObserver observer1;
-    MockSurfaceObserver observer2;
-    MockSurfaceObserver observer3;
-
-    //Both of these observers should still get their notifications
-    //regardless of the unregistration of observer2
-    EXPECT_CALL(observer1, hidden_set_to(_, true)).Times(2);
-    EXPECT_CALL(observer3, hidden_set_to(_, true)).Times(2);
-
-    auto const remove_observer = [&]{
-        surface.unregister_interest(observer2);
-    };
-
-    EXPECT_CALL(observer2, hidden_set_to(_, true)).Times(1)
-        .WillOnce(InvokeWithoutArgs(remove_observer));
-
-    surface.register_interest(mt::fake_shared(observer1));
-    surface.register_interest(mt::fake_shared(observer2));
-    surface.register_interest(mt::fake_shared(observer3));
-
-    surface.set_hidden(true);
-    surface.set_hidden(true);
-}
-
 TEST_F(BasicSurfaceTest, notifies_of_client_close_request)
 {
     using namespace testing;
 
-    MockSurfaceObserver mock_surface_observer;
+    EXPECT_CALL(*mock_surface_observer, client_surface_close_requested(_)).Times(1);
 
-    EXPECT_CALL(mock_surface_observer, client_surface_close_requested(_)).Times(1);
-
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
 
     surface.request_client_surface_close();
 }
@@ -1226,10 +1157,9 @@ TEST_F(BasicSurfaceTest, notifies_of_rename)
 {
     using namespace testing;
 
-    MockSurfaceObserver mock_surface_observer;
-    surface.register_interest(mt::fake_shared(mock_surface_observer));
+    surface.register_interest(mock_surface_observer, executor);
 
-    EXPECT_CALL(mock_surface_observer, renamed(_, StrEq("Steve")));
+    EXPECT_CALL(*mock_surface_observer, renamed(_, StrEq("Steve")));
 
     surface.rename("Steve");
 }
@@ -1625,11 +1555,13 @@ TEST_F(BasicSurfaceTest, notifies_when_first_visible)
 {
     using namespace testing;
     auto observer = std::make_shared<VisibilityObserver>();
-    surface.register_interest(observer);
+    surface.register_interest(observer, executor);
 
     EXPECT_THAT(observer->exposes(), Eq(0));
     EXPECT_THAT(observer->hides(), Eq(0));
     surface.configure(mir_window_attrib_visibility, mir_window_visibility_exposed);
+
+    executor.execute();
 
     EXPECT_THAT(observer->exposes(), Eq(1));
     EXPECT_THAT(observer->hides(), Eq(0));

--- a/tests/unit-tests/scene/test_rendering_tracker.cpp
+++ b/tests/unit-tests/scene/test_rendering_tracker.cpp
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "mir/scene/surface_observer.h"
 #include "src/server/scene/rendering_tracker.h"
 #include "mir/test/doubles/mock_surface.h"
 

--- a/tests/unit-tests/scene/test_session_manager.cpp
+++ b/tests/unit-tests/scene/test_session_manager.cpp
@@ -176,7 +176,7 @@ TEST_F(SessionManagerSessionListenerSetup, additional_listeners_receive_surface_
     auto session = session_manager.open_session(__LINE__, mir::Fd{mir::Fd::invalid}, "XPlane", std::shared_ptr<mf::EventSink>());
     auto bs = std::dynamic_pointer_cast<mc::BufferStream>(session->create_buffer_stream(
         mg::BufferProperties{{640, 480}, mir_pixel_format_abgr_8888, mg::BufferUsage::hardware}));
-    session->create_surface(nullptr, {}, mt::make_surface_spec(bs), mt::fake_shared(observer));
+    session->create_surface(nullptr, {}, mt::make_surface_spec(bs), mt::fake_shared(observer), nullptr);
 }
 
 namespace

--- a/tests/unit-tests/scene/test_surface.cpp
+++ b/tests/unit-tests/scene/test_surface.cpp
@@ -123,7 +123,7 @@ TEST_F(SurfaceCreation, resize_updates_stream_and_state)
     ms::OutputPropertiesCache cache;
     auto const observer = std::make_shared<ms::SurfaceEventSource>(mf::SurfaceId(), cache, mock_event_sink);
 
-    surface.add_observer(observer);
+    surface.register_interest(observer);
 
     ASSERT_THAT(surface.window_size(), Ne(new_size));
 
@@ -140,7 +140,7 @@ TEST_F(SurfaceCreation, duplicate_resize_ignored)
     ms::OutputPropertiesCache cache;
     auto const observer = std::make_shared<ms::SurfaceEventSource>(mf::SurfaceId(), cache, mock_event_sink);
 
-    surface.add_observer(observer);
+    surface.register_interest(observer);
 
     ASSERT_THAT(surface.window_size(), Ne(new_size));
 
@@ -208,7 +208,7 @@ TEST_F(SurfaceCreation, consume_calls_send_event)
     ms::OutputPropertiesCache cache;
     auto const observer = std::make_shared<ms::SurfaceEventSource>(mf::SurfaceId(), cache, mock_event_sink);
 
-    surface.add_observer(observer);
+    surface.register_interest(observer);
 
     EXPECT_CALL(*mock_event_sink, handle_event(mt::MirKeyboardEventMatches(key_event.get()))).Times(1);
     EXPECT_CALL(*mock_event_sink, handle_event(mt::MirTouchEventMatches(touch_event.get()))).Times(1);

--- a/tests/unit-tests/scene/test_surface.cpp
+++ b/tests/unit-tests/scene/test_surface.cpp
@@ -24,6 +24,7 @@
 #include "mir/test/doubles/mock_buffer_stream.h"
 #include "mir/test/doubles/mock_input_surface.h"
 #include "mir/test/doubles/stub_buffer.h"
+#include "mir/test/doubles/explicit_executor.h"
 #include "mir/test/event_matchers.h"
 
 #include <gmock/gmock.h>
@@ -59,7 +60,7 @@ struct SurfaceCreation : public ::testing::Test
     {
     }
 
-    virtual void SetUp()
+    void SetUp() override
     {
         using namespace testing;
 
@@ -73,12 +74,17 @@ struct SurfaceCreation : public ::testing::Test
             .WillByDefault(InvokeArgument<0>(&stub_buffer));
     }
 
+    void TearDown() override
+    {
+        executor.execute();
+    }
+
     std::shared_ptr<testing::NiceMock<mtd::MockBufferStream>> mock_buffer_stream = std::make_shared<testing::NiceMock<mtd::MockBufferStream>>();
-    std::list<ms::StreamInfo> streams{ { mock_buffer_stream, {}, {} } }; 
+    std::list<ms::StreamInfo> streams{ { mock_buffer_stream, {}, {} } };
     std::function<void()> change_notification;
     int notification_count = 0;
     mtd::StubBuffer stub_buffer;
-    
+
     std::string surface_name = "test_surfaceA";
     MirPixelFormat pf = mir_pixel_format_abgr_8888;
     geom::Size size = geom::Size{43, 420};
@@ -86,6 +92,11 @@ struct SurfaceCreation : public ::testing::Test
     geom::Rectangle rect = geom::Rectangle{geom::Point{geom::X{0}, geom::Y{0}}, size};
     std::shared_ptr<ms::SceneReport> const report = mr::null_scene_report();
     ms::BasicSurface surface;
+    std::shared_ptr<mt::doubles::MockEventSink> const mock_event_sink = std::make_shared<mt::doubles::MockEventSink>();
+    ms::OutputPropertiesCache cache;
+    std::shared_ptr<ms::SurfaceEventSource> observer =
+        std::make_shared<ms::SurfaceEventSource>(mf::SurfaceId(), cache, mock_event_sink);
+    mtd::ExplicitExecutor executor;
 };
 
 }
@@ -119,11 +130,7 @@ TEST_F(SurfaceCreation, resize_updates_stream_and_state)
     using namespace testing;
     geom::Size const new_size{123, 456};
 
-    auto const mock_event_sink = std::make_shared<mt::doubles::MockEventSink>();
-    ms::OutputPropertiesCache cache;
-    auto const observer = std::make_shared<ms::SurfaceEventSource>(mf::SurfaceId(), cache, mock_event_sink);
-
-    surface.register_interest(observer);
+    surface.register_interest(observer, executor);
 
     ASSERT_THAT(surface.window_size(), Ne(new_size));
 
@@ -136,16 +143,14 @@ TEST_F(SurfaceCreation, duplicate_resize_ignored)
 {
     using namespace testing;
     geom::Size const new_size{123, 456};
-    auto const mock_event_sink = std::make_shared<mt::doubles::MockEventSink>();
-    ms::OutputPropertiesCache cache;
-    auto const observer = std::make_shared<ms::SurfaceEventSource>(mf::SurfaceId(), cache, mock_event_sink);
 
-    surface.register_interest(observer);
+    surface.register_interest(observer, executor);
 
     ASSERT_THAT(surface.window_size(), Ne(new_size));
 
     EXPECT_CALL(*mock_event_sink, handle_event(_)).Times(1);
     surface.resize(new_size);
+    executor.execute();
     EXPECT_THAT(surface.window_size(), Eq(new_size));
 
     Mock::VerifyAndClearExpectations(mock_buffer_stream.get());
@@ -185,15 +190,6 @@ TEST_F(SurfaceCreation, impossible_resize_clamps)
 TEST_F(SurfaceCreation, consume_calls_send_event)
 {
     using namespace testing;
-    ms::BasicSurface surface(
-        nullptr /* session */,
-        {} /* wayland_surface */,
-        surface_name,
-        rect,
-        mir_pointer_unconfined,
-        streams,
-        std::shared_ptr<mg::CursorImage>(),
-        report);
 
     auto key_event = mev::make_key_event(
         MirInputDeviceId(0), std::chrono::nanoseconds(0), std::vector<uint8_t>{},
@@ -204,15 +200,12 @@ TEST_F(SurfaceCreation, consume_calls_send_event)
     mev::add_touch(*touch_event, 0, mir_touch_action_down, mir_touch_tooltype_finger, 0, 0,
         0, 0, 0, 0);
 
-    auto const mock_event_sink = std::make_shared<mt::doubles::MockEventSink>();
-    ms::OutputPropertiesCache cache;
-    auto const observer = std::make_shared<ms::SurfaceEventSource>(mf::SurfaceId(), cache, mock_event_sink);
-
-    surface.register_interest(observer);
+    surface.register_interest(observer, executor);
 
     EXPECT_CALL(*mock_event_sink, handle_event(mt::MirKeyboardEventMatches(key_event.get()))).Times(1);
     EXPECT_CALL(*mock_event_sink, handle_event(mt::MirTouchEventMatches(touch_event.get()))).Times(1);
 
     surface.consume(std::move(key_event));
     surface.consume(std::move(touch_event));
+    executor.execute();
 }

--- a/tests/unit-tests/scene/test_surface_impl.cpp
+++ b/tests/unit-tests/scene/test_surface_impl.cpp
@@ -180,7 +180,7 @@ TEST_F(Surface, emits_resize_events)
     ms::OutputPropertiesCache cache;
     auto const observer = std::make_shared<ms::SurfaceEventSource>(stub_id, cache, sink);
 
-    surface->add_observer(observer);
+    surface->register_interest(observer);
 
     auto e = mev::make_window_resize_event(stub_id, new_size);
     EXPECT_CALL(*sink, handle_event(MirResizeEventEq(e.get())))
@@ -200,7 +200,7 @@ TEST_F(Surface, emits_resize_events_only_on_change)
     ms::OutputPropertiesCache cache;
     auto const observer = std::make_shared<ms::SurfaceEventSource>(stub_id, cache, sink);
 
-    surface->add_observer(observer);
+    surface->register_interest(observer);
 
     auto e = mev::make_window_resize_event(stub_id, new_size);
     EXPECT_CALL(*sink, handle_event(MirResizeEventEq(e.get())))
@@ -238,7 +238,7 @@ TEST_F(Surface, sends_focus_notifications_when_focus_gained_and_lost)
     ms::OutputPropertiesCache cache;
     auto const observer = std::make_shared<ms::SurfaceEventSource>(stub_id, cache, mt::fake_shared(sink));
 
-    surface->add_observer(observer);
+    surface->register_interest(observer);
 
     surface->configure(mir_window_attrib_focus, mir_window_focus_state_focused);
     surface->configure(mir_window_attrib_focus, mir_window_focus_state_unfocused);
@@ -256,7 +256,7 @@ TEST_F(Surface, emits_client_close_events)
     ms::OutputPropertiesCache cache;
     auto const observer = std::make_shared<ms::SurfaceEventSource>(stub_id, cache, sink);
 
-    surface->add_observer(observer);
+    surface->register_interest(observer);
 
     MirCloseWindowEvent e;
     e.to_close_window()->set_surface_id(stub_id.as_value());

--- a/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
+++ b/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
@@ -75,7 +75,7 @@ struct StubCursorImages
 struct MockSurface
     : ms::BasicSurface
 {
-    MockSurface(std::shared_ptr<ms::Session> const& session)
+    MockSurface(std::shared_ptr<ms::Session> const& session, mir::Executor& executor)
         : ms::BasicSurface{
               session,
               {},
@@ -84,11 +84,24 @@ struct MockSurface
               mir_pointer_unconfined,
               { { std::make_shared<testing::NiceMock<mtd::MockBufferStream>>(), {0, 0}, {} } },
               {},
-              mir::report::null_scene_report()}
+              mir::report::null_scene_report()},
+          executor{executor}
     {
     }
 
+    void register_interest(std::weak_ptr<ms::SurfaceObserver> const& observer)
+    {
+        BasicSurface::register_interest(observer, executor);
+    }
+
+    void register_interest(std::weak_ptr<ms::SurfaceObserver> const& observer, mir::Executor&)
+    {
+        register_interest(observer);
+    }
+
     MOCK_METHOD0(request_client_surface_close, void());
+
+    mir::Executor& executor;
 };
 
 struct MockShell
@@ -193,8 +206,8 @@ struct DecorationBasicDecoration
     StubCursorImages cursor_images;
     std::shared_ptr<msd::BasicDecoration> basic_decoration;
     std::shared_ptr<NiceMock<mtd::MockSceneSession>> session{std::make_shared<NiceMock<mtd::MockSceneSession>>()};
-    StrictMock<MockSurface> window_surface{session};
-    StrictMock<MockSurface> decoration_surface{session};
+    StrictMock<MockSurface> window_surface{session, executor};
+    StrictMock<MockSurface> decoration_surface{session, executor};
     msh::SurfaceSpecification creation_params;
     NiceMock<mtd::MockBufferStream> buffer_stream;
 };

--- a/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
+++ b/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
@@ -158,7 +158,7 @@ struct DecorationBasicDecoration
                 {
                     creation_params = params;
                     decoration_surface.resize({params.width.value(), params.height.value()});
-                    decoration_surface.add_observer(observer);
+                    decoration_surface.register_interest(observer);
                     return mt::fake_shared(decoration_surface);
                 }));
         ON_CALL(*session, create_buffer_stream(_))

--- a/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
+++ b/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
@@ -133,11 +133,12 @@ struct MockShell
         uint64_t,
         MirResizeEdge));
 
-    MOCK_METHOD4(create_surface, std::shared_ptr<ms::Surface>(
+    MOCK_METHOD5(create_surface, std::shared_ptr<ms::Surface>(
         std::shared_ptr<ms::Session> const&,
         mw::Weak<mf::WlSurface> const&,
         msh::SurfaceSpecification const&,
-        std::shared_ptr<ms::SurfaceObserver> const&));
+        std::shared_ptr<ms::SurfaceObserver> const&,
+        mir::Executor*));
 
     MOCK_METHOD2(destroy_surface, void(
         std::shared_ptr<ms::Session> const&,
@@ -149,12 +150,13 @@ struct DecorationBasicDecoration
 {
     void SetUp() override
     {
-        ON_CALL(shell, create_surface(_, _, _, _))
+        ON_CALL(shell, create_surface(_, _, _, _, _))
             .WillByDefault(Invoke([this](
                     std::shared_ptr<ms::Session> const&,
                     mw::Weak<mf::WlSurface> const&,
                     msh::SurfaceSpecification const& params,
-                    std::shared_ptr<ms::SurfaceObserver> const& observer) -> std::shared_ptr<ms::Surface>
+                    std::shared_ptr<ms::SurfaceObserver> const& observer,
+                    mir::Executor*) -> std::shared_ptr<ms::Surface>
                 {
                     creation_params = params;
                     decoration_surface.resize({params.width.value(), params.height.value()});

--- a/tests/unit-tests/shell/test_default_persistent_surface_store.cpp
+++ b/tests/unit-tests/shell/test_default_persistent_surface_store.cpp
@@ -16,6 +16,7 @@
 
 #include "mir/shell/persistent_surface_store.h"
 
+#include "mir/scene/surface_observer.h"
 #include "src/server/shell/default_persistent_surface_store.h"
 #include "mir/test/doubles/mock_surface.h"
 


### PR DESCRIPTION
This updates the surface observer to use the new observer system. Some changes are needed to allow safely moving the observation calls between threads (such as using a shared pointer instead of raw pointer to events). There's still some bits to finish and crashes/deadlocks to sort out before it's ready to merge.