### PR TITLE
Attempt to refactor geometry types without breaking MirAL ABI

### DIFF
--- a/include/core/mir/geometry/forward.h
+++ b/include/core/mir/geometry/forward.h
@@ -78,10 +78,12 @@ using DeltaYF = generic::DeltaY<float>;
 // Just to be clear, mir::geometry::Stride is the stride of the buffer in bytes
 using Stride = generic::Value<int, StrideTag>;
 
+#ifndef LEGACY_MIRAL_GEOMETRY_TYPES
 using Point = generic::Point<int>;
 using Size = generic::Size<int>;
 using Displacement = generic::Displacement<int>;
 using Rectangle = generic::Rectangle<int>;
+#endif // LEGACY_MIRAL_GEOMETRY_TYPES
 
 using PointF = generic::Point<float>;
 using SizeF = generic::Size<float>;

--- a/include/core/mir/geometry/rectangles.h
+++ b/include/core/mir/geometry/rectangles.h
@@ -33,18 +33,18 @@ class Rectangles
 {
 public:
     Rectangles();
-    Rectangles(std::initializer_list<Rectangle> const& rects);
+    Rectangles(std::initializer_list<generic::Rectangle<int>> const& rects);
     /* We want to keep implicit copy and move methods */
 
-    void add(Rectangle const& rect);
+    void add(generic::Rectangle<int> const& rect);
     /// removes at most one matching rectangle
-    void remove(Rectangle const& rect);
+    void remove(generic::Rectangle<int> const& rect);
     void clear();
-    Rectangle bounding_rectangle() const;
+    generic::Rectangle<int> bounding_rectangle() const;
     void confine(Point& point) const;
 
-    typedef std::vector<Rectangle>::const_iterator const_iterator;
-    typedef std::vector<Rectangle>::size_type size_type;
+    typedef std::vector<generic::Rectangle<int>>::const_iterator const_iterator;
+    typedef std::vector<generic::Rectangle<int>>::size_type size_type;
     const_iterator begin() const;
     const_iterator end() const;
     size_type size() const;
@@ -53,7 +53,7 @@ public:
     bool operator!=(Rectangles const& rect) const;
 
 private:
-    std::vector<Rectangle> rectangles;
+    std::vector<generic::Rectangle<int>> rectangles;
 };
 
 

--- a/include/miral/miral/legacy_geometry.h
+++ b/include/miral/miral/legacy_geometry.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIRAL_LEGACY_GEOMETRY_H_
+#define MIRAL_LEGACY_GEOMETRY_H_
+
+// Prevents new Point, Rectangle, etc from being defined as typedefs to the generic version
+#define LEGACY_MIRAL_GEOMETRY_TYPES
+
+#include <mir/geometry/point.h>
+#include <mir/geometry/size.h>
+#include <mir/geometry/displacement.h>
+#include <mir/geometry/rectangle.h>
+
+namespace mir
+{
+namespace geometry
+{
+
+class Point: public generic::Point<int>
+{
+public:
+    template<typename... Args>
+    constexpr Point(Args... args) noexcept : generic::Point<int>{args...} {}
+};
+
+class Size: public generic::Size<int>
+{
+public:
+    template<typename... Args>
+    constexpr Size(Args... args) noexcept : generic::Size<int>{args...} {}
+};
+
+class Displacement: public generic::Displacement<int>
+{
+public:
+    template<typename... Args>
+    constexpr Displacement(Args... args) noexcept : generic::Displacement<int>{args...} {}
+};
+
+class Rectangle: public generic::Rectangle<int>
+{
+public:
+    template<typename... Args>
+    constexpr Rectangle(Args... args) noexcept : generic::Rectangle<int>{args...} {}
+
+    constexpr Rectangle(Point a, Size b) noexcept : generic::Rectangle<int>{a, b} {}
+};
+
+}
+}
+
+#endif // MIRAL_LEGACY_GEOMETRY_H_

--- a/include/miral/miral/output.h
+++ b/include/miral/miral/output.h
@@ -17,9 +17,10 @@
 #ifndef MIRAL_OUTPUT_H
 #define MIRAL_OUTPUT_H
 
+#include "legacy_geometry.h"
+
 #include <mir_toolkit/common.h>
 
-#include <mir/geometry/rectangle.h>
 #include <mir/int_wrapper.h>
 
 #include <memory>

--- a/include/miral/miral/window.h
+++ b/include/miral/miral/window.h
@@ -18,9 +18,7 @@
 #define MIRAL_WINDOW_H
 
 #include "miral/application.h"
-
-#include <mir/geometry/point.h>
-#include <mir/geometry/size.h>
+#include "legacy_geometry.h"
 
 #include <memory>
 

--- a/include/miral/miral/window_info.h
+++ b/include/miral/miral/window_info.h
@@ -19,6 +19,7 @@
 
 #include "miral/window.h"
 #include "miral/window_specification.h"
+#include "legacy_geometry.h"
 
 #include <mir/geometry/rectangles.h>
 #include <mir/optional_value.h>

