### PR TITLE
Handle the new libinput events

### DIFF
--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -91,21 +91,23 @@ auto get_scroll_axis(libinput_event_pointer* event, libinput_pointer_axis axis, 
     {
         return {};
     }
+    auto const libinput_event_type = libinput_event_get_type(libinput_event_pointer_get_base_event(event));
 
     mir::geometry::generic::Value<float, Tag> const precise{
         libinput_event_pointer_get_axis_value(event, axis) * scale};
     auto const stop = precise.as_value() == 0;
     mir::geometry::generic::Value<int, Tag> const discrete{
-        libinput_event_pointer_get_axis_source(event) == LIBINPUT_POINTER_AXIS_SOURCE_WHEEL ?
-            libinput_event_pointer_get_axis_value_discrete(event, axis) :
-            0};
+        (libinput_event_type == LIBINPUT_EVENT_POINTER_AXIS &&
+            libinput_event_pointer_get_axis_source(event) == LIBINPUT_POINTER_AXIS_SOURCE_WHEEL) ?
+        libinput_event_pointer_get_axis_value_discrete(event, axis) :
+        0};
     mir::geometry::generic::Value<int, Tag> const value120{
 #ifdef MIR_LIBINPUT_HAS_VALUE120
-        libinput_event_get_type(libinput_event_pointer_get_base_event(event)) == LIBINPUT_EVENT_POINTER_SCROLL_WHEEL ?
-            libinput_event_pointer_get_scroll_value_v120(event, axis) :
-            0
+        libinput_event_type == LIBINPUT_EVENT_POINTER_SCROLL_WHEEL ?
+        libinput_event_pointer_get_scroll_value_v120(event, axis) :
+        0
 #else
-        discrete.as_value() * 120
+        0
 #endif
     };
 

--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -218,13 +218,13 @@ void mie::LibInputDevice::process_event(libinput_event* event)
         case LIBINPUT_EVENT_POINTER_SCROLL_FINGER:
         case LIBINPUT_EVENT_POINTER_SCROLL_CONTINUOUS:
 #else
-    /*
-	 * This event is deprecated as of libinput 1.19. Use
-	 * @ref LIBINPUT_EVENT_POINTER_SCROLL_WHEEL,
-	 * @ref LIBINPUT_EVENT_POINTER_SCROLL_FINGER, and
-	 * @ref LIBINPUT_EVENT_POINTER_SCROLL_CONTINUOUS instead.
-     */
-     case LIBINPUT_EVENT_POINTER_AXIS:
+        /*
+        * This event is deprecated as of libinput 1.19. Use
+        * @ref LIBINPUT_EVENT_POINTER_SCROLL_WHEEL,
+        * @ref LIBINPUT_EVENT_POINTER_SCROLL_FINGER, and
+        * @ref LIBINPUT_EVENT_POINTER_SCROLL_CONTINUOUS instead.
+        */
+        case LIBINPUT_EVENT_POINTER_AXIS:
 #endif
             sink->handle_input(convert_axis_event(libinput_event_get_pointer_event(event)));
             break;

