### PR TITLE
Make all death tests threadsafe

### DIFF
--- a/tests/unit-tests/dispatch/test_threaded_dispatcher.cpp
+++ b/tests/unit-tests/dispatch/test_threaded_dispatcher.cpp
@@ -257,6 +257,7 @@ TEST_F(ThreadedDispatcherDeathTest, exceptions_in_threadpool_trigger_termination
 {
     using namespace testing;
     using namespace std::chrono_literals;
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
     constexpr char const* exception_msg = "Ducks! Ducks attack!";
 
@@ -402,6 +403,7 @@ TEST_F(ThreadedDispatcherDeathTest, destroying_dispatcher_from_a_callback_is_an_
 {
     using namespace testing;
     using namespace std::literals::chrono_literals;
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
     MIR_EXPECT_EXIT(
     {

--- a/tests/unit-tests/test_thread_pool_executor.cpp
+++ b/tests/unit-tests/test_thread_pool_executor.cpp
@@ -73,6 +73,7 @@ TEST(ThreadPoolExecutor, work_executed_from_within_work_item_is_not_blocked_by_w
 
 TEST(ThreadPoolExecutorDeathTest, unhandled_exception_in_work_item_causes_termination_by_default)
 {
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     EXPECT_DEATH(
         {
             mir::thread_pool_executor.spawn(


### PR DESCRIPTION
I noticed on [this](https://github.com/MirServer/mir/runs/6685721560?check_suite_focus=true) random failure the last test to run was `ThreadedDispatcherDeathTest`. Running that manually I didn't see it fail, but I did notice:
```
[WARNING] /build/googletest-OI1WhS/googletest-1.10.0.20201025/googletest/src/gtest-death-test.cc:1123:: Death tests use fork(), which is unsafe particularly in a threaded context. For this test, Google Test detected 3 threads. See https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-tests-and-threads for more explanation and suggested solutions, especially if this is the last message you see before your test times out.
```
I don't fully understand [death tests and threads](http://google.github.io/googletest/advanced.html#death-tests-and-threads), but it seems we're already adding the flag in test_udev_wrapper.cpp, so that's probably a good thing to do. This PR at least removes the warning, and hopefully also fixes some of our random CI failures.