### PR TITLE
Fix ThreadedDispatcherSignalTest.keeps_dispatching_after_signal_interruption

### DIFF
--- a/tests/unit-tests/dispatch/test_threaded_dispatcher.cpp
+++ b/tests/unit-tests/dispatch/test_threaded_dispatcher.cpp
@@ -371,7 +371,7 @@ TEST(ThreadedDispatcherSignalTest, keeps_dispatching_after_signal_interruption)
                 stop_and_restart_process.~CrossProcessAction();
                 exit_success_sync.~CrossProcessSync();
             }
-            exit(HasFailure() ? EXIT_FAILURE : EXIT_SUCCESS);
+            _exit(HasFailure() ? EXIT_FAILURE : EXIT_SUCCESS);
         },
         []{ return 1; });
 


### PR DESCRIPTION
Don't try to cleanup child process on exit.

There can be "random" cleanup left by other tests that we don't care about.

Fixes #2377