### PR TITLE
Modernize touch events

### DIFF
--- a/include/common/mir/events/event_builders.h
+++ b/include/common/mir/events/event_builders.h
@@ -26,7 +26,7 @@
 #include "mir/frontend/surface_id.h"
 #include "mir/events/input_device_state.h"
 #include "mir/events/scroll_axis.h"
-#include "mir/events/contact_state.h"
+#include "mir/events/touch_contact.h"
 
 #include <memory>
 #include <functional>
@@ -188,7 +188,14 @@ EventUPtr make_touch_event(
     std::chrono::nanoseconds timestamp,
     std::vector<uint8_t> const& mac,
     MirInputEventModifiers modifiers,
-    std::vector<ContactState> const& contacts);
+    std::vector<TouchContactV1> const& contacts);
+
+EventUPtr make_touch_event(
+    MirInputDeviceId device_id,
+    std::chrono::nanoseconds timestamp,
+    std::vector<uint8_t> const& mac,
+    MirInputEventModifiers modifiers,
+    std::vector<TouchContact> const& contacts);
 
 EventUPtr clone_event(MirEvent const& event);
 void transform_positions(MirEvent& event, mir::geometry::Displacement const& movement);

--- a/include/common/mir/events/touch_contact.h
+++ b/include/common/mir/events/touch_contact.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_EVENTS_TOUCH_CONTACT_H_
+#define MIR_EVENTS_TOUCH_CONTACT_H_
+
+#include "mir_toolkit/event.h"
+#include "contact_state.h"
+#include "mir/geometry/point.h"
+
+namespace mir
+{
+namespace events
+{
+
+using TouchContactV1 = ContactState;
+
+struct TouchContactV2
+{
+    TouchContactV2()
+        : touch_id{0},
+          action{mir_touch_action_up},
+          tooltype{mir_touch_tooltype_unknown},
+          position{},
+          pressure{0},
+          touch_major{0},
+          touch_minor{0},
+          orientation{0}
+    {
+    }
+
+    TouchContactV2(
+        MirTouchId touch_id,
+        MirTouchAction action,
+        MirTouchTooltype tooltype,
+        geometry::PointF position,
+        float pressure,
+        float touch_major,
+        float touch_minor,
+        float orientation)
+        : touch_id{touch_id},
+          action{action},
+          tooltype{tooltype},
+          position{position},
+          pressure{pressure},
+          touch_major{touch_major},
+          touch_minor{touch_minor},
+          orientation{orientation}
+    {
+    }
+
+    TouchContactV2(
+        TouchContactV1 contact)
+        : touch_id{contact.touch_id},
+          action{contact.action},
+          tooltype{contact.tooltype},
+          position{contact.x, contact.y},
+          pressure{contact.pressure},
+          touch_major{contact.touch_major},
+          touch_minor{contact.touch_minor},
+          orientation{contact.orientation}
+    {
+    }
+
+    auto operator==(TouchContactV2 const& rhs) const -> bool
+    {
+        return
+            touch_id == rhs.touch_id &&
+            action == rhs.action &&
+            tooltype == rhs.tooltype &&
+            position == rhs.position &&
+            pressure == rhs.pressure &&
+            touch_major == rhs.touch_major &&
+            touch_minor == rhs.touch_minor &&
+            orientation == rhs.orientation;
+    }
+
+    MirTouchId touch_id;
+    MirTouchAction action;
+    MirTouchTooltype tooltype;
+    geometry::PointF position;
+    float pressure;
+    float touch_major;
+    float touch_minor;
+    float orientation;
+};
+
+using TouchContact = TouchContactV2;
+
+}
+}
+
+#endif // MIR_EVENTS_TOUCH_CONTACT_H_

--- a/include/platform/mir/input/event_builder.h
+++ b/include/platform/mir/input/event_builder.h
@@ -18,7 +18,7 @@
 #define MIR_INPUT_EVENT_BUILDER_H_
 
 #include "mir_toolkit/event.h"
-#include "mir/events/contact_state.h"
+#include "mir/events/touch_contact.h"
 #include "mir/events/scroll_axis.h"
 #include <memory>
 #include <chrono>
