### PR TITLE
Refactor SurfaceObserver types to be compatible with new observer system

### DIFF
--- a/include/test/mir/test/doubles/stub_surface.h
+++ b/include/test/mir/test/doubles/stub_surface.h
@@ -42,7 +42,7 @@ struct StubSurface : scene::Surface
     geometry::Point top_left() const override { return {}; }
     geometry::Rectangle input_bounds() const override { return {}; }
     bool input_area_contains(geometry::Point const&) const override { return false; }
-    void consume(MirEvent const*) override {}
+    void consume(std::shared_ptr<MirEvent const> const&) override {}
     void set_alpha(float) override {}
     void set_orientation(MirOrientation) override {}
     void set_transformation(glm::mat4 const&) override {}

--- a/src/include/server/mir/input/surface.h
+++ b/src/include/server/mir/input/surface.h
@@ -49,7 +49,7 @@ public:
     virtual bool input_area_contains(geometry::Point const& point) const = 0;
     virtual std::shared_ptr<graphics::CursorImage> cursor_image() const = 0;
     virtual InputReceptionMode reception_mode() const = 0;
-    virtual void consume(MirEvent const* event) = 0;
+    virtual void consume(std::shared_ptr<MirEvent const> const& event) = 0;
 
 protected:
     Surface() = default;

--- a/src/include/server/mir/scene/null_surface_observer.h
+++ b/src/include/server/mir/scene/null_surface_observer.h
@@ -38,7 +38,7 @@ public:
     void alpha_set_to(Surface const* surf, float alpha) override;
     void orientation_set_to(Surface const* surf, MirOrientation orientation) override;
     void transformation_set_to(Surface const* surf, glm::mat4 const& t) override;
-    void cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image) override;
+    void cursor_image_set_to(Surface const* surf, std::weak_ptr<mir::graphics::CursorImage> const& image) override;
     void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) override;
     void client_surface_close_requested(Surface const* surf) override;
     void renamed(Surface const* surf, std::string const& name) override;

--- a/src/include/server/mir/scene/null_surface_observer.h
+++ b/src/include/server/mir/scene/null_surface_observer.h
@@ -41,7 +41,7 @@ public:
     void cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image) override;
     void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) override;
     void client_surface_close_requested(Surface const* surf) override;
-    void renamed(Surface const* surf, char const* name) override;
+    void renamed(Surface const* surf, std::string const& name) override;
     void cursor_image_removed(Surface const* surf) override;
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
     void input_consumed(Surface const* surf, MirEvent const* event) override;

--- a/src/include/server/mir/scene/null_surface_observer.h
+++ b/src/include/server/mir/scene/null_surface_observer.h
@@ -44,7 +44,7 @@ public:
     void renamed(Surface const* surf, std::string const& name) override;
     void cursor_image_removed(Surface const* surf) override;
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
-    void input_consumed(Surface const* surf, MirEvent const* event) override;
+    void input_consumed(Surface const* surf, std::shared_ptr<MirEvent const> const& event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
     void application_id_set_to(Surface const* surf, std::string const& application_id) override;

--- a/src/include/server/mir/scene/surface_event_source.h
+++ b/src/include/server/mir/scene/surface_event_source.h
@@ -45,7 +45,7 @@ public:
     void orientation_set_to(Surface const* surf, MirOrientation orientation) override;
     void client_surface_close_requested(Surface const* surf) override;
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
-    void input_consumed(Surface const* surf, MirEvent const* event) override;
+    void input_consumed(Surface const* surf, std::shared_ptr<MirEvent const> const& event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
 
 private:

--- a/src/include/server/mir/scene/surface_observer.h
+++ b/src/include/server/mir/scene/surface_observer.h
@@ -26,6 +26,7 @@
 #include <glm/glm.hpp>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace mir
 {
@@ -62,7 +63,7 @@ public:
     virtual void renamed(Surface const* surf, std::string const& name) = 0;
     virtual void cursor_image_removed(Surface const* surf) = 0;
     virtual void placed_relative(Surface const* surf, geometry::Rectangle const& placement) = 0;
-    virtual void input_consumed(Surface const* surf, MirEvent const* event) = 0;
+    virtual void input_consumed(Surface const* surf, std::shared_ptr<MirEvent const> const& event) = 0;
     virtual void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) = 0;
     virtual void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) = 0;
     virtual void application_id_set_to(Surface const* surf, std::string const& application_id) = 0;

--- a/src/include/server/mir/scene/surface_observer.h
+++ b/src/include/server/mir/scene/surface_observer.h
@@ -59,7 +59,7 @@ public:
     virtual void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) = 0;
     virtual void cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image) = 0;
     virtual void client_surface_close_requested(Surface const* surf) = 0;
