### PR TITLE
Update WLCS XFAIL list

### DIFF
--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -91,8 +91,6 @@ set(EXPECTED_FAILURES
 
   XdgToplevelStableTest.touch_can_not_steal_pointer_based_move # https://github.com/MirServer/mir/issues/1792
 
-  LayerShellPopup/XdgPopupTest.grabbed_popup_does_not_get_keyboard_focus/0
-
   ForeignToplevelHandleTest.can_maximize_foreign_while_fullscreen # https://github.com/MirServer/mir/issues/2164
 
   # See https://github.com/MirServer/mir/issues/2324

--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -91,10 +91,7 @@ set(EXPECTED_FAILURES
 
   XdgToplevelStableTest.touch_can_not_steal_pointer_based_move # https://github.com/MirServer/mir/issues/1792
 
-  # Fixed by https://github.com/MirServer/wlcs/pull/203
-  LayerShellPopup/XdgPopupTest.non_grabbed_popup_does_not_get_keyboard_focus/0
   LayerShellPopup/XdgPopupTest.grabbed_popup_does_not_get_keyboard_focus/0
-  LayerShellPopup/XdgPopupTest.grabbed_popup_gets_done_event_when_new_toplevel_created/0
 
   ForeignToplevelHandleTest.can_maximize_foreign_while_fullscreen # https://github.com/MirServer/mir/issues/2164
 


### PR DESCRIPTION
With WLCS CI now publishing into Mir CI we've got a new WLCS, and that has fixed a couple of tests we XFAILed.