--- a/include/miral/miral/window_management_policy.h
+++ b/include/miral/miral/window_management_policy.h
@@ -17,6 +17,8 @@
 #ifndef MIRAL_WINDOW_MANAGEMENT_POLICY_H
 #define MIRAL_WINDOW_MANAGEMENT_POLICY_H
 
+#include "legacy_geometry.h"
+
 #include <mir/geometry/displacement.h>
 #include <mir/geometry/rectangles.h>
 #include <mir_toolkit/common.h>

--- a/include/miral/miral/window_manager_tools.h
+++ b/include/miral/miral/window_manager_tools.h
@@ -19,8 +19,7 @@
 
 #include "miral/application.h"
 #include "window_info.h"
-
-#include <mir/geometry/displacement.h>
+#include "legacy_geometry.h"
 
 #include <functional>
 #include <memory>

--- a/include/miral/miral/window_specification.h
+++ b/include/miral/miral/window_specification.h
@@ -17,10 +17,10 @@
 #ifndef MIRAL_WINDOW_SPECIFICATION_H
 #define MIRAL_WINDOW_SPECIFICATION_H
 
+#include "legacy_geometry.h"
+
 #include <mir_toolkit/common.h>
 
-#include <mir/geometry/displacement.h>
-#include <mir/geometry/rectangles.h>
 #include <mir/optional_value.h>
 #include <mir/int_wrapper.h>
 

--- a/include/miral/miral/zone.h
+++ b/include/miral/miral/zone.h
@@ -17,9 +17,10 @@
 #ifndef MIRAL_ZONE_H
 #define MIRAL_ZONE_H
 
+#include "legacy_geometry.h"
+
 #include <mir_toolkit/common.h>
 
-#include <mir/geometry/rectangle.h>
 #include <mir/int_wrapper.h>
 
 #include <memory>

--- a/src/miral/window_manager_tools_implementation.h
+++ b/src/miral/window_manager_tools_implementation.h
@@ -18,9 +18,7 @@
 #define MIRAL_WINDOW_MANAGER_TOOLS_IMPLEMENTATION_H
 
 #include "miral/application.h"
-
-#include <mir/geometry/displacement.h>
-#include <mir/geometry/rectangle.h>
+#include "miral/legacy_geometry.h"
 
 #include <functional>
 #include <memory>

--- a/tests/miral/drag_active_window.cpp
+++ b/tests/miral/drag_active_window.cpp
@@ -72,8 +72,8 @@ TEST_P(ForMoveableTypes, moves)
     create_window_of_type(GetParam());
 
     Displacement const movement{10, 10};
-    auto const initial_position = window.top_left();
-    auto const expected_position = initial_position + movement;
+    Point const initial_position = window.top_left();
+    Point const expected_position = initial_position + movement;
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
 
@@ -139,8 +139,8 @@ TEST_F(DragWindow, can_drag_satellite)
     create_window_of_type(mir_window_type_satellite);
 
     Displacement const movement{10, 10};
-    auto const initial_position = window.top_left();
-    auto const expected_position = initial_position + movement;
+    Point const initial_position = window.top_left();
+    Point const expected_position = initial_position + movement;
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
 

