### PR TITLE
trivial: Use C++17 [[fallthrough]] attribute

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -1308,7 +1308,7 @@ void miral::BasicWindowManager::place_and_size_for_state(
         if (modifications.output_id().is_set() &&
            (!window_info.has_output_id() || modifications.output_id().value() != window_info.output_id()))
                 break;
-        // Falls through.
+        [[fallthrough]];
     default:
         if (new_state == window_info.state())
             return;

--- a/src/platforms/gbm-kms/server/display_helpers.cpp
+++ b/src/platforms/gbm-kms/server/display_helpers.cpp
@@ -142,7 +142,7 @@ mgmh::DRMHelper::open_all_devices(
                     continue;
                 }
 
-                // Falls through.
+                [[fallthrough]];
             case EINVAL:
                 mir::log_warning(
                     "Failed to detect whether device %s supports KMS, but continuing anyway",

--- a/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
@@ -241,7 +241,7 @@ auto probe_display_platform(
                             throw std::runtime_error{std::string{"Device "}+device.devnode()+" does not support KMS"};
                         }
 
-                        // Falls through.
+                        [[fallthrough]];
                     case EINVAL:
                         mir::log_warning(
                             "Failed to detect whether device %s supports KMS, continuing with lower confidence",

--- a/tests/unit-tests/scene/test_surface_state_tracker.cpp
+++ b/tests/unit-tests/scene/test_surface_state_tracker.cpp
@@ -30,7 +30,7 @@ auto precedence(MirWindowState state) -> int
     switch (state)
     {
     case mir_window_state_restored: return 1;
-    case mir_window_state_horizmaximized: // fallthrough
+    case mir_window_state_horizmaximized: [[fallthrough]];
     case mir_window_state_vertmaximized: return 2;
     case mir_window_state_maximized: return 3;
     case mir_window_state_attached: return 4;


### PR DESCRIPTION
It exists, is standardised, so why not. Compilers might not continue to treat a `//fallthrough` or `//falls through` comment equivalently!