### PR TITLE
Add --add-all-wayland-extensions option

### DIFF
--- a/include/platform/mir/options/configuration.h
+++ b/include/platform/mir/options/configuration.h
@@ -44,6 +44,7 @@ extern char const* const x11_display_opt;
 extern char const* const x11_scale_opt;
 extern char const* const wayland_extensions_opt;
 extern char const* const add_wayland_extensions_opt;
+extern char const* const add_all_wayland_extensions_opt;
 extern char const* const drop_wayland_extensions_opt;
 extern char const* const idle_timeout_opt;
 

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -334,6 +334,16 @@ struct miral::WaylandExtensions::Self
             }
         }
 
+        if (server.get_options()->is_set(mo::add_all_wayland_extensions_opt))
+        {
+            for (auto const& extension : supported_extensions)
+            {
+                selected_extensions.insert(extension);
+                manually_enabled_extensions.insert(extension);
+                manually_disabled_extensions.erase(extension);
+            }
+        }
+
         if (server.get_options()->is_set(mo::drop_wayland_extensions_opt))
         {
             auto const dropped = Self::parse_extensions_option(
@@ -445,6 +455,11 @@ void miral::WaylandExtensions::operator()(mir::Server& server) const
         mo::add_wayland_extensions_opt,
         ("Additional Wayland extensions to enable. [" + Self::serialize_colon_list(non_default_extensions) + "]"),
         mir::OptionType::string);
+
+    server.add_configuration_option(
+        mo::add_all_wayland_extensions_opt,
+        ("Enable all Wayland extensions not explicitly dropped"),
+        mir::OptionType::null);
 
     server.add_configuration_option(
         mo::drop_wayland_extensions_opt,

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -42,6 +42,7 @@ char const* const mo::x11_display_opt             = "enable-x11";
 char const* const mo::x11_scale_opt               = "x11-scale";
 char const* const mo::wayland_extensions_opt      = "wayland-extensions";
 char const* const mo::add_wayland_extensions_opt  = "add-wayland-extensions";
+char const* const mo::add_all_wayland_extensions_opt = "add-all-wayland-extensions";
 char const* const mo::drop_wayland_extensions_opt = "drop-wayland-extensions";
 char const* const mo::idle_timeout_opt            = "idle-timeout";
 

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -213,3 +213,10 @@ MIR_PLATFORM_2.8 {
     vtable?for?mir::graphics::common::EGLContextExecutor;
    };
 } MIRPLATFORM_2.7;
+
+MIR_PLATFORM_2.9 {
+ global:
+  extern "C++" {
+    mir::options::add_all_wayland_extensions_opt;
+  };
+} MIRPLATFORM_2.8;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -219,4 +219,4 @@ MIR_PLATFORM_2.9 {
   extern "C++" {
     mir::options::add_all_wayland_extensions_opt;
   };
-} MIRPLATFORM_2.8;
+} MIR_PLATFORM_2.8;


### PR DESCRIPTION
Convenient for development and debugging, as well as running in contexts where all clients are fully trusted