### PR TITLE
Change default MIR_RUN_PERFORMANCE_TESTS option to OFF

### DIFF
--- a/tests/performance-tests/CMakeLists.txt
+++ b/tests/performance-tests/CMakeLists.txt
@@ -27,7 +27,7 @@ CMAKE_DEPENDENT_OPTION(
 )
 
 CMAKE_DEPENDENT_OPTION(
-  MIR_RUN_PERFORMANCE_TESTS "Run mir_performance_tests as part of testsuite" ON
+  MIR_RUN_PERFORMANCE_TESTS "Run mir_performance_tests as part of testsuite" OFF
   "XVFB_RUN_EXECUTABLE;GLMARK2_EXECUTABLE" OFF
 )
 


### PR DESCRIPTION
This test more that doubles the time taken by `make ptest`. That's not worth it as it is very unlikely to detect problems during normal development activities.