### PR TITLE
Screencopy: wait for damage before copying frame

### DIFF
--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -160,7 +160,8 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
                 ctx.display,
                 ctx.wayland_executor,
                 ctx.graphic_buffer_allocator,
-                ctx.screen_shooter);
+                ctx.screen_shooter,
+                ctx.surface_stack);
         }),
 };
 

--- a/src/server/frontend_wayland/wlr_screencopy_v1.cpp
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.cpp
@@ -41,6 +41,7 @@ struct WlrScreencopyV1Ctx
     std::shared_ptr<Executor> const wayland_executor;
     std::shared_ptr<graphics::GraphicBufferAllocator> const allocator;
     std::shared_ptr<compositor::ScreenShooter> const screen_shooter;
+    std::shared_ptr<SurfaceStack> const surface_stack;
 };
 
 class WlrScreencopyManagerV1Global
@@ -103,13 +104,15 @@ auto mf::create_wlr_screencopy_manager_unstable_v1(
     wl_display* display,
     std::shared_ptr<Executor> const& wayland_executor,
     std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
-    std::shared_ptr<compositor::ScreenShooter> const& screen_shooter)
+    std::shared_ptr<compositor::ScreenShooter> const& screen_shooter,
+    std::shared_ptr<SurfaceStack> const& surface_stack)
 -> std::shared_ptr<wayland::WlrScreencopyManagerV1::Global>
 {
     auto ctx = std::shared_ptr<WlrScreencopyV1Ctx>{new WlrScreencopyV1Ctx{
         wayland_executor,
         allocator,
-        screen_shooter}};
+        screen_shooter,
+        surface_stack}};
     return std::make_shared<WlrScreencopyManagerV1Global>(display, std::move(ctx));
 }
 

--- a/src/server/frontend_wayland/wlr_screencopy_v1.cpp
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.cpp
@@ -211,13 +211,13 @@ void mf::WlrScreencopyV1DamageTracker::capture_on_damage(Frame* frame)
         // We capture the given frame immediately, and also push an empty capture area so that if we get another
         // capture request with the same params it will wait for damage since this frame.
         frame->capture(std::nullopt);
-        areas.push_back(std::make_unique<Area>(frame_params));
         // If an unusually high number of capture areas have been created for some reason, clear the list rather than
         // getting bogged down (it's ok, worst case scenario waiting for damage doesn't work)
         if (areas.size() > 100)
         {
             areas.clear();
         }
+        areas.push_back(std::make_unique<Area>(frame_params));
     }
 }
 

--- a/src/server/frontend_wayland/wlr_screencopy_v1.cpp
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.cpp
@@ -38,17 +38,6 @@ namespace mg = mir::graphics;
 namespace ms = mir::scene;
 namespace geom = mir::geometry;
 
-struct mf::WlrScreencopyDamageTracker::FrameParams
-{
-    geom::Rectangle area;
-    wl_resource* output;
-
-    auto operator==(FrameParams const& other) const -> bool
-    {
-        return area == other.area && output == other.output;
-    }
-};
-
 class mf::WlrScreencopyV1DamageTracker::Area
 {
 public:

--- a/src/server/frontend_wayland/wlr_screencopy_v1.h
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.h
@@ -101,7 +101,7 @@ private:
     std::shared_ptr<scene::SceneChangeNotification> change_notifier;
     /// Frames that are waiting for damage before they are captured. If the frame object is null that means no damage
     /// has been received since a previous frame with the same params.
-    std::vector<Area> areas;
+    std::vector<std::unique_ptr<Area>> areas;
 };
 }
 }

--- a/src/server/frontend_wayland/wlr_screencopy_v1.h
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.h
@@ -18,8 +18,8 @@
 #define MIR_FRONTEND_WLR_SCREENCOPY_V1_H
 
 #include "wlr-screencopy-unstable-v1_wrapper.h"
-#include "mir/geometry/forward.h"
 #include "mir/wayland/wayland_base.h"
+#include "mir/geometry/rectangle.h"
 
 #include <memory>
 