-    virtual void renamed(Surface const* surf, char const* name) = 0;
+    virtual void renamed(Surface const* surf, std::string const& name) = 0;
     virtual void cursor_image_removed(Surface const* surf) = 0;
     virtual void placed_relative(Surface const* surf, geometry::Rectangle const& placement) = 0;
     virtual void input_consumed(Surface const* surf, MirEvent const* event) = 0;

--- a/src/include/server/mir/scene/surface_observer.h
+++ b/src/include/server/mir/scene/surface_observer.h
@@ -58,7 +58,7 @@ public:
     virtual void orientation_set_to(Surface const* surf, MirOrientation orientation) = 0;
     virtual void transformation_set_to(Surface const* surf, glm::mat4 const& t) = 0;
     virtual void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) = 0;
-    virtual void cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image) = 0;
+    virtual void cursor_image_set_to(Surface const* surf, std::weak_ptr<mir::graphics::CursorImage> const& image) = 0;
     virtual void client_surface_close_requested(Surface const* surf) = 0;
     virtual void renamed(Surface const* surf, std::string const& name) = 0;
     virtual void cursor_image_removed(Surface const* surf) = 0;

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -47,7 +47,7 @@ public:
     void renamed(Surface const* surf, std::string const&) override;
     void cursor_image_removed(Surface const* surf) override;
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
-    void input_consumed(Surface const* surf, MirEvent const* event) override;
+    void input_consumed(Surface const* surf, std::shared_ptr<MirEvent const> const& event) override;
     void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
     void application_id_set_to(Surface const* surf, std::string const& application_id) override;

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -42,7 +42,7 @@ public:
     void orientation_set_to(Surface const* surf, MirOrientation orientation) override;
     void transformation_set_to(Surface const* surf, glm::mat4 const& t) override;
     void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) override;
-    void cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image) override;
+    void cursor_image_set_to(Surface const* surf, std::weak_ptr<mir::graphics::CursorImage> const& image) override;
     void client_surface_close_requested(Surface const* surf) override;
     void renamed(Surface const* surf, std::string const&) override;
     void cursor_image_removed(Surface const* surf) override;

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -44,7 +44,7 @@ public:
     void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) override;
     void cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image) override;
     void client_surface_close_requested(Surface const* surf) override;
-    void renamed(Surface const* surf, char const*) override;
+    void renamed(Surface const* surf, std::string const&) override;
     void cursor_image_removed(Surface const* surf) override;
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
     void input_consumed(Surface const* surf, MirEvent const* event) override;

--- a/src/miroil/eventdispatch.cpp
+++ b/src/miroil/eventdispatch.cpp
@@ -17,11 +17,13 @@
 #include "miroil/eventdispatch.h"
 #include <miral/window.h>
 #include <mir/scene/surface.h>
+#include <mir/events/event_builders.h>
+#include <mir/events/input_event.h>
 
 void miroil::dispatch_input_event(const miral::Window& window, const MirInputEvent* event)
 {
-    auto e = reinterpret_cast<MirEvent const*>(event); // naughty
-
     if (auto surface = std::shared_ptr<mir::scene::Surface>(window))
-        surface->consume(e);
+    {
+        surface->consume(mir::events::clone_event(*event));
+    }
 }

