### PR TITLE
Don't run failing tests on riscv64 PPA builds

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -45,10 +45,10 @@ endif
 
 # Disable miral tests on Launchpad riscv64 (MirServer/mir#2375)
 ifeq ($(USER) $(DEB_HOST_ARCH),buildd riscv64)
-	COMMON_CONFIGURE_OPTIONS += -DMIR_RUN_MIRAL_TESTS=OFF
+  COMMON_CONFIGURE_OPTIONS += -DMIR_RUN_MIRAL_TESTS=OFF
   # Disable unit tests on Launchpad riscv64 jammy kinetic
-	ifneq ($(filter jammy kinetic,$(DEB_DISTRIBUTION)),)
-	  COMMON_CONFIGURE_OPTIONS += -DMIR_RUN_UNIT_TESTS=OFF
+  ifneq ($(filter jammy kinetic,$(DEB_DISTRIBUTION)),)
+    COMMON_CONFIGURE_OPTIONS += -DMIR_RUN_UNIT_TESTS=OFF
   endif
 endif
 

--- a/debian/rules
+++ b/debian/rules
@@ -45,7 +45,11 @@ endif
 
 # Disable miral tests on Launchpad riscv64 (MirServer/mir#2375)
 ifeq ($(USER) $(DEB_HOST_ARCH),buildd riscv64)
-	COMMON_CONFIGURE_OPTIONS += -DMIR_BUILD_MIRAL_TESTS=OFF
+	COMMON_CONFIGURE_OPTIONS += -DMIR_RUN_MIRAL_TESTS=OFF
+  # Disable unit tests on Launchpad riscv64 jammy kinetic
+	ifneq ($(filter jammy kinetic,$(DEB_DISTRIBUTION)),)
+	  COMMON_CONFIGURE_OPTIONS += -DMIR_RUN_UNIT_TESTS=OFF
+  endif
 endif
 
 export DEB_BUILD_MAINT_OPTIONS


### PR DESCRIPTION
Unit tests are hanging on riscv64+jammy|kinetic, so don't run them. (Yes, I know!)

Also changed to _build_ the miral tests. So, in principle, we can install from the PPA to investigate.