@@ -83,9 +83,10 @@ public:
         float hscroll_value, float vscroll_value,
         float hscroll_discrete, float vscroll_discrete) = 0;
 
+    [[deprecated("use the newest version of touch_event() instead")]]
     virtual EventUPtr touch_event(
         std::optional<Timestamp> timestamp,
-        std::vector<mir::events::ContactState> const& contacts) = 0;
+        std::vector<mir::events::TouchContactV1> const& contacts) = 0;
 
     [[deprecated("use the pointer_event() that includes all properties instead")]]
     virtual EventUPtr pointer_axis_with_stop_event(
@@ -107,6 +108,10 @@ public:
         MirPointerAxisSource axis_source,
         events::ScrollAxisH h_scroll,
         events::ScrollAxisV v_scroll) = 0;
+
+    virtual EventUPtr touch_event(
+        std::optional<Timestamp> timestamp,
+        std::vector<mir::events::TouchContact> const& contacts) = 0;
 
 protected:
     EventBuilder(EventBuilder const&) = delete;

--- a/src/common/events/event_builders.cpp
+++ b/src/common/events/event_builders.cpp
@@ -444,7 +444,21 @@ mir::EventUPtr mev::make_touch_event(
     std::chrono::nanoseconds timestamp,
     std::vector<uint8_t> const& cookie,
     MirInputEventModifiers modifiers,
-    std::vector<mev::ContactState> const& contacts)
+    std::vector<mev::TouchContactV1> const& contacts)
+{
+    std::vector<mev::TouchContact> contacts_new{begin(contacts), end(contacts)};
+    auto e = new_event<MirTouchEvent>(device_id, timestamp, cookie, modifiers, contacts_new);
+    return make_uptr_event(e);
+}
+
+// Intentionally uses TouchContactV2 instad of TouchContact as a reminder that a new copy of this function will be needed
+// for each TouchContact struct version.
+mir::EventUPtr mev::make_touch_event(
+    MirInputDeviceId device_id,
+    std::chrono::nanoseconds timestamp,
+    std::vector<uint8_t> const& cookie,
+    MirInputEventModifiers modifiers,
+    std::vector<mev::TouchContactV2> const& contacts)
 {
     auto e = new_event<MirTouchEvent>(device_id, timestamp, cookie, modifiers, contacts);
     return make_uptr_event(e);

--- a/src/common/events/event_builders.cpp
+++ b/src/common/events/event_builders.cpp
@@ -231,8 +231,7 @@ void mev::add_touch(
 
     tev->set_id(current_index, touch_id);
     tev->set_tool_type(current_index, tooltype);
-    tev->set_x(current_index, x_axis_value);
-    tev->set_y(current_index, y_axis_value);
+    tev->set_position(current_index, {x_axis_value, y_axis_value});
     tev->set_pressure(current_index, pressure_value);
     tev->set_touch_major(current_index, touch_major_value);
     tev->set_touch_minor(current_index, touch_minor_value);
@@ -405,10 +404,7 @@ void mev::transform_positions(MirEvent& event, mir::geometry::Displacement const
             auto tev = event.to_input()->to_touch();
             for (unsigned i = 0; i < tev->pointer_count(); i++)
             {
-                auto x = tev->x(i);
-                auto y = tev->y(i);
-                tev->set_x(i, x - movement.dx.as_int());
-                tev->set_y(i, y - movement.dy.as_int());
+                tev->set_position(i, tev->position(i) - geom::DisplacementF{movement});
             }
         }
     }
@@ -432,8 +428,7 @@ void mev::scale_positions(MirEvent& event, float scale)
             auto tev = event.to_input()->to_touch();
             for (unsigned i = 0; i < tev->pointer_count(); i++)
             {
-                tev->set_x(i, tev->x(i) * scale);
-                tev->set_y(i, tev->y(i) * scale);
+                tev->set_position(i, as_point(as_displacement(tev->position(i)) * scale));
             }
         }
     }

