### PR TITLE
Simplify timestamp calibration

### DIFF
--- a/src/server/input/default_event_builder.cpp
+++ b/src/server/input/default_event_builder.cpp
@@ -204,29 +204,12 @@ auto mi::DefaultEventBuilder::calibrate_timestamp(std::optional<Timestamp> times
     using namespace std::chrono_literals;
 
     auto const now = clock->now().time_since_epoch();
-    auto offset = timestamp_offset.load();
-    if (!timestamp)
+    if (timestamp && timestamp.value() <= now && timestamp.value() >= now - 1s)
     {
-        return now;
+        return timestamp.value();
     }
     else
     {
-        // If the offset has not been set yet or timestamp + offset is in the future, the offset needs to be set
-        if (offset == Timestamp::max() || timestamp.value() + offset > now)
-        {
-            // If the timestamp is in the future or more than 1 second in the past, the platform must be using a
-            // different time base
-            if (timestamp.value() > now || timestamp.value() < now - 1s)
-            {
-                // Therefore the offset should be set to give the event the current time
-                timestamp_offset = offset = now - timestamp.value();
-            }
-            else
-            {
-                // Otherwise, the platform is using the same time base so it's timestamps should be unchanged
-                timestamp_offset = offset = 0s;
-            }
-        }
-        return timestamp.value() + offset;
+        return now;
     }
 }

--- a/src/server/input/default_event_builder.cpp
+++ b/src/server/input/default_event_builder.cpp
@@ -31,7 +31,6 @@ mi::DefaultEventBuilder::DefaultEventBuilder(
     std::shared_ptr<mir::cookie::Authority> const& cookie_authority)
     : device_id(device_id),
       clock(clock),
-      timestamp_offset(Timestamp::max()),
       cookie_authority(cookie_authority)
 {
 }
@@ -204,7 +203,9 @@ auto mi::DefaultEventBuilder::calibrate_timestamp(std::optional<Timestamp> times
     using namespace std::chrono_literals;
 
     auto const now = clock->now().time_since_epoch();
-    if (timestamp && timestamp.value() <= now && timestamp.value() >= now - 1s)
+    /// Only use timestamp if it is within the last 10 seconds (otherwise, a time source other than CLOCK_MONOTONIC
+    /// is probably being used, which we ignore)
+    if (timestamp && timestamp.value() <= now && timestamp.value() >= now - 10s)
     {
         return timestamp.value();
     }

--- a/src/server/input/default_event_builder.h
+++ b/src/server/input/default_event_builder.h
@@ -109,8 +109,6 @@ private:
 
     MirInputDeviceId const device_id;
     std::shared_ptr<time::Clock> const clock;
-    /// Added to input timestams to get calibrated timestamps for events. Is Timestamp::max() until initial event.
-    std::atomic<Timestamp> timestamp_offset;
     std::shared_ptr<cookie::Authority> const cookie_authority;
 };
 }

--- a/tests/unit-tests/input/test_default_event_builder.cpp
+++ b/tests/unit-tests/input/test_default_event_builder.cpp
@@ -88,10 +88,10 @@ TEST_F(DefaultEventBuilder, when_timestamp_is_much_older_than_clock_then_clock_t
     EXPECT_THAT(event_timestamp(20s), Eq(400s));
 }
 
-TEST_F(DefaultEventBuilder, when_timestamp_is_much_older_than_clock_then_offset_persists)
+TEST_F(DefaultEventBuilder, when_timestamp_is_much_older_than_clock_repeatedly_then_clock_timestamp_is_used)
 {
     clock.advance_by(400s);
     event_timestamp(20s);
     clock.advance_by(2s);
-    EXPECT_THAT(event_timestamp(22s - 10ms), Eq(402s - 10ms));
+    EXPECT_THAT(event_timestamp(22s - 10ms), Eq(402s));
 }


### PR DESCRIPTION
Use the timestamp if it is reasonable, and use the measured current time otherwise. As discussed in #2591.