### PR TITLE
Include null terminator in keymap

### DIFF
--- a/src/server/frontend_wayland/keyboard_helper.cpp
+++ b/src/server/frontend_wayland/keyboard_helper.cpp
@@ -168,7 +168,8 @@ void mf::KeyboardHelper::set_keymap(std::shared_ptr<mi::Keymap> const& new_keyma
         compiled_keymap.get(),
         XKB_KEYMAP_FORMAT_TEXT_V1),
         free};
-    auto length = strlen(buffer.get());
+    // so the null terminator is included
+    auto length = strlen(buffer.get()) + 1;
 
     mir::AnonymousShmFile shm_buffer{length};
     memcpy(shm_buffer.base_ptr(), buffer.get(), length);

--- a/src/server/frontend_wayland/virtual_keyboard_v1.cpp
+++ b/src/server/frontend_wayland/virtual_keyboard_v1.cpp
@@ -83,8 +83,7 @@ auto load_keymap(uint32_t format, mir::Fd fd, size_t size) -> std::shared_ptr<mi
         }
     }
 
-    // Keymaps seem to be null-terminated. It's unclear if they're supposed to be or not. Either way, BufferKeymap does
-    // not expect a null-terminated keymap
+    // Keymaps are null-terminated, BufferKeymap does not expect a null-terminated buffer
     while (buffer.back() == '\0')
     {
         buffer.pop_back();


### PR DESCRIPTION
Fixes #2533. I haven't observed any bugs related to this, but it is technically required by the latest wayland.xml (my impression is that in previous versions it was ambiguous but the new behavior was always generally expected, so changing behavior for all versions should be most correct).