### PR TITLE
[build]: Remove unnecessary files from release tarballs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,10 @@
 debian/*       export-ignore
 debian         export-ignore
 .github/*      export-ignore
+spread         export-ignore
+spread.yaml    export-ignore
+tools/make_release_tarball    export-ignore
+tools/ppa-upload.sh           export-ignore
+tools/process_snaps.py        export-ignore
+tools/requirements.txt        export-ignore
+bors.toml      export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,7 @@
 .gitattributes export-ignore
 .gitignore     export-ignore
-debian/*       export-ignore
 debian         export-ignore
-.github/*      export-ignore
+.github        export-ignore
 spread         export-ignore
 spread.yaml    export-ignore
 tools/make_release_tarball    export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 .gitattributes export-ignore
+.gitignore     export-ignore
 debian/*       export-ignore
+debian         export-ignore
 .github/*      export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.gitattributes export-ignore
+debian/*       export-ignore
+.github/*      export-ignore


### PR DESCRIPTION
There's no need for our release tarballs to contain a `debian/`
directory, or the GitHub CI metadata.

I'm *pretty* sure that GitHub will respect the git attributes when
generating the tarball.