### PR TITLE
Allow --add-wayland-extenions all and clean up help message

### DIFF
--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -462,7 +462,7 @@ void miral::WaylandExtensions::operator()(mir::Server& server) const
 
     server.add_configuration_option(
         mo::add_wayland_extensions_opt,
-        ("Wayland extensions to enable, in addition to default extensions. Use `all` to enable all supported extensions."),
+        ("Wayland extensions to enable in addition to default extensions. Use `all` to enable all supported extensions."),
         mir::OptionType::string);
 
     server.add_configuration_option(

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -180,7 +180,7 @@ struct miral::WaylandExtensions::Self
         return extension;
     }
 
-    static auto serialize_colon_list(std::vector<std::string> extensions) -> std::string
+    static auto serialize_list(std::vector<std::string> extensions, std::string const& joiner) -> std::string
     {
         bool at_start = true;
         std::string result;
@@ -189,7 +189,7 @@ struct miral::WaylandExtensions::Self
             if (at_start)
                 at_start = false;
             else
-                result += ":";
+                result += joiner;
             result += extension;
         }
         return result;
@@ -208,9 +208,9 @@ struct miral::WaylandExtensions::Self
         {
             throw mir::AbnormalExit{
                 "Unsupported wayland extensions: " +
-                serialize_colon_list(errors) +
-                ". Supported extensions are: " +
-                serialize_colon_list({begin(supported_extensions), end(supported_extensions)})};
+                serialize_list(errors, ":") +
+                ". " +
+                describe_extensions()};
         }
     }
 
@@ -399,6 +399,23 @@ struct miral::WaylandExtensions::Self
         }
     }
 
+    auto describe_extensions() const -> std::string
+    {
+        std::vector<std::string> non_default_extensions;
+        for (auto const& extension : supported_extensions)
+        {
+            if (default_extensions.find(extension) == default_extensions.end())
+            {
+                non_default_extensions.push_back(extension);
+            }
+        }
+        std::string const joiner = "\n  ";
+        return "Default extensions:" + joiner +
+            serialize_list({default_extensions.begin(), default_extensions.end()}, joiner) +
+            "\nAdditional supported extensions:" + joiner +
+            serialize_list(non_default_extensions, joiner);
+    }
+
     std::set<std::string> const recommended_extensions;
     std::vector<Builder> wayland_extension_hooks;
     std::map<std::string, EnableCallback> conditional_extensions;