--- a/src/common/events/touch_event.cpp
+++ b/src/common/events/touch_event.cpp
@@ -70,32 +70,18 @@ void MirTouchEvent::set_id(size_t index, int id)
     contacts[index].touch_id = id;
 }
 
-float MirTouchEvent::x(size_t index) const
+geom::PointF MirTouchEvent::position(size_t index) const
 {
     throw_if_out_of_bounds(index);
 
-    return contacts[index].position.x.as_value();
+    return contacts[index].position;
 }
 
-void MirTouchEvent::set_x(size_t index, float x)
+void MirTouchEvent::set_position(size_t index, geom::PointF position)
 {
     throw_if_out_of_bounds(index);
 
-    contacts[index].position.x = geom::XF{x};
-}
-
-float MirTouchEvent::y(size_t index) const
-{
-    throw_if_out_of_bounds(index);
-
-    return contacts[index].position.y.as_value();
-}
-
-void MirTouchEvent::set_y(size_t index, float y)
-{
-    throw_if_out_of_bounds(index);
-
-    contacts[index].position.y = geom::YF{y};
+    contacts[index].position = position;
 }
 
 float MirTouchEvent::touch_major(size_t index) const

--- a/src/common/events/touch_event.cpp
+++ b/src/common/events/touch_event.cpp
@@ -19,6 +19,8 @@
 
 #include <stdexcept>
 
+namespace geom = mir::geometry;
+
 MirTouchEvent::MirTouchEvent() : MirInputEvent(mir_input_event_type_touch)
 {
 }
@@ -27,7 +29,7 @@ MirTouchEvent::MirTouchEvent(MirInputDeviceId id,
                              std::chrono::nanoseconds timestamp,
                              std::vector<uint8_t> const& cookie,
                              MirInputEventModifiers modifiers,
-                             std::vector<mir::events::ContactState> const& contacts)
+                             std::vector<mir::events::TouchContact> const& contacts)
     : MirInputEvent(mir_input_event_type_touch, id, timestamp, modifiers, cookie),
       contacts{contacts}
 {
@@ -72,28 +74,28 @@ float MirTouchEvent::x(size_t index) const
 {
     throw_if_out_of_bounds(index);
 
-    return contacts[index].x;
+    return contacts[index].position.x.as_value();
 }
 
 void MirTouchEvent::set_x(size_t index, float x)
 {
     throw_if_out_of_bounds(index);
 
-    contacts[index].x = x;
+    contacts[index].position.x = geom::XF{x};
 }
 
 float MirTouchEvent::y(size_t index) const
 {
     throw_if_out_of_bounds(index);
 
-    return contacts[index].y;
+    return contacts[index].position.y.as_value();
 }
 
 void MirTouchEvent::set_y(size_t index, float y)
 {
     throw_if_out_of_bounds(index);
 
-    contacts[index].y = y;
+    contacts[index].position.y = geom::YF{y};
 }
 
 float MirTouchEvent::touch_major(size_t index) const

--- a/src/common/input/input_event.cpp
+++ b/src/common/input/input_event.cpp
@@ -220,9 +220,9 @@ float mir_touch_event_axis_value(MirTouchEvent const* event,
     switch (axis)
     {
     case mir_touch_axis_x:
-        return event->x(touch_index);
+        return event->position(touch_index).x.as_value();
     case mir_touch_axis_y:
-        return event->y(touch_index);
+        return event->position(touch_index).y.as_value();
     case mir_touch_axis_pressure:
         return event->pressure(touch_index);
     case mir_touch_axis_touch_major:

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -524,3 +524,10 @@ MIR_COMMON_2.9 {
     MirPointerEvent::axis_source*;
   };
 } MIR_COMMON_2.8;
+
+MIR_COMMON_2.10 {
+  extern "C++" {
+    MirTouchEvent::set_position*;
+    MirTouchEvent::position*;
+  };
+} MIR_COMMON_2.9;

--- a/src/include/common/mir/events/touch_event.h
+++ b/src/include/common/mir/events/touch_event.h
@@ -29,7 +29,7 @@ struct MirTouchEvent : MirInputEvent
                   std::chrono::nanoseconds timestamp,
                   std::vector<uint8_t> const& cookie,
                   MirInputEventModifiers modifiers,
-                  std::vector<mir::events::ContactState> const& contacts);
+                  std::vector<mir::events::TouchContact> const& contacts);
     auto clone() const -> MirTouchEvent* override;
 
     size_t pointer_count() const;
