### PR TITLE
mmap keymap fd instead of reading from it

### DIFF
--- a/src/server/frontend_wayland/virtual_keyboard_v1.cpp
+++ b/src/server/frontend_wayland/virtual_keyboard_v1.cpp
@@ -58,7 +58,7 @@ auto load_keymap(uint32_t format, mir::Fd fd, size_t size) -> std::shared_ptr<mi
         BOOST_THROW_EXCEPTION(std::runtime_error("invalid keymap format " + std::to_string(format)));
     }
 
-    void* const data = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+    void* const data = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
     if (data == MAP_FAILED)
     {
         BOOST_THROW_EXCEPTION(std::system_error(errno, std::system_category(), "failed to mmap keymap fd"));

--- a/src/server/frontend_wayland/virtual_keyboard_v1.cpp
+++ b/src/server/frontend_wayland/virtual_keyboard_v1.cpp
@@ -58,7 +58,7 @@ auto load_keymap(uint32_t format, mir::Fd fd, size_t size) -> std::shared_ptr<mi
         BOOST_THROW_EXCEPTION(std::runtime_error("invalid keymap format " + std::to_string(format)));
     }
 
-    void* const data = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+    void* const data = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (data == MAP_FAILED)
     {
         BOOST_THROW_EXCEPTION(std::system_error(errno, std::system_category(), "failed to mmap keymap fd"));

--- a/src/server/frontend_wayland/virtual_keyboard_v1.cpp
+++ b/src/server/frontend_wayland/virtual_keyboard_v1.cpp
@@ -61,7 +61,7 @@ auto load_keymap(uint32_t format, mir::Fd fd, size_t size) -> std::shared_ptr<mi
     void* const data = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (data == MAP_FAILED)
     {
-        BOOST_THROW_EXCEPTION(std::runtime_error("failed to mmap keymap fd"));
+        BOOST_THROW_EXCEPTION(std::system_error(errno, std::system_category(), "failed to mmap keymap fd"));
     }
     std::vector<char> buffer(size);
     memcpy(buffer.data(), data, size);

--- a/src/server/frontend_wayland/virtual_keyboard_v1.cpp
+++ b/src/server/frontend_wayland/virtual_keyboard_v1.cpp
@@ -27,6 +27,7 @@
 #include "mir/log.h"
 
 #include <cstring>
+#include <sys/mman.h>
 
 namespace mf = mir::frontend;
 namespace mw = mir::wayland;
@@ -57,31 +58,14 @@ auto load_keymap(uint32_t format, mir::Fd fd, size_t size) -> std::shared_ptr<mi
         BOOST_THROW_EXCEPTION(std::runtime_error("invalid keymap format " + std::to_string(format)));
     }
 
-    std::vector<char> buffer(size);
-    char* current = buffer.data();
-    size_t remaining = size;
-    while (remaining > 0)
+    void* const data = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (data == MAP_FAILED)
     {
-        auto const result = read(fd, current, remaining);
-        if (result < 0)
-        {
-            BOOST_THROW_EXCEPTION(std::runtime_error(
-                "failed to read from keymap fd: " +
-                std::string{strerror(errno)}));
-        }
-        else if (result == 0)
-        {
-            BOOST_THROW_EXCEPTION(std::runtime_error(
-                "keymap fd hit EOF " +
-                std::to_string(remaining) +
-                " bytes before specified size"));
-        }
-        else
-        {
-            current += result;
-            remaining -= result;
-        }
+        BOOST_THROW_EXCEPTION(std::runtime_error("failed to mmap keymap fd"));
     }
+    std::vector<char> buffer(size);
+    memcpy(buffer.data(), data, size);
+    munmap(data, size);
 
     // Keymaps seem to be null-terminated. It's unclear if they're supposed to be or not. Either way, BufferKeymap does
     // not expect a null-terminated keymap

--- a/tests/mir_test_framework/mmap_wrapper.cpp
+++ b/tests/mir_test_framework/mmap_wrapper.cpp
@@ -24,9 +24,17 @@
 #include "mir_test_framework/interposer_helper.h"
 
 #include <boost/throw_exception.hpp>
-#include <dlfcn.h>
+#include <sys/syscall.h>
 
 namespace mtf = mir_test_framework;
+
+#ifdef SYS_mmap
+// 64-bit
+#define MMAP_SYSCALL SYS_mmap
+#else
+// 32-bit
+#define MMAP_SYSCALL SYS_mmap2
+#endif
 
 namespace
 {
@@ -45,15 +53,15 @@ void* mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
         return *val;
     }
 
-    void* (*real_mmap)(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
-    *(void **)(&real_mmap) = dlsym(RTLD_NEXT, "mmap");
-
-    if (!real_mmap)
+    if (offset)
     {
-        using namespace std::literals::string_literals;
-        // Oops! What has gone on here?!
-        BOOST_THROW_EXCEPTION((std::runtime_error{"Failed to find mmap() symbol: "s + dlerror()}));
+        // The libc mmap() function we're implementing takes an offset in bytes, but the mmap2 version of the syscall
+        // present on 32-bit systems takes an offset in 4kB units. It might be possible to do the right thing, but since
+        // this is just for tests and we shouldn't use offset, simply error.
+        BOOST_THROW_EXCEPTION((std::runtime_error{"wrapped mmap called with offset"}));
     }
-    return (*real_mmap)(addr, length, prot, flags, fd, offset);
-}
 
+    // We previously loaded the mmap symbol from libc, but this broke on armhf for unknown reasons. Instead, call the
+    // syscall it wraps directly.
+    return (void*)syscall(MMAP_SYSCALL, addr, length, prot, flags, fd, offset);
+}


### PR DESCRIPTION
This and #2508 are the final two pieces required to make input work with wayvnc. I don't completely understand why reading from the fd works for squeekboard and not wayvnc, but mmap works for both and it's what wlroots does.