--- a/src/miroil/surface.cpp
+++ b/src/miroil/surface.cpp
@@ -52,7 +52,7 @@ public:
   void
   reception_mode_set_to(mir::scene::Surface const * /*surf*/,
                         mir::input::InputReceptionMode /*mode*/) override{};
-  void renamed(mir::scene::Surface const *surf, char const *name) override;
+  void renamed(mir::scene::Surface const *surf, std::string const& name) override;
   void start_drag_and_drop(mir::scene::Surface const *surf,
                            std::vector<uint8_t> const &handle) override;
   void transformation_set_to(mir::scene::Surface const *surf,
@@ -141,9 +141,9 @@ void miroil::SurfaceObserverImpl::placed_relative(mir::scene::Surface const* sur
     listener->placed_relative(surf, placement);
 }
 
-void miroil::SurfaceObserverImpl::renamed(mir::scene::Surface const* surf, char const* name)
+void miroil::SurfaceObserverImpl::renamed(mir::scene::Surface const* surf, std::string const& name)
 {
-    listener->renamed(surf, name);
+    listener->renamed(surf, name.c_str());
 }
 
 void miroil::SurfaceObserverImpl::start_drag_and_drop(mir::scene::Surface const* surf, std::vector<uint8_t> const& handle)

--- a/src/miroil/surface.cpp
+++ b/src/miroil/surface.cpp
@@ -35,7 +35,7 @@ public:
                           mir::geometry::Size const &content_size) override;
   void cursor_image_removed(mir::scene::Surface const *surf) override;
   void cursor_image_set_to(mir::scene::Surface const *surf,
-                           mir::graphics::CursorImage const &image) override;
+                           std::weak_ptr<mir::graphics::CursorImage> const& image) override;
   void depth_layer_set_to(mir::scene::Surface const *surf,
                           MirDepthLayer depth_layer) override;
   void frame_posted(mir::scene::Surface const *surf, int frames_available,
@@ -101,9 +101,12 @@ void miroil::SurfaceObserverImpl::cursor_image_removed(mir::scene::Surface const
     listener->cursor_image_removed(surf);
 }
 
-void miroil::SurfaceObserverImpl::cursor_image_set_to(mir::scene::Surface const* surf, mir::graphics::CursorImage const& image)
+void miroil::SurfaceObserverImpl::cursor_image_set_to(mir::scene::Surface const* surf, std::weak_ptr<mir::graphics::CursorImage> const& image)
 {
-    listener->cursor_image_set_to(surf, image);
+    if (auto const locked = image.lock())
+    {
+        listener->cursor_image_set_to(surf, *locked);
+    }
 }
 
 void miroil::SurfaceObserverImpl::depth_layer_set_to(mir::scene::Surface const* surf, MirDepthLayer depth_layer)

--- a/src/miroil/surface.cpp
+++ b/src/miroil/surface.cpp
@@ -42,7 +42,7 @@ public:
                     mir::geometry::Rectangle const& area) override;
   void hidden_set_to(mir::scene::Surface const *surf, bool hide) override;
   void input_consumed(mir::scene::Surface const *surf,
-                      MirEvent const *event) override;
+                      std::shared_ptr<MirEvent const> const& event) override;
   void moved_to(mir::scene::Surface const *surf,
                 mir::geometry::Point const &top_left) override;
   void orientation_set_to(mir::scene::Surface const *surf,
@@ -121,9 +121,9 @@ void miroil::SurfaceObserverImpl::hidden_set_to(mir::scene::Surface const* surf,
     listener->hidden_set_to(surf, hide);
 }
 
-void miroil::SurfaceObserverImpl::input_consumed(mir::scene::Surface const* surf, MirEvent const* event)
+void miroil::SurfaceObserverImpl::input_consumed(mir::scene::Surface const* surf, std::shared_ptr<MirEvent const> const& event)
 {
-    listener->input_consumed(surf, event);
+    listener->input_consumed(surf, event.get());
 }
 
 void miroil::SurfaceObserverImpl::moved_to(mir::scene::Surface const* surf, mir::geometry::Point const& top_left)

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -115,7 +115,7 @@ private:
     /// Surface observer
     ///@{
     void attrib_changed(scene::Surface const*, MirWindowAttrib attrib, int) override;
-    void renamed(scene::Surface const*, char const* name) override;
+    void renamed(scene::Surface const*, std::string const& name) override;
     void application_id_set_to(scene::Surface const*, std::string const& application_id) override;
     ///@}
 
@@ -459,11 +459,10 @@ void mf::ForeignSurfaceObserver::attrib_changed(const scene::Surface*, MirWindow
     }
 }
 
