### PR TITLE
Add a libmiral-bin metapackage

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -484,7 +484,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmiral5 (= ${libmiral5:Version}),
+Depends: libmiral5,
 Description: MirAL binary metapackage
  MirAL provides an ABI-stable abstraction layer for Mir based shells,
  insulating them from mirserver ABI breaks.

--- a/debian/control
+++ b/debian/control
@@ -479,12 +479,25 @@ Description: Display server for Ubuntu - ABI preserving abstraction layer
  .
  Contains the shared library containing MirAL abstraction layer.
 
-Package: libmiral-dev
+Package: libmiral-bin
 Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends: libmiral5 (= ${libmiral5:Version}),
+Description: MirAL binary metapackage
+ MirAL provides an ABI-stable abstraction layer for Mir based shells,
+ insulating them from mirserver ABI breaks.
+ .
+ This package depends on the latest shared library containing MirAL abstraction
+ layer.
+
+Package: libmiral-dev
+Section: libdevel
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: libmiral-bin (= ${libmiral-bin:Version}),
 # ${source:Version} is technically incorrect, but Launchpad doesn't do BinNMUs
 # so it's harmless.
          libmircommon-dev (= ${source:Version}),

--- a/debian/rules
+++ b/debian/rules
@@ -110,5 +110,5 @@ override_dh_shlibdeps:
 	dh_shlibdeps -Xmir-test-data
 
 override_dh_gencontrol:
-	dh_gencontrol -Nlibmiral5 -Nlibmiral-dev
-	dh_gencontrol -plibmiral5 -plibmiral-dev -- -v$(MIRAL_VERSION) -V'libmiral5:Version=$(MIRAL_VERSION)'
+	dh_gencontrol -Nlibmiral5 -Nlibmiral-bin -Nlibmiral-dev
+	dh_gencontrol -plibmiral5 -plibmiral-bin -plibmiral-dev -- -v$(MIRAL_VERSION) -V'libmiral5:Version=$(MIRAL_VERSION)'


### PR DESCRIPTION
We have the following in a scattering of downstreams:
```yaml
    stage-packages:
      - try:
          - libmiral5
      - else:
          - libmiral4
```
Having a stable name will avoid that in future