### PR TITLE
renderers/gl: Clear framebuffer to opaque black, not fully-transparent.

### DIFF
--- a/src/renderers/gl/renderer.cpp
+++ b/src/renderers/gl/renderer.cpp
@@ -299,7 +299,7 @@ mrg::Renderer::Program::Program(GLuint program_id)
 
 mrg::Renderer::Renderer(RenderTarget& render_target)
     : render_target(render_target),
-      clear_color{0.0f, 0.0f, 0.0f, 0.0f},
+      clear_color{0.0f, 0.0f, 0.0f, 1.0f},
       program_factory{std::make_unique<ProgramFactory>()},
       display_transform(1)
 {

--- a/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
+++ b/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
@@ -226,10 +226,10 @@ TEST_F(GLRenderer, avoids_src_alpha_for_rgbx_blending)  // LP: #1423462
     renderer.render(renderable_list);
 }
 
-TEST_F(GLRenderer, clears_all_channels_zero)
+TEST_F(GLRenderer, clears_to_opaque_black)
 {
     InSequence seq;
-    EXPECT_CALL(mock_gl, glClearColor(0.0f, 0.0f, 0.0f, 0.0f));
+    EXPECT_CALL(mock_gl, glClearColor(0.0f, 0.0f, 0.0f, 1.0f));
     EXPECT_CALL(mock_gl, glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE));
     EXPECT_CALL(mock_gl, glClear(_));
 


### PR DESCRIPTION
The fully-transparent `glClearColor` was introduced in 2015 in commit dabbc2bc1f
titled “merge mir” (it is not a merge commit).

Since the practical result of a fully-transparent framebuffer is expensive black
on all hardware platforms (at least until transparent displays become a thing),
switch the behaviour *back* to clearing the framebuffer to black.

Fixes: #2427