### PR TITLE
Add a new driver quirk to disable KMS modeset probe

### DIFF
--- a/src/platforms/gbm-kms/server/display_helpers.cpp
+++ b/src/platforms/gbm-kms/server/display_helpers.cpp
@@ -135,15 +135,13 @@ mgmh::DRMHelper::open_all_devices(
             case 0: break;
 
             case ENOSYS:
-                if (getenv("MIR_MESA_KMS_DISABLE_MODESET_PROBE") == nullptr &&
-                    getenv("MIR_GBM_KMS_DISABLE_MODESET_PROBE")  == nullptr)
+                if (quirks.require_modesetting_support(device))
                 {
                     mir::log_info("Ignoring non-KMS DRM device %s", device.devnode());
                     error = ENOSYS;
                     continue;
                 }
 
-                mir::log_debug("MIR_MESA_KMS_DISABLE_MODESET_PROBE is set");
                 // Falls through.
             case EINVAL:
                 mir::log_warning(

--- a/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
@@ -236,12 +236,11 @@ auto probe_display_platform(
                         break;
 
                     case ENOSYS:
-                        if (getenv("MIR_MESA_KMS_DISABLE_MODESET_PROBE") == nullptr)
+                        if (quirks.require_modesetting_support(device))
                         {
                             throw std::runtime_error{std::string{"Device "}+device.devnode()+" does not support KMS"};
                         }
 
-                        mir::log_debug("MIR_MESA_KMS_DISABLE_MODESET_PROBE is set");
                         // Falls through.
                     case EINVAL:
                         mir::log_warning(

--- a/src/platforms/gbm-kms/server/kms/quirks.cpp
+++ b/src/platforms/gbm-kms/server/kms/quirks.cpp
@@ -86,7 +86,8 @@ public:
 
             // If we didn't `continue` above, we're ignoring...
             mir::log_warning(
-                "Ignoring unexpected value for %s option: %s (expects value of the form “skip:<type>:<value>”)",
+                "Ignoring unexpected value for %s option: %s "
+                "(expects value of the form “skip:<type>:<value>” or ”disable-kms-probe:<value>”)",
                 quirks_option_name,
                 quirk.c_str());
         }

--- a/src/platforms/gbm-kms/server/kms/quirks.h
+++ b/src/platforms/gbm-kms/server/kms/quirks.h
@@ -48,6 +48,12 @@ public:
     [[nodiscard]]
     auto should_skip(udev::Device const& device) const -> bool;
 
+    /**
+     * Should we require this device to have modesetting support?
+     */
+    [[nodiscard]]
+    auto require_modesetting_support(udev::Device const& device) const -> bool;
+
     static void add_quirks_option(boost::program_options::options_description& config);
 
 private:


### PR DESCRIPTION
With an implicit `display-quirks=disable-kms-probe:virtio_gpu` as we need it for virtio