### PR TITLE
ExplicitExecutor: repeat execute until queue is drained

### DIFF
--- a/tests/include/mir/test/doubles/explicit_executor.h
+++ b/tests/include/mir/test/doubles/explicit_executor.h
@@ -54,13 +54,20 @@ public:
 
     void execute()
     {
-        std::unique_lock lock{mutex};
-        auto const items = std::move(work_items);
-        work_items.clear();
-        lock.unlock();
-        for (auto const& work : items)
+        while (true)
         {
-            work();
+            std::unique_lock lock{mutex};
+            auto const items = std::move(work_items);
+            work_items.clear();
+            lock.unlock();
+            if (items.empty())
+            {
+                break;
+            }
+            for (auto const& work : items)
+            {
+                work();
+            }
         }
     }
 

--- a/tests/include/mir/test/doubles/explicit_executor.h
+++ b/tests/include/mir/test/doubles/explicit_executor.h
@@ -54,21 +54,19 @@ public:
 
     void execute()
     {
-        while (true)
+        decltype(work_items) drained_items;
+        do
         {
-            std::unique_lock lock{mutex};
-            auto const items = std::move(work_items);
-            work_items.clear();
-            lock.unlock();
-            if (items.empty())
+            drained_items.clear();
             {
-                break;
+                std::lock_guard lock{mutex};
+                swap(drained_items, work_items);
             }
-            for (auto const& work : items)
+            for (auto const& work : drained_items)
             {
                 work();
             }
-        }
+        } while (!drained_items.empty());
     }
 
 private:

--- a/tests/unit-tests/graphics/test_software_cursor.cpp
+++ b/tests/unit-tests/graphics/test_software_cursor.cpp
@@ -194,9 +194,9 @@ TEST_F(SoftwareCursor, tolerates_being_hidden_while_being_shown)
     EXPECT_CALL(mock_input_scene, add_input_visualization(_))
         .WillOnce(Invoke([&](auto)
             {
-                cursor.hide(); // should do nothing
+                cursor.hide();
             }));
-    EXPECT_CALL(mock_input_scene, remove_input_visualization(_)).Times(0);
+    EXPECT_CALL(mock_input_scene, remove_input_visualization(_));
 
     cursor.show(stub_cursor_image);
     executor.execute();
@@ -214,8 +214,9 @@ TEST_F(SoftwareCursor, tolerates_being_hidden_while_being_reshown)
     EXPECT_CALL(mock_input_scene, add_input_visualization(_))
         .WillOnce(Invoke([&](auto)
             {
-                cursor.hide(); // should do nothing
+                cursor.hide();
             }));
+    EXPECT_CALL(mock_input_scene, remove_input_visualization(_));
 
     cursor.show(stub_cursor_image);
     executor.execute();

--- a/tests/unit-tests/graphics/test_software_cursor.cpp
+++ b/tests/unit-tests/graphics/test_software_cursor.cpp
@@ -196,7 +196,7 @@ TEST_F(SoftwareCursor, tolerates_being_hidden_while_being_shown)
             {
                 cursor.hide();
             }));
-    EXPECT_CALL(mock_input_scene, remove_input_visualization(_));
+    EXPECT_CALL(mock_input_scene, remove_input_visualization(_)).Times(AnyNumber());
 
     cursor.show(stub_cursor_image);
     executor.execute();
@@ -216,7 +216,7 @@ TEST_F(SoftwareCursor, tolerates_being_hidden_while_being_reshown)
             {
                 cursor.hide();
             }));
-    EXPECT_CALL(mock_input_scene, remove_input_visualization(_));
+    EXPECT_CALL(mock_input_scene, remove_input_visualization(_)).Times(AnyNumber());
 
     cursor.show(stub_cursor_image);
     executor.execute();


### PR DESCRIPTION
Makes some tests work in my better surface observer branch, and seems to be a general improvement to me.