### PR TITLE
platform: Document Display::configure harder.

### DIFF
--- a/include/platform/mir/graphics/display.h
+++ b/include/platform/mir/graphics/display.h
@@ -119,6 +119,11 @@ public:
 
     /**
      * Sets a new output configuration.
+     *
+     * \note   A call to configure() may invalidate any and all existing DisplayBuffers. See
+     *         \ref apply_if_configuration_preserves_display_buffers for a configure that guarantees
+     *         preservation of all DisplayBuffers.
+     *         DisplayBuffers may \em only be invalidated by a call to configure.
      */
     virtual void configure(DisplayConfiguration const& conf) = 0;
 


### PR DESCRIPTION
It seems that not everyone can psychically intuit the invariant that the `DisplayBuffer`s
provided by a `Display` must remain vaild at all times, and are only invalidated by a call
to `Display::configure`.

This should really go in some higher-level narrative documentation, but making the call's
documentation more explicit is a cheap way to make things better.