### PR TITLE
Don't wake threads that can't run

### DIFF
--- a/src/common/linearising_executor.cpp
+++ b/src/common/linearising_executor.cpp
@@ -73,7 +73,7 @@ private:
             }
             idle = true;
         }
-        idle_changed.notify_all();
+        idle_changed.notify_one();
     }
 
     std::mutex mutex;

--- a/src/common/linearising_executor.cpp
+++ b/src/common/linearising_executor.cpp
@@ -59,18 +59,20 @@ private:
     // Execute items from the queue one at a time, until none are left
     void work_loop()
     {
-        std::unique_lock lock{mutex};
-        while (!workqueue.empty())
         {
+            std::unique_lock lock{mutex};
+            while (!workqueue.empty())
             {
-                auto work = std::move(workqueue.front());
-                workqueue.pop_front();
-                lock.unlock();
-                work();
+                {
+                    auto work = std::move(workqueue.front());
+                    workqueue.pop_front();
+                    lock.unlock();
+                    work();
+                }
+                lock.lock();
             }
-            lock.lock();
+            idle = true;
         }
-        idle = true;
         idle_changed.notify_all();
     }
 

--- a/src/common/system_executor.cpp
+++ b/src/common/system_executor.cpp
@@ -46,8 +46,10 @@ public:
 
     void release()
     {
-        std::lock_guard lock{mutex};
-        raised = true;
+        {
+            std::lock_guard lock{mutex};
+            raised = true;
+        }
         cv.notify_all();
     }
 

--- a/src/common/thread/recursive_read_write_mutex.cpp
+++ b/src/common/thread/recursive_read_write_mutex.cpp
@@ -57,7 +57,7 @@ void mir::RecursiveReadWriteMutex::read_unlock()
 
         --(my_count->count);
     }
-    cv.notify_all();
+    cv.notify_one();
 }
 
 void mir::RecursiveReadWriteMutex::write_lock()

--- a/src/common/thread/recursive_read_write_mutex.cpp
+++ b/src/common/thread/recursive_read_write_mutex.cpp
@@ -48,14 +48,15 @@ void mir::RecursiveReadWriteMutex::read_unlock()
 {
     auto const my_id = std::this_thread::get_id();
 
-    std::lock_guard lock{mutex};
-    auto const my_count = std::find_if(
-        read_locking_threads.begin(),
-        read_locking_threads.end(),
-        [my_id](ThreadLockCount const& candidate) { return my_id == candidate.id; });
+    {
+        std::lock_guard lock{mutex};
+        auto const my_count = std::find_if(
+            read_locking_threads.begin(),
+            read_locking_threads.end(),
+            [my_id](ThreadLockCount const& candidate) { return my_id == candidate.id; });
 
-    --(my_count->count);
-
+        --(my_count->count);
+    }
     cv.notify_all();
 }
 
@@ -81,7 +82,9 @@ void mir::RecursiveReadWriteMutex::write_lock()
 
 void mir::RecursiveReadWriteMutex::write_unlock()
 {
-    std::lock_guard lock{mutex};
-    --write_locking_thread.count;
+    {
+        std::lock_guard lock{mutex};
+        --write_locking_thread.count;
+    }
     cv.notify_all();
 }

--- a/src/platforms/common/server/egl_context_executor.cpp
+++ b/src/platforms/common/server/egl_context_executor.cpp
@@ -34,7 +34,7 @@ mgc::EGLContextExecutor::~EGLContextExecutor() noexcept
         std::lock_guard lock{mutex};
         shutdown_requested = true;
     }
-    new_work.notify_all();
+    new_work.notify_one();
     egl_thread.join();
 }
 
@@ -45,7 +45,7 @@ void mgc::EGLContextExecutor::spawn(
         std::lock_guard lock{mutex};
         work_queue.emplace_back(std::move(functor));
     }
-    new_work.notify_all();
+    new_work.notify_one();
 }
 
 void mgc::EGLContextExecutor::process_loop(mgc::EGLContextExecutor* const me)

--- a/src/platforms/eglstream-kms/server/threaded_drm_event_handler.cpp
+++ b/src/platforms/eglstream-kms/server/threaded_drm_event_handler.cpp
@@ -39,8 +39,10 @@ mge::ThreadedDRMEventHandler::ThreadedDRMEventHandler(mir::Fd drm_fd)
 mge::ThreadedDRMEventHandler::~ThreadedDRMEventHandler()
 {
     {
-        std::lock_guard lock{expectation_mutex};
-        shutdown = true;
+        {
+            std::lock_guard lock{expectation_mutex};
+            shutdown = true;
+        }
         expectations_changed.notify_all();
     }
     if (dispatch_thread.joinable())

--- a/src/platforms/eglstream-kms/server/threaded_drm_event_handler.cpp
+++ b/src/platforms/eglstream-kms/server/threaded_drm_event_handler.cpp
@@ -43,7 +43,7 @@ mge::ThreadedDRMEventHandler::~ThreadedDRMEventHandler()
             std::lock_guard lock{expectation_mutex};
             shutdown = true;
         }