@@ -438,18 +455,19 @@ void miral::WaylandExtensions::operator()(mir::Server& server) const
 
     server.add_configuration_option(
         mo::wayland_extensions_opt,
-        ("Exhaustive list of all Wayland extensions to enable. [" + Self::serialize_colon_list(supported_extensions) + "]"),
+        ("Colon-separated list of Wayland extensions to enable. "
+         "If used, default extensions will NOT be enabled unless specified. " +
+         self->describe_extensions()),
         mir::OptionType::string);
 
     server.add_configuration_option(
         mo::add_wayland_extensions_opt,
-        ("Additional Wayland extensions to enable, or `all` to enable all supported extensions. [" +
-         Self::serialize_colon_list(non_default_extensions) + "]"),
+        ("Wayland extensions to enable, in addition to default extensions. Use `all` to enable all supported extensions."),
         mir::OptionType::string);
 
     server.add_configuration_option(
         mo::drop_wayland_extensions_opt,
-        ("Wayland extensions to disable. [" + Self::serialize_colon_list(default_extensions) + "]"),
+        ("Wayland extensions to disable."),
         mir::OptionType::string);
 
     server.add_pre_init_callback([self=self, &server]

--- a/src/miral/wayland_extensions.cpp
+++ b/src/miral/wayland_extensions.cpp
@@ -324,8 +324,8 @@ struct miral::WaylandExtensions::Self
 
         if (server.get_options()->is_set(mo::add_wayland_extensions_opt))
         {
-            auto const added = Self::parse_extensions_option(
-                server.get_options()->get<std::string>(mo::add_wayland_extensions_opt));
+            auto const value = server.get_options()->get<std::string>(mo::add_wayland_extensions_opt);
+            auto const added = value == "all" ? supported_extensions : Self::parse_extensions_option(value);
             for (auto const& extension : added)
             {
                 selected_extensions.insert(extension);
@@ -443,7 +443,8 @@ void miral::WaylandExtensions::operator()(mir::Server& server) const
 
     server.add_configuration_option(
         mo::add_wayland_extensions_opt,
-        ("Additional Wayland extensions to enable. [" + Self::serialize_colon_list(non_default_extensions) + "]"),
+        ("Additional Wayland extensions to enable, or `all` to enable all supported extensions. [" +
+         Self::serialize_colon_list(non_default_extensions) + "]"),
         mir::OptionType::string);
 
     server.add_configuration_option(


### PR DESCRIPTION
Alternative to #2468, does not introduce a new command line option, instead allowing `--add-wayland-extensions all`. While I was in this part of the code, I improved our help and error messages relating to extensions. Now we only print the extension list once in help, and each extensions is on a different line so they're easier to read and copy/paste.

Before:
```
  --wayland-extensions arg              Exhaustive list of all Wayland 
                                        extensions to enable. 
                                        [wl_shell:xdg_wm_base:zwlr_foreign_topl
                                        evel_manager_v1:zwlr_layer_shell_v1:zwl
                                        r_screencopy_manager_v1:zwp_idle_inhibi
                                        t_manager_v1:zwp_input_method_manager_v
                                        2:zwp_pointer_constraints_v1:zwp_relati
                                        ve_pointer_manager_v1:zwp_text_input_ma
                                        nager_v1:zwp_text_input_manager_v2:zwp_
                                        text_input_manager_v3:zwp_virtual_keybo
                                        ard_manager_v1:zxdg_output_manager_v1:z
                                        xdg_shell_v6]
  --add-wayland-extensions arg          Additional Wayland extensions to 
                                        enable. [zwlr_foreign_toplevel_manager_
                                        v1:zwlr_layer_shell_v1:zwlr_screencopy_
                                        manager_v1:zwp_idle_inhibit_manager_v1:
                                        zwp_input_method_manager_v2:zwp_pointer
                                        _constraints_v1:zwp_relative_pointer_ma
                                        nager_v1:zwp_virtual_keyboard_manager_v
                                        1]
  --drop-wayland-extensions arg         Wayland extensions to disable. 
                                        [wl_shell:xdg_wm_base:zwp_text_input_ma
                                        nager_v1:zwp_text_input_manager_v2:zwp_
                                        text_input_manager_v3:zxdg_output_manag
                                        er_v1:zxdg_shell_v6]
```
After:
```
  --wayland-extensions arg              Colon-separated list of Wayland 
                                        extensions to enable. If used, default 
                                        extensions will NOT be enabled unless 
                                        specified. Default extensions:
                                          wl_shell
                                          xdg_wm_base
                                          zwp_text_input_manager_v1
                                          zwp_text_input_manager_v2
                                          zwp_text_input_manager_v3
                                          zxdg_output_manager_v1
                                          zxdg_shell_v6
                                        Additional supported extensions:
                                          zwlr_foreign_toplevel_manager_v1
                                          zwlr_layer_shell_v1
                                          zwlr_screencopy_manager_v1
                                          zwp_idle_inhibit_manager_v1
                                          zwp_input_method_manager_v2
                                          zwp_pointer_constraints_v1
                                          zwp_relative_pointer_manager_v1
                                          zwp_virtual_keyboard_manager_v1
  --add-wayland-extensions arg          Wayland extensions to enable, in 
                                        addition to default extensions. Use 
                                        `all` to enable all supported 
                                        extensions.
  --drop-wayland-extensions arg         Wayland extensions to disable.
```