### PR TITLE
[MultiMonitorArbiter] track buffer users better

### DIFF
--- a/src/server/compositor/multi_monitor_arbiter.cpp
+++ b/src/server/compositor/multi_monitor_arbiter.cpp
@@ -118,7 +118,11 @@ void mc::MultiMonitorArbiter::add_current_buffer_user(mc::CompositorID id)
     // First try and find an empty slot in our vector…
     for (auto& slot : current_buffer_users)
     {
-        if (!slot)
+        if (slot == id)
+        {
+            return;
+        }
+        else if (!slot)
         {
             slot = id;
             return;


### PR DESCRIPTION
The compositor ID should not be added repeatedly when there is no new buffer available