-        expectations_changed.notify_all();
+        expectations_changed.notify_one();
     }
     if (dispatch_thread.joinable())
     {
@@ -68,7 +68,7 @@ public:
 
     ~NotifyOnScopeExit()
     {
-        notifier.notify_all();
+        notifier.notify_one();
     }
 private:
     std::condition_variable& notifier;

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -389,7 +389,7 @@ void mgw::DisplayClient::Output::swap_buffers()
                 std::lock_guard lock{mutex};
                 posted = true;
             }
-            cv.notify_all();
+            cv.notify_one();
         }
 
         void wait_for_done()

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -385,8 +385,10 @@ void mgw::DisplayClient::Output::swap_buffers()
 
         void frame_done(wl_callback*, uint32_t)
         {
-            std::lock_guard lock{mutex};
-            posted = true;
+            {
+                std::lock_guard lock{mutex};
+                posted = true;
+            }
             cv.notify_all();
         }
 

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -142,10 +142,12 @@ auto connect_xwayland_wl_client(
     wayland_connector->run_on_wayland_display(
         [ctx, wayland_fd, scale](wl_display* display)
         {
-            std::lock_guard lock{ctx->mutex};
-            ctx->client = wl_client_create(display, wayland_fd);
-            mf::WlClient::from(ctx->client)->set_output_geometry_scale(scale);
-            ctx->ready = true;
+            {
+                std::lock_guard lock{ctx->mutex};
+                ctx->client = wl_client_create(display, wayland_fd);
+                mf::WlClient::from(ctx->client)->set_output_geometry_scale(scale);
+                ctx->ready = true;
+            }
             ctx->condition_variable.notify_all();
         });
 

--- a/src/server/frontend_xwayland/xwayland_server.cpp
+++ b/src/server/frontend_xwayland/xwayland_server.cpp
@@ -148,7 +148,7 @@ auto connect_xwayland_wl_client(
                 mf::WlClient::from(ctx->client)->set_output_geometry_scale(scale);
                 ctx->ready = true;
             }
-            ctx->condition_variable.notify_all();
+            ctx->condition_variable.notify_one();
         });
 
     std::unique_lock client_lock{ctx->mutex};

--- a/src/server/glib_main_loop.cpp
+++ b/src/server/glib_main_loop.cpp
@@ -377,8 +377,10 @@ void mir::GLibMainLoop::reprocess_all_sources()
                     detail::add_idle_gsource(main_context, G_PRIORITY_LOW,
                         [&]
                         {
-                            std::lock_guard lock{reprocessed_mutex};
-                            reprocessed = true;
+                            {
+                                std::lock_guard lock{reprocessed_mutex};
+                                reprocessed = true;
+                            }
                             reprocessed_cv.notify_all();
                         });
 

--- a/src/server/glib_main_loop.cpp
+++ b/src/server/glib_main_loop.cpp
@@ -381,7 +381,7 @@ void mir::GLibMainLoop::reprocess_all_sources()
                                 std::lock_guard lock{reprocessed_mutex};
                                 reprocessed = true;
                             }
-                            reprocessed_cv.notify_all();
+                            reprocessed_cv.notify_one();
                         });
 
                     before_iteration_hook = []{};

--- a/src/server/input/default_input_device_hub.cpp
+++ b/src/server/input/default_input_device_hub.cpp
@@ -101,11 +101,13 @@ void mi::ExternalInputDeviceHub::remove_observer(std::weak_ptr<InputDeviceObserv
         data->observer_queue->enqueue_with_guaranteed_execution(
             [&,this]
             {
-                std::lock_guard lock{data->mutex};
-                data->observers.remove(observer);
+                {
+                    std::lock_guard lock{data->mutex};
+                    data->observers.remove(observer);
 
-                std::lock_guard cond_var_lock{mutex};
-                removed = true;
+                    std::lock_guard cond_var_lock{mutex};
+                    removed = true;
+                }
                 cv.notify_one();
             });
 

--- a/tests/integration-tests/compositor/multithread_harness.h
+++ b/tests/integration-tests/compositor/multithread_harness.h
@@ -77,8 +77,10 @@ class Synchronizer : public SynchronizerController,
 
         void activate_waiting_child()
         {
-            std::unique_lock lk(sync_mutex);
-            paused = false;
+            {
+                std::unique_lock lk(sync_mutex);
+                paused = false;
+            }
             cv.notify_all();
         };
 

--- a/tests/integration-tests/test_surface_stack_with_compositor.cpp
+++ b/tests/integration-tests/test_surface_stack_with_compositor.cpp
@@ -88,8 +88,10 @@ struct CountingDisplaySyncGroup : public mtd::StubDisplaySyncGroup
 private:
     void increment_post_count()
     {
-        std::unique_lock lk(mutex);
-        ++post_count_;
+        {
+            std::unique_lock lk(mutex);
+            ++post_count_;
+        }
         count_cv.notify_all();
     }
 

--- a/tests/mir_test/signal.cpp
+++ b/tests/mir_test/signal.cpp
@@ -22,8 +22,10 @@ namespace mt = mir::test;
 
 void mt::Signal::raise()
 {
-    std::lock_guard lock(mutex);
-    signalled = true;
+    {
+        std::lock_guard lock(mutex);
+        signalled = true;
+    }
     cv.notify_all();
 }
 

--- a/tests/mir_test_framework/async_server_runner.cpp
+++ b/tests/mir_test_framework/async_server_runner.cpp
@@ -85,8 +85,10 @@ void mtf::AsyncServerRunner::start_server()
                             this,
                             [this]
                             {
-                                std::lock_guard lock(mutex);
-                                server_running = true;
+                                {
+                                    std::lock_guard lock(mutex);
+                                    server_running = true;
+                                }
                                 started.notify_one();
                             });
                     });
