### PR TITLE
Bind shm textures when we create the buffers

### DIFF
--- a/src/platforms/common/server/buffer_from_wl_shm.cpp
+++ b/src/platforms/common/server/buffer_from_wl_shm.cpp
@@ -338,6 +338,7 @@ public:
     {
         wait_for_upload();
         ShmBuffer::bind();
+        notify_consumed();
     }
 
     void wait_for_upload() const
@@ -364,8 +365,6 @@ public:
     template<typename T>
     auto map_generic() -> std::unique_ptr<mir::renderer::software::Mapping<T>>
     {
-        notify_consumed();
-
         class Mapping : public mir::renderer::software::Mapping<T>
         {
         public:

--- a/src/platforms/common/server/buffer_from_wl_shm.cpp
+++ b/src/platforms/common/server/buffer_from_wl_shm.cpp
@@ -17,6 +17,7 @@
 #include "buffer_from_wl_shm.h"
 #include "shm_buffer.h"
 
+#include "mir/graphics/egl_context_executor.h"
 #include "mir/renderer/sw/pixel_source.h"
 #include "mir/executor.h"
 
@@ -310,11 +311,12 @@ public:
         mir::geometry::Stride stride,
         MirPixelFormat format,
         std::function<void()>&& on_consumed)
-        : ShmBuffer(size, format, std::move(egl_delegate)),
+        : ShmBuffer(size, format, egl_delegate),
           on_consumed{std::move(on_consumed)},
           buffer{std::move(buffer)},
           stride_{stride}
     {
+        egl_delegate->spawn([this](){ bind(); });
     }
 
     void bind() override

--- a/src/platforms/common/server/buffer_from_wl_shm.cpp
+++ b/src/platforms/common/server/buffer_from_wl_shm.cpp
@@ -327,24 +327,19 @@ public:
             }
             upload_cv.notify_one();
         });
+
+        std::unique_lock lock{upload_mutex};
+        upload_cv.wait(lock, [&] { return uploaded; });
     }
 
     ~WlShmBuffer()
     {
-        wait_for_upload();
     }
 
     void bind() override
     {
-        wait_for_upload();
         ShmBuffer::bind();
         notify_consumed();
-    }
-
-    void wait_for_upload() const
-    {
-        std::unique_lock lock{upload_mutex};
-        upload_cv.wait(lock, [&] { return uploaded; });
     }
 
     auto map_readable() -> std::unique_ptr<mir::renderer::software::Mapping<unsigned char const>> override


### PR DESCRIPTION
Fixes #2620

This would be better synchronised using an egl fence, but Chris has volunteered to fix that later.