### PR TITLE
wlcs: Add target to list XFAIL tests which don't exist

### DIFF
--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -125,3 +125,14 @@ if (MIR_RUN_WLCS_TESTS)
 endif()
 
 install(TARGETS miral_wlcs_integration LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/mir)
+
+add_custom_target(
+  list_missing_wlcs_xfail_tests
+
+  COMMAND
+    ${CMAKE_COMMAND}
+      -DWLCS_BINARY=${WLCS_BINARY}
+      -DWLCS_INTEGRATION=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/miral_wlcs_integration.so
+      -DTESTS_TO_QUERY="${EXPECTED_FAILURES}"
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/print_missing_wlcs_tests.cmake
+)

--- a/tests/acceptance-tests/wayland/print_missing_wlcs_tests.cmake
+++ b/tests/acceptance-tests/wayland/print_missing_wlcs_tests.cmake
@@ -1,0 +1,26 @@
+separate_arguments(TESTS_TO_QUERY)
+string(REPLACE ";" ":" TESTS_TO_QUERY_STR "${TESTS_TO_QUERY}")
+  
+foreach (test_name IN LISTS TESTS_TO_QUERY)
+  execute_process(
+    COMMAND
+      ${WLCS_BINARY} ${WLCS_INTEGRATION} --gtest_list_tests --gtest_filter=${TESTS_TO_QUERY_STR}
+    RESULT_VARIABLE
+      wlcs_success
+    OUTPUT_VARIABLE
+      wlcs_output
+  )
+  
+  if (wlcs_success)
+    message(FATAL_ERROR "Failed to run WLCS to query tests: ${wlcs_success}")
+  endif()
+
+  string(REPLACE "." ";" split_test_name ${test_name})
+  list(GET split_test_name 0 test_suite)
+  list(GET split_test_name 1 test_name)
+  
+  if (NOT ((wlcs_output MATCHES ".*${test_suite}.*") AND (wlcs_output MATCHES ".*${test_name}.*")))
+    message("Test ${test_suite}.${test_name} does not exist in WLCS")
+  endif()
+endforeach()
+


### PR DESCRIPTION
You can run the `list_missing_wlcs_xfail_tests` to get a list of the tests that we mark as expected failures that don't exist in the installed version of WLCS.

We don't want to *fail* XFAIL tests which don't exist, because we want to be able to mark a test that is *going* to land in WLCS as XFAIL.

However, where we've added tests to the expected failure list because the *test* is incorrect we should periodically run this target and remove any XFAILs that are now removed in WLCS.