### PR TITLE
Add quirks for false-positive compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if(MIR_FATAL_COMPILE_WARNINGS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 endif()
 
-set(MIR_COMPILER_QUIRKS "" CACHE STRING "List of compiler quirks to enable")
+set(MIR_COMPILER_QUIRKS "" CACHE STRING "Semicolon-separated list of compiler quirks to enable")
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-Wmismatched-tags HAS_W_MISMATCHED_TAGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,8 @@ if(MIR_FATAL_COMPILE_WARNINGS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 endif()
 
+set(MIR_COMPILER_QUIRKS "" CACHE STRING "List of compiler quirks to enable")
+
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-Wmismatched-tags HAS_W_MISMATCHED_TAGS)
 

--- a/debian/rules
+++ b/debian/rules
@@ -34,6 +34,9 @@ COMMON_CONFIGURE_OPTIONS = \
 ifeq ($(filter ppc64el,$(DEB_HOST_ARCH)),ppc64el)
 	COMMON_CONFIGURE_OPTIONS += -DMIR_COMPILER_QUIRKS="libinput_environment.cpp:restrict"
 endif
+ifeq ($(filter riscv64,$(DEB_HOST_ARCH)),riscv64)
+	COMMON_CONFIGURE_OPTIONS += -DMIR_COMPILER_QUIRKS="test_linearising_executor.cpp:use-after-free"
+endif
 
 # Disable LTO if optimizations are off
 ifeq ($(filter noopt,$(DEB_BUILD_OPTIONS)),noopt)

--- a/debian/rules
+++ b/debian/rules
@@ -32,10 +32,16 @@ COMMON_CONFIGURE_OPTIONS = \
   -DMIR_LINK_TIME_OPTIMIZATION=ON\
 
 ifeq ($(filter ppc64el,$(DEB_HOST_ARCH)),ppc64el)
-	COMMON_CONFIGURE_OPTIONS += -DMIR_COMPILER_QUIRKS="libinput_environment.cpp:restrict"
+	# Disable spurious error on GCC-12
+	ifneq ($(shell gcc --version | grep '12.[[:digit:]]\+.[[:digit:]]\+$$'),)
+		COMMON_CONFIGURE_OPTIONS += -DMIR_COMPILER_QUIRKS="libinput_environment.cpp:restrict"
+	endif
 endif
 ifeq ($(filter riscv64,$(DEB_HOST_ARCH)),riscv64)
-	COMMON_CONFIGURE_OPTIONS += -DMIR_COMPILER_QUIRKS="test_linearising_executor.cpp:use-after-free"
+	# Disable spurious error on GCC-12
+	ifneq ($(shell gcc --version | grep '12.[[:digit:]]\+.[[:digit:]]\+$$'),)
+		COMMON_CONFIGURE_OPTIONS += -DMIR_COMPILER_QUIRKS="test_linearising_executor.cpp:use-after-free"
+	endif
 endif
 
 # Disable LTO if optimizations are off

--- a/debian/rules
+++ b/debian/rules
@@ -31,6 +31,10 @@ COMMON_CONFIGURE_OPTIONS = \
   -DMIR_BUILD_INTERPROCESS_TESTS=OFF\
   -DMIR_LINK_TIME_OPTIMIZATION=ON\
 
+ifeq ($(filter ppc64el,$(DEB_HOST_ARCH)),ppc64el)
+	COMMON_CONFIGURE_OPTIONS += -DMIR_COMPILER_QUIRKS="libinput_environment.cpp:restrict"
+endif
+
 # Disable LTO if optimizations are off
 ifeq ($(filter noopt,$(DEB_BUILD_OPTIONS)),noopt)
 	COMMON_CONFIGURE_OPTIONS += -DMIR_LINK_TIME_OPTIMIZATION=OFF

--- a/tests/mir_test_framework/CMakeLists.txt
+++ b/tests/mir_test_framework/CMakeLists.txt
@@ -61,6 +61,12 @@ set_property(
     SOURCE udev_environment.cpp
     PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
 
+if ("libinput_environment.cpp:restrict" IN_LIST MIR_COMPILER_QUIRKS)
+  set_property(
+    SOURCE libinput_environment.cpp
+    PROPERTY COMPILE_OPTIONS -Wno-error=restrict)
+endif()
+
 # Umockdev uses glib, which uses the deprecated "register" storage qualifier
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Dregister=")
 

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -142,6 +142,13 @@ set_property(
   SOURCE graphics/test_platform_prober.cpp
   PROPERTY COMPILE_OPTIONS -Wno-variadic-macros)
 
+if ("test_linearising_executor.cpp:use-after-free" IN_LIST MIR_COMPILER_QUIRKS)
+  set_property(
+    SOURCE test_linearising_executor.cpp
+    PROPERTY COMPILE_OPTIONS -Wno-error=use-after-free  # riscv64 spuriously warns here
+  )
+endif()
+
 if (MIR_USE_PRECOMPILED_HEADERS)
   target_precompile_headers(
     mir_unit_tests


### PR DESCRIPTION
We semi-regularly run into toolchain bugs where a warning false-positives on our test code¹. Add the minimal infrastructure to let us disable `-Werror` on the smallest easily-accessible code unit, and quirk off `Werror` on the current set of gcc-12 false-positives.

¹: GTest is apparently a compiler fuzzing suite