### PR TITLE
eglstream-kms: Retain DRM device access for whole probe.

### DIFF
--- a/src/platforms/eglstream-kms/server/platform_symbols.cpp
+++ b/src/platforms/eglstream-kms/server/platform_symbols.cpp
@@ -177,11 +177,12 @@ auto probe_display_platform(
             {
                 // Check we can acquire the device...
                 mir::Fd drm_fd;
+                std::unique_ptr<mir::Device> device_holder;
                 try
                 {
                     auto const devnum = mge::devnum_for_device(device);
 
-                    auto device_holder = console->acquire_device(
+                    device_holder = console->acquire_device(
                         major(devnum), minor(devnum),
                         std::make_unique<mgc::OneShotDeviceObserver>(drm_fd)).get();
 


### PR DESCRIPTION
Oops. While fixing up #2426 I changed the scope of `device_holder`, so that
it would almost immediately go out of scope. This broke probing on the VT
console provider, as the VT console provider, and *only* the VT console
provider, drops DRM master when you release the `mir::Device`.

Fixes: #2431.