-void mf::ForeignSurfaceObserver::renamed(ms::Surface const*, char const* name_c_str)
+void mf::ForeignSurfaceObserver::renamed(ms::Surface const*, std::string const& name)
 {
     std::lock_guard lock{mutex};
 
-    std::string name = name_c_str;
     with_toplevel_handle(lock, [name](ForeignToplevelHandleV1& handle)
         {
             handle.send_title_event(name);

--- a/src/server/frontend_wayland/wayland_surface_observer.cpp
+++ b/src/server/frontend_wayland/wayland_surface_observer.cpp
@@ -103,16 +103,14 @@ void mf::WaylandSurfaceObserver::placed_relative(ms::Surface const*, geometry::R
         });
 }
 
-void mf::WaylandSurfaceObserver::input_consumed(ms::Surface const*, MirEvent const* event)
+void mf::WaylandSurfaceObserver::input_consumed(ms::Surface const*, std::shared_ptr<MirEvent const> const& event)
 {
-    if (mir_event_get_type(event) == mir_event_type_input)
+    if (mir_event_get_type(event.get()) == mir_event_type_input)
     {
-        std::shared_ptr<MirEvent> owned_event = mev::clone_event(*event);
-
         run_on_wayland_thread_unless_window_destroyed(
-            [owned_event](Impl* impl, WindowWlSurfaceRole*)
+            [event](Impl* impl, WindowWlSurfaceRole*)
             {
-                auto const input_event = mir_event_get_input_event(owned_event.get());
+                auto const input_event = mir_event_get_input_event(event.get());
                 impl->input_dispatcher->handle_event(input_event);
             });
     }

--- a/src/server/frontend_wayland/wayland_surface_observer.h
+++ b/src/server/frontend_wayland/wayland_surface_observer.h
@@ -49,7 +49,7 @@ public:
     void content_resized_to(scene::Surface const*, geometry::Size const& content_size) override;
     void client_surface_close_requested(scene::Surface const*) override;
     void placed_relative(scene::Surface const*, geometry::Rectangle const& placement) override;
-    void input_consumed(scene::Surface const*, MirEvent const* event) override;
+    void input_consumed(scene::Surface const*, std::shared_ptr<MirEvent const> const& event) override;
     ///@}
 
     /// Should only be called from the Wayland thread

--- a/src/server/frontend_xwayland/xwayland_surface_observer.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.cpp
@@ -88,10 +88,11 @@ void mf::XWaylandSurfaceObserver::client_surface_close_requested(ms::Surface con
     wm_surface->scene_surface_close_requested();
 }
 
-void mf::XWaylandSurfaceObserver::input_consumed(ms::Surface const*, MirEvent const* event)
+void mf::XWaylandSurfaceObserver::input_consumed(ms::Surface const*, std::shared_ptr<MirEvent const> const& event)
 {
-    if (mir_event_get_type(event) == mir_event_type_input)
+    if (mir_event_get_type(event.get()) == mir_event_type_input)
     {
+        // Must clone the event so we can scale the positions to XWayland scale
         std::shared_ptr<MirEvent> owned_event = mev::clone_event(*event);
         mev::scale_positions(*owned_event, scale);
 

--- a/src/server/frontend_xwayland/xwayland_surface_observer.h
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.h
@@ -56,7 +56,7 @@ public:
     void content_resized_to(scene::Surface const*, geometry::Size const& content_size) override;
     void moved_to(scene::Surface const*, geometry::Point const& top_left) override;
     void client_surface_close_requested(scene::Surface const*) override;
-    void input_consumed(scene::Surface const*, MirEvent const* event) override;
+    void input_consumed(scene::Surface const*, std::shared_ptr<MirEvent const> const& event) override;
     ///@}
 
     /// Can be called from any thread

--- a/src/server/input/cursor_controller.cpp
+++ b/src/server/input/cursor_controller.cpp
@@ -81,7 +81,7 @@ struct UpdateCursorOnSurfaceChanges : ms::NullSurfaceObserver
     {
         cursor_controller->update_cursor_image();
     }
-    void cursor_image_set_to(ms::Surface const*, const mir::graphics::CursorImage&) override
+    void cursor_image_set_to(ms::Surface const*, std::weak_ptr<mir::graphics::CursorImage> const&) override
     {
         cursor_controller->update_cursor_image();
     }

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -124,7 +124,7 @@ void deliver_without_relative_motion(
     mev::transform_positions(*to_deliver, geom::Displacement{bounds.top_left.x.as_int(), bounds.top_left.y.as_int()});
     if (!drag_and_drop_handle.empty())
         mev::set_drag_and_drop_handle(*to_deliver, drag_and_drop_handle);
-    surface->consume(to_deliver.get());
+    surface->consume(std::move(to_deliver));
 }
 
 void deliver(
@@ -139,7 +139,7 @@ void deliver(
 
     auto const& bounds = surface->input_bounds();
     mev::transform_positions(*to_deliver, geom::Displacement{bounds.top_left.x.as_int(), bounds.top_left.y.as_int()});
-    surface->consume(to_deliver.get());
+    surface->consume(std::move(to_deliver));
 }
 
 }
@@ -459,7 +459,7 @@ void mi::SurfaceInputDispatcher::send_enter_exit_event(std::shared_ptr<mi::Surfa
 
     if (!drag_and_drop_handle.empty())
         mev::set_drag_and_drop_handle(*event, drag_and_drop_handle);
-    surface->consume(event.get());
+    surface->consume(std::move(event));
 }
 
 mi::SurfaceInputDispatcher::PointerInputState& mi::SurfaceInputDispatcher::ensure_pointer_state(MirInputDeviceId id)

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -95,7 +95,9 @@ void ms::SurfaceObservers::transformation_set_to(Surface const* surf, glm::mat4 
         { observer->transformation_set_to(surf, t); });
 }
 
-void ms::SurfaceObservers::cursor_image_set_to(Surface const* surf, graphics::CursorImage const& image)
+void ms::SurfaceObservers::cursor_image_set_to(
+    Surface const* surf,
+    std::weak_ptr<mir::graphics::CursorImage> const& image)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
         { observer->cursor_image_set_to(surf, image); });
@@ -563,7 +565,7 @@ void ms::BasicSurface::set_cursor_image(std::shared_ptr<mg::CursorImage> const& 
     }
 
     if (image)
-        observers->cursor_image_set_to(this, *image);
+        observers->cursor_image_set_to(this, image);
     else
         observers->cursor_image_removed(this);
 }
@@ -625,7 +627,7 @@ void ms::BasicSurface::set_cursor_from_buffer(
         std::lock_guard lock(guard);
         cursor_image_ = image;
     }
-    observers->cursor_image_set_to(this, *image);
+    observers->cursor_image_set_to(this, image);
 }
 
 auto ms::BasicSurface::wayland_surface() -> mw::Weak<mf::WlSurface> const&

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -131,7 +131,7 @@ void ms::SurfaceObservers::placed_relative(Surface const* surf, geometry::Rectan
                  { observer->placed_relative(surf, placement); });
 }
 
