### PR TITLE
More default quirks

### DIFF
--- a/src/platforms/gbm-kms/server/kms/quirks.cpp
+++ b/src/platforms/gbm-kms/server/kms/quirks.cpp
@@ -157,8 +157,8 @@ private:
     // Mir's gbm-kms support isn't (yet) working with evdi
     std::unordered_set<std::string> drivers_to_skip = { "nvidia", "evdi" };
     std::unordered_set<std::string> devnodes_to_skip;
-    // We know this is currently useful for virtio_gpu
-    std::unordered_set<std::string> skip_modesetting_support = { "virtio_gpu" };
+    // We know this is currently useful for virtio_gpu, vc4-drm and v3d
+    std::unordered_set<std::string> skip_modesetting_support = { "virtio_gpu", "vc4-drm", "v3d" };
 };
 
 mgg::Quirks::Quirks(const options::Option& options)


### PR DESCRIPTION
We're already skipping the modesetting check in Frame and mir-kiosk, just consolidating these as defaults:

* RPi3b: vc4-drm
* RPi4: vc4-drm & v3d