@@ -63,7 +63,7 @@ struct MirTouchEvent : MirInputEvent
     void set_action(size_t index, MirTouchAction action);
 
 private:
-    std::vector<mir::events::ContactState> contacts;
+    std::vector<mir::events::TouchContact> contacts;
     void throw_if_out_of_bounds(size_t index) const;
 };
 

--- a/src/include/common/mir/events/touch_event.h
+++ b/src/include/common/mir/events/touch_event.h
@@ -38,11 +38,8 @@ struct MirTouchEvent : MirInputEvent
     int id(size_t index) const;
     void set_id(size_t index, int id);
 
-    float x(size_t index) const;
-    void set_x(size_t index, float x);
-
-    float y(size_t index) const;
-    void set_y(size_t index, float y);
+    mir::geometry::PointF position(size_t index) const;
+    void set_position(size_t index, mir::geometry::PointF position);
 
     float touch_major(size_t index) const;
     void set_touch_major(size_t index, float major);

--- a/src/include/server/mir/input/validator.h
+++ b/src/include/server/mir/input/validator.h
@@ -17,7 +17,7 @@
 #ifndef MIR_INPUT_VALIDATOR_H_
 #define MIR_INPUT_VALIDATOR_H_
 
-#include "mir/events/contact_state.h"
+#include "mir/events/touch_contact.h"
 
 #include <memory>
 #include <unordered_map>
@@ -39,13 +39,13 @@ public:
 private:
     std::mutex state_guard;
     std::function<void(MirEvent const&)> const dispatch_valid_event;
-    std::unordered_map<MirInputDeviceId, std::vector<events::ContactState>> last_event_by_device;
+    std::unordered_map<MirInputDeviceId, std::vector<events::TouchContact>> last_event_by_device;
 
     void handle_touch_event(MirEvent const& event);
     void ensure_stream_validity_locked(std::lock_guard<std::mutex> const& lg,
-                                       std::vector<events::ContactState> const& new_state,
-                                       std::vector<events::ContactState> & last_state,
-                                       std::function<void(std::vector<events::ContactState> const&)> const&);
+                                       std::vector<events::TouchContact> const& new_state,
+                                       std::vector<events::TouchContact> & last_state,
+                                       std::function<void(std::vector<events::TouchContact> const&)> const&);
 };
 }
 }

