### PR TITLE
eglstream-kms: Handle EGL errors in `devnum_for_device`

### DIFF
--- a/src/platforms/eglstream-kms/server/platform_symbols.cpp
+++ b/src/platforms/eglstream-kms/server/platform_symbols.cpp
@@ -295,7 +295,7 @@ auto probe_display_platform(
                 EGLint num_configs;
                 if (eglChooseConfig(display, config_attribs, &config, 1, &num_configs) != EGL_TRUE)
                 {
-                    mir::log_warning("Failed to create EGL context");
+                    mir::log_warning("Failed to create EGL context: no EGL_STREAM_BIT_KHR configs supported");
                     continue;
                 }
                 EGLContext ctx{EGL_NO_CONTEXT};
@@ -319,7 +319,7 @@ auto probe_display_platform(
 
                 if (ctx == EGL_NO_CONTEXT)
                 {
-                    mir::log_warning("Failed to create EGL context");
+                    mir::log_warning("Failed to create EGL context: %s", mg::egl_category().message(eglGetError()).c_str());
                     continue;
                 }
 


### PR DESCRIPTION
It seems that Mesa is now exposing rendernodes as EGLDevices, but using the EGL query to find the device node of such devices fails.

Handle those exceptions by assuming the device is unsuitable.

Fixes: #2426 