### PR TITLE
Wayland platform threadsafe swap_buffers()

### DIFF
--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -332,7 +332,7 @@ void mir::graphics::wayland::Display::stop()
 
 void mir::graphics::wayland::Display::spawn(std::function<void()>&& work)
 {
-    std::unique_lock<std::mutex> lock{workqueue_mutex};
+    std::unique_lock lock{workqueue_mutex};
     workqueue.emplace_back(std::move(work));
     lock.unlock();
     flush_wl();

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -30,6 +30,7 @@
 #include <xkbcommon/xkbcommon.h>
 
 #include <thread>
+#include <deque>
 
 namespace mir
 {
@@ -148,10 +149,14 @@ private:
     std::chrono::nanoseconds touch_time;
 
     std::thread runner;
-    void run() const;
+    void run();
     void stop();
     auto get_touch_contact(int32_t id) -> decltype(touch_contacts)::iterator;
     void flush_wl() const;
+
+    std::mutex workqueue_mutex;
+    std::deque<std::function<void()>> workqueue;
+    void spawn(std::function<void()>&& work) override;
 };
 
 }

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -393,15 +393,19 @@ void mgw::DisplayClient::Output::swap_buffers()
 {
     struct FrameSync
     {
-        explicit FrameSync(wl_surface* surface) :
-            callback{wl_surface_frame(surface)}
+        explicit FrameSync(wl_surface* surface):
+            surface{surface}
         {
+        }
+
+        void init()
+        {
+            callback = wl_surface_frame(surface);
             static struct wl_callback_listener const frame_listener =
                 {
                     [](void* data, auto... args)
                         { static_cast<FrameSync*>(data)->frame_done(args...); },
                 };
-
             wl_callback_add_listener(callback, &frame_listener, this);
         }
 
@@ -425,12 +429,19 @@ void mgw::DisplayClient::Output::swap_buffers()
             cv.wait_for(lock, std::chrono::milliseconds{100}, [this]{ return posted; });
         }
 
+        wl_surface* const surface;
+
+        wl_callback* callback;
         std::mutex mutex;
         bool posted = false;
         std::condition_variable cv;
+    };
 
-        wl_callback* const callback;
-    } frame_sync{surface};
+    auto const frame_sync = std::make_shared<FrameSync>(surface);
+    owner->spawn([frame_sync]()
+        {
+            frame_sync->init();
+        });
 
     // Avoid throttling compositing by blocking in eglSwapBuffers().
     // Instead we use the frame "done" notification.
@@ -439,7 +450,7 @@ void mgw::DisplayClient::Output::swap_buffers()
     if (eglSwapBuffers(owner->egldisplay, eglsurface) != EGL_TRUE)
         BOOST_THROW_EXCEPTION(egl_error("Failed to perform buffer swap"));
 
-    frame_sync.wait_for_done();
+    frame_sync->wait_for_done();
 }
 
 void mgw::DisplayClient::Output::bind()

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -58,7 +58,7 @@ public:
     DisplayConfigurationOutput dcout;
 
     wl_output* const output;
-    DisplayClient const* const owner;
+    DisplayClient* const owner;
 
     wl_surface* const surface;
     xdg_surface* shell_surface{nullptr};

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -24,6 +24,7 @@
 #include <mir/graphics/display_configuration.h>
 #include <mir/renderer/gl/render_target.h>
 #include <mir/graphics/gl_config.h>
+#include <mir/executor.h>
 
 #include "protocol/xdg-shell-client.h"
 #include <wayland-client.h>
@@ -47,6 +48,7 @@ namespace wayland
 {
 
 class DisplayClient
+    : public Executor
 {
 public:
     DisplayClient(wl_display* display,


### PR DESCRIPTION
Fixes #2450 by making `DisplayClient` an executor and running the frame request on it