### PR TITLE
Stop using `signal()` has unspecified behaviour in multithreaded programs

### DIFF
--- a/examples/client/wayland_client.c
+++ b/examples/client/wayland_client.c
@@ -409,9 +409,15 @@ int main()
 
     wl_output_add_listener(globals->output, &output_listener, NULL);
 
-    signal(SIGINT, shutdown);
-    signal(SIGTERM, shutdown);
-    signal(SIGHUP, shutdown);
+    struct sigaction sig_handler_new;
+    sigfillset(&sig_handler_new.sa_mask);
+    sig_handler_new.sa_flags = 0;
+    sig_handler_new.sa_handler = shutdown;
+
+    sigaction(SIGINT, &sig_handler_new, NULL);
+    sigaction(SIGTERM, &sig_handler_new, NULL);
+    sigaction(SIGHUP, &sig_handler_new, NULL);
+
     running = 1;
 
     while (wl_display_dispatch(display) && running)

--- a/tests/unit-tests/dispatch/test_threaded_dispatcher.cpp
+++ b/tests/unit-tests/dispatch/test_threaded_dispatcher.cpp
@@ -318,10 +318,6 @@ TEST_F(ThreadedDispatcherTest, DISABLED_sets_thread_names_appropriately)
     EXPECT_TRUE(dispatched->wait_for(10s));
 }
 
-void sigcont_handler(int)
-{
-}
-
 // Regression test for: lp #1439719
 TEST(ThreadedDispatcherSignalTest, keeps_dispatching_after_signal_interruption)
 {
@@ -348,7 +344,11 @@ TEST(ThreadedDispatcherSignalTest, keeps_dispatching_after_signal_interruption)
                  * When there's a signal handler for SIGCONT installed then
                  * any blocked syscall will (correctly) return EINTR, so install one.
                  */
-                signal(SIGCONT, &sigcont_handler);
+                struct sigaction sig_handler_new;
+                sigfillset(&sig_handler_new.sa_mask);
+                sig_handler_new.sa_flags = 0;
+                sig_handler_new.sa_handler = [](auto) {};
+                sigaction(SIGCONT, &sig_handler_new, nullptr);
 
                 md::ThreadedDispatcher dispatcher{"Test thread", dispatchable};
                 // Ensure the dispatcher has started


### PR DESCRIPTION
Use `sigaction() throughout as `signal()` has unspecified behaviour in multithreaded programs.