### PR TITLE
tests: fix XDG_RUNTIME_DIR handling

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,7 @@ export DPKG_GENSYMBOLS_CHECK_LEVEL = 4
 # Enable verbose debugging output from the testsuite
 export MIR_SERVER_LOGGING = on
 override_dh_auto_test:
+	export XDG_RUNTIME_DIR=/tmp
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
   ifeq ($(DEB_HOST_ARCH_ENDIAN),little)
 	GTEST_OUTPUT=xml:./ dh_auto_build -- ARGS="-V" ptest

--- a/tests/integration-tests/test_display_server_main_loop_events.cpp
+++ b/tests/integration-tests/test_display_server_main_loop_events.cpp
@@ -337,11 +337,6 @@ private:
 
 struct DisplayServerMainLoopEvents : testing::Test
 {
-    DisplayServerMainLoopEvents()
-    {
-        if (getenv("XDG_RUNTIME_DIR") == nullptr)
-            env.emplace_back("XDG_RUNTIME_DIR", "/tmp");
-    }
     void use_config_for_expectations(TestMainLoopServerConfig& server_config)
     {
         mock_compositor = server_config.the_mock_compositor();

--- a/tests/mir_test_framework/async_server_runner.cpp
+++ b/tests/mir_test_framework/async_server_runner.cpp
@@ -53,9 +53,6 @@ std::string const get_log_filename(const ::testing::TestInfo* test_info)
 mtf::AsyncServerRunner::AsyncServerRunner()
 : output_filename{get_log_filename(::testing::UnitTest::GetInstance()->current_test_info())}
 {
-    if (getenv("XDG_RUNTIME_DIR") == nullptr)
-        add_to_environment("XDG_RUNTIME_DIR", "/tmp");
-
     unsetenv("WAYLAND_DISPLAY");    // We don't want to conflict with any existing Wayland server
     configure_from_commandline(server);
 

--- a/tests/mir_test_framework/server_runner.cpp
+++ b/tests/mir_test_framework/server_runner.cpp
@@ -34,8 +34,6 @@ namespace mtf = mir_test_framework;
 mtf::ServerRunner::ServerRunner()
 {
     unsetenv("WAYLAND_DISPLAY");    // We don't want to conflict with any existing server
-    if (getenv("XDG_RUNTIME_DIR") == nullptr)
-        env.emplace_back("XDG_RUNTIME_DIR", "/tmp");
 }
 
 void mtf::ServerRunner::start_server()

--- a/tests/mir_test_framework/test_display_server.cpp
+++ b/tests/mir_test_framework/test_display_server.cpp
@@ -194,8 +194,6 @@ void miral::TestRuntimeEnvironment::add_to_environment(char const* key, char con
 
 miral::TestRuntimeEnvironment::TestRuntimeEnvironment()
 {
-    if (getenv("XDG_RUNTIME_DIR") == nullptr)
-        add_to_environment("XDG_RUNTIME_DIR", "/tmp");
 }
 
 void TestDisplayServer::invoke_runner(std::function<void(MirRunner& runner)> const& f)

--- a/tests/performance-tests/system_performance_test.cpp
+++ b/tests/performance-tests/system_performance_test.cpp
@@ -161,8 +161,6 @@ SystemPerformanceTest::SystemPerformanceTest() :
     mir_sock{"mir_test_socket_" + std::to_string(getpid())}
 {
     env.emplace_back("WAYLAND_DISPLAY", mir_sock.c_str());
-    if (getenv("XDG_RUNTIME_DIR") == nullptr)
-        env.emplace_back("XDG_RUNTIME_DIR", "/tmp");
 }
 
 void SystemPerformanceTest::set_up_with(std::string const server_args)


### PR DESCRIPTION
---

I left this one be:

https://github.com/MirServer/mir/blob/3661378e54ffd9fc96c72442b6c51cbf6e830e5c/tests/miral/external_client.cpp#L72-L73

It may still be I need something extra for CI, let's see.