-void ms::SurfaceObservers::input_consumed(Surface const* surf, MirEvent const* event)
+void ms::SurfaceObservers::input_consumed(Surface const* surf, std::shared_ptr<MirEvent const> const& event)
 {
     for_each([&](std::shared_ptr<SurfaceObserver> const& observer)
                  { observer->input_consumed(surf, event); });
@@ -780,7 +780,7 @@ int ms::BasicSurface::buffers_ready_for_compositor(void const* id) const
     return max_buf;
 }
 
-void ms::BasicSurface::consume(MirEvent const* event)
+void ms::BasicSurface::consume(std::shared_ptr<MirEvent const> const& event)
 {
     observers->input_consumed(this, event);
 }

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -113,7 +113,7 @@ void ms::SurfaceObservers::client_surface_close_requested(Surface const* surf)
         { observer->client_surface_close_requested(surf); });
 }
 
-void ms::SurfaceObservers::renamed(Surface const* surf, char const* name)
+void ms::SurfaceObservers::renamed(Surface const* surf, std::string const& name)
 {
     for_each([&surf, name](std::shared_ptr<SurfaceObserver> const& observer)
         { observer->renamed(surf, name); });

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -100,7 +100,7 @@ public:
     geometry::Point top_left() const override;
     geometry::Rectangle input_bounds() const override;
     bool input_area_contains(geometry::Point const& point) const override;
-    void consume(MirEvent const* event) override;
+    void consume(std::shared_ptr<MirEvent const> const& event) override;
     void set_alpha(float alpha) override;
     void set_orientation(MirOrientation orientation) override;
     void set_transformation(glm::mat4 const&) override;

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -31,7 +31,7 @@ void ms::NullSurfaceObserver::transformation_set_to(Surface const*, glm::mat4 co
 void ms::NullSurfaceObserver::reception_mode_set_to(Surface const*, input::InputReceptionMode) {}
 void ms::NullSurfaceObserver::cursor_image_set_to(Surface const*, graphics::CursorImage const&) {}
 void ms::NullSurfaceObserver::client_surface_close_requested(Surface const*) {}
-void ms::NullSurfaceObserver::renamed(Surface const*, char const*) {}
+void ms::NullSurfaceObserver::renamed(Surface const*, std::string const&) {}
 void ms::NullSurfaceObserver::cursor_image_removed(Surface const*) {}
 void ms::NullSurfaceObserver::placed_relative(Surface const*, geometry::Rectangle const&) {}
 void ms::NullSurfaceObserver::input_consumed(Surface const*, MirEvent const*) {}

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -29,7 +29,7 @@ void ms::NullSurfaceObserver::alpha_set_to(Surface const*, float) {}
 void ms::NullSurfaceObserver::orientation_set_to(Surface const*, MirOrientation) {}
 void ms::NullSurfaceObserver::transformation_set_to(Surface const*, glm::mat4 const&) {}
 void ms::NullSurfaceObserver::reception_mode_set_to(Surface const*, input::InputReceptionMode) {}
-void ms::NullSurfaceObserver::cursor_image_set_to(Surface const*, graphics::CursorImage const&) {}
+void ms::NullSurfaceObserver::cursor_image_set_to(Surface const*, std::weak_ptr<mir::graphics::CursorImage> const&) {}
 void ms::NullSurfaceObserver::client_surface_close_requested(Surface const*) {}
 void ms::NullSurfaceObserver::renamed(Surface const*, std::string const&) {}
 void ms::NullSurfaceObserver::cursor_image_removed(Surface const*) {}

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -34,7 +34,7 @@ void ms::NullSurfaceObserver::client_surface_close_requested(Surface const*) {}
 void ms::NullSurfaceObserver::renamed(Surface const*, std::string const&) {}
 void ms::NullSurfaceObserver::cursor_image_removed(Surface const*) {}
 void ms::NullSurfaceObserver::placed_relative(Surface const*, geometry::Rectangle const&) {}
-void ms::NullSurfaceObserver::input_consumed(Surface const*, MirEvent const*) {}
+void ms::NullSurfaceObserver::input_consumed(Surface const*, std::shared_ptr<MirEvent const> const&) {}
 void ms::NullSurfaceObserver::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&) {}
 void ms::NullSurfaceObserver::depth_layer_set_to(Surface const*, MirDepthLayer) {}
 void ms::NullSurfaceObserver::application_id_set_to(Surface const*, std::string const&) {}

--- a/src/server/scene/surface_change_notification.cpp
+++ b/src/server/scene/surface_change_notification.cpp
@@ -78,7 +78,7 @@ void ms::SurfaceChangeNotification::reception_mode_set_to(Surface const*, input:
     notify_scene_change();
 }
 
-void ms::SurfaceChangeNotification::renamed(Surface const*, char const*)
+void ms::SurfaceChangeNotification::renamed(Surface const*, std::string const&)
 {
     notify_scene_change();
 }

--- a/src/server/scene/surface_change_notification.h
+++ b/src/server/scene/surface_change_notification.h
@@ -41,7 +41,7 @@ public:
     void alpha_set_to(Surface const* surf, float) override;
     void transformation_set_to(Surface const* surf, glm::mat4 const&) override;
     void reception_mode_set_to(Surface const* surf, input::InputReceptionMode mode) override;
-    void renamed(Surface const* surf, char const*) override;
+    void renamed(Surface const* surf, std::string const&) override;
 
 private:
     std::function<void()> const notify_scene_change;

--- a/src/server/scene/surface_event_source.cpp
+++ b/src/server/scene/surface_event_source.cpp
@@ -80,7 +80,7 @@ void ms::SurfaceEventSource::placed_relative(Surface const*, geometry::Rectangle
     event_sink->handle_event(mev::make_window_placement_event(id, placement));
 }
 
-void ms::SurfaceEventSource::input_consumed(Surface const*, MirEvent const* event)
+void ms::SurfaceEventSource::input_consumed(Surface const*, std::shared_ptr<MirEvent const> const& event)
 {
     auto ev = mev::clone_event(*event);
     mev::set_window_id(*ev, id.as_value());

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -514,7 +514,7 @@ void msh::AbstractShell::set_keyboard_focus_surface(
         update_confinement_for(new_keyboard_focus_surface);
 
         input_targeter->set_focus(new_keyboard_focus_surface);
-        new_keyboard_focus_surface->consume(seat->create_device_state().get());
+        new_keyboard_focus_surface->consume(seat->create_device_state());
         new_keyboard_focus_surface->add_observer(focus_surface_observer);
     }
     else

--- a/src/server/shell/decoration/input.cpp
+++ b/src/server/shell/decoration/input.cpp
@@ -43,11 +43,11 @@ struct msd::InputManager::Observer
 
     /// Overrides from NullSurfaceObserver
     /// @{
-    void input_consumed(ms::Surface const*, MirEvent const* event) override
+    void input_consumed(ms::Surface const*, std::shared_ptr<MirEvent const> const& event) override
     {
-        if (mir_event_get_type(event) != mir_event_type_input)
+        if (mir_event_get_type(event.get()) != mir_event_type_input)
             return;
-        MirInputEvent const* const input_ev = mir_event_get_input_event(event);
+        MirInputEvent const* const input_ev = mir_event_get_input_event(event.get());
         auto const timestamp = std::chrono::nanoseconds{mir_input_event_get_event_time(input_ev)};
         switch (mir_input_event_get_type(input_ev))
         {

--- a/src/server/shell/decoration/window.cpp
+++ b/src/server/shell/decoration/window.cpp
@@ -261,7 +261,7 @@ public:
         update();
     }
 
-    void renamed(ms::Surface const*, char const* /*name*/) override
+    void renamed(ms::Surface const*, std::string const& /*name*/) override
     {
         update();
     }

--- a/tests/include/mir/test/doubles/mock_surface.h
+++ b/tests/include/mir/test/doubles/mock_surface.h
@@ -73,7 +73,7 @@ struct MockSurface : public scene::BasicSurface
     MOCK_METHOD2(configure, int(MirWindowAttrib, int));
     MOCK_METHOD1(add_observer, void(std::shared_ptr<scene::SurfaceObserver> const&));
     MOCK_METHOD1(remove_observer, void(std::weak_ptr<scene::SurfaceObserver> const&));
-    MOCK_METHOD1(consume, void(MirEvent const*));
+    MOCK_METHOD1(consume, void(std::shared_ptr<MirEvent const> const& event));
 
     MOCK_CONST_METHOD0(primary_buffer_stream, std::shared_ptr<frontend::BufferStream>());
     MOCK_METHOD1(set_streams, void(std::list<scene::StreamInfo> const&));

--- a/tests/unit-tests/input/test_cursor_controller.cpp
+++ b/tests/unit-tests/input/test_cursor_controller.cpp
@@ -144,7 +144,7 @@ struct StubInputSurface : public mtd::StubSurface
         {
             std::unique_lock lk(observer_guard);
             for (auto o : observers)
-                o->cursor_image_set_to(this, *image);
+                o->cursor_image_set_to(this, image);
         }
     }
 

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -68,9 +68,9 @@ public:
     MOCK_METHOD2(content_resized_to, void(ms::Surface const*, geom::Size const&));
     MOCK_METHOD3(frame_posted, void(ms::Surface const*, int, geom::Rectangle const&));
     MOCK_METHOD2(hidden_set_to, void(ms::Surface const*, bool));
-    MOCK_METHOD2(renamed, void(ms::Surface const*, char const*));
+    MOCK_METHOD2(renamed, void(ms::Surface const*, std::string const&));
     MOCK_METHOD1(client_surface_close_requested, void(ms::Surface const*));
-    MOCK_METHOD2(cursor_image_set_to, void(ms::Surface const*, mir::graphics::CursorImage const& image));
+    MOCK_METHOD2(cursor_image_set_to, void(ms::Surface const*, std::weak_ptr<mir::graphics::CursorImage> const& image));
     MOCK_METHOD1(cursor_image_removed, void(ms::Surface const*));
     MOCK_METHOD2(application_id_set_to, void(ms::Surface const*, std::string const&));
 };

--- a/tests/unit-tests/scene/test_surface.cpp
+++ b/tests/unit-tests/scene/test_surface.cpp
@@ -213,6 +213,6 @@ TEST_F(SurfaceCreation, consume_calls_send_event)
     EXPECT_CALL(*mock_event_sink, handle_event(mt::MirKeyboardEventMatches(key_event.get()))).Times(1);
     EXPECT_CALL(*mock_event_sink, handle_event(mt::MirTouchEventMatches(touch_event.get()))).Times(1);
 
-    surface.consume(key_event.get());
-    surface.consume(touch_event.get());
+    surface.consume(std::move(key_event));
+    surface.consume(std::move(touch_event));
 }

--- a/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
+++ b/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
@@ -175,7 +175,7 @@ struct DecorationBasicDecoration
 
     void decoration_event(mir::EventUPtr event)
     {
-        decoration_surface.consume(event.get());
+        decoration_surface.consume(std::move(event));
         executor.execute();
     }
 


### PR DESCRIPTION
Because the modern observer system does not always send notifications on the same thread, it needs to be given types it can hold ownership of. This PR changes types used by SurfaceObserver to work. All methods still take a raw surface pointer, which is generally not used and should be removed, but that is out of scope here.