### PR TITLE
Wayland platform: improve failed to connect error

### DIFF
--- a/src/platforms/wayland/platform.cpp
+++ b/src/platforms/wayland/platform.cpp
@@ -20,8 +20,6 @@
 
 #include "mir/graphics/egl_error.h"
 
-#include <boost/throw_exception.hpp>
-
 namespace mg = mir::graphics;
 namespace mgw = mir::graphics::wayland;
 using namespace std::literals;
@@ -30,10 +28,6 @@ mgw::Platform::Platform(struct wl_display* const wl_display, std::shared_ptr<mg:
     wl_display{wl_display},
     report{report}
 {
-    if (!wl_display)
-    {
-        BOOST_THROW_EXCEPTION(mg::egl_error("Failed to connect to wayland"));
-    }
 }
 
 mir::UniqueModulePtr<mg::Display> mgw::Platform::create_display(

--- a/src/platforms/wayland/wayland_display.cpp
+++ b/src/platforms/wayland/wayland_display.cpp
@@ -17,8 +17,8 @@
 #include "wayland_display.h"
 
 #include <mir/options/option.h>
+#include <mir/fatal.h>
 #include <boost/throw_exception.hpp>
-#include <optional>
 
 namespace mpw = mir::platform::wayland;
 
@@ -48,25 +48,22 @@ void mpw::add_connection_options(boost::program_options::options_description& co
 
 auto mpw::connection(options::Option const& options) -> struct wl_display*
 {
-    auto const wayland_host = options.is_set(wayland_host_option_name) ?
-        std::make_optional(options.get<std::string>(wayland_host_option_name)) :
-        std::nullopt;
+    if (!options.is_set(wayland_host_option_name))
+    {
+        fatal_error("%s option required for Wayland platform", wayland_host_option_name);
+    }
 
-    static auto const wayland_display = std::make_unique<WaylandDisplay>(
-        wayland_host ? wayland_host->c_str() : nullptr);
+    auto const wayland_host = options.get<std::string>(wayland_host_option_name);
+    static auto const wayland_display = std::make_unique<WaylandDisplay>(wayland_host.c_str());
 
     if (wayland_display->wl_display)
     {
         return wayland_display->wl_display;
     }
-    else if (wayland_host)
-    {
-        BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Failed to connect to Wayland display '" + wayland_host.value() + "'"));
-    }
     else
     {
-        BOOST_THROW_EXCEPTION(std::runtime_error("Failed to connect to default Wayland display"));
+        BOOST_THROW_EXCEPTION(std::runtime_error(
+            "Failed to connect to Wayland display '" + wayland_host + "'"));
     }
 }
 

--- a/src/platforms/wayland/wayland_display.cpp
+++ b/src/platforms/wayland/wayland_display.cpp
@@ -17,6 +17,8 @@
 #include "wayland_display.h"
 
 #include <mir/options/option.h>
+#include <boost/throw_exception.hpp>
+#include <optional>
 
 namespace mpw = mir::platform::wayland;
 
@@ -46,10 +48,26 @@ void mpw::add_connection_options(boost::program_options::options_description& co
 
 auto mpw::connection(options::Option const& options) -> struct wl_display*
 {
-    static auto const wayland_display = std::make_unique<WaylandDisplay>(options.is_set(wayland_host_option_name) ?
-        options.get<std::string>(wayland_host_option_name).c_str() : nullptr);
+    auto const wayland_host = options.is_set(wayland_host_option_name) ?
+        std::make_optional(options.get<std::string>(wayland_host_option_name)) :
+        std::nullopt;
 
-    return wayland_display->wl_display;
+    static auto const wayland_display = std::make_unique<WaylandDisplay>(
+        wayland_host ? wayland_host->c_str() : nullptr);
+
+    if (wayland_display->wl_display)
+    {
+        return wayland_display->wl_display;
+    }
+    else if (wayland_host)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error(
+            "Failed to connect to Wayland display '" + wayland_host.value() + "'"));
+    }
+    else
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("Failed to connect to default Wayland display"));
+    }
 }
 
 auto mir::platform::wayland::connection_options_supplied(mir::options::Option const& options) -> bool


### PR DESCRIPTION
This was giving me an "EGL_SUCCESS" error in the common case that the Wayland host is set to a display that does not currently exist. I see no reason why this would ever be an EGL error, or why the exception should be thrown so far from were the error can initially be detected. This PR drops gives the relevant context of the display name it tried to connect to.