### PR TITLE
udev: Test (and fix) Context::char_device_from_devnum

### DIFF
--- a/src/platform/udev/udev_wrapper.cpp
+++ b/src/platform/udev/udev_wrapper.cpp
@@ -300,7 +300,7 @@ auto mu::Context::device_from_syspath(std::string const& syspath) -> std::unique
 
 auto mu::Context::char_device_from_devnum(dev_t devnum) -> std::unique_ptr<Device>
 {
-    return std::make_unique<DeviceImpl>(udev_device_new_from_devnum(context, 'C', devnum));
+    return std::make_unique<DeviceImpl>(udev_device_new_from_devnum(context, 'c', devnum));
 }
 
 udev* mu::Context::ctx() const

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -187,6 +187,9 @@ mir_add_wrapped_executable(mir_umock_unit_tests NOINSTALL
   ${MIR_PLATFORM_OBJECTS}
 )
 
+string(REGEX MATCH "^[0-9]*\.[0-9]*" UMOCKDEV_VERSION_MINOR ${UMOCKDEV_VERSION})
+set_source_files_properties(${UMOCK_UNIT_TEST_SOURCES} PROPERTIES COMPILE_DEFINITIONS UMOCKDEV_VERSION=${UMOCKDEV_VERSION_MINOR})
+
 add_dependencies(mir_umock_unit_tests GMock)
 
 set_target_properties(

--- a/tests/unit-tests/test_udev_wrapper.cpp
+++ b/tests/unit-tests/test_udev_wrapper.cpp
@@ -146,6 +146,20 @@ TEST_F(UdevWrapperTest, UdevDeviceHasCorrectMajorMinorNumbers)
     EXPECT_THAT(minor(devnum), Eq(42));
 }
 
+TEST_F(UdevWrapperTest, UdevCharDeviceFromDevnumWorks)
+{
+    using namespace testing;
+    udev_environment.add_standard_device("standard-drm-devices");
+
+    mir::udev::Context ctx;
+    // DRM devices have major 226, minors starting from 0
+    auto dev = ctx.char_device_from_devnum(makedev(226, 0));
+
+    dev_t devnum = dev->devnum();
+    EXPECT_THAT(major(devnum), Eq(226));
+    EXPECT_THAT(minor(devnum), Eq(0));
+    EXPECT_THAT(dev->devnode(), StrEq("/dev/dri/card0"));
+}
 
 TEST_F(UdevWrapperTest, UdevDeviceComparisonIsReflexive)
 {

--- a/tests/unit-tests/test_udev_wrapper.cpp
+++ b/tests/unit-tests/test_udev_wrapper.cpp
@@ -148,6 +148,10 @@ TEST_F(UdevWrapperTest, UdevDeviceHasCorrectMajorMinorNumbers)
 
 TEST_F(UdevWrapperTest, UdevCharDeviceFromDevnumWorks)
 {
+    // Workaround spurious failures seen with UMOCKDEV_VERSION=0.14.1 (on Focal)
+    if (UMOCKDEV_VERSION < 1.17)
+        return;
+
     using namespace testing;
     udev_environment.add_standard_device("standard-drm-devices");
 


### PR DESCRIPTION
Fixes: https://github.com/MirServer/mir-test-tools/issues/50