### PR TITLE
Send keyboard modifiers after keyboard enter

### DIFF
--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -58,8 +58,6 @@ void mf::WlKeyboard::focus_on(WlSurface* surface)
         send_leave_event(serial, focused_surface.value().raw_resource());
     }
 
-    focused_surface = mw::make_weak(surface);
-
     if (surface)
     {
         // TODO: Send the surface's keymap here
@@ -92,6 +90,8 @@ void mf::WlKeyboard::focus_on(WlSurface* surface)
         wl_array_release(&key_state);
         send_modifiers_event(serial, depressed_modifiers, latched_modifiers, locked_modifiers, group_modifiers);
     }
+
+    focused_surface = mw::make_weak(surface);
 }
 
 void mf::WlKeyboard::send_repeat_info(int32_t rate, int32_t delay)
@@ -118,6 +118,9 @@ void mf::WlKeyboard::send_modifiers(uint32_t depressed, uint32_t latched, uint32
     locked_modifiers = locked;
     group_modifiers = group;
 
-    auto const serial = wl_display_get_serial(wl_client_get_display(client));
-    send_modifiers_event(serial, depressed, latched, locked, group);
+    if (focused_surface)
+    {
+        auto const serial = wl_display_get_serial(wl_client_get_display(client));
+        send_modifiers_event(serial, depressed, latched, locked, group);
+    }
 }

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -90,6 +90,7 @@ void mf::WlKeyboard::focus_on(WlSurface* surface)
         auto const serial = wl_display_next_serial(wl_client_get_display(client));
         send_enter_event(serial, surface->raw_resource(), &key_state);
         wl_array_release(&key_state);
+        send_modifiers_event(serial, depressed_modifiers, latched_modifiers, locked_modifiers, group_modifiers);
     }
 }
 
@@ -112,6 +113,11 @@ void mf::WlKeyboard::send_key(uint32_t timestamp, int scancode, bool down)
 
 void mf::WlKeyboard::send_modifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group)
 {
+    depressed_modifiers = depressed;
+    latched_modifiers = latched;
+    locked_modifiers = locked;
+    group_modifiers = group;
+
     auto const serial = wl_display_get_serial(wl_client_get_display(client));
     send_modifiers_event(serial, depressed, latched, locked, group);
 }

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -44,6 +44,11 @@ private:
     std::unique_ptr<KeyboardHelper> const helper;
     wayland::Weak<WlSurface> focused_surface;
 
+    uint32_t depressed_modifiers = 0;
+    uint32_t latched_modifiers = 0;
+    uint32_t locked_modifiers = 0;
+    uint32_t group_modifiers = 0;
+
     /// WlSeat::FocusListener override
     void focus_on(WlSurface* surface) override;
 


### PR DESCRIPTION
Possibly a naive implementation (as I've not read the protocol requirements)

Fixes: #2535
Fixes: #2025