--- a/tests/miral/popup_window_placement.cpp
+++ b/tests/miral/popup_window_placement.cpp
@@ -351,7 +351,7 @@ TEST_F(PopupWindowPlacement, given_aux_rect_near_right_side_and_offset_placement
     modification.window_placement_gravity() = mir_placement_gravity_northwest;
     modification.aux_rect_placement_gravity() = mir_placement_gravity_northeast;
 
-    auto const expected_position = on_left_edge() + Displacement{-1*x_offset, y_offset};
+    Point const expected_position = on_left_edge() + Displacement{-1*x_offset, y_offset};
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
     basic_window_manager.modify_window(basic_window_manager.info_for(child), modification);
@@ -369,7 +369,7 @@ TEST_F(PopupWindowPlacement, given_aux_rect_near_bottom_and_offset_placement_is_
     modification.window_placement_gravity() = mir_placement_gravity_northwest;
     modification.aux_rect_placement_gravity() = mir_placement_gravity_southwest;
 
-    auto const expected_position = on_top_edge() + Displacement{x_offset, -1*y_offset};
+    Point const expected_position = on_top_edge() + Displacement{x_offset, -1*y_offset};
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
     basic_window_manager.modify_window(basic_window_manager.info_for(child), modification);
@@ -386,7 +386,7 @@ TEST_F(PopupWindowPlacement, given_aux_rect_near_bottom_right_and_offset_placeme
     modification.window_placement_gravity() = mir_placement_gravity_northwest;
     modification.aux_rect_placement_gravity() = mir_placement_gravity_southeast;
 
-    auto const expected_position = aux_rect_position().top_left - as_displacement(child.size()) - displacement;
+    Point const expected_position = aux_rect_position().top_left - as_displacement(child.size()) - displacement;
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
     basic_window_manager.modify_window(basic_window_manager.info_for(child), modification);
@@ -460,7 +460,7 @@ TEST_F(PopupWindowPlacement, given_aux_rect_near_bottom_right_and_offset_placeme
     modification.window_placement_gravity() = mir_placement_gravity_northwest;
     modification.aux_rect_placement_gravity() = mir_placement_gravity_southwest;
 
-    auto const expected_position = display_area.bottom_right() - as_displacement(child.size());
+    Point const expected_position = display_area.bottom_right() - as_displacement(child.size());
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
     basic_window_manager.modify_window(basic_window_manager.info_for(child), modification);
@@ -474,7 +474,7 @@ TEST_F(PopupWindowPlacement, given_aux_rect_near_right_side_placement_can_resize
     modification.window_placement_gravity() = mir_placement_gravity_northwest;
     modification.aux_rect_placement_gravity() = mir_placement_gravity_northeast;
 
-    auto const expected_position = aux_rect_position().top_right();
+    Point const expected_position = aux_rect_position().top_right();
     Size const expected_size{as_size(display_area.bottom_right()-aux_rect_position().bottom_right()).width, child.size().height};
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
@@ -510,7 +510,7 @@ TEST_F(PopupWindowPlacement, given_aux_rect_near_bottom_placement_can_resize_in_
     modification.window_placement_gravity() = mir_placement_gravity_northwest;
     modification.aux_rect_placement_gravity() = mir_placement_gravity_southwest;
 
-    auto const expected_position = aux_rect_position().bottom_left();
+    Point const expected_position = aux_rect_position().bottom_left();
     Size const expected_size{child.size().width, as_size(display_area.bottom_left()-aux_rect_position().bottom_left()).height};
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
@@ -544,8 +544,8 @@ TEST_F(PopupWindowPlacement, given_aux_rect_near_bottom_right_and_offset_placeme
     modification.window_placement_gravity() = mir_placement_gravity_northwest;
     modification.aux_rect_placement_gravity() = mir_placement_gravity_southeast;
 
-    auto const expected_position = aux_rect_position().bottom_right();
-    auto const expected_size = as_size(display_area.bottom_right()-expected_position);
+    Point const expected_position = aux_rect_position().bottom_right();
+    Size const expected_size = as_size(display_area.bottom_right()-expected_position);
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
     EXPECT_CALL(*window_manager_policy, advise_resize(_, expected_size));

--- a/tests/miral/window_placement_anchors_to_parent.cpp
+++ b/tests/miral/window_placement_anchors_to_parent.cpp
@@ -108,7 +108,7 @@ TEST_F(WindowPlacementAnchorsToParent, given_rect_anchor_right_of_parent_client_
         mir_placement_gravity_northwest,
         MirPlacementHints(mir_placement_hints_slide_y|mir_placement_hints_resize_x));
 
-    auto const expected_position = parent_position + Displacement{parent_width, parent_height/2};
+    Point const expected_position = parent_position + Displacement{parent_width, parent_height/2};
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
     EXPECT_CALL(*window_manager_policy, advise_resize(_, _)).Times(0);
@@ -128,7 +128,7 @@ TEST_F(WindowPlacementAnchorsToParent, given_rect_anchor_above_parent_client_is_
         mir_placement_gravity_southeast,
         mir_placement_hints_slide_x);
 
-    auto const expected_position = parent_position + DeltaX{parent_width/2 + rect_size}
+    Point const expected_position = parent_position + DeltaX{parent_width/2 + rect_size}
                                    - as_displacement(initial_child_size);
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
@@ -151,7 +151,7 @@ TEST_F(WindowPlacementAnchorsToParent, given_offset_right_of_parent_client_is_an
 
     modification.aux_rect_placement_offset() = Displacement{rect_size, 0};
 
-    auto const expected_position = parent_position + Displacement{parent_width, parent_height/2};
+    Point const expected_position = parent_position + Displacement{parent_width, parent_height/2};
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
     EXPECT_CALL(*window_manager_policy, advise_resize(_, _)).Times(0);
@@ -173,7 +173,7 @@ TEST_F(WindowPlacementAnchorsToParent, given_offset_above_parent_client_is_ancho
 
     modification.aux_rect_placement_offset() = Displacement{0, -rect_size};
 
-    auto const expected_position = parent_position + DeltaX{parent_width/2 + rect_size}
+    Point const expected_position = parent_position + DeltaX{parent_width/2 + rect_size}
                                    - as_displacement(initial_child_size);
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
@@ -196,7 +196,7 @@ TEST_F(WindowPlacementAnchorsToParent, given_rect_and_offset_below_left_parent_c
 
     modification.aux_rect_placement_offset() = Displacement{-rect_size, rect_size};
 
-    auto const expected_position = parent_position + DeltaY{parent_height} - as_displacement(initial_child_size).dx;
+    Point const expected_position = parent_position + DeltaY{parent_height} - as_displacement(initial_child_size).dx;
 
     EXPECT_CALL(*window_manager_policy, advise_move_to(_, expected_position));
     EXPECT_CALL(*window_manager_policy, advise_resize(_, _)).Times(0);


### PR DESCRIPTION
Attempt to do #2475 without breaking the MirAL ABI. Unclear if this is useful. Not yet working but I could probably make it work.