### PR TITLE
Expose miral::Zone::id()

### DIFF
--- a/debian/libmiral5.symbols
+++ b/debian/libmiral5.symbols
@@ -408,3 +408,4 @@ libmiral.so.5 libmiral5 #MINVER#
  (c++)"vtable for miral::CanonicalWindowManagerPolicy@MIRAL_3.6" 3.6.0
  (c++)"vtable for miral::MinimalWindowManager@MIRAL_3.6" 3.6.0
  (c++)"vtable for miral::WindowManagementPolicy@MIRAL_3.6" 3.6.0
+ (c++)"miral::Zone::id() const@MIRAL_3.6" 3.6.0

--- a/include/miral/miral/zone.h
+++ b/include/miral/miral/zone.h
@@ -39,13 +39,10 @@ public:
     Zone& operator=(Zone const& other); ///< Copies private data by value
     ~Zone();
 
-    /// Returns false if any properties are different (even if they are the same zone)
-    /// Will always return false if they are different zones (even if they have the same extents)
+    /// Returns true only if all properties including IDs match
     auto operator==(Zone const& other) const -> bool;
 
-    /// Multiple zone objects with different extents may be the "same" zone. For example, the arguments of
-    /// miral::WindowManagementPolicy::advise_output_update() are old and new instances of the same zone, so
-    /// updated.is_same_zone(original) will return true even though the extents may not be equal.
+    /// Returns if true if zone IDs match, even if extents are different
     auto is_same_zone(Zone const& other) const -> bool;
 
     /// The area of this zone in global display coordinates

--- a/include/miral/miral/zone.h
+++ b/include/miral/miral/zone.h
@@ -53,6 +53,7 @@ public:
     void extents(Rectangle const& extents);
 
     /// An arbitrary number that uniquely identifies this zone, reguardless of how it is resized and moved
+    /// \remark Since MirAL 3.6
     auto id() const -> int;
 
 private:

--- a/include/miral/miral/zone.h
+++ b/include/miral/miral/zone.h
@@ -55,6 +55,9 @@ public:
     /// Does not make this a different zone
     void extents(Rectangle const& extents);
 
+    /// An arbitrary number that uniquely identifies this zone, reguardless of how it is resized and moved
+    auto id() const -> int;
+
 private:
     class Self;
     std::unique_ptr<Self> self;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -279,6 +279,7 @@ global:
     miral::Zone::extents*;
     miral::Zone::is_same_zone*;
     miral::Zone::operator*;
+    miral::Zone::id*;
     miral::application_for*;
     miral::apply_lifecycle_state_to*;
     miral::display_configuration_options*;

--- a/src/miral/zone.cpp
+++ b/src/miral/zone.cpp
@@ -78,3 +78,8 @@ void miral::Zone::extents(Rectangle const& extents)
 {
     self->extents = extents;
 }
+
+auto miral::Zone::id() const -> int
+{
+    return self->id.as_value();
+}


### PR DESCRIPTION
Not having this has been a recurring annoyance in writing shells. With the ID a shell can have a hashmap of zones, store an associated zone with a window, etc. Without it identifying zones is much less convenient and efficient.