--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -101,7 +101,7 @@ auto get_scroll_axis(libinput_event_pointer* event, libinput_pointer_axis axis, 
             0};
     mir::geometry::generic::Value<int, Tag> const value120{
 #ifdef MIR_LIBINPUT_HAS_VALUE120
-        libinput_event_pointer_get_axis_source(event) == LIBINPUT_POINTER_AXIS_SOURCE_WHEEL ?
+        libinput_event_get_type(libinput_event_pointer_get_base_event(event)) == LIBINPUT_EVENT_POINTER_SCROLL_WHEEL ?
             libinput_event_pointer_get_scroll_value_v120(event, axis) :
             0
 #else
@@ -197,7 +197,19 @@ void mie::LibInputDevice::process_event(libinput_event* event)
         case LIBINPUT_EVENT_POINTER_BUTTON:
             sink->handle_input(convert_button_event(libinput_event_get_pointer_event(event)));
             break;
-        case LIBINPUT_EVENT_POINTER_AXIS:
+#ifdef MIR_LIBINPUT_HAS_VALUE120
+        case LIBINPUT_EVENT_POINTER_SCROLL_WHEEL:
+        case LIBINPUT_EVENT_POINTER_SCROLL_FINGER:
+        case LIBINPUT_EVENT_POINTER_SCROLL_CONTINUOUS:
+#else
+    /*
+	 * This event is deprecated as of libinput 1.19. Use
+	 * @ref LIBINPUT_EVENT_POINTER_SCROLL_WHEEL,
+	 * @ref LIBINPUT_EVENT_POINTER_SCROLL_FINGER, and
+	 * @ref LIBINPUT_EVENT_POINTER_SCROLL_CONTINUOUS instead.
+     */
+     case LIBINPUT_EVENT_POINTER_AXIS:
+#endif
             sink->handle_input(convert_axis_event(libinput_event_get_pointer_event(event)));
             break;
         // touch events are processed as a batch of changes over all touch pointts

--- a/src/platforms/evdev/libinput_device.h
+++ b/src/platforms/evdev/libinput_device.h
@@ -90,6 +90,8 @@ private:
     MirPointerButtons button_state;
     mir::geometry::DeltaYF vertical_scroll_scale{1.0};
     mir::geometry::DeltaXF horizontal_scroll_scale{1.0};
+    mir::geometry::DeltaY vertical_scroll_value120_accum;
+    mir::geometry::DeltaX horizontal_scroll_value120_accum;
     mir::optional_value<TouchscreenSettings> touchscreen;
 
     struct ContactData

--- a/src/platforms/evdev/libinput_device.h
+++ b/src/platforms/evdev/libinput_device.h
@@ -88,8 +88,8 @@ private:
     InputDeviceInfo info;
     mir::geometry::PointF pointer_pos;
     MirPointerButtons button_state;
-    double vertical_scroll_scale{1.0};
-    double horizontal_scroll_scale{1.0};
+    mir::geometry::DeltaYF vertical_scroll_scale{1.0};
+    mir::geometry::DeltaXF horizontal_scroll_scale{1.0};
     mir::optional_value<TouchscreenSettings> touchscreen;
 
     struct ContactData

--- a/tests/include/mir/test/doubles/mock_libinput.h
+++ b/tests/include/mir/test/doubles/mock_libinput.h
@@ -54,7 +54,6 @@ public:
     libinput_event* setup_pointer_scroll_wheel_event(
         libinput_device* dev, uint64_t event_time,
         std::optional<double> horizontal, std::optional<double> vertical,
-        double horizontal_discrete, double vertical_discrete,
         double horizontal_value120, double vertical_value120);
     libinput_event* setup_finger_axis_event(
         libinput_device* dev, uint64_t event_time,

--- a/tests/include/mir/test/doubles/mock_libinput.h
+++ b/tests/include/mir/test/doubles/mock_libinput.h
@@ -50,8 +50,12 @@ public:
     libinput_event* setup_axis_event(
         libinput_device* dev, uint64_t event_time,
         std::optional<double> horizontal, std::optional<double> vertical,
-        double horizontal_discrete = 0.0, double vertical_discrete = 0.0,
-        double horizontal_value120 = 0.0, double vertical_value120 = 0.0);
+        double horizontal_discrete = 0.0, double vertical_discrete = 0.0);
+    libinput_event* setup_pointer_scroll_wheel_event(
+        libinput_device* dev, uint64_t event_time,
+        std::optional<double> horizontal, std::optional<double> vertical,
+        double horizontal_discrete, double vertical_discrete,
+        double horizontal_value120, double vertical_value120);
     libinput_event* setup_finger_axis_event(
         libinput_device* dev, uint64_t event_time,
         std::optional<double> horizontal, std::optional<double> vertical);
@@ -92,6 +96,7 @@ public:
     MOCK_METHOD1(libinput_event_pointer_get_axis_source, libinput_pointer_axis_source(libinput_event_pointer*));
     MOCK_METHOD2(libinput_event_pointer_get_axis_value_discrete, double(libinput_event_pointer*, libinput_pointer_axis));
     MOCK_METHOD2(libinput_event_pointer_get_scroll_value_v120, double(libinput_event_pointer*, libinput_pointer_axis));
+    MOCK_METHOD(libinput_event*, libinput_event_pointer_get_base_event, (libinput_event_pointer* event));
     MOCK_METHOD2(libinput_event_pointer_has_axis,int(libinput_event_pointer *,libinput_pointer_axis));
 
     MOCK_METHOD1(libinput_event_touch_get_time, uint32_t(libinput_event_touch*));

--- a/tests/include/mir/test/doubles/mock_libinput.h
+++ b/tests/include/mir/test/doubles/mock_libinput.h
@@ -96,6 +96,7 @@ public:
     MOCK_METHOD2(libinput_event_pointer_get_axis_value_discrete, double(libinput_event_pointer*, libinput_pointer_axis));
     MOCK_METHOD2(libinput_event_pointer_get_scroll_value_v120, double(libinput_event_pointer*, libinput_pointer_axis));
     MOCK_METHOD(libinput_event*, libinput_event_pointer_get_base_event, (libinput_event_pointer* event));
+    MOCK_METHOD(double, libinput_event_pointer_get_scroll_value, (libinput_event_pointer* event, libinput_pointer_axis axis));
     MOCK_METHOD2(libinput_event_pointer_has_axis,int(libinput_event_pointer *,libinput_pointer_axis));
 
     MOCK_METHOD1(libinput_event_touch_get_time, uint32_t(libinput_event_touch*));

--- a/tests/mir_test_doubles/mock_libinput.cpp
+++ b/tests/mir_test_doubles/mock_libinput.cpp
@@ -235,6 +235,11 @@ double libinput_event_pointer_get_scroll_value_v120(libinput_event_pointer* even
 {
     return global_libinput->libinput_event_pointer_get_scroll_value_v120(event, axis);
 }
+
+double libinput_event_pointer_get_scroll_value(libinput_event_pointer* event, libinput_pointer_axis axis)
+{
+    return global_libinput->libinput_event_pointer_get_scroll_value(event, axis);
+}
 #else
 double libinput_event_pointer_get_scroll_value_v120(libinput_event_pointer* event, libinput_pointer_axis axis)
 {
@@ -246,7 +251,6 @@ libinput_event* libinput_event_pointer_get_base_event(libinput_event_pointer* ev
 {
     return global_libinput->libinput_event_pointer_get_base_event(event);
 }
-
 
 int libinput_event_pointer_has_axis(libinput_event_pointer* event, libinput_pointer_axis axis)
 {
@@ -862,6 +866,10 @@ libinput_event* mtd::MockLibInput::setup_pointer_scroll_wheel_event(
 #ifdef MIR_LIBINPUT_HAS_VALUE120
     ON_CALL(*this, libinput_event_get_type(event))
         .WillByDefault(Return(LIBINPUT_EVENT_POINTER_SCROLL_WHEEL));
+    ON_CALL(*this, libinput_event_pointer_get_scroll_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+        .WillByDefault(Return(vertical.value_or(0.0)));
+    ON_CALL(*this, libinput_event_pointer_get_scroll_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
+        .WillByDefault(Return(horizontal.value_or(0.0)));
     ON_CALL(*this, libinput_event_pointer_get_scroll_value_v120(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
         .WillByDefault(Return(vertical_value120));
     ON_CALL(*this, libinput_event_pointer_get_scroll_value_v120(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
@@ -877,6 +885,10 @@ libinput_event* mtd::MockLibInput::setup_pointer_scroll_wheel_event(
         .WillByDefault(Return(vertical_value120/120));
     ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
         .WillByDefault(Return(horizontal_value120/120));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+        .WillByDefault(Return(vertical.value_or(0.0)));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
+        .WillByDefault(Return(horizontal.value_or(0.0)));
 #endif
     ON_CALL(*this, libinput_event_get_pointer_event(event))
         .WillByDefault(Return(pointer_event));
@@ -890,10 +902,6 @@ libinput_event* mtd::MockLibInput::setup_pointer_scroll_wheel_event(
         .WillByDefault(Return(horizontal.operator bool()));
     ON_CALL(*this, libinput_event_pointer_has_axis(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
         .WillByDefault(Return(vertical.operator bool()));
-    ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-        .WillByDefault(Return(vertical.value_or(0.0)));
-    ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
-        .WillByDefault(Return(horizontal.value_or(0.0)));
     ON_CALL(*this, libinput_event_pointer_get_base_event(pointer_event))
         .WillByDefault(Return(event));
     return event;

--- a/tests/mir_test_doubles/mock_libinput.cpp
+++ b/tests/mir_test_doubles/mock_libinput.cpp
@@ -16,6 +16,9 @@
 
 #include "mir/test/doubles/mock_libinput.h"
 
+#include <boost/throw_exception.hpp>
+#include <stdexcept>
+
 namespace mtd = mir::test::doubles;
 using namespace testing;
 
@@ -875,9 +878,21 @@ libinput_event* mtd::MockLibInput::setup_pointer_scroll_wheel_event(
     ON_CALL(*this, libinput_event_pointer_get_scroll_value_v120(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
         .WillByDefault(Return(horizontal_value120));
     ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-        .WillByDefault(Return(0));
+        .WillByDefault(
+            InvokeWithoutArgs(
+                []() -> double
+                {
+                    BOOST_THROW_EXCEPTION((
+                        std::logic_error{"axis_value_discrete only returns a non-zero value on EVENT_POINTER_AXIS events"}));
+                }));
     ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
-        .WillByDefault(Return(0));
+        .WillByDefault(
+            InvokeWithoutArgs(
+                []() -> double
+                {
+                    BOOST_THROW_EXCEPTION((
+                        std::logic_error{"axis_value_discrete only returns a non-zero value on EVENT_POINTER_AXIS events"}));
+                }));
 #else
     ON_CALL(*this, libinput_event_get_type(event))
         .WillByDefault(Return(LIBINPUT_EVENT_POINTER_AXIS));

--- a/tests/mir_test_doubles/mock_libinput.cpp
+++ b/tests/mir_test_doubles/mock_libinput.cpp
@@ -860,8 +860,18 @@ libinput_event* mtd::MockLibInput::setup_pointer_scroll_wheel_event(
     auto pointer_event = reinterpret_cast<libinput_event_pointer*>(event);
     push_back(event);
 
+#ifdef MIR_LIBINPUT_HAS_VALUE120
     ON_CALL(*this, libinput_event_get_type(event))
         .WillByDefault(Return(LIBINPUT_EVENT_POINTER_SCROLL_WHEEL));
+    ON_CALL(*this, libinput_event_pointer_get_scroll_value_v120(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+        .WillByDefault(Return(vertical_value120));
+    ON_CALL(*this, libinput_event_pointer_get_scroll_value_v120(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
+        .WillByDefault(Return(horizontal_value120));
+#else
+    (void)horizontal_value120;(void)vertical_value120;
+    ON_CALL(*this, libinput_event_get_type(event))
+        .WillByDefault(Return(LIBINPUT_EVENT_POINTER_AXIS));
+#endif
     ON_CALL(*this, libinput_event_get_pointer_event(event))
         .WillByDefault(Return(pointer_event));
     ON_CALL(*this, libinput_event_get_device(event))
@@ -878,10 +888,6 @@ libinput_event* mtd::MockLibInput::setup_pointer_scroll_wheel_event(
         .WillByDefault(Return(vertical_discrete));
     ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
         .WillByDefault(Return(horizontal_discrete));
-    ON_CALL(*this, libinput_event_pointer_get_scroll_value_v120(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-        .WillByDefault(Return(vertical_value120));
-    ON_CALL(*this, libinput_event_pointer_get_scroll_value_v120(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
-        .WillByDefault(Return(horizontal_value120));
     ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
         .WillByDefault(Return(vertical.value_or(0.0)));
     ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))

--- a/tests/mir_test_doubles/mock_libinput.cpp
+++ b/tests/mir_test_doubles/mock_libinput.cpp
@@ -242,6 +242,12 @@ double libinput_event_pointer_get_scroll_value_v120(libinput_event_pointer* even
 }
 #endif
 
+libinput_event* libinput_event_pointer_get_base_event(libinput_event_pointer* event)
+{
+    return global_libinput->libinput_event_pointer_get_base_event(event);
+}
+
+
 int libinput_event_pointer_has_axis(libinput_event_pointer* event, libinput_pointer_axis axis)
 {
     return global_libinput->libinput_event_pointer_has_axis(event, axis);
@@ -808,6 +814,45 @@ libinput_event* mtd::MockLibInput::setup_button_event(libinput_device* dev, uint
 libinput_event* mtd::MockLibInput::setup_axis_event(
     libinput_device* dev, uint64_t event_time,
     std::optional<double> horizontal, std::optional<double> vertical,
+    double horizontal_discrete, double vertical_discrete)
+{
+#ifdef MIR_LIBINPUT_HAS_VALUE120
+    return setup_pointer_scroll_wheel_event(dev, event_time, horizontal, vertical,
+                                            horizontal_discrete, vertical_discrete, 0.0, 0.0);
+#else
+    auto event = get_next_fake_ptr<libinput_event*>();
+    auto pointer_event = reinterpret_cast<libinput_event_pointer*>(event);
+    push_back(event);
+
+    ON_CALL(*this, libinput_event_get_type(event))
+        .WillByDefault(Return(LIBINPUT_EVENT_POINTER_AXIS));
+    ON_CALL(*this, libinput_event_get_pointer_event(event))
+        .WillByDefault(Return(pointer_event));
+    ON_CALL(*this, libinput_event_get_device(event))
+        .WillByDefault(Return(dev));
+    ON_CALL(*this, libinput_event_pointer_get_time_usec(pointer_event))
+        .WillByDefault(Return(event_time));
+    ON_CALL(*this, libinput_event_pointer_get_axis_source(pointer_event))
+        .WillByDefault(Return(LIBINPUT_POINTER_AXIS_SOURCE_WHEEL));
+    ON_CALL(*this, libinput_event_pointer_has_axis(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
+        .WillByDefault(Return(horizontal.operator bool()));
+    ON_CALL(*this, libinput_event_pointer_has_axis(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+        .WillByDefault(Return(vertical.operator bool()));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+        .WillByDefault(Return(vertical_discrete));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
+        .WillByDefault(Return(horizontal_discrete));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+        .WillByDefault(Return(vertical.value_or(0.0)));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
+        .WillByDefault(Return(horizontal.value_or(0.0)));
+    return event;
+#endif
+}
+
+libinput_event* mtd::MockLibInput::setup_pointer_scroll_wheel_event(
+    libinput_device* dev, uint64_t event_time,
+    std::optional<double> horizontal, std::optional<double> vertical,
     double horizontal_discrete, double vertical_discrete,
     double horizontal_value120, double vertical_value120)
 {
@@ -816,7 +861,7 @@ libinput_event* mtd::MockLibInput::setup_axis_event(
     push_back(event);
 
     ON_CALL(*this, libinput_event_get_type(event))
-        .WillByDefault(Return(LIBINPUT_EVENT_POINTER_AXIS));
+        .WillByDefault(Return(LIBINPUT_EVENT_POINTER_SCROLL_WHEEL));
     ON_CALL(*this, libinput_event_get_pointer_event(event))
         .WillByDefault(Return(pointer_event));
     ON_CALL(*this, libinput_event_get_device(event))
@@ -841,6 +886,8 @@ libinput_event* mtd::MockLibInput::setup_axis_event(
         .WillByDefault(Return(vertical.value_or(0.0)));
     ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
         .WillByDefault(Return(horizontal.value_or(0.0)));
+    ON_CALL(*this, libinput_event_pointer_get_base_event(pointer_event))
+        .WillByDefault(Return(event));
     return event;
 }
 
@@ -853,9 +900,17 @@ libinput_event* mtd::MockLibInput::setup_finger_axis_event(
     auto event = get_next_fake_ptr<libinput_event*>();
     auto pointer_event = reinterpret_cast<libinput_event_pointer*>(event);
     push_back(event);
-
+#ifdef MIR_LIBINPUT_HAS_VALUE120
+    ON_CALL(*this, libinput_event_get_type(event))
+        .WillByDefault(Return(LIBINPUT_EVENT_POINTER_SCROLL_FINGER));
+    ON_CALL(*this, libinput_event_pointer_get_scroll_value_v120(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+        .WillByDefault(Return(0));
+    ON_CALL(*this, libinput_event_pointer_get_scroll_value_v120(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
+        .WillByDefault(Return(0));
+#else
     ON_CALL(*this, libinput_event_get_type(event))
         .WillByDefault(Return(LIBINPUT_EVENT_POINTER_AXIS));
+#endif
     ON_CALL(*this, libinput_event_get_device(event))
         .WillByDefault(Return(dev));
     ON_CALL(*this, libinput_event_get_pointer_event(event))

--- a/tests/mir_test_doubles/mock_libinput.cpp
+++ b/tests/mir_test_doubles/mock_libinput.cpp
@@ -818,7 +818,7 @@ libinput_event* mtd::MockLibInput::setup_axis_event(
 {
 #ifdef MIR_LIBINPUT_HAS_VALUE120
     return setup_pointer_scroll_wheel_event(dev, event_time, horizontal, vertical,
-                                            horizontal_discrete, vertical_discrete, 0.0, 0.0);
+                                            120*horizontal_discrete, 120*vertical_discrete);
 #else
     auto event = get_next_fake_ptr<libinput_event*>();
     auto pointer_event = reinterpret_cast<libinput_event_pointer*>(event);
@@ -853,7 +853,6 @@ libinput_event* mtd::MockLibInput::setup_axis_event(
 libinput_event* mtd::MockLibInput::setup_pointer_scroll_wheel_event(
     libinput_device* dev, uint64_t event_time,
     std::optional<double> horizontal, std::optional<double> vertical,
-    double horizontal_discrete, double vertical_discrete,
     double horizontal_value120, double vertical_value120)
 {
     auto event = get_next_fake_ptr<libinput_event*>();
@@ -867,10 +866,17 @@ libinput_event* mtd::MockLibInput::setup_pointer_scroll_wheel_event(
         .WillByDefault(Return(vertical_value120));
     ON_CALL(*this, libinput_event_pointer_get_scroll_value_v120(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
         .WillByDefault(Return(horizontal_value120));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+        .WillByDefault(Return(0));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
+        .WillByDefault(Return(0));
 #else
-    (void)horizontal_value120;(void)vertical_value120;
     ON_CALL(*this, libinput_event_get_type(event))
         .WillByDefault(Return(LIBINPUT_EVENT_POINTER_AXIS));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+        .WillByDefault(Return(vertical_value120/120));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
+        .WillByDefault(Return(horizontal_value120/120));
 #endif
     ON_CALL(*this, libinput_event_get_pointer_event(event))
         .WillByDefault(Return(pointer_event));
@@ -884,10 +890,6 @@ libinput_event* mtd::MockLibInput::setup_pointer_scroll_wheel_event(
         .WillByDefault(Return(horizontal.operator bool()));
     ON_CALL(*this, libinput_event_pointer_has_axis(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
         .WillByDefault(Return(vertical.operator bool()));
-    ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-        .WillByDefault(Return(vertical_discrete));
-    ON_CALL(*this, libinput_event_pointer_get_axis_value_discrete(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
-        .WillByDefault(Return(horizontal_discrete));
     ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
         .WillByDefault(Return(vertical.value_or(0.0)));
     ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))

--- a/tests/mir_test_doubles/mock_libinput.cpp
+++ b/tests/mir_test_doubles/mock_libinput.cpp
@@ -919,6 +919,10 @@ libinput_event* mtd::MockLibInput::setup_finger_axis_event(
 #ifdef MIR_LIBINPUT_HAS_VALUE120
     ON_CALL(*this, libinput_event_get_type(event))
         .WillByDefault(Return(LIBINPUT_EVENT_POINTER_SCROLL_FINGER));
+    ON_CALL(*this, libinput_event_pointer_get_scroll_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+        .WillByDefault(Return(vertical.value_or(0.0)));
+    ON_CALL(*this, libinput_event_pointer_get_scroll_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
+        .WillByDefault(Return(horizontal.value_or(0.0)));
     ON_CALL(*this, libinput_event_pointer_get_scroll_value_v120(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
         .WillByDefault(Return(0));
     ON_CALL(*this, libinput_event_pointer_get_scroll_value_v120(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
@@ -926,6 +930,10 @@ libinput_event* mtd::MockLibInput::setup_finger_axis_event(
 #else
     ON_CALL(*this, libinput_event_get_type(event))
         .WillByDefault(Return(LIBINPUT_EVENT_POINTER_AXIS));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
+        .WillByDefault(Return(vertical.value_or(0.0)));
+    ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
+        .WillByDefault(Return(horizontal.value_or(0.0)));
 #endif
     ON_CALL(*this, libinput_event_get_device(event))
         .WillByDefault(Return(dev));
@@ -939,10 +947,8 @@ libinput_event* mtd::MockLibInput::setup_finger_axis_event(
         .WillByDefault(Return(horizontal.operator bool()));
     ON_CALL(*this, libinput_event_pointer_has_axis(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
         .WillByDefault(Return(vertical.operator bool()));
-    ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL))
-        .WillByDefault(Return(vertical.value_or(0.0)));
-    ON_CALL(*this, libinput_event_pointer_get_axis_value(pointer_event, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL))
-        .WillByDefault(Return(horizontal.value_or(0.0)));
+    ON_CALL(*this, libinput_event_pointer_get_base_event(pointer_event))
+        .WillByDefault(Return(event));
     return event;
 }
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -59,10 +59,10 @@ template<typename Tag>
 std::ostream& operator<<(std::ostream& out, mev::ScrollAxisV1<Tag> const& axis)
 {
     return out
-        << "precise: " << axis.precise
+        << "(precise: " << axis.precise
         << ", discrete: " << axis.discrete
         << ", value120: " << axis.value120
-        << ", stop: " << axis.stop;
+        << ", stop: " << axis.stop << ")";
 }
 }
 }
@@ -666,18 +666,22 @@ TEST_F(LibInputDeviceOnMouse, hi_res_scroll_scroll_is_accumulated)
     env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, 0.0f, 50.0f);
     process_events(mouse);
 
-    Mock::VerifyAndClearExpectations(fake_device);
+    Mock::VerifyAndClearExpectations(&mock_builder);
+    ASSERT_THAT(env.mock_libinput.events.size(), Eq(0));
+
     EXPECT_CALL(mock_builder, pointer_event(
         _, _, _, _, _, _, _,
         mev::ScrollAxisV{geom::DeltaYF{1}, geom::DeltaY{0}, geom::DeltaY{50}, false}));
-    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, 0.0f, 50.0f);
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_2, {}, 1.0f, 0.0f, 50.0f);
     process_events(mouse);
 
-    Mock::VerifyAndClearExpectations(fake_device);
+    Mock::VerifyAndClearExpectations(&mock_builder);
+    ASSERT_THAT(env.mock_libinput.events.size(), Eq(0));
+
     EXPECT_CALL(mock_builder, pointer_event(
         _, _, _, _, _, _, _,
         mev::ScrollAxisV{geom::DeltaYF{1}, geom::DeltaY{1}, geom::DeltaY{50}, false}));
-    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, 0.0f, 50.0f);
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_3, {}, 1.0f, 0.0f, 50.0f);
     process_events(mouse);
 }
 #endif
@@ -693,11 +697,13 @@ TEST_F(LibInputDeviceOnMouse, hi_res_scroll_scroll_is_accumulated_negative)
     env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, -1.0f, 0.0f, -350.0f);
     process_events(mouse);
 
-    Mock::VerifyAndClearExpectations(fake_device);
+    Mock::VerifyAndClearExpectations(&mock_builder);
+    ASSERT_THAT(env.mock_libinput.events.size(), Eq(0));
+
     EXPECT_CALL(mock_builder, pointer_event(
         _, _, _, _, _, _, _,
         mev::ScrollAxisV{geom::DeltaYF{-1}, geom::DeltaY{-1}, geom::DeltaY{-10}, false}));
-    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, -1.0f, 0.0f, -10.0f);
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_2, {}, -1.0f, 0.0f, -10.0f);
     process_events(mouse);
 }
 #endif

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -586,9 +586,11 @@ TEST_F(LibInputDeviceOnMouse, process_event_handles_scroll)
 TEST_F(LibInputDeviceOnMouse, hi_res_scroll_is_picked_up)
 {
 #ifdef MIR_LIBINPUT_HAS_VALUE120
-    auto const expected = 165;
+    auto const expected_v120 = 165;
+    auto const expected_discrete = 0;
 #else
-    auto const expected = 120;
+    auto const expected_v120 = 0;
+    auto const expected_discrete = 1;
 #endif
 
     EXPECT_CALL(mock_builder, pointer_event(
@@ -596,7 +598,7 @@ TEST_F(LibInputDeviceOnMouse, hi_res_scroll_is_picked_up)
         Eq(std::nullopt), geom::DisplacementF{},
         mir_pointer_axis_source_wheel,
         mev::ScrollAxisH{},
-        mev::ScrollAxisV{geom::DeltaYF{1}, geom::DeltaY{0}, geom::DeltaY{expected}, false}));
+        mev::ScrollAxisV{geom::DeltaYF{1}, geom::DeltaY{expected_discrete}, geom::DeltaY{expected_v120}, false}));
 
     mouse.start(&mock_sink, &mock_builder);
     env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, 0.0f, 165);

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -605,12 +605,12 @@ TEST_F(LibInputDeviceOnMouse, hi_res_scroll_is_picked_up)
     process_events(mouse);
 }
 
-TEST_F(LibInputDeviceOnMouse, hi_res_scroll_does_not_combine_with_discrete)
+TEST_F(LibInputDeviceOnMouse, hi_res_scroll_does_not_combine_with_precise)
 {
     EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_vscroll, 1.0f)));
 
     mouse.start(&mock_sink, &mock_builder);
-    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, 0.0f, 120.0f);
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, 0.0f, 250.0f);
     process_events(mouse);
 }
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -573,13 +573,8 @@ TEST_F(LibInputDeviceOnMouse, process_event_handles_scroll)
     InSequence seq;
     // expect two scroll events..
 
-#ifdef MIR_LIBINPUT_HAS_VALUE120
     mev::ScrollAxisV const scroll_axis_v_1{geom::DeltaYF{-20}, geom::DeltaY{2}, geom::DeltaY{240}, false};
     mev::ScrollAxisH const scroll_axis_h_2{geom::DeltaXF{5}, geom::DeltaX{1}, geom::DeltaX{120}, false};
-#else
-    mev::ScrollAxisV const scroll_axis_v_1{geom::DeltaYF{-20}, geom::DeltaY{2}, geom::DeltaY{240}, false};
-    mev::ScrollAxisH const scroll_axis_h_2{geom::DeltaXF{5}, geom::DeltaX{1}, geom::DeltaX{120}, false};
-#endif
 
     EXPECT_CALL(mock_builder, pointer_event(
         {time_stamp_1}, mir_pointer_action_motion, 0,

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -569,8 +569,8 @@ TEST_F(LibInputDeviceOnMouse, process_event_handles_scroll)
     EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_hscroll, 5.0f)));
 
     mouse.start(&mock_sink, &mock_builder);
-    env.mock_libinput.setup_axis_event(fake_device, event_time_1, {}, -20.0, 0, 2, 0, 240);
-    env.mock_libinput.setup_axis_event(fake_device, event_time_2, 5.0, {}, 1, 0, 120, 0);
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, -20.0, 0, 2, 0, 240);
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_2, 5.0, {}, 1, 0, 120, 0);
     process_events(mouse);
 }
 
@@ -590,7 +590,7 @@ TEST_F(LibInputDeviceOnMouse, hi_res_scroll_is_picked_up)
         mev::ScrollAxisV{geom::DeltaYF{1}, geom::DeltaY{1}, geom::DeltaY{expected}, false}));
 
     mouse.start(&mock_sink, &mock_builder);
-    env.mock_libinput.setup_axis_event(fake_device, event_time_1, {}, 1.0f, {}, 1, 0.0f, 165);
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, {}, 1, 0.0f, 165);
     process_events(mouse);
 }
 
@@ -599,7 +599,7 @@ TEST_F(LibInputDeviceOnMouse, hi_res_scroll_does_not_combine_with_discrete)
     EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_vscroll, 1.0f)));
 
     mouse.start(&mock_sink, &mock_builder);
-    env.mock_libinput.setup_axis_event(fake_device, event_time_1, {}, 1.0f, {}, 1, 0.0f, 120.0f);
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, {}, 1, 0.0f, 120.0f);
     process_events(mouse);
 }
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -553,24 +553,33 @@ TEST_F(LibInputDeviceOnMouse, process_event_handles_scroll)
 {
     InSequence seq;
     // expect two scroll events..
+
+#ifdef MIR_LIBINPUT_HAS_VALUE120
+    mev::ScrollAxisV const scroll_axis_v_1{geom::DeltaYF{-20}, geom::DeltaY{0}, geom::DeltaY{240}, false};
+    mev::ScrollAxisH const scroll_axis_h_2{geom::DeltaXF{5}, geom::DeltaX{0}, geom::DeltaX{120}, false};
+#else
+    mev::ScrollAxisV const scroll_axis_v_1{geom::DeltaYF{-20}, geom::DeltaY{2}, geom::DeltaY{0}, false};
+    mev::ScrollAxisH const scroll_axis_h_2{geom::DeltaXF{5}, geom::DeltaX{1}, geom::DeltaX{0}, false};
+#endif
+
     EXPECT_CALL(mock_builder, pointer_event(
         {time_stamp_1}, mir_pointer_action_motion, 0,
         Eq(std::nullopt), geom::DisplacementF{},
         mir_pointer_axis_source_wheel,
         mev::ScrollAxisH{},
-        mev::ScrollAxisV{geom::DeltaYF{-20}, geom::DeltaY{2}, geom::DeltaY{240}, false}));
+        scroll_axis_v_1));
     EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_vscroll, -20.0f)));
     EXPECT_CALL(mock_builder, pointer_event(
         {time_stamp_2}, mir_pointer_action_motion, 0,
         Eq(std::nullopt), geom::DisplacementF{},
         mir_pointer_axis_source_wheel,
-        mev::ScrollAxisH{geom::DeltaXF{5}, geom::DeltaX{1}, geom::DeltaX{120}, false},
+        scroll_axis_h_2,
         mev::ScrollAxisV{{}, {}, false}));
     EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_hscroll, 5.0f)));
 
     mouse.start(&mock_sink, &mock_builder);
-    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, -20.0, 0, 2, 0, 240);
-    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_2, 5.0, {}, 1, 0, 120, 0);
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, -20.0, 0, 240);
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_2, 5.0, {}, 120, 0);
     process_events(mouse);
 }
 
@@ -587,10 +596,10 @@ TEST_F(LibInputDeviceOnMouse, hi_res_scroll_is_picked_up)
         Eq(std::nullopt), geom::DisplacementF{},
         mir_pointer_axis_source_wheel,
         mev::ScrollAxisH{},
-        mev::ScrollAxisV{geom::DeltaYF{1}, geom::DeltaY{1}, geom::DeltaY{expected}, false}));
+        mev::ScrollAxisV{geom::DeltaYF{1}, geom::DeltaY{0}, geom::DeltaY{expected}, false}));
 
     mouse.start(&mock_sink, &mock_builder);
-    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, {}, 1, 0.0f, 165);
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, 0.0f, 165);
     process_events(mouse);
 }
 
@@ -599,7 +608,7 @@ TEST_F(LibInputDeviceOnMouse, hi_res_scroll_does_not_combine_with_discrete)
     EXPECT_CALL(mock_sink, handle_input(mt::PointerAxisChange(mir_pointer_axis_vscroll, 1.0f)));
 
     mouse.start(&mock_sink, &mock_builder);
-    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, {}, 1, 0.0f, 120.0f);
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, 0.0f, 120.0f);
     process_events(mouse);
 }
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -293,7 +293,10 @@ struct LibInputDevice : public ::testing::Test
     void process_events(mie::LibInputDevice& device)
     {
         for (auto event : env.mock_libinput.events)
+        {
             device.process_event(event);
+        }
+        env.mock_libinput.events.clear();
     }
 };
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -51,6 +51,22 @@ namespace mev = mir::events;
 namespace mtd = mt::doubles;
 namespace geom = mir::geometry;
 
+namespace mir
+{
+namespace events
+{
+template<typename Tag>
+std::ostream& operator<<(std::ostream& out, mev::ScrollAxisV1<Tag> const& axis)
+{
+    return out
+        << "precise: " << axis.precise
+        << ", discrete: " << axis.discrete
+        << ", value120: " << axis.value120
+        << ", stop: " << axis.stop;
+}
+}
+}
+
 namespace
 {
 using namespace ::testing;

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -587,9 +587,9 @@ TEST_F(LibInputDeviceOnMouse, hi_res_scroll_is_picked_up)
 {
 #ifdef MIR_LIBINPUT_HAS_VALUE120
     auto const expected_v120 = 165;
-    auto const expected_discrete = 0;
+    auto const expected_discrete = 1;
 #else
-    auto const expected_v120 = 0;
+    auto const expected_v120 = 120;
     auto const expected_discrete = 1;
 #endif
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -571,11 +571,11 @@ TEST_F(LibInputDeviceOnMouse, process_event_handles_scroll)
     // expect two scroll events..
 
 #ifdef MIR_LIBINPUT_HAS_VALUE120
-    mev::ScrollAxisV const scroll_axis_v_1{geom::DeltaYF{-20}, geom::DeltaY{0}, geom::DeltaY{240}, false};
-    mev::ScrollAxisH const scroll_axis_h_2{geom::DeltaXF{5}, geom::DeltaX{0}, geom::DeltaX{120}, false};
+    mev::ScrollAxisV const scroll_axis_v_1{geom::DeltaYF{-20}, geom::DeltaY{2}, geom::DeltaY{240}, false};
+    mev::ScrollAxisH const scroll_axis_h_2{geom::DeltaXF{5}, geom::DeltaX{1}, geom::DeltaX{120}, false};
 #else
-    mev::ScrollAxisV const scroll_axis_v_1{geom::DeltaYF{-20}, geom::DeltaY{2}, geom::DeltaY{0}, false};
-    mev::ScrollAxisH const scroll_axis_h_2{geom::DeltaXF{5}, geom::DeltaX{1}, geom::DeltaX{0}, false};
+    mev::ScrollAxisV const scroll_axis_v_1{geom::DeltaYF{-20}, geom::DeltaY{2}, geom::DeltaY{240}, false};
+    mev::ScrollAxisH const scroll_axis_h_2{geom::DeltaXF{5}, geom::DeltaX{1}, geom::DeltaX{120}, false};
 #endif
 
     EXPECT_CALL(mock_builder, pointer_event(
@@ -636,11 +636,23 @@ TEST_F(LibInputDeviceOnMouse, hi_res_scroll_scroll_can_be_multiple_discrete_step
 
     EXPECT_CALL(mock_builder, pointer_event(
         _, _, _, _, _, _, _,
-        mev::ScrollAxisV{geom::DeltaYF{1}, geom::DeltaY{2}, geom::DeltaY{270}, false}));
-    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, 0.0f, 270.0f);
+        mev::ScrollAxisV{geom::DeltaYF{1}, geom::DeltaY{2}, geom::DeltaY{240}, false}));
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, 0.0f, 240.0f);
     process_events(mouse);
 }
 
+TEST_F(LibInputDeviceOnMouse, hi_res_scroll_scroll_can_be_negative)
+{
+    mouse.start(&mock_sink, &mock_builder);
+
+    EXPECT_CALL(mock_builder, pointer_event(
+        _, _, _, _, _, _, _,
+        mev::ScrollAxisV{geom::DeltaYF{-1}, geom::DeltaY{-2}, geom::DeltaY{-240}, false}));
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, -1.0f, 0.0f, -240.0f);
+    process_events(mouse);
+}
+
+#ifdef MIR_LIBINPUT_HAS_VALUE120
 TEST_F(LibInputDeviceOnMouse, hi_res_scroll_scroll_is_accumulated)
 {
     mouse.start(&mock_sink, &mock_builder);
@@ -651,6 +663,7 @@ TEST_F(LibInputDeviceOnMouse, hi_res_scroll_scroll_is_accumulated)
     env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, 0.0f, 50.0f);
     process_events(mouse);
 
