### PR TITLE
CMake: Use non-fat LTO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,15 +112,22 @@ endif()
 # Link time optimization allows leaner, cleaner libraries
 option(MIR_LINK_TIME_OPTIMIZATION "Enables the linker to optimize binaries." OFF)
 if(MIR_LINK_TIME_OPTIMIZATION)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
   if(${CMAKE_COMPILER_IS_GNUCXX})
-    # clang defaults to fat LTO, but gcc needs an option to specify
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffat-lto-objects")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffat-lto-objects")
+    # Disable fat LTO for a (small) compile performance improvement
+    # We don't ship any LTO-enabled static libraries.
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-fat-lto-objects")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-fat-lto-objects")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
     set(CMAKE_NM "gcc-nm")
     set(CMAKE_AR "gcc-ar")
     set(CMAKE_RANLIB "gcc-ranlib")
+  endif()
+  if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    # On clang we can use Thin LTO for a rather more
+    # substantial compile performance improvement
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto=thin")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto=thin")
   endif()
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -185,6 +185,21 @@ add_subdirectory(mir_test/)
 add_subdirectory(mir_test_framework/)
 add_subdirectory(mir_test_doubles/)
 
+set_target_properties(
+  mir-public-test
+  PROPERTIES COMPILE_OPTIONS -fno-lto  # Make double sure we don't generate LTO objects
+)
+
+set_target_properties(
+  mir-public-test-doubles
+  PROPERTIES COMPILE_OPTIONS -fno-lto  # Make double sure we don't generate LTO objects
+)
+
+set_target_properties(
+  mir-public-test-framework
+  PROPERTIES COMPILE_OPTIONS -fno-lto  # Make double sure we don't generate LTO objects
+)
+
 add_library(mir-test-assist STATIC
   $<TARGET_OBJECTS:mir-public-test>
   $<TARGET_OBJECTS:mir-public-test-doubles>


### PR DESCRIPTION
Fat LTO objects slow down the build. We don't *need* fat LTO objects, as we don't ship any LTO'd static archives.