### PR TITLE
Prevent deadlocks in ObserverMultiplexer

### DIFF
--- a/src/include/server/mir/observer_multiplexer.h
+++ b/src/include/server/mir/observer_multiplexer.h
@@ -20,16 +20,12 @@
 #define MIR_OBSERVER_MULTIPLEXER_H_
 
 #include "mir/observer_registrar.h"
-#include "mir/raii.h"
 #include "mir/posix_rw_mutex.h"
 #include "mir/executor.h"
-#include "mir/main_loop.h"
 
 #include <vector>
 #include <algorithm>
 #include <mutex>
-#include <thread>
-#include <shared_mutex>
 
 namespace mir
 {

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -37,6 +37,7 @@
 #include "mir/emergency_cleanup.h"
 #include "mir/log.h"
 #include "mir/report_exception.h"
+#include "mir/main_loop.h"
 
 #include <boost/throw_exception.hpp>
 

--- a/src/server/scene/default_configuration.cpp
+++ b/src/server/scene/default_configuration.cpp
@@ -25,6 +25,7 @@
 #include "mir/scene/session.h"
 #include "mir/scene/session_container.h"
 #include "mir/shell/display_configuration_controller.h"
+#include "mir/main_loop.h"
 
 #include "broadcasting_session_event_sink.h"
 #include "mediating_display_changer.h"

--- a/tests/unit-tests/test_observer_multiplexer.cpp
+++ b/tests/unit-tests/test_observer_multiplexer.cpp
@@ -627,7 +627,7 @@ TEST(ObserverMultiplexer, can_trigger_observer_during_observation_from_other_thr
     executor.drain_work();
 }
 
-TEST(ObserverMultiplexer, can_trigger_singl_observer_during_single_observer_observation_from_other_thread)
+TEST(ObserverMultiplexer, can_trigger_single_observer_during_single_observer_observation_from_other_thread)
 {
     using namespace testing;
     constexpr char const* first_observation = "Elementary, my dear Watson";

--- a/tests/unit-tests/test_observer_multiplexer.cpp
+++ b/tests/unit-tests/test_observer_multiplexer.cpp
@@ -599,6 +599,97 @@ TEST(ObserverMultiplexer, can_trigger_observers_from_observers)
     executor.drain_work();
 }
 
+TEST(ObserverMultiplexer, can_trigger_observer_during_observation_from_other_thread)
+{
+    using namespace testing;
+    constexpr char const* first_observation = "Elementary, my dear Watson";
+    constexpr char const* second_observation = "You're one microscopic cog in his catastrophic plan";
+
+    auto observer = std::make_shared<NiceMock<MockObserver>>();
+
+    ThreadedExecutor executor;
+    TestObserverMultiplexer multiplexer{executor};
+
+    EXPECT_CALL(*observer, observation_made(StrEq(first_observation)))
+        .WillOnce(InvokeWithoutArgs([&]()
+            {
+                mt::AutoJoinThread([&]()
+                    {
+                        multiplexer.observation_made(second_observation);
+                    });
+            }));
+    EXPECT_CALL(*observer, observation_made(StrEq(second_observation)));
+
+    multiplexer.register_interest(observer);
+
+    multiplexer.observation_made(first_observation);
+
+    executor.drain_work();
+}
+
+TEST(ObserverMultiplexer, can_trigger_singl_observer_during_single_observer_observation_from_other_thread)
+{
+    using namespace testing;
+    constexpr char const* first_observation = "Elementary, my dear Watson";
+    constexpr char const* second_observation = "You're one microscopic cog in his catastrophic plan";
+
+    auto observer = std::make_shared<NiceMock<MockObserver>>();
+
+    ThreadedExecutor executor;
+    TestObserverMultiplexer multiplexer{executor};
+
+    EXPECT_CALL(*observer, observation_made(StrEq(first_observation)))
+        .WillOnce(InvokeWithoutArgs([&]()
+            {
+                mt::AutoJoinThread([&]()
+                    {
+                        multiplexer.single_observer_observation(*observer, second_observation);
+                    });
+            }));
+    EXPECT_CALL(*observer, observation_made(StrEq(second_observation)));
+
+    multiplexer.register_interest(observer);
+
+    multiplexer.single_observer_observation(*observer, first_observation);
+
+    executor.drain_work();
+}
+
+TEST(ObserverMultiplexer, can_remove_observer_during_other_observers_observation_from_other_thread)
+{
+    using namespace testing;
+    constexpr char const* first_observation = "Elementary, my dear Watson";
+    constexpr char const* second_observation = "You're one microscopic cog in his catastrophic plan";
+
+    auto observer_a = std::make_shared<NiceMock<MockObserver>>();
+    auto observer_b = std::make_shared<NiceMock<MockObserver>>();
+
+    ThreadedExecutor executor;
+    TestObserverMultiplexer multiplexer{executor};
+
+    EXPECT_CALL(*observer_a, observation_made(StrEq(first_observation)))
+        .WillOnce(InvokeWithoutArgs([&]()
+            {
+                mt::AutoJoinThread([&]()
+                    {
+                        multiplexer.unregister_interest(*observer_b);
+                    });
+            }));
+    EXPECT_CALL(*observer_a, observation_made(StrEq(second_observation)));
+
+    EXPECT_CALL(*observer_b, observation_made(StrEq(first_observation))).Times(AnyNumber()); // May or may not be called
+    EXPECT_CALL(*observer_b, observation_made(StrEq(second_observation))).Times(0);
+
+    multiplexer.register_interest(observer_a);
+    multiplexer.register_interest(observer_b);
+
+    multiplexer.observation_made(first_observation);
+    executor.drain_work();
+
+    multiplexer.observation_made(second_observation);
+    executor.drain_work();
+}
+
 TEST(ObserverMultiplexer, addition_takes_effect_immediately_even_in_callback)
 {
     using namespace testing;


### PR DESCRIPTION
This PR adds three multiplexer tests (all of which previously deadlocked) and fixes all of them.

The core issue was that spawning an observation required locking the same mutex that remained locked while observations were being processed. The use of `recursive_mutex` mitigated that if everything was on the same thread, but if the receiving-observation thread was blocked on some other thread, which was blocked on sending an observation there was trouble.

This PR uses separate mutexes for spawning and running observations. Both are locked when an observer is unregistered, but unregister does not lock them simultaneously.

This fixes some of the deadlocks I've encountered in #2371, and assuming it's correct is an overall improvement.