@@ -55,7 +55,16 @@ auto create_wlr_screencopy_manager_unstable_v1(
 class WlrScreencopyV1DamageTracker : public wayland::LifetimeTracker
 {
 public:
-    struct FrameParams;
+    struct FrameParams
+    {
+        geometry::Rectangle area;
+        wl_resource* output;
+
+        auto operator==(FrameParams const& other) const -> bool
+        {
+            return area == other.area && output == other.output;
+        }
+    };
 
     class Frame
     {

--- a/src/server/frontend_wayland/wlr_screencopy_v1.h
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.h
@@ -35,12 +35,14 @@ class GraphicBufferAllocator;
 namespace frontend
 {
 class OutputManager;
+class SurfaceStack;
 
 auto create_wlr_screencopy_manager_unstable_v1(
     wl_display* display,
     std::shared_ptr<Executor> const& wayland_executor,
     std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
-    std::shared_ptr<compositor::ScreenShooter> const& screen_shooter)
+    std::shared_ptr<compositor::ScreenShooter> const& screen_shooter,
+    std::shared_ptr<SurfaceStack> const& surface_stack)
 -> std::shared_ptr<wayland::WlrScreencopyManagerV1::Global>;
 }
 }

--- a/src/server/frontend_wayland/wlr_screencopy_v1.h
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.h
@@ -52,7 +52,7 @@ auto create_wlr_screencopy_manager_unstable_v1(
 -> std::shared_ptr<wayland::WlrScreencopyManagerV1::Global>;
 
 /// Tracks damage and captures frames when needed. Each instance used by a single manager (and thus a single client).
-class WlrScreencopyDamageTracker : public wayland::LifetimeTracker
+class WlrScreencopyV1DamageTracker : public wayland::LifetimeTracker
 {
 public:
     struct FrameParams;
@@ -66,8 +66,8 @@ public:
         virtual void capture(std::optional<geometry::Rectangle> const& damage) = 0;
     };
 
-    WlrScreencopyDamageTracker(Executor& wayland_executor, SurfaceStack& surface_stack);
-    ~WlrScreencopyDamageTracker();
+    WlrScreencopyV1DamageTracker(Executor& wayland_executor, SurfaceStack& surface_stack);
+    ~WlrScreencopyV1DamageTracker();
 
     void capture_on_damage(Frame* frame);
 

--- a/tests/include/mir/test/doubles/mock_frontend_surface_stack.h
+++ b/tests/include/mir/test/doubles/mock_frontend_surface_stack.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef MIR_TEST_DOUBLES_MOCK_SURFACE_STACK_H_
+#define MIR_TEST_DOUBLES_MOCK_SURFACE_STACK_H_
+
+#include "mir/frontend/surface_stack.h"
+
+#include <gmock/gmock.h>
+
+namespace mir
+{
+namespace test
+{
+namespace doubles
+{
+
+struct MockFrontendSurfaceStack : public frontend::SurfaceStack
+{
+    MOCK_METHOD((void), add_observer, (std::shared_ptr<scene::Observer> const& observer), (override));
+    MOCK_METHOD((void), remove_observer, (std::weak_ptr<scene::Observer> const& observer), (override));
+    MOCK_METHOD((scene::SurfaceList), stacking_order_of, (scene::SurfaceSet const& surfaces), (const));
+};
+
+}
+}
+}
+
+
+#endif /* MIR_TEST_DOUBLES_MOCK_SURFACE_STACK_H_ */

--- a/tests/unit-tests/frontend_wayland/CMakeLists.txt
+++ b/tests/unit-tests/frontend_wayland/CMakeLists.txt
@@ -1,6 +1,7 @@
 list(
   APPEND UNIT_TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/test_wayland_timespec.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_screencopy_v1_damage_tracker.cpp
 )
 
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/tests/unit-tests/frontend_wayland/test_screencopy_v1_damage_tracker.cpp
+++ b/tests/unit-tests/frontend_wayland/test_screencopy_v1_damage_tracker.cpp
@@ -119,7 +119,7 @@ TEST_F(DamageTrackerV1, captures_first_frame_immediately_when_requested)
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, captures_second_frame_after_scene_changed)
+TEST_F(DamageTrackerV1, when_scene_changed_second_frame_is_captured)
 {
     geom::Rectangle const area{{}, {20, 30}};
     capture_frame_with_area(area);
@@ -133,7 +133,7 @@ TEST_F(DamageTrackerV1, captures_second_frame_after_scene_changed)
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, captures_second_frame_after_area_damaged)
+TEST_F(DamageTrackerV1, when_area_damaged_second_frame_is_captured)
 {
     geom::Rectangle const area{{}, {20, 30}};
     capture_frame_with_area(area);
@@ -147,7 +147,7 @@ TEST_F(DamageTrackerV1, captures_second_frame_after_area_damaged)
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, captures_frame_with_correct_damage_when_area_inside_capture_area_damaged)
+TEST_F(DamageTrackerV1, when_area_inside_capture_area_is_damaged_frame_is_captured_with_correct_damage)
 {
     geom::Rectangle const capture_area{{}, {20, 30}};
     geom::Rectangle const area_inside_capture_area{{2, 4}, {5, 7}};
@@ -194,7 +194,7 @@ TEST_F(DamageTrackerV1, damage_is_relative_to_capture_area_position)
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, frame_is_not_captured_when_damage_is_outside_its_area)
+TEST_F(DamageTrackerV1, when_damage_is_outside_of_frames_area_frame_is_not_captured)
 {
     geom::Rectangle const area{{}, {20, 30}};
     geom::Rectangle const damage{{25, 0}, {5, 5}};
@@ -209,7 +209,7 @@ TEST_F(DamageTrackerV1, frame_is_not_captured_when_damage_is_outside_its_area)
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, captures_second_frame_immediately_if_scene_has_changed_since_first_frame)
+TEST_F(DamageTrackerV1, when_scene_has_changed_since_first_frame_the_second_frame_is_captured_immediately)
 {
     geom::Rectangle const area{{}, {20, 30}};
     capture_frame_with_area(area);
@@ -223,7 +223,7 @@ TEST_F(DamageTrackerV1, captures_second_frame_immediately_if_scene_has_changed_s
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, captures_second_frame_immediately_if_area_has_been_damaged_since_first_frame)
+TEST_F(DamageTrackerV1, when_area_has_been_damaged_since_first_frame_the_second_frame_is_captured_immediately)
 {
     geom::Rectangle const area{{}, {20, 30}};
     capture_frame_with_area(area);
@@ -237,7 +237,7 @@ TEST_F(DamageTrackerV1, captures_second_frame_immediately_if_area_has_been_damag
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, waits_for_damage_to_capture_third_frame_after_second_frame_captured_immediately)
+TEST_F(DamageTrackerV1, when_second_frame_is_captured_immediately_the_third_frame_is_not_captured_until_there_is_damage)
 {
     geom::Rectangle const area{{}, {20, 30}};
     capture_frame_with_area(area);
@@ -269,7 +269,7 @@ TEST_F(DamageTrackerV1, captures_third_frame_immediately_after_getting_damage)
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, captures_correct_frame_when_there_are_multiple_frames_and_only_one_is_damaged)
+TEST_F(DamageTrackerV1, when_there_are_multiple_frames_and_only_one_is_damaged_the_correct_frame_is_captured)
 {
     geom::Rectangle const area_a{{ 0, 0}, {20, 30}};
     geom::Rectangle const area_b{{25, 0}, {20, 30}};
@@ -296,7 +296,7 @@ TEST_F(DamageTrackerV1, captures_correct_frame_when_there_are_multiple_frames_an
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, captures_pending_frames_when_tracker_is_destroyed)
+TEST_F(DamageTrackerV1, when_tracker_is_destroyed_pending_frames_area_captured)
 {
     geom::Rectangle const area_a{{ 0, 0}, {20, 30}};
     geom::Rectangle const area_b{{25, 0}, {20, 30}};
@@ -339,7 +339,7 @@ TEST_F(DamageTrackerV1, creating_new_areas_does_not_result_in_pending_frames_bei
     }
 }
 
-TEST_F(DamageTrackerV1, captures_immediately_when_additional_frame_is_queued_with_same_area_as_pending_frame)
+TEST_F(DamageTrackerV1, when_additional_frame_is_queued_with_same_area_then_pending_frame_is_captured_immediately)
 {
     geom::Rectangle const area{{}, {20, 30}};
     capture_frame_with_area(area);
@@ -354,7 +354,7 @@ TEST_F(DamageTrackerV1, captures_immediately_when_additional_frame_is_queued_wit
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, allows_multiple_pending_frames_with_the_same_area_if_outputs_are_different)
+TEST_F(DamageTrackerV1, when_outputs_are_different_allows_multiple_pending_frames_with_the_same_area)
 {
     geom::Rectangle const area{{}, {20, 30}};
     capture_frame_with_area(area);
@@ -389,7 +389,7 @@ TEST_F(DamageTrackerV1, allows_multiple_pending_frames_with_the_same_area_if_out
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, captures_second_frame_on_second_area_immediately_when_second_area_is_already_damaged_and_first_area_has_pending_frame)
+TEST_F(DamageTrackerV1, when_second_area_is_already_damaged_and_first_area_has_pending_frame_second_frame_is_captured_on_second_area_immediately)
 {
     geom::Rectangle const area_a{{ 0, 0}, {20, 30}};
     geom::Rectangle const area_b{{25, 0}, {20, 30}};
@@ -410,7 +410,7 @@ TEST_F(DamageTrackerV1, captures_second_frame_on_second_area_immediately_when_se
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, captures_with_full_damage_when_partial_damage_is_followed_by_full_damage)
+TEST_F(DamageTrackerV1, when_partial_damage_is_followed_by_full_damage_frame_is_captured_with_full_damage)
 {
     geom::Rectangle const area{{}, {20, 30}};
     capture_frame_with_area(area);
@@ -427,7 +427,7 @@ TEST_F(DamageTrackerV1, captures_with_full_damage_when_partial_damage_is_followe
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, captures_with_full_damage_when_full_damage_is_followed_by_partial_damage)
+TEST_F(DamageTrackerV1, when_full_damage_is_followed_by_partial_damage_frame_is_captured_with_full_damage)
 {
     geom::Rectangle const area{{}, {20, 30}};
     capture_frame_with_area(area);
@@ -444,7 +444,7 @@ TEST_F(DamageTrackerV1, captures_with_full_damage_when_full_damage_is_followed_b
     executor.execute();
 }
 
-TEST_F(DamageTrackerV1, captured_with_combined_area_when_multiple_damages_happen_before_capture)
+TEST_F(DamageTrackerV1, when_multiple_damages_happen_before_capture_frame_is_captured_with_combined_damage_areas)
 {
     geom::Rectangle const area{{}, {20, 30}};
     geom::Rectangle const damage_a{{0, 5}, {10, 6}};

--- a/tests/unit-tests/frontend_wayland/test_screencopy_v1_damage_tracker.cpp
+++ b/tests/unit-tests/frontend_wayland/test_screencopy_v1_damage_tracker.cpp
@@ -1,0 +1,465 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "src/server/frontend_wayland/wlr_screencopy_v1.h"
+#include "mir/scene/observer.h"
+#include "mir/test/doubles/mock_frontend_surface_stack.h"
+#include "mir/test/doubles/mock_surface.h"
+#include "mir/test/doubles/explicit_executor.h"
+#include "mir/test/fake_shared.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace mf = mir::frontend;
+namespace ms = mir::scene;
+namespace mw = mir::wayland;
+namespace geom = mir::geometry;
+namespace mt = mir::test;
+namespace mtd = mir::test::doubles;
+
+using namespace testing;
+
+namespace
+{
+struct MockFrame : mf::WlrScreencopyV1DamageTracker::Frame, mw::LifetimeTracker
+{
+public:
+    MockFrame(geom::Rectangle const& rect)
+        : params{rect, nullptr}
+    {
+    }
+
+    auto destroyed_flag() const -> std::shared_ptr<bool const> override
+    {
+        return LifetimeTracker::destroyed_flag();
+    }
+
+    auto parameters() const -> mf::WlrScreencopyV1DamageTracker::FrameParams const& override
+    {
+        return params;
+    }
+
+    MOCK_METHOD(void, capture, (std::optional<geom::Rectangle> const& damage), (override));
+
+    mf::WlrScreencopyV1DamageTracker::FrameParams params;
+};
+
+struct DamageTrackerV1 : Test
+{
+    NiceMock<mtd::MockSurface> surface;
+    NiceMock<mtd::MockFrontendSurfaceStack> surface_stack;
+    mtd::ExplicitExecutor executor;
+    mf::WlrScreencopyV1DamageTracker tracker{executor, surface_stack};
+    std::shared_ptr<ms::Observer> scene_observer;
+    std::shared_ptr<ms::SurfaceObserver> surface_observer;
+
+    void SetUp() override
+    {
+        ON_CALL(surface_stack, add_observer(_)).WillByDefault(Invoke([this]
+            (std::shared_ptr<ms::Observer>  const& observer)
+            {
+                scene_observer = observer;
+                observer->surface_exists(mt::fake_shared(surface));
+            }));
+        ON_CALL(surface, add_observer(_)).WillByDefault(SaveArg<0>(&surface_observer));
+    }
+
+    void TearDown() override
+    {
+        executor.execute();
+    }
+
+    void capture_frame_with_area(geom::Rectangle const& area)
+    {
+        NiceMock<MockFrame> frame{area};
+        tracker.capture_on_damage(&frame);
+        executor.execute();
+    }
+
+    void damage_whole_scene()
+    {
+        ASSERT_THAT(scene_observer, NotNull());
+        scene_observer->scene_changed();
+    }
+
+    void damage_area(geom::Rectangle const& damage)
+    {
+        ASSERT_THAT(surface_observer, NotNull());
+        surface_observer->frame_posted(&surface, 1, damage);
+    }
+};
+}
+
+TEST_F(DamageTrackerV1, does_not_register_scene_observer_when_not_used)
+{
+    EXPECT_CALL(surface_stack, add_observer(_)).Times(0);
+    mf::WlrScreencopyV1DamageTracker tracker{executor, surface_stack};
+}
+
+TEST_F(DamageTrackerV1, captures_first_frame_immediately_when_requested)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    StrictMock<MockFrame> frame{area};
+    EXPECT_CALL(frame, capture(Eq(std::nullopt)));
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, captures_second_frame_after_scene_changed)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    capture_frame_with_area(area);
+
+    StrictMock<MockFrame> frame{area};
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+
+    EXPECT_CALL(frame, capture(Eq(std::nullopt)));
+    damage_whole_scene();
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, captures_second_frame_after_area_damaged)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    capture_frame_with_area(area);
+
+    StrictMock<MockFrame> frame{area};
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+
+    EXPECT_CALL(frame, capture(Eq(area)));
+    damage_area(area);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, captures_frame_with_correct_damage_when_area_inside_capture_area_damaged)
+{
+    geom::Rectangle const capture_area{{}, {20, 30}};
+    geom::Rectangle const area_inside_capture_area{{2, 4}, {5, 7}};
+    capture_frame_with_area(capture_area);
+
+    StrictMock<MockFrame> frame{capture_area};
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+
+    EXPECT_CALL(frame, capture(Eq(area_inside_capture_area)));
+    damage_area(area_inside_capture_area);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, damage_clipped_to_capture_area)
+{
+    geom::Rectangle const capture_area{{}, {20, 30}};
+    geom::Rectangle const area_intersecting_with_capture_area{{-10, 5}, {45, 66}};
+    geom::Rectangle const expected_damage_area{{0, 5}, {20, 25}};
+    capture_frame_with_area(capture_area);
+
+    StrictMock<MockFrame> frame{capture_area};
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+
+    EXPECT_CALL(frame, capture(Eq(expected_damage_area)));
+    damage_area(area_intersecting_with_capture_area);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, damage_is_relative_to_capture_area_position)
+{
+    geom::Rectangle const capture_area{{5, 12}, {20, 30}};
+    geom::Rectangle const area_inside_capture_area{{10, 14}, {5, 5}};
+    geom::Rectangle const expected_damage_area{{5, 2}, {5, 5}};
+    capture_frame_with_area(capture_area);
+
+    StrictMock<MockFrame> frame{capture_area};
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+
+    EXPECT_CALL(frame, capture(Eq(expected_damage_area)));
+    damage_area(area_inside_capture_area);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, frame_is_not_captured_when_damage_is_outside_its_area)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    geom::Rectangle const damage{{25, 0}, {5, 5}};
+    capture_frame_with_area(area);
+
+    StrictMock<MockFrame> frame{area};
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+
+    EXPECT_CALL(frame, capture(_)).Times(0);
+    damage_area(damage);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, captures_second_frame_immediately_if_scene_has_changed_since_first_frame)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    capture_frame_with_area(area);
+
+    damage_whole_scene();
+    executor.execute();
+
+    StrictMock<MockFrame> frame{area};
+    EXPECT_CALL(frame, capture(_)).Times(1);
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, captures_second_frame_immediately_if_area_has_been_damaged_since_first_frame)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    capture_frame_with_area(area);
+
+    damage_area(area);
+    executor.execute();
+
+    StrictMock<MockFrame> frame{area};
+    EXPECT_CALL(frame, capture(_)).Times(1);
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, waits_for_damage_to_capture_third_frame_after_second_frame_captured_immediately)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    capture_frame_with_area(area);
+
+    damage_whole_scene();
+    capture_frame_with_area(area);
+
+    StrictMock<MockFrame> frame{area};
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+
+    EXPECT_CALL(frame, capture(Eq(std::nullopt)));
+    damage_whole_scene();
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, captures_third_frame_immediately_after_getting_damage)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    capture_frame_with_area(area);
+
+    damage_whole_scene();
+    capture_frame_with_area(area);
+    damage_whole_scene();
+
+    StrictMock<MockFrame> frame{area};
+    EXPECT_CALL(frame, capture(Eq(std::nullopt)));
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, captures_correct_frame_when_there_are_multiple_frames_and_only_one_is_damaged)
+{
+    geom::Rectangle const area_a{{ 0, 0}, {20, 30}};
+    geom::Rectangle const area_b{{25, 0}, {20, 30}};
+    geom::Rectangle const area_c{{50, 0}, {20, 30}};
+    capture_frame_with_area(area_a);
+    capture_frame_with_area(area_b);
+    capture_frame_with_area(area_c);
+
+    StrictMock<MockFrame> frame_a{area_a};
+    EXPECT_CALL(frame_a, capture(_)).Times(0);
+    tracker.capture_on_damage(&frame_a);
+
+    StrictMock<MockFrame> frame_b{area_b};
+    tracker.capture_on_damage(&frame_b);
+
+    StrictMock<MockFrame> frame_c{area_c};
+    EXPECT_CALL(frame_c, capture(_)).Times(0);
+    tracker.capture_on_damage(&frame_c);
+
+    executor.execute();
+
+    EXPECT_CALL(frame_b, capture(_));
+    damage_area(area_b);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, captures_pending_frames_when_tracker_is_destroyed)
+{
+    geom::Rectangle const area_a{{ 0, 0}, {20, 30}};
+    geom::Rectangle const area_b{{25, 0}, {20, 30}};
+
+    std::optional<mf::WlrScreencopyV1DamageTracker> tracker;
+    tracker.emplace(executor, surface_stack);
+    {
+        NiceMock<MockFrame> frame_a{area_a};
+        tracker->capture_on_damage(&frame_a);
+        NiceMock<MockFrame> frame_b{area_b};
+        tracker->capture_on_damage(&frame_b);
+        executor.execute();
+    }
+
+    StrictMock<MockFrame> frame_a{area_a};
+    tracker->capture_on_damage(&frame_a);
+    StrictMock<MockFrame> frame_b{area_b};
+    tracker->capture_on_damage(&frame_b);
+    executor.execute();
+
+    EXPECT_CALL(frame_a, capture(_));
+    EXPECT_CALL(frame_b, capture(_));
+    tracker.reset();
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, creating_new_areas_does_not_result_in_pending_frames_being_captured)
+{
+    // This catches problems that may occur when the area list is expanded
+
+    std::vector<std::shared_ptr<StrictMock<MockFrame>>> frames;
+
+    for (int i = 0; i < 20; i++)
+    {
+        geom::Rectangle area{{i * 10, 0}, {5, 5}};
+        capture_frame_with_area(area);
+        frames.push_back(std::make_shared<StrictMock<MockFrame>>(area));
+        EXPECT_CALL(*frames.back(), capture(_)).Times(0);
+        tracker.capture_on_damage(frames.back().get());
+    }
+}
+
+TEST_F(DamageTrackerV1, captures_immediately_when_additional_frame_is_queued_with_same_area_as_pending_frame)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    capture_frame_with_area(area);
+
+    StrictMock<MockFrame> frame_a{area};
+    tracker.capture_on_damage(&frame_a);
+    executor.execute();
+
+    EXPECT_CALL(frame_a, capture(_));
+    StrictMock<MockFrame> frame_b{area};
+    tracker.capture_on_damage(&frame_b);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, allows_multiple_pending_frames_with_the_same_area_if_outputs_are_different)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    capture_frame_with_area(area);
+    wl_resource* output_a{reinterpret_cast<wl_resource*>(1)};
+    wl_resource* output_b{reinterpret_cast<wl_resource*>(2)};
+
+    {
+        NiceMock<MockFrame> frame_a{area};
+        frame_a.params.output = output_a;
+        tracker.capture_on_damage(&frame_a);
+
+        NiceMock<MockFrame> frame_b{area};
+        frame_b.params.output = output_b;
+        tracker.capture_on_damage(&frame_b);
+
+        executor.execute();
+    }
+
+    StrictMock<MockFrame> frame_a{area};
+    frame_a.params.output = output_a;
+    tracker.capture_on_damage(&frame_a);
+    executor.execute();
+
+    StrictMock<MockFrame> frame_b{area};
+    frame_b.params.output = output_b;
+    tracker.capture_on_damage(&frame_b);
+    executor.execute();
+
+    EXPECT_CALL(frame_a, capture(_));
+    EXPECT_CALL(frame_b, capture(_));
+    damage_whole_scene();
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, captures_second_frame_on_second_area_immediately_when_second_area_is_already_damaged_and_first_area_has_pending_frame)
+{
+    geom::Rectangle const area_a{{ 0, 0}, {20, 30}};
+    geom::Rectangle const area_b{{25, 0}, {20, 30}};
+    capture_frame_with_area(area_a);
+    capture_frame_with_area(area_b);
+
+    damage_area(area_b);
+    executor.execute();
+
+    StrictMock<MockFrame> frame_a{area_a};
+    EXPECT_CALL(frame_a, capture(_)).Times(0);
+    tracker.capture_on_damage(&frame_a);
+    executor.execute();
+
+    StrictMock<MockFrame> frame_b{area_b};
+    EXPECT_CALL(frame_b, capture(_));
+    tracker.capture_on_damage(&frame_b);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, captures_with_full_damage_when_partial_damage_is_followed_by_full_damage)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    capture_frame_with_area(area);
+
+    damage_area(area);
+    executor.execute();
+
+    damage_whole_scene();
+    executor.execute();
+
+    StrictMock<MockFrame> frame{area};
+    EXPECT_CALL(frame, capture(Eq(std::nullopt)));
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, captures_with_full_damage_when_full_damage_is_followed_by_partial_damage)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    capture_frame_with_area(area);
+
+    damage_whole_scene();
+    executor.execute();
+
+    damage_area(area);
+    executor.execute();
+
+    StrictMock<MockFrame> frame{area};
+    EXPECT_CALL(frame, capture(Eq(std::nullopt)));
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+}
+
+TEST_F(DamageTrackerV1, captured_with_combined_area_when_multiple_damages_happen_before_capture)
+{
+    geom::Rectangle const area{{}, {20, 30}};
+    geom::Rectangle const damage_a{{0, 5}, {10, 6}};
+    geom::Rectangle const damage_b{{5, 5}, {10, 8}};
+    geom::Rectangle const damage_combined{{0, 5}, {15, 8}};
+    capture_frame_with_area(area);
+
+    damage_area(damage_a);
+    executor.execute();
+
+    damage_area(damage_b);
+    executor.execute();
+
+    StrictMock<MockFrame> frame{area};
+    EXPECT_CALL(frame, capture(Eq(damage_combined)));
+    tracker.capture_on_damage(&frame);
+    executor.execute();
+}


### PR DESCRIPTION
Waits until the copy area has been damaged in `.copy_with_damage` request.

The protocol isn't designed very well and is not super clear in how this is supposed to be implemented. The naive way would be to start waiting for damage when the request comes in, but that would allow a client to miss frames. Instead the way this is built is to dynamically create `CaptureArea`s for each area the client captures and track damage to those areas. That way a frame can be captured immediately with the correct damage if the damage happened between one frame being captured and the following frame being requested.

It would be nice to have this tested, but we need the screenshoter to work in WLCS for that and it currently does not.