@@ -100,8 +102,10 @@ void mtf::AsyncServerRunner::start_server()
                 mir::report_exception(error);
                 FAIL() << error.str();
             }
-            std::lock_guard lock(mutex);
-            server_running = false;
+            {
+                std::lock_guard lock(mutex);
+                server_running = false;
+            }
             started.notify_one();
         });
 

--- a/tests/mir_test_framework/passthrough_tracker.cpp
+++ b/tests/mir_test_framework/passthrough_tracker.cpp
@@ -22,8 +22,10 @@ namespace mtf = mir_test_framework;
 
 void mtf::PassthroughTracker::note_passthrough()
 {
-    std::unique_lock lk(mutex);
-    num_passthrough++;
+    {
+        std::unique_lock lk(mutex);
+        num_passthrough++;
+    }
     cv.notify_all();
 }
 

--- a/tests/mir_test_framework/server_runner.cpp
+++ b/tests/mir_test_framework/server_runner.cpp
@@ -99,8 +99,10 @@ std::shared_ptr<mir::MainLoop> mtf::ServerRunner::start_mir_server()
                     this,
                     [&]
                     {
-                        std::lock_guard lock(mutex);
-                        started = true;
+                        {
+                            std::lock_guard lock(mutex);
+                            started = true;
+                        }
                         started_cv.notify_one();
                     });
             });

--- a/tests/mir_test_framework/test_display_server.cpp
+++ b/tests/mir_test_framework/test_display_server.cpp
@@ -95,9 +95,11 @@ void miral::TestDisplayServer::start_server()
                             // leaving start_mir_server().
                             main_loop->enqueue(this, [&]
                                 {
-                                     std::lock_guard lock(mutex);
-                                     server_running = &server;
-                                     started.notify_one();
+                                    {
+                                        std::lock_guard lock(mutex);
+                                        server_running = &server;
+                                    }
+                                    started.notify_one();
                                 });
                         });
 
@@ -126,8 +128,10 @@ void miral::TestDisplayServer::start_server()
                 mir::fatal_error(e.what());
             }
 
-            std::lock_guard lock(mutex);
-            server_running = nullptr;
+            {
+                std::lock_guard lock(mutex);
+                server_running = nullptr;
+            }
             started.notify_one();
          });
 

--- a/tests/miral/wayland_extensions.cpp
+++ b/tests/miral/wayland_extensions.cpp
@@ -80,9 +80,11 @@ struct WaylandExtensions : miral::TestServer
 
         client.code = [&](struct wl_display* display)
             {
-                std::lock_guard lock{mutex};
-                code(display);
-                client_run = true;
+                {
+                    std::lock_guard lock{mutex};
+                    code(display);
+                    client_run = true;
+                }
                 cv.notify_one();
             };
 

--- a/tests/unit-tests/test_glib_main_loop.cpp
+++ b/tests/unit-tests/test_glib_main_loop.cpp
@@ -919,8 +919,10 @@ class Counter
 public:
     int operator++()
     {
-        std::lock_guard lock(mutex);
-        cv.notify_one();
+        {
+            std::lock_guard lock(mutex);
+            cv.notify_one();
+        }
         return ++counter;
     }
 

--- a/tests/unit-tests/test_observer_multiplexer.cpp
+++ b/tests/unit-tests/test_observer_multiplexer.cpp
@@ -80,7 +80,6 @@ public:
                         {
                             std::lock_guard lock{work_mutex};
                             work_pending.pop();
-                            work_changed.notify_all();
                         }
                         work_changed.notify_all();
                     }
@@ -107,8 +106,10 @@ public:
 
     void spawn(std::function<void()>&& work) override
     {
-        std::lock_guard lock{work_mutex};
-        work_pending.emplace(std::move(work));
+        {
+            std::lock_guard lock{work_mutex};
+            work_pending.emplace(std::move(work));
+        }
         work_changed.notify_all();
     }
 


### PR DESCRIPTION
1. Do not call `condition_variable::notify_*` under lock: The woken thread cannot get lock the mutex.
2. Call `condition_variable::notify_one()` when only one thread will be able to proceed.