### PR TITLE
wayland_client: Fix build error with recent clang

### DIFF
--- a/examples/client/wayland_client.c
+++ b/examples/client/wayland_client.c
@@ -368,8 +368,11 @@ static void shutdown(int signum)
     }
 }
 
-int main()
+int main(int argc, char** argv)
 {
+    (void)argc;
+    (void)argv;
+
     struct wl_display* display = wl_display_connect(NULL);
     struct globals* globals;
     globals = calloc(sizeof *globals, 1);


### PR DESCRIPTION
Clang now reports a `-Wstrict-prototypes` error:
```
wayland_client.c:371:9: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
```

So use the full prototype of `int main(int, char**)`.