### PR TITLE
Only call global_mock->XInitThreads() if global mock exists

### DIFF
--- a/tests/mir_test_doubles/mock_x11.cpp
+++ b/tests/mir_test_doubles/mock_x11.cpp
@@ -221,7 +221,14 @@ XErrorHandler XSetErrorHandler(XErrorHandler handler)
 
 Status XInitThreads()
 {
-    return global_mock->XInitThreads();
+    if (global_mock)
+    {
+        return global_mock->XInitThreads();
+    }
+    else
+    {
+        return 0;
+    }
 }
 
 int XSetWMHints(Display* display, Window window, XWMHints* wmhints)


### PR DESCRIPTION
Fixes #2568