### PR TITLE
[mir-smoke-test-runner] Enable working in a Wayland only environment

### DIFF
--- a/tools/mir-smoke-test-runner.sh
+++ b/tools/mir-smoke-test-runner.sh
@@ -21,6 +21,12 @@ if [ -z "$XDG_RUNTIME_DIR" ]; then
   export XDG_RUNTIME_DIR=/tmp
 fi
 
+# Support for running in a Wayland-only environment
+if [ -O "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ] && [ -z "$DISPLAY" ]; then
+  echo Setting up MIR_SERVER_WAYLAND_HOST for Wayland platform
+  export MIR_SERVER_WAYLAND_HOST="${WAYLAND_DISPLAY:-wayland-0}"
+fi
+
 # Start with eglinfo for the system
 echo Running eglinfo client
 date --utc --iso-8601=seconds | xargs echo "[timestamp] Start :" ${client}


### PR DESCRIPTION
Inspired by https://github.com/MirServer/mir/pull/2423#issuecomment-1129215985

Wayland support on desktop is becoming common and we ought to be able to run our smoke tests without reliance on X11.

This still retains the existing default of running on the X11 platform, but if that isn't available then we should try working on Wayland. If neither X11 nor Wayland support is available, the "hardware" platforms are still selectable.

This will allow, for example, the following to work:

```
miral-app -kiosk -terminal mir-smoke-test-runner
```