### PR TITLE
mtf: Add mmap() interposer

### DIFF
--- a/tests/include/mir_test_framework/interposer_helper.h
+++ b/tests/include/mir_test_framework/interposer_helper.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <memory>
+#include <functional>
+#include <optional>
+#include <list>
+#include <atomic>
+#include <mutex>
+
+namespace mir_test_framework
+{
+using InterposerHandle = std::unique_ptr<void, void(*)(void*)>;
+
+template<typename Returns, typename... Args>
+class InterposerHandlers
+{
+public:
+    using Handler = std::function<std::optional<Returns>(Args...)>;
+  
+    static auto add(Handler handler) -> InterposerHandle
+    {
+        handlers_added.store(true);
+        auto& me = instance();
+        std::lock_guard lock{me.mutex};
+        auto iterator = me.handlers.emplace(me.handlers.begin(), std::move(handler));
+        auto remove_callback = [](void* iterator)
+            {
+                auto to_remove = static_cast<typename std::list<Handler>::iterator*>(iterator);
+                remove(to_remove);
+            };
+        return InterposerHandle{
+            static_cast<void*>(new typename std::list<Handler>::iterator{iterator}),
+            remove_callback};
+    }
+
+    static auto run(Args ...args) -> std::optional<Returns>
+    {
+        if (handlers_added)
+        {
+            auto& me = instance();
+            std::lock_guard lock{me.mutex};
+            for (auto const& handler: me.handlers)
+            {
+                if (auto val = handler(args...))
+                {
+                    return val;
+                }
+            }
+        }
+        return std::nullopt;
+    }
+
+private:
+    // We want to ensure that run() doesn't call instance() too early (e.g. during coverage setup)
+    // as that leads to destruction order issues. (https://github.com/MirServer/mir/issues/2387)
+    static std::atomic<bool> handlers_added;
+
+    static auto instance() -> InterposerHandlers&
+    {
+        // static local so we don't have to worry about initialization order
+        static InterposerHandlers handlers;
+        return handlers;
+    }
+
+    static void remove(typename std::list<Handler>::iterator* to_remove)
+    {
+        auto& me = instance();
+        std::lock_guard lock{me.mutex};
+        me.handlers.erase(*to_remove);
+        delete to_remove;
+    }
+
+    std::mutex mutex;
+    std::list<Handler> handlers;
+};
+
+template<typename Returns, typename... Args>
+std::atomic<bool> InterposerHandlers<Returns, Args...>::handlers_added{false};
+}

--- a/tests/include/mir_test_framework/mmap_wrapper.h
+++ b/tests/include/mir_test_framework/mmap_wrapper.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef MIR_TEST_FRAMEWORK_MMAP_WRAPPER_H_
+#define MIR_TEST_FRAMEWORK_MMAP_WRAPPER_H_
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <sys/mman.h>
+
+namespace mir_test_framework
+{
+using MmapHandlerHandle = std::unique_ptr<void, void(*)(void*)>;
+using MmapHandler =
+    std::function<std::optional<void*>(void *addr, size_t length, int prot, int flags, int fd, off_t offset)>;
+/**
+ * Add a function to the mmap() interposer.
+ *
+ * When code calls ::mmap() the test framework first checks against all of the registered
+ * handlers, returning the value from the first handler to return an occupied optional<void*>
+ *
+ * \note    The new handler is added to the \em start of the handler chain; it will be called
+ *          before any existing handler on mmap().
+ *
+ * \param handler [in]  Handler to call when mmap() is called. The handler should return an
+ *                      occupied optional<void*> only when it wants to claim this invocation.
+ * \return  An opaque handle to this instance of the handler. Dropping the handle unregisters the
+ *          mmap() handler.
+ */
+MmapHandlerHandle add_mmap_handler(MmapHandler handler);
+}
+
+#endif //MIR_TEST_FRAMEWORK_MMAP_WRAPPER_H_
+

--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -46,6 +46,8 @@ add_library(mir-public-test-framework OBJECT
   ${PROJECT_SOURCE_DIR}/tests/include/mir_test_framework/open_wrapper.h
   test_server.cpp  ${PROJECT_SOURCE_DIR}/include/test/miral/test_server.h
   test_display_server.cpp  ${PROJECT_SOURCE_DIR}/include/test/miral/test_display_server.h
+  ${PROJECT_SOURCE_DIR}/tests/include/mir_test_framework/mmap_wrapper.h
+  mmap_wrapper.cpp
 )
 
 target_link_libraries(mir-public-test-framework

--- a/tests/mir_test_framework/mmap_wrapper.cpp
+++ b/tests/mir_test_framework/mmap_wrapper.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* As suggested by umockdev, _FILE_OFFSET_BITS breaks our open() interposing,
+ * as it results in a (platform dependent!) subset of {__open64, __open64_2,
+ * __open, __open_2} being defined (not just declared) in the header, causing
+ * the build to fail with duplicate definitions.
+ */
+
+#include "mir_test_framework/mmap_wrapper.h"
+#include "mir_test_framework/interposer_helper.h"
+
+#include <boost/throw_exception.hpp>
+#include <dlfcn.h>
+
+namespace mtf = mir_test_framework;
+
+namespace
+{
+using MmapInterposer = mtf::InterposerHandlers<void*, void *, size_t, int, int, int, off_t>;
+}
+
+mtf::MmapHandlerHandle mtf::add_mmap_handler(MmapHandler handler)
+{
+    return MmapInterposer::add(std::move(handler));
+}
+
+void* mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
+{
+    if (auto val = MmapInterposer::run(addr, length, prot, flags, fd, offset))
+    {
+        return *val;
+    }
+
+    void* (*real_mmap)(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
+    *(void **)(&real_mmap) = dlsym(RTLD_NEXT, "mmap");
+
+    if (!real_mmap)
+    {
+        using namespace std::literals::string_literals;
+        // Oops! What has gone on here?!
+        BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to find mmap() symbol: "s + dlerror()}));
+    }
+    return (*real_mmap)(addr, length, prot, flags, fd, offset);
+}
+


### PR DESCRIPTION
The new Platform API tests need to add the ability of `MockDRM` to intercept `mmap()` calls. Take the existing `open()` interceptor, file off the serial numbers, and use it for `mmap()`, too.