+    Mock::VerifyAndClearExpectations(fake_device);
     EXPECT_CALL(mock_builder, pointer_event(
         _, _, _, _, _, _, _,
         mev::ScrollAxisV{geom::DeltaYF{1}, geom::DeltaY{0}, geom::DeltaY{50}, false}));
@@ -664,6 +677,27 @@ TEST_F(LibInputDeviceOnMouse, hi_res_scroll_scroll_is_accumulated)
     env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, 1.0f, 0.0f, 50.0f);
     process_events(mouse);
 }
+#endif
+
+#ifdef MIR_LIBINPUT_HAS_VALUE120
+TEST_F(LibInputDeviceOnMouse, hi_res_scroll_scroll_is_accumulated_negative)
+{
+    mouse.start(&mock_sink, &mock_builder);
+
+    EXPECT_CALL(mock_builder, pointer_event(
+        _, _, _, _, _, _, _,
+        mev::ScrollAxisV{geom::DeltaYF{-1}, geom::DeltaY{-2}, geom::DeltaY{-350}, false}));
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, -1.0f, 0.0f, -350.0f);
+    process_events(mouse);
+
+    Mock::VerifyAndClearExpectations(fake_device);
+    EXPECT_CALL(mock_builder, pointer_event(
+        _, _, _, _, _, _, _,
+        mev::ScrollAxisV{geom::DeltaYF{-1}, geom::DeltaY{-1}, geom::DeltaY{-10}, false}));
+    env.mock_libinput.setup_pointer_scroll_wheel_event(fake_device, event_time_1, {}, -1.0f, 0.0f, -10.0f);
+    process_events(mouse);
+}
+#endif
 
 TEST_F(LibInputDeviceOnTouchScreen, process_event_ignores_uncorrelated_touch_up_events)
 {


### PR DESCRIPTION
Do not conflate `LIBINPUT_EVENT_POINTER_AXIS` with `LIBINPUT_EVENT_POINTER_SCROLL_WHEEL` etc.

Fixes: #2565