### PR TITLE
platform/graphics: Drop `DisplayConfiguration::for_each_card`

### DIFF
--- a/include/platform/mir/graphics/display_configuration.h
+++ b/include/platform/mir/graphics/display_configuration.h
@@ -210,8 +210,6 @@ class DisplayConfiguration
 public:
     virtual ~DisplayConfiguration() = default;
 
-    /** Executes a function object for each card in the configuration. */
-    virtual void for_each_card(std::function<void(DisplayConfigurationCard const&)> f) const = 0;
     /** Executes a function object for each output in the configuration. */
     virtual void for_each_output(std::function<void(DisplayConfigurationOutput const&)> f) const = 0;
     virtual void for_each_output(std::function<void(UserDisplayConfigurationOutput&)> f) = 0;

--- a/include/test/mir/test/doubles/mock_display_configuration.h
+++ b/include/test/mir/test/doubles/mock_display_configuration.h
@@ -31,10 +31,6 @@ namespace doubles
 struct MockDisplayConfiguration : public graphics::DisplayConfiguration
 {
     MOCK_CONST_METHOD1(
-        for_each_card,
-        void(std::function<void(graphics::DisplayConfigurationCard const&)>));
-
-    MOCK_CONST_METHOD1(
         for_each_output,
         void(std::function<void(graphics::DisplayConfigurationOutput const&)>));
 

--- a/include/test/mir/test/doubles/null_display_configuration.h
+++ b/include/test/mir/test/doubles/null_display_configuration.h
@@ -27,9 +27,6 @@ namespace doubles
 {
 class NullDisplayConfiguration : public graphics::DisplayConfiguration
 {
-    void for_each_card(std::function<void(graphics::DisplayConfigurationCard const&)>) const override
-    {
-    }
     void for_each_output(std::function<void(graphics::DisplayConfigurationOutput const&)>) const override
     {
     }

--- a/include/test/mir/test/doubles/stub_display_configuration.h
+++ b/include/test/mir/test/doubles/stub_display_configuration.h
@@ -84,8 +84,6 @@ public:
         std::vector<graphics::DisplayConfigurationCard> const& cards,
         std::vector<graphics::DisplayConfigurationOutput> const& outputs);
 
-    void for_each_card(std::function<void(graphics::DisplayConfigurationCard const&)> f) const override;
-
     void for_each_output(std::function<void(graphics::DisplayConfigurationOutput const&)> f) const override;
 
     void for_each_output(std::function<void(graphics::UserDisplayConfigurationOutput&)> f) override;

--- a/src/platform/graphics/display_configuration.cpp
+++ b/src/platform/graphics/display_configuration.cpp
@@ -138,7 +138,6 @@ std::ostream& mg::operator<<(std::ostream& out, mg::DisplayConfigurationOutput c
 
 std::ostream& mg::operator<<(std::ostream& out, mg::DisplayConfiguration const& val)
 {
-    val.for_each_card([&out](auto card) { out << card << std::endl; });
     val.for_each_output([&out](DisplayConfigurationOutput const& output) { out << output << std::endl; });
 
     return out;
@@ -208,13 +207,11 @@ bool mg::operator==(DisplayConfiguration const& lhs, DisplayConfiguration const&
     std::vector<DisplayConfigurationCard> lhs_cards;
     std::vector<DisplayConfigurationOutput> lhs_outputs;
 
-    lhs.for_each_card([&lhs_cards](DisplayConfigurationCard const& card) { lhs_cards.emplace_back(card); });
     lhs.for_each_output([&lhs_outputs](DisplayConfigurationOutput const& output) { lhs_outputs.emplace_back(output); });
 
     std::vector<DisplayConfigurationCard> rhs_cards;
     std::vector<DisplayConfigurationOutput> rhs_outputs;
 
-    rhs.for_each_card([&rhs_cards](DisplayConfigurationCard const& card) { rhs_cards.emplace_back(card); });
     rhs.for_each_output([&rhs_outputs](DisplayConfigurationOutput const& output) { rhs_outputs.emplace_back(output); });
 
     return lhs_cards == rhs_cards && lhs_outputs == rhs_outputs;

--- a/src/platforms/eglstream-kms/server/kms_display_configuration.cpp
+++ b/src/platforms/eglstream-kms/server/kms_display_configuration.cpp
@@ -181,12 +181,6 @@ mge::KMSDisplayConfiguration::KMSDisplayConfiguration(
 {
 }
 
-void mge::KMSDisplayConfiguration::for_each_card(
-    std::function<void(DisplayConfigurationCard const&)> f) const
-{
-    f(card);
-}
-
 void mge::KMSDisplayConfiguration::for_each_output(
     std::function<void(DisplayConfigurationOutput const&)> f) const
 {

--- a/src/platforms/eglstream-kms/server/kms_display_configuration.h
+++ b/src/platforms/eglstream-kms/server/kms_display_configuration.h
@@ -37,7 +37,6 @@ public:
     KMSDisplayConfiguration(int drm_fd, EGLDisplay dpy);
     KMSDisplayConfiguration(KMSDisplayConfiguration const& conf);
 
-    void for_each_card(std::function<void(DisplayConfigurationCard const&)> f) const override;
     void for_each_output(std::function<void(DisplayConfigurationOutput const&)> f) const override;
     void for_each_output(std::function<void(UserDisplayConfigurationOutput&)> f) override;
     std::unique_ptr<DisplayConfiguration> clone() const override;

--- a/src/platforms/gbm-kms/server/kms/real_kms_display_configuration.cpp
+++ b/src/platforms/gbm-kms/server/kms/real_kms_display_configuration.cpp
@@ -63,12 +63,6 @@ mgg::RealKMSDisplayConfiguration& mgg::RealKMSDisplayConfiguration::operator=(
     return *this;
 }
 
-void mgg::RealKMSDisplayConfiguration::for_each_card(
-    std::function<void(DisplayConfigurationCard const&)> f) const
-{
-    f(card);
-}
-
 void mgg::RealKMSDisplayConfiguration::for_each_output(
     std::function<void(DisplayConfigurationOutput const&)> f) const
 {

--- a/src/platforms/gbm-kms/server/kms/real_kms_display_configuration.h
+++ b/src/platforms/gbm-kms/server/kms/real_kms_display_configuration.h
@@ -40,7 +40,6 @@ public:
     RealKMSDisplayConfiguration(RealKMSDisplayConfiguration const& conf);
     RealKMSDisplayConfiguration& operator=(RealKMSDisplayConfiguration const& conf);
 
-    void for_each_card(std::function<void(DisplayConfigurationCard const&)> f) const override;
     void for_each_output(std::function<void(DisplayConfigurationOutput const&)> f) const override;
     void for_each_output(std::function<void(UserDisplayConfigurationOutput&)> f) override;
     std::unique_ptr<DisplayConfiguration> clone() const override;

--- a/src/platforms/rpi-dispmanx/display.cpp
+++ b/src/platforms/rpi-dispmanx/display.cpp
@@ -45,12 +45,6 @@ public:
     {
     }
 
-    void for_each_card(std::function<void(mg::DisplayConfigurationCard const&)> f) const override
-    {
-        mg::DisplayConfigurationCard const the_card{mg::DisplayConfigurationCardId{1}, 1};
-        f(the_card);
-    }
-
     void for_each_output(std::function<void(mg::DisplayConfigurationOutput const&)> f) const override
     {
         f(the_output);

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -935,7 +935,6 @@ public:
     explicit WaylandDisplayConfiguration(std::vector<DisplayConfigurationOutput> && outputs);
     WaylandDisplayConfiguration(WaylandDisplayConfiguration const&);
 
-    void for_each_card(std::function<void(DisplayConfigurationCard const&)> f) const override;
     void for_each_output(std::function<void(DisplayConfigurationOutput const&)> f) const override;
     void for_each_output(std::function<void(UserDisplayConfigurationOutput&)> f) override;
     auto clone() const -> std::unique_ptr<DisplayConfiguration> override;
@@ -982,12 +981,6 @@ mgw::WaylandDisplayConfiguration::WaylandDisplayConfiguration(WaylandDisplayConf
     DisplayConfiguration(),
     outputs{rhs.outputs}
 {
-}
-
-void mgw::WaylandDisplayConfiguration::for_each_card(
-    std::function<void(DisplayConfigurationCard const&)> f) const
-{
-    f(card);
 }
 
 void mgw::WaylandDisplayConfiguration::for_each_output(

--- a/src/platforms/x11/graphics/display_configuration.cpp
+++ b/src/platforms/x11/graphics/display_configuration.cpp
@@ -72,11 +72,6 @@ mgx::DisplayConfiguration::DisplayConfiguration(DisplayConfiguration const& othe
 {
 }
 
-void mgx::DisplayConfiguration::for_each_card(std::function<void(mg::DisplayConfigurationCard const&)> f) const
-{
-    f(card);
-}
-
 void mgx::DisplayConfiguration::for_each_output(std::function<void(mg::DisplayConfigurationOutput const&)> f) const
 {
     for (auto const& output : configuration)

--- a/src/platforms/x11/graphics/display_configuration.h
+++ b/src/platforms/x11/graphics/display_configuration.h
@@ -43,7 +43,6 @@ public:
 
     virtual ~DisplayConfiguration() = default;
 
-    void for_each_card(std::function<void(DisplayConfigurationCard const&)> f) const override;
     void for_each_output(std::function<void(DisplayConfigurationOutput const&)> f) const override;
     void for_each_output(std::function<void(UserDisplayConfigurationOutput&)> f) override;
     std::unique_ptr<graphics::DisplayConfiguration> clone() const override;

--- a/tests/mir_test_doubles/stub_display_configuration.cpp
+++ b/tests/mir_test_doubles/stub_display_configuration.cpp
@@ -273,10 +273,6 @@ mtd::StubDisplayConfig::StubDisplayConfig(
 {
 }
 
-void mtd::StubDisplayConfig::for_each_card(std::function<void(graphics::DisplayConfigurationCard const&)> /*f*/) const
-{
-}
-
 void mtd::StubDisplayConfig::for_each_output(std::function<void(graphics::DisplayConfigurationOutput const&)> f) const
 {
     for (auto& disp : outputs)

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -246,11 +246,6 @@ struct FakeDisplayConfiguration : public mir::graphics::DisplayConfiguration
     {
     }
 
-    void for_each_card(std::function<void(mir::graphics::DisplayConfigurationCard const&)> /*f*/) const override
-    {
-        throw std::runtime_error("FakeDisplayConfiguration::for_each_card is not implemented");
-    }
-
     void for_each_output(std::function<void(mir::graphics::DisplayConfigurationOutput const&)> f) const override
     {
         for (auto const& output : outputs)

--- a/tests/unit-tests/graphics/test_overlapping_output_grouping.cpp
+++ b/tests/unit-tests/graphics/test_overlapping_output_grouping.cpp
@@ -57,17 +57,6 @@ public:
     {
     }
 
-    void for_each_card(std::function<void(mg::DisplayConfigurationCard const&)> f) const override
-    {
-        mg::DisplayConfigurationCard card
-        {
-            mg::DisplayConfigurationCardId{1},
-            outputs.size()
-        };
-
-        f(card);
-    }
-
     void for_each_output(std::function<void(mg::DisplayConfigurationOutput const&)> f) const override
     {
         uint32_t i = 1;

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_cursor.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_cursor.cpp
@@ -189,11 +189,6 @@ struct StubKMSDisplayConfiguration : public mgg::KMSDisplayConfiguration
             });
     }
 
-    void for_each_card(std::function<void(mg::DisplayConfigurationCard const&)> f) const override
-    {
-        stub_config.for_each_card(f);
-    }
-
     void for_each_output(std::function<void(mg::DisplayConfigurationOutput const&)> f) const override
     {
         stub_config.for_each_output(f);


### PR DESCRIPTION
Nothing has ever used this information, and in the new platform interface
we have one `DisplayPlatform` per card anyway.