--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -393,18 +393,17 @@ mir::EventUPtr mie::LibInputDevice::convert_touch_frame(libinput_event_touch* to
     // TODO make libinput indicate tool type
     auto const tool = mir_touch_tooltype_finger;
 
-    std::vector<events::ContactState> contacts;
+    std::vector<events::TouchContact> contacts;
     for(auto it = begin(last_seen_properties); it != end(last_seen_properties);)
     {
         auto & id = it->first;
         auto & data = it->second;
 
-        contacts.push_back(events::ContactState{
+        contacts.push_back(events::TouchContact{
                            id,
                            data.action,
                            tool,
-                           data.x,
-                           data.y,
+                           {data.x, data.y},
                            data.pressure,
                            data.major,
                            data.minor,
@@ -428,7 +427,7 @@ mir::EventUPtr mie::LibInputDevice::convert_touch_frame(libinput_event_touch* to
     int emptyTouches = 0;
     for (const auto &contact: contacts)
     {
-        if (contact.x == 0 && contact.y == 0)
+        if (contact.position == geom::PointF{})
             emptyTouches++;
     }
     if (contacts.empty() || emptyTouches > 1)

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -81,7 +81,7 @@ class NullPointerInput : public mir::input::wayland::PointerInput
 
 class NullTouchInput : public mir::input::wayland::TouchInput
 {
-    void touch_event(std::chrono::nanoseconds, std::vector<mir::events::ContactState> const&) override
+    void touch_event(std::chrono::nanoseconds, std::vector<mir::events::TouchContact> const&) override
     {
     }
 };
@@ -442,8 +442,9 @@ void mir::graphics::wayland::Display::touch_down(
 
         touch_time = std::chrono::milliseconds{time};
         contact->action = mir_touch_action_down;
-        contact->x = wl_fixed_to_double(x) + touch_displacement.dx.as_int();
-        contact->y = wl_fixed_to_double(y) + touch_displacement.dy.as_int();
+        contact->position = geom::PointF{
+            wl_fixed_to_double(x) + touch_displacement.dx.as_int(),
+            wl_fixed_to_double(y) + touch_displacement.dy.as_int()};
     }
 }
 
@@ -471,8 +472,9 @@ void mir::graphics::wayland::Display::touch_motion(wl_touch* touch, uint32_t tim
 
         touch_time = std::chrono::milliseconds{time};
         contact->action = mir_touch_action_change;
-        contact->x = wl_fixed_to_double(x) + touch_displacement.dx.as_int();
-        contact->y = wl_fixed_to_double(y) + touch_displacement.dy.as_int();
+        contact->position = geom::PointF{
+            wl_fixed_to_double(x) + touch_displacement.dx.as_int(),
+            wl_fixed_to_double(y) + touch_displacement.dy.as_int()};
     }
 
     DisplayClient::touch_motion(touch, time, id, x, y);

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -20,7 +20,7 @@
 #include "displayclient.h"
 
 #include <mir/fd.h>
-#include <mir/events/contact_state.h>
+#include <mir/events/touch_contact.h>
 #include <mir/graphics/display.h>
 #include <mir/graphics/display_report.h>
 #include <mir/renderer/gl/context_source.h>
@@ -141,7 +141,7 @@ private:
     geometry::DisplacementF pointer_scroll;
     std::chrono::nanoseconds pointer_time;
     MirPointerAxisSource pointer_axis_source_ = mir_pointer_axis_source_none;
-    std::vector<events::ContactState> touch_contacts;
+    std::vector<events::TouchContact> touch_contacts;
     std::chrono::nanoseconds touch_time;
 
     std::thread runner;

--- a/src/platforms/wayland/display_input.h
+++ b/src/platforms/wayland/display_input.h
@@ -18,7 +18,7 @@
 #define MIR_PLATFORMS_WAYLAND_DISPLAY_INPUT_H_
 
 #include <mir/fd.h>
-#include <mir/events/contact_state.h>
+#include <mir/events/touch_contact.h>
 #include <mir/geometry/point.h>
 #include <mir/geometry/displacement.h>
 
@@ -78,7 +78,7 @@ public:
 class TouchInput
 {
 public:
-    virtual void touch_event(std::chrono::nanoseconds event_time, std::vector<events::ContactState> const& contacts) = 0;
+    virtual void touch_event(std::chrono::nanoseconds event_time, std::vector<events::TouchContact> const& contacts) = 0;
 
     TouchInput() = default;
     virtual ~TouchInput() = default;

--- a/src/platforms/wayland/input_device.cpp
+++ b/src/platforms/wayland/input_device.cpp
@@ -258,7 +258,7 @@ miw::TouchInputDevice::TouchInputDevice(std::shared_ptr<dispatch::ActionQueue> c
 }
 
 void mir::input::wayland::TouchInputDevice::touch_event(
-    std::chrono::nanoseconds event_time, std::vector<events::ContactState> const& contacts)
+    std::chrono::nanoseconds event_time, std::vector<events::TouchContact> const& contacts)
 {
     enqueue([=](EventBuilder* b)
     {

--- a/src/platforms/wayland/input_device.h
+++ b/src/platforms/wayland/input_device.h
@@ -126,7 +126,7 @@ public:
     TouchInputDevice(std::shared_ptr<dispatch::ActionQueue> const& action_queue);
 
 private:
-    void touch_event(std::chrono::nanoseconds event_time, std::vector<events::ContactState> const& contacts) override;
+    void touch_event(std::chrono::nanoseconds event_time, std::vector<events::TouchContact> const& contacts) override;
 };
 }
 }

--- a/src/server/input/default_event_builder.cpp
+++ b/src/server/input/default_event_builder.cpp
@@ -183,7 +183,16 @@ mir::EventUPtr mir::input::DefaultEventBuilder::pointer_event(
 
 mir::EventUPtr mi::DefaultEventBuilder::touch_event(
     std::optional<Timestamp> source_timestamp,
-    std::vector<events::ContactState> const& contacts)
+    std::vector<events::TouchContactV1> const& contacts)
+{
+    return touch_event(
+        source_timestamp,
+        std::vector<events::TouchContactV2>{begin(contacts), end(contacts)});
+}
+
+mir::EventUPtr mi::DefaultEventBuilder::touch_event(
+    std::optional<Timestamp> source_timestamp,
+    std::vector<events::TouchContactV2> const& contacts)
 {
     std::vector<uint8_t> vec_cookie{};
     auto const timestamp = calibrate_timestamp(source_timestamp);

--- a/src/server/input/default_event_builder.h
+++ b/src/server/input/default_event_builder.h
@@ -51,7 +51,7 @@ public:
 
     EventUPtr touch_event(
         std::optional<Timestamp> source_timestamp,
-        std::vector<events::ContactState> const& contacts) override;
+        std::vector<events::TouchContactV1> const& contacts) override;
 
     EventUPtr pointer_event(
         std::optional<Timestamp> source_timestamp,
@@ -103,6 +103,12 @@ public:
         MirPointerAxisSource axis_source,
         events::ScrollAxisV1H h_scroll,
         events::ScrollAxisV1V v_scroll) override;
+
+    // Intentionally uses TouchContactV2* instad of TouchContact* as a reminder that a new copy of this function will be
+    // needed for each TouchContact struct version.
+    EventUPtr touch_event(
+        std::optional<Timestamp> timestamp,
+        std::vector<mir::events::TouchContactV2> const& contacts) override;
 
 private:
     auto calibrate_timestamp(std::optional<Timestamp> source_timestamp) -> Timestamp;

--- a/tests/integration-tests/input/test_single_seat_setup.cpp
+++ b/tests/integration-tests/input/test_single_seat_setup.cpp
@@ -245,21 +245,21 @@ TEST_F(SingleSeatInputDeviceHubSetup, forwards_touch_spots_to_visualizer)
 
     auto touch_event_1 = builder->touch_event(
         arbitrary_timestamp,
-        {{0, mir_touch_action_down, mir_touch_tooltype_finger, 21.0f, 34.0f, 50.0f, 15.0f, 5.0f, 4.0f}});
+        {{0, mir_touch_action_down, mir_touch_tooltype_finger, {21.0f, 34.0f}, 50.0f, 15.0f, 5.0f, 4.0f}});
 
     auto touch_event_2 = builder->touch_event(
         arbitrary_timestamp,
-        {{0, mir_touch_action_change, mir_touch_tooltype_finger, 24.0f, 34.0f, 50.0f, 15.0f, 5.0f, 4.0f},
-         {1, mir_touch_action_down, mir_touch_tooltype_finger, 60.0f, 34.0f, 50.0f, 15.0f, 5.0f, 4.0f}});
+        {{0, mir_touch_action_change, mir_touch_tooltype_finger, {24.0f, 34.0f}, 50.0f, 15.0f, 5.0f, 4.0f},
+         {1, mir_touch_action_down, mir_touch_tooltype_finger, {60.0f, 34.0f}, 50.0f, 15.0f, 5.0f, 4.0f}});
 
     auto touch_event_3 = builder->touch_event(
         arbitrary_timestamp,
-        {{0, mir_touch_action_up, mir_touch_tooltype_finger, 24.0f, 34.0f, 50.0f, 15.0f, 5.0f, 4.0f},
-         {1, mir_touch_action_change, mir_touch_tooltype_finger, 70.0f, 30.0f, 50.0f, 15.0f, 5.0f, 4.0f}});
+        {{0, mir_touch_action_up, mir_touch_tooltype_finger, {24.0f, 34.0f}, 50.0f, 15.0f, 5.0f, 4.0f},
+         {1, mir_touch_action_change, mir_touch_tooltype_finger, {70.0f, 30.0f}, 50.0f, 15.0f, 5.0f, 4.0f}});
 
     auto touch_event_4 = builder->touch_event(
         arbitrary_timestamp,
-        {{1, mir_touch_action_up, mir_touch_tooltype_finger, 70.0f, 35.0f, 50.0f, 15.0f, 5.0f, 4.0f}});
+        {{1, mir_touch_action_up, mir_touch_tooltype_finger, {70.0f, 35.0f}, 50.0f, 15.0f, 5.0f, 4.0f}});
 
 
     using Spot = mi::TouchVisualizer::Spot;

--- a/tests/mir_test_framework/fake_input_device_impl.cpp
+++ b/tests/mir_test_framework/fake_input_device_impl.cpp
@@ -243,7 +243,7 @@ void mtf::FakeInputDeviceImpl::InputDevice::synthesize_events(synthesis::TouchPa
     {
         auto touch_event = builder->touch_event(
             event_time,
-            {{MirTouchId{1}, touch_action, mir_touch_tooltype_finger, abs_x, abs_y, 1.0f, 8.0f, 5.0f, 0.0f}});
+            {{MirTouchId{1}, touch_action, mir_touch_tooltype_finger, {abs_x, abs_y}, 1.0f, 8.0f, 5.0f, 0.0f}});
         touch_event->to_input()->set_event_time(event_time);
 
         sink->handle_input(std::move(touch_event));

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -90,7 +90,7 @@ struct MockEventBuilder : mi::EventBuilder
             });
 
         ON_CALL(*this, touch_event(_, _)).WillByDefault(
-            [this](std::optional<Timestamp> time, std::vector<mir::events::ContactState> const& contacts)
+            [this](std::optional<Timestamp> time, std::vector<mir::events::TouchContact> const& contacts)
             {
                 return builder.touch_event(time, contacts);
             });
@@ -115,7 +115,13 @@ struct MockEventBuilder : mi::EventBuilder
     using EventBuilder::Timestamp;
 
     MOCK_METHOD(mir::EventUPtr, key_event, (std::optional<Timestamp>, MirKeyboardAction, xkb_keysym_t, int));
-    MOCK_METHOD(mir::EventUPtr, touch_event, (std::optional<Timestamp>, std::vector<mir::events::ContactState> const&));
+
+    mir::EventUPtr touch_event(std::optional<Timestamp>, std::vector<mir::events::TouchContactV1> const&)
+    {
+        BOOST_THROW_EXCEPTION(std::logic_error{"Deprecated touch_event() called"});
+    }
+
+    MOCK_METHOD(mir::EventUPtr, touch_event, (std::optional<Timestamp>, std::vector<mir::events::TouchContactV2> const&));
     MOCK_METHOD(mir::EventUPtr, pointer_event,
                 (std::optional<Timestamp>, MirPointerAction, MirPointerButtons, std::optional<mir::geometry::PointF>,
                  mir::geometry::DisplacementF, MirPointerAxisSource, mir::events::ScrollAxisH,
@@ -907,8 +913,8 @@ TEST_F(LibInputDeviceOnTouchScreen, process_event_handles_touch_down_events)
     float x = 100;
     float y = 7;
 
-    std::vector<mev::ContactState> contacts{
-        {slot, mir_touch_action_down, mir_touch_tooltype_finger, x, y, pressure,
+    std::vector<mev::TouchContact> contacts{
+        {slot, mir_touch_action_down, mir_touch_tooltype_finger, {x, y}, pressure,
             major, minor, orientation}};
 
     InSequence seq;
@@ -932,8 +938,8 @@ TEST_F(LibInputDeviceOnTouchScreen, process_event_handles_touch_move_events)
     float x = 100;
     float y = 7;
 
-    std::vector<mev::ContactState> contacts{
-        {slot, mir_touch_action_change, mir_touch_tooltype_finger, x, y,
+    std::vector<mev::TouchContact> contacts{
+        {slot, mir_touch_action_change, mir_touch_tooltype_finger, {x, y},
          pressure, major, minor, orientation}};
 
     InSequence seq;
@@ -956,9 +962,9 @@ TEST_F(LibInputDeviceOnTouchScreen, process_event_handles_touch_up_events_withou
     float x = 30;
     float y = 20;
     float orientation = 0;
-    std::vector<mev::ContactState> contact_down{{slot, mir_touch_action_down, mir_touch_tooltype_finger, x, y,
+    std::vector<mev::TouchContact> contact_down{{slot, mir_touch_action_down, mir_touch_tooltype_finger, {x, y},
         pressure, major, minor, orientation}};
-    std::vector<mev::ContactState> contact_up{{slot, mir_touch_action_up, mir_touch_tooltype_finger, x, y,
+    std::vector<mev::TouchContact> contact_up{{slot, mir_touch_action_up, mir_touch_tooltype_finger, {x, y},
         pressure, major, minor, orientation}};
 
 

--- a/tests/unit-tests/input/test_idle_poking_dispatcher.cpp
+++ b/tests/unit-tests/input/test_idle_poking_dispatcher.cpp
@@ -76,8 +76,7 @@ auto touch_ev() -> std::shared_ptr<MirEvent>
     auto const touch_ev = std::make_shared<MirTouchEvent>();
     touch_ev->set_pointer_count(1);
     touch_ev->set_action(0, mir_touch_action_down);
-    touch_ev->set_x(0, 0);
-    touch_ev->set_y(0, 0);
+    touch_ev->set_position(0, {});
     return touch_ev;
 }
 }

--- a/tests/unit-tests/input/test_input_event.cpp
+++ b/tests/unit-tests/input/test_input_event.cpp
@@ -184,8 +184,7 @@ TEST(TouchEventProperties, axis_values_used_by_qtmir_copied)
     float x_value = 19, y_value = 23, touch_major = .3, touch_minor = .2, pressure = .9;
     MirTouchEvent old_ev;
     old_ev.set_pointer_count(1);
-    old_ev.set_x(0, x_value);
-    old_ev.set_y(0, y_value);
+    old_ev.set_position(0, {x_value, y_value});
     old_ev.set_touch_major(0, touch_major);
     old_ev.set_touch_minor(0, touch_minor);
     old_ev.set_pressure(0, pressure);

--- a/tests/unit-tests/input/test_seat_input_device_tracker.cpp
+++ b/tests/unit-tests/input/test_seat_input_device_tracker.cpp
@@ -37,6 +37,7 @@ namespace mt = mir::test;
 namespace mtd = mt::doubles;
 namespace mi = mir::input;
 namespace geom = mir::geometry;
+namespace mev = mir::events;
 namespace
 {
 
@@ -110,7 +111,7 @@ TEST_F(SeatInputDeviceTracker, throws_on_unknown_device)
     EXPECT_CALL(mock_dispatcher, dispatch(_)).Times(0);
     EXPECT_THROW(
         {
-            tracker.dispatch(some_device_builder.touch_event(arbitrary_timestamp,{}));
+            tracker.dispatch(some_device_builder.touch_event(arbitrary_timestamp, std::vector<mev::TouchContact>{}));
         },
         std::logic_error);
 }
@@ -120,7 +121,7 @@ TEST_F(SeatInputDeviceTracker, dispatch_posts_to_input_dispatcher)
     EXPECT_CALL(mock_dispatcher, dispatch(_));
 
     tracker.add_device(some_device);
-    tracker.dispatch(some_device_builder.touch_event(arbitrary_timestamp, {}));
+    tracker.dispatch(some_device_builder.touch_event(arbitrary_timestamp, std::vector<mev::TouchContact>{}));
 }
 
 TEST_F(SeatInputDeviceTracker, forwards_touch_spots_to_visualizer)


### PR DESCRIPTION
This renames `ContactState` to `TouchContact`, and versions it similar to how scroll axis is versioned. The old `ContactState` struct is kept around for ABI stability, and is aliased to `TouchContactV1`

The motivation for this is that I want to add local position to touch events (and pointer events) as part of my work on #1792, but to do that without breaking ABI I need more flexibility in the touch contact struct.