### PR TITLE
Split up wayland_base.h

### DIFF
--- a/include/wayland/mir/wayland/global.h
+++ b/include/wayland/mir/wayland/global.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Canonical Ltd.
+ * Copyright © 2022 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,
@@ -14,13 +14,34 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_WAYLAND_BASE_H_
-#define MIR_WAYLAND_BASE_H_
+#ifndef MIR_WAYLAND_GLOBAL_H_
+#define MIR_WAYLAND_GLOBAL_H_
 
-#include "lifetime_tracker.h"
-#include "weak.h"
-#include "resource.h"
-#include "global.h"
-#include "protocol_error.h"
+struct wl_global;
 
-#endif // MIR_WAYLAND_BASE_H_
+namespace mir
+{
+namespace wayland
+{
+class Global
+{
+public:
+    template<int V>
+    struct Version
+    {
+    };
+
+    explicit Global(wl_global* global);
+    virtual ~Global();
+
+    Global(Global const&) = delete;
+    Global& operator=(Global const&) = delete;
+
+    virtual auto interface_name() const -> char const* = 0;
+
+    wl_global* const global;
+};
+}
+}
+
+#endif // MIR_WAYLAND_GLOBAL_H_

--- a/include/wayland/mir/wayland/lifetime_tracker.h
+++ b/include/wayland/mir/wayland/lifetime_tracker.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_WAYLAND_LIFETIME_TRACKER_H_
+#define MIR_WAYLAND_LIFETIME_TRACKER_H_
+
+#include "mir/int_wrapper.h"
+
+#include <memory>
+#include <functional>
+
+namespace mir
+{
+namespace wayland
+{
+namespace detail
+{
+struct DestroyListenerIdTag;
+}
+
+typedef IntWrapper<detail::DestroyListenerIdTag> DestroyListenerId;
+
+/// The base class of any object that wants to provide a destroyed flag
+/// The destroyed flag is only created when needed and automatically set to true on destruction
+/// This pattern is only safe in a single-threaded context
+class LifetimeTracker
+{
+public:
+    LifetimeTracker();
+    LifetimeTracker(LifetimeTracker const&) = delete;
+    LifetimeTracker& operator=(LifetimeTracker const&) = delete;
+
+    virtual ~LifetimeTracker();
+    /// The pointed-at bool contains false if this object is still alive and true if it has been destroyed.
+    auto destroyed_flag() const -> std::shared_ptr<bool const>;
+    /// The given function will be called just before the object is marked as destroyed. The returned ID can be used
+    /// to remove the listener in which case it is never called. DestroyListenerId{} (value 0) is never returned, and so
+    /// it can be used as a null ID. Destroy listener call order is undefined.
+    auto add_destroy_listener(std::function<void()> listener) const -> DestroyListenerId;
+    /// If the given ID maps to a destroy listener, that listener is dropped without being called. If the listener has
+    /// already been dropped or never existed, this call is ignored.
+    void remove_destroy_listener(DestroyListenerId id) const;
+
+protected:
+    /// Subclasses are not required to call this, but may do so during the destruction process if the object needs to
+    /// get marked as destroyed and fire its destroy listeners before some other part of the destructor runs.
+    void mark_destroyed() const;
+
+private:
+    struct Impl;
+
+    /// Since many Wayland objects are created and the features of this class are used for only a few, impl is created
+    /// lazily to conserve memory.
+    std::unique_ptr<Impl> mutable impl;
+};
+}
+}
+
+#endif // MIR_WAYLAND_LIFETIME_TRACKER_H_

--- a/include/wayland/mir/wayland/protocol_error.h
+++ b/include/wayland/mir/wayland/protocol_error.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_WAYLAND_PROTOCOL_ERROR_H_
+#define MIR_WAYLAND_PROTOCOL_ERROR_H_
+
+#include <stdexcept>
+
+struct wl_resource;
+struct wl_client;
+
+namespace mir
+{
+namespace wayland
+{
+/// For when the protocol does not provide an appropriate error code
+uint32_t const generic_error_code = -1;
+
+/**
+ * An exception type representing a Wayland protocol error
+ *
+ * Throwing one of these from a request handler will result in the client
+ * being sent a \a code error on \a source, with the printf-style \a fmt string
+ * populated as the message.:
+ */
+class ProtocolError : public std::runtime_error
+{
+public:
+    [[gnu::format (printf, 4, 5)]]  // Format attribute counts the hidden this parameter
+    ProtocolError(wl_resource* source, uint32_t code, char const* fmt, ...);
+
+    auto message() const -> char const*;
+    auto resource() const -> wl_resource*;
+    auto code() const -> uint32_t;
+private:
+    std::string error_message;
+    wl_resource* const source;
+    uint32_t const error_code;
+};
+
+void internal_error_processing_request(wl_client* client, char const* method_name);
+void tried_to_send_unsupported_event(wl_client* client, wl_resource* resource, char const* event, int required_version);
+}
+}
+
+#endif // MIR_WAYLAND_PROTOCOL_ERROR_H_

--- a/include/wayland/mir/wayland/resource.h
+++ b/include/wayland/mir/wayland/resource.h
@@ -20,6 +20,7 @@
 #include "lifetime_tracker.h"
 
 struct wl_resource;
+struct wl_client;
 
 namespace mir
 {
@@ -34,7 +35,10 @@ public:
     {
     };
 
-    Resource();
+    Resource(wl_resource* resource);
+
+    wl_resource* const resource;
+    wl_client* const client;
 };
 }
 }

--- a/include/wayland/mir/wayland/resource.h
+++ b/include/wayland/mir/wayland/resource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Canonical Ltd.
+ * Copyright © 2022 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,
@@ -14,13 +14,29 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_WAYLAND_BASE_H_
-#define MIR_WAYLAND_BASE_H_
+#ifndef MIR_WAYLAND_RESOURCE_H_
+#define MIR_WAYLAND_RESOURCE_H_
 
 #include "lifetime_tracker.h"
-#include "weak.h"
-#include "resource.h"
-#include "global.h"
-#include "protocol_error.h"
 
-#endif // MIR_WAYLAND_BASE_H_
+struct wl_resource;
+
+namespace mir
+{
+namespace wayland
+{
+class Resource
+    : public virtual LifetimeTracker
+{
+public:
+    template<int V>
+    struct Version
+    {
+    };
+
+    Resource();
+};
+}
+}
+
+#endif // MIR_WAYLAND_RESOURCE_H_

--- a/include/wayland/mir/wayland/weak.h
+++ b/include/wayland/mir/wayland/weak.h
@@ -17,6 +17,7 @@
 #ifndef MIR_WAYLAND_WEAK_H_
 #define MIR_WAYLAND_WEAK_H_
 
+#include <memory>
 #include <boost/throw_exception.hpp>
 
 namespace mir

--- a/include/wayland/mir/wayland/weak.h
+++ b/include/wayland/mir/wayland/weak.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_WAYLAND_WEAK_H_
+#define MIR_WAYLAND_WEAK_H_
+
+#include <boost/throw_exception.hpp>
+
+namespace mir
+{
+namespace wayland
+{
+/// A weak handle to a Wayland resource (or any Destroyable)
+/// May only be safely used from the Wayland thread
+template<typename T>
+class Weak
+{
+public:
+    Weak()
+        : resource{nullptr},
+          destroyed_flag{nullptr}
+    {
+    }
+
+    explicit Weak(T* resource)
+        : resource{resource},
+          destroyed_flag{resource ? resource->destroyed_flag() : nullptr}
+    {
+    }
+
+    Weak(Weak<T> const&) = default;
+    auto operator=(Weak<T> const&) -> Weak<T>& = default;
+
+    auto operator==(Weak<T> const& other) const -> bool
+    {
+        if (*this && other)
+        {
+            return resource == other.resource;
+        }
+        else
+        {
+            return (!*this && !other);
+        }
+    }
+
+    auto operator!=(Weak<T> const& other) const -> bool
+    {
+        return !(*this == other);
+    }
+
+    auto is(T const& other) const -> bool
+    {
+        if (*this)
+        {
+            return resource == &other;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    operator bool() const
+    {
+        return resource && !*destroyed_flag;
+    }
+
+    auto value() const -> T&
+    {
+        if (!*this)
+        {
+            BOOST_THROW_EXCEPTION(std::logic_error(
+                std::string{"Attempted access of "} +
+                (resource ? "destroyed" : "null") +
+                " wayland::Weak<" + typeid(T).name() + ">"));
+        }
+        return *resource;
+    }
+
+private:
+    T* resource;
+    /// Is null if and only if resource is null
+    /// If the target bool is true then resource has been freed and should not be used
+    std::shared_ptr<bool const> destroyed_flag;
+};
+
+template<typename T>
+auto make_weak(T* resource) -> Weak<T>
+{
+    return Weak<T>{resource};
+}
+
+template<typename T>
+auto as_nullable_ptr(Weak<T> const& weak) -> T*
+{
+    return weak ? &weak.value() : nullptr;
+}
+}
+}
+
+#endif // MIR_WAYLAND_WEAK_H_

--- a/src/platform/graphics/linux_dmabuf.cpp
+++ b/src/platform/graphics/linux_dmabuf.cpp
@@ -20,6 +20,7 @@
 
 
 #include "wayland_wrapper.h"
+#include "mir/wayland/protocol_error.h"
 #include "mir/graphics/egl_extensions.h"
 #include "mir/graphics/egl_error.h"
 #include "mir/renderer/gl/context.h"

--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -33,7 +33,7 @@
 #include "mir/renderer/gl/context_source.h"
 #include "mir/renderer/gl/context.h"
 #include "mir/raii.h"
-#include "mir/wayland/wayland_base.h"
+#include "mir/wayland/protocol_error.h"
 
 #define MIR_LOG_COMPONENT "platform-eglstream-kms"
 #include "mir/log.h"

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -17,6 +17,7 @@
 #include "foreign_toplevel_manager_v1.h"
 
 #include "wayland_utils.h"
+#include "mir/wayland/weak.h"
 #include "mir/frontend/surface_stack.h"
 #include "mir/shell/shell.h"
 #include "mir/shell/surface_specification.h"

--- a/src/server/frontend_wayland/input_method_grab_keyboard_v2.h
+++ b/src/server/frontend_wayland/input_method_grab_keyboard_v2.h
@@ -17,6 +17,8 @@
 #ifndef MIR_FRONTEND_INPUT_METHOD_GRAB_KEYBOARD_V2_H
 #define MIR_FRONTEND_INPUT_METHOD_GRAB_KEYBOARD_V2_H
 
+#include "mir/wayland/weak.h"
+
 #include "input-method-unstable-v2_wrapper.h"
 #include "keyboard_helper.h"
 

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -24,6 +24,8 @@
 
 #include "mir/shell/surface_specification.h"
 #include "mir/log.h"
+#include "mir/wayland/weak.h"
+#include "mir/wayland/protocol_error.h"
 #include <boost/throw_exception.hpp>
 #include <deque>
 #include <vector>

--- a/src/server/frontend_wayland/output_manager.h
+++ b/src/server/frontend_wayland/output_manager.h
@@ -21,6 +21,7 @@
 #include <mir/graphics/null_display_configuration_observer.h>
 
 #include "wayland_wrapper.h"
+#include "mir/wayland/weak.h"
 
 #include <optional>
 #include <memory>

--- a/src/server/frontend_wayland/virtual_keyboard_v1.cpp
+++ b/src/server/frontend_wayland/virtual_keyboard_v1.cpp
@@ -28,6 +28,7 @@
 
 #include <cstring>
 #include <sys/mman.h>
+#include <boost/throw_exception.hpp>
 
 namespace mf = mir::frontend;
 namespace mw = mir::wayland;

--- a/src/server/frontend_wayland/virtual_pointer_v1.cpp
+++ b/src/server/frontend_wayland/virtual_pointer_v1.cpp
@@ -19,6 +19,8 @@
 #include "wl_pointer.h"
 #include "output_manager.h"
 
+#include "mir/wayland/weak.h"
+#include "mir/wayland/protocol_error.h"
 #include "mir/input/virtual_input_device.h"
 #include "mir/input/input_device_registry.h"
 #include "mir/input/device.h"

--- a/src/server/frontend_wayland/wayland_input_dispatcher.h
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.h
@@ -20,7 +20,7 @@
 #include "mir_toolkit/common.h"
 #include "mir_toolkit/events/event.h"
 #include "mir/geometry/point.h"
-#include "mir/wayland/wayland_base.h"
+#include "mir/wayland/weak.h"
 
 #include <memory>
 #include <chrono>

--- a/src/server/frontend_wayland/wayland_surface_observer.h
+++ b/src/server/frontend_wayland/wayland_surface_observer.h
@@ -19,6 +19,7 @@
 
 #include "wayland_input_dispatcher.h"
 #include <mir/scene/null_surface_observer.h>
+#include <mir/wayland/weak.h>
 
 #include <memory>
 #include <optional>

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -20,7 +20,7 @@
 #include "wl_surface_role.h"
 #include "wl_client.h"
 
-#include "mir/wayland/wayland_base.h"
+#include "mir/wayland/weak.h"
 #include "mir/geometry/displacement.h"
 #include "mir/geometry/size.h"
 #include "mir/geometry/rectangle.h"

--- a/src/server/frontend_wayland/wl_client.h
+++ b/src/server/frontend_wayland/wl_client.h
@@ -24,7 +24,7 @@ struct wl_display;
 #include <memory>
 #include <functional>
 
-#include "mir/wayland/wayland_base.h"
+#include "mir/wayland/lifetime_tracker.h"
 
 namespace mir
 {

--- a/src/server/frontend_wayland/wl_data_source.cpp
+++ b/src/server/frontend_wayland/wl_data_source.cpp
@@ -17,6 +17,7 @@
 #include "wl_data_source.h"
 #include "mir/scene/clipboard.h"
 #include "mir/executor.h"
+#include "mir/wayland/weak.h"
 
 #include <vector>
 

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -17,6 +17,8 @@
 #ifndef MIR_FRONTEND_WL_KEYBOARD_H
 #define MIR_FRONTEND_WL_KEYBOARD_H
 
+#include "mir/wayland/weak.h"
+
 #include "wayland_wrapper.h"
 #include "keyboard_helper.h"
 #include "wl_seat.h"

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -19,7 +19,7 @@
 
 
 #include "wayland_wrapper.h"
-
+#include "mir/wayland/weak.h"
 #include "mir/geometry/point.h"
 #include "mir/geometry/displacement.h"
 #include "mir/events/scroll_axis.h"

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -18,6 +18,7 @@
 #define MIR_FRONTEND_WL_SEAT_H
 
 #include "wayland_wrapper.h"
+#include "mir/wayland/weak.h"
 
 #include <unordered_map>
 #include <vector>

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -26,6 +26,7 @@
 
 #include "wayland_frontend.tp.h"
 
+#include "mir/wayland/protocol_error.h"
 #include "mir/graphics/buffer_properties.h"
 #include "mir/scene/session.h"
 #include "mir/frontend/wayland.h"

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -18,6 +18,7 @@
 #define MIR_FRONTEND_WL_SURFACE_H
 
 #include "wayland_wrapper.h"
+#include "mir/wayland/weak.h"
 
 #include "wl_surface_role.h"
 

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -18,7 +18,7 @@
 #define MIR_FRONTEND_WL_TOUCH_H
 
 #include "wayland_wrapper.h"
-
+#include "mir/wayland/weak.h"
 #include "mir/geometry/point.h"
 
 #include <unordered_map>

--- a/src/server/frontend_wayland/wlr_screencopy_v1.cpp
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.cpp
@@ -23,6 +23,8 @@
 #include "mir/scene/scene_change_notification.h"
 #include "mir/frontend/surface_stack.h"
 #include "mir/geometry/rectangles.h"
+#include "mir/wayland/weak.h"
+#include "mir/wayland/protocol_error.h"
 #include "mir/executor.h"
 #include "wayland_wrapper.h"
 #include "wayland_timespec.h"
@@ -31,6 +33,7 @@
 #include <boost/throw_exception.hpp>
 #include <mutex>
 #include <optional>
+
 
 namespace mf = mir::frontend;
 namespace mw = mir::wayland;

--- a/src/server/frontend_wayland/wlr_screencopy_v1.h
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.h
@@ -18,7 +18,6 @@
 #define MIR_FRONTEND_WLR_SCREENCOPY_V1_H
 
 #include "wlr-screencopy-unstable-v1_wrapper.h"
-#include "mir/wayland/wayland_base.h"
 #include "mir/geometry/rectangle.h"
 
 #include <memory>

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -19,6 +19,7 @@
 #include "wl_surface.h"
 #include "wayland_utils.h"
 
+#include "mir/wayland/protocol_error.h"
 #include "mir/frontend/wayland.h"
 #include "mir/shell/surface_specification.h"
 #include "mir/shell/shell.h"

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -20,6 +20,7 @@
 #include "window_wl_surface_role.h"
 #include "wayland_utils.h"
 
+#include "mir/wayland/protocol_error.h"
 #include "mir/frontend/wayland.h"
 #include "mir/shell/surface_specification.h"
 #include "mir/scene/surface.h"

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -19,7 +19,7 @@
 
 #include "mir/scene/surface.h"
 #include "mir/proof_of_mutex_lock.h"
-#include "mir/wayland/wayland_base.h"
+#include "mir/wayland/weak.h"
 #include "mir/geometry/rectangle.h"
 #include "mir_toolkit/common.h"
 #include "mir/synchronised.h"

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -27,7 +27,7 @@
 #include "mir/scene/session.h"
 #include "mir/scene/surface.h"
 #include "mir/input/seat.h"
-#include "mir/wayland/wayland_base.h"
+#include "mir/wayland/weak.h"
 #include "decoration/manager.h"
 
 #include <algorithm>

--- a/src/server/shell/decoration/basic_decoration.cpp
+++ b/src/server/shell/decoration/basic_decoration.cpp
@@ -29,7 +29,7 @@
 #include "mir/graphics/buffer_properties.h"
 #include "mir/compositor/buffer_stream.h"
 #include "mir/input/cursor_images.h"
-#include "mir/wayland/wayland_base.h"
+#include "mir/wayland/weak.h"
 #include "mir/log.h"
 
 #include <boost/throw_exception.hpp>

--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -5,7 +5,10 @@ add_compile_definitions(MIR_LOG_COMPONENT_FALLBACK="mirwayland")
 add_subdirectory(generator/)
 
 set(STANDARD_SOURCES
-  wayland_base.cpp
+  lifetime_tracker.cpp
+  resource.cpp
+  global.cpp
+  protocol_error.cpp
 )
 
 add_library(mirwayland SHARED

--- a/src/wayland/generator/interface.cpp
+++ b/src/wayland/generator/interface.cpp
@@ -120,7 +120,6 @@ Emitter Interface::declaration() const
             },
             event_prototypes(),
             (has_destroy_request ? nullptr : "void destroy_and_delete() const;"),
-            member_vars(),
             enum_declarations(),
             event_opcodes(),
             (thunks_impl_contents().is_valid() ? "struct Thunks;" : nullptr),
@@ -235,13 +234,8 @@ Emitter Interface::constructor_impl() const
     {
         impls.push_back(Lines{
             {nmspace, generated_name, "(", constructor_args(), ")"},
-            {"    : client{wl_resource_get_client(resource)},"},
-            {"      resource{resource}"},
+            {"    : Resource{resource}"},
             Block{
-                "if (resource == nullptr)",
-                Block{
-                    "BOOST_THROW_EXCEPTION((std::bad_alloc{}));",
-                },
                 "wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);",
             }
         });
@@ -257,13 +251,8 @@ Emitter Interface::constructor_impl(std::string const& parent_interface) const
 {
     return Lines{
         {nmspace, generated_name, "(", constructor_args(parent_interface), ")"},
-        {"    : client{wl_resource_get_client(parent.resource)},"},
-        {"      resource{wl_resource_create(client, &", wl_name, "_interface_data, wl_resource_get_version(parent.resource), 0)}"},
+        {"    : Resource{wl_resource_create(client, &", wl_name, "_interface_data, wl_resource_get_version(parent.resource), 0)}"},
         Block{
-            "if (resource == nullptr)",
-            Block{
-                "BOOST_THROW_EXCEPTION((std::bad_alloc{}));",
-            },
             "wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);",
         }
     };
@@ -323,15 +312,6 @@ Emitter Interface::event_impls() const
     }
     return EmptyLineList{impls};
 }
-
-Emitter Interface::member_vars() const
-{
-    return Lines{
-        {"struct wl_client* const client;"},
-        {"struct wl_resource* const resource;"}
-    };
-}
-
 
 Emitter Interface::is_instance_prototype() const
 {

--- a/src/wayland/generator/interface.cpp
+++ b/src/wayland/generator/interface.cpp
@@ -251,7 +251,10 @@ Emitter Interface::constructor_impl(std::string const& parent_interface) const
 {
     return Lines{
         {nmspace, generated_name, "(", constructor_args(parent_interface), ")"},
-        {"    : Resource{wl_resource_create(client, &", wl_name, "_interface_data, wl_resource_get_version(parent.resource), 0)}"},
+        {"    : Resource{wl_resource_create("},
+        {"          wl_resource_get_client(parent.resource),"},
+        {"          &", wl_name, "_interface_data,"},
+        {"          wl_resource_get_version(parent.resource), 0)}"},
         Block{
             "wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);",
         }

--- a/src/wayland/generator/interface.h
+++ b/src/wayland/generator/interface.h
@@ -60,7 +60,6 @@ private:
     Emitter virtual_request_prototypes() const;
     Emitter event_prototypes() const;
     Emitter event_impls() const;
-    Emitter member_vars() const;
     Emitter enum_declarations() const;
     Emitter enum_impls() const;
     Emitter event_opcodes() const;

--- a/src/wayland/generator/wrapper_generator.cpp
+++ b/src/wayland/generator/wrapper_generator.cpp
@@ -58,9 +58,7 @@ Emitter impl_includes(std::string const& protocol_name)
     return Lines{
         {"#include \"", protocol_name, "_wrapper.h\""},
         empty_line,
-        "#include <boost/throw_exception.hpp>",
         "#include <boost/exception/diagnostic_information.hpp>",
-        empty_line,
         "#include <wayland-server-core.h>",
         empty_line,
         "#include \"mir/log.h\"",

--- a/src/wayland/generator/wrapper_generator.cpp
+++ b/src/wayland/generator/wrapper_generator.cpp
@@ -48,7 +48,8 @@ Emitter header_includes()
         "#include \"mir/fd.h\"",
         "#include <wayland-server-core.h>",
         empty_line,
-        "#include \"mir/wayland/wayland_base.h\"",
+        "#include \"mir/wayland/resource.h\"",
+        "#include \"mir/wayland/global.h\"",
     };
 }
 
@@ -63,6 +64,7 @@ Emitter impl_includes(std::string const& protocol_name)
         "#include <wayland-server-core.h>",
         empty_line,
         "#include \"mir/log.h\"",
+        "#include \"mir/wayland/protocol_error.h\"",
     };
 }
 

--- a/src/wayland/global.cpp
+++ b/src/wayland/global.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Canonical Ltd.
+ * Copyright © 2022 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,
@@ -14,13 +14,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_WAYLAND_BASE_H_
-#define MIR_WAYLAND_BASE_H_
+#include "mir/wayland/global.h"
 
-#include "lifetime_tracker.h"
-#include "weak.h"
-#include "resource.h"
-#include "global.h"
-#include "protocol_error.h"
+#include <boost/throw_exception.hpp>
+#include <wayland-server-core.h>
 
-#endif // MIR_WAYLAND_BASE_H_
+namespace mw = mir::wayland;
+
+mw::Global::Global(wl_global* global)
+    : global{global}
+{
+    if (global == nullptr)
+    {
+        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
+    }
+}
+
+mw::Global::~Global()
+{
+    wl_global_destroy(global);
+}

--- a/src/wayland/lifetime_tracker.cpp
+++ b/src/wayland/lifetime_tracker.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir/wayland/lifetime_tracker.h"
+
+#include <map>
+
+namespace mw = mir::wayland;
+
+struct mw::LifetimeTracker::Impl
+{
+    std::shared_ptr<bool> destroyed{nullptr};
+    std::map<DestroyListenerId, std::function<void()>> destroy_listeners;
+    DestroyListenerId last_id{0};
+};
+
+mw::LifetimeTracker::LifetimeTracker()
+{
+}
+
+mw::LifetimeTracker::~LifetimeTracker()
+{
+    mark_destroyed();
+}
+
+auto mw::LifetimeTracker::destroyed_flag() const -> std::shared_ptr<bool const>
+{
+    if (!impl)
+    {
+        impl = std::make_unique<Impl>();
+    }
+    if (!impl->destroyed)
+    {
+        impl->destroyed = std::make_shared<bool>(false);
+    }
+    return impl->destroyed;
+}
+
+auto mw::LifetimeTracker::add_destroy_listener(std::function<void()> listener) const -> DestroyListenerId
+{
+    if (!impl)
+    {
+        impl = std::make_unique<Impl>();
+    }
+    auto const id = DestroyListenerId{impl->last_id.as_value() + 1};
+    impl->last_id = id;
+    impl->destroy_listeners[id] = listener;
+    return id;
+}
+
+void mw::LifetimeTracker::remove_destroy_listener(DestroyListenerId id) const
+{
+    if (impl)
+    {
+        impl->destroy_listeners.erase(id);
+    }
+}
+
+void mw::LifetimeTracker::mark_destroyed() const
+{
+    if (impl)
+    {
+        auto const local_listeners = std::move(impl->destroy_listeners);
+        impl->destroy_listeners.clear();
+        for (auto const& listener : local_listeners)
+        {
+            listener.second();
+        }
+        if (impl->destroyed)
+        {
+            *impl->destroyed = true;
+        }
+    }
+}

--- a/src/wayland/resource.cpp
+++ b/src/wayland/resource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Canonical Ltd.
+ * Copyright © 2022 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,
@@ -14,13 +14,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_WAYLAND_BASE_H_
-#define MIR_WAYLAND_BASE_H_
+#include "mir/wayland/resource.h"
 
-#include "lifetime_tracker.h"
-#include "weak.h"
-#include "resource.h"
-#include "global.h"
-#include "protocol_error.h"
+#include <wayland-server-core.h>
 
-#endif // MIR_WAYLAND_BASE_H_
+namespace mw = mir::wayland;
+
+mw::Resource::Resource()
+{
+}

--- a/src/wayland/resource.cpp
+++ b/src/wayland/resource.cpp
@@ -16,10 +16,17 @@
 
 #include "mir/wayland/resource.h"
 
+#include <boost/throw_exception.hpp>
 #include <wayland-server-core.h>
 
 namespace mw = mir::wayland;
 
-mw::Resource::Resource()
+mw::Resource::Resource(wl_resource* resource)
+    : resource{resource},
+      client{wl_resource_get_client(resource)}
 {
+    if (resource == nullptr)
+    {
+        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
+    }
 }

--- a/tests/acceptance-tests/wayland-generator/expected.cpp
+++ b/tests/acceptance-tests/wayland-generator/expected.cpp
@@ -777,7 +777,10 @@ struct mw::DataOffer::Thunks
 int const mw::DataOffer::Thunks::supported_version = 3;
 
 mw::DataOffer::DataOffer(DataDevice const& parent)
-    : Resource{wl_resource_create(client, &wl_data_offer_interface_data, wl_resource_get_version(parent.resource), 0)}
+    : Resource{wl_resource_create(
+          wl_resource_get_client(parent.resource),
+          &wl_data_offer_interface_data,
+          wl_resource_get_version(parent.resource), 0)}
 {
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }

--- a/tests/acceptance-tests/wayland-generator/expected.cpp
+++ b/tests/acceptance-tests/wayland-generator/expected.cpp
@@ -6,12 +6,11 @@
 
 #include "protocol_wrapper.h"
 
-#include <boost/throw_exception.hpp>
 #include <boost/exception/diagnostic_information.hpp>
-
 #include <wayland-server-core.h>
 
 #include "mir/log.h"
+#include "mir/wayland/protocol_error.h"
 
 namespace mir
 {
@@ -71,13 +70,8 @@ struct mw::Callback::Thunks
 int const mw::Callback::Thunks::supported_version = 1;
 
 mw::Callback::Callback(struct wl_resource* resource, Version<1>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -212,13 +206,8 @@ struct mw::Compositor::Thunks
 int const mw::Compositor::Thunks::supported_version = 4;
 
 mw::Compositor::Compositor(struct wl_resource* resource, Version<4>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -357,13 +346,8 @@ struct mw::ShmPool::Thunks
 int const mw::ShmPool::Thunks::supported_version = 1;
 
 mw::ShmPool::ShmPool(struct wl_resource* resource, Version<1>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -476,13 +460,8 @@ struct mw::Shm::Thunks
 int const mw::Shm::Thunks::supported_version = 1;
 
 mw::Shm::Shm(struct wl_resource* resource, Version<1>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -647,13 +626,8 @@ struct mw::Buffer::Thunks
 int const mw::Buffer::Thunks::supported_version = 1;
 
 mw::Buffer::Buffer(struct wl_resource* resource, Version<1>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -803,13 +777,8 @@ struct mw::DataOffer::Thunks
 int const mw::DataOffer::Thunks::supported_version = 3;
 
 mw::DataOffer::DataOffer(DataDevice const& parent)
-    : client{wl_resource_get_client(parent.resource)},
-      resource{wl_resource_create(client, &wl_data_offer_interface_data, wl_resource_get_version(parent.resource), 0)}
+    : Resource{wl_resource_create(client, &wl_data_offer_interface_data, wl_resource_get_version(parent.resource), 0)}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -985,13 +954,8 @@ struct mw::DataSource::Thunks
 int const mw::DataSource::Thunks::supported_version = 3;
 
 mw::DataSource::DataSource(struct wl_resource* resource, Version<3>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -1225,13 +1189,8 @@ struct mw::DataDevice::Thunks
 int const mw::DataDevice::Thunks::supported_version = 3;
 
 mw::DataDevice::DataDevice(struct wl_resource* resource, Version<3>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -1436,13 +1395,8 @@ struct mw::DataDeviceManager::Thunks
 int const mw::DataDeviceManager::Thunks::supported_version = 3;
 
 mw::DataDeviceManager::DataDeviceManager(struct wl_resource* resource, Version<3>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -1577,13 +1531,8 @@ struct mw::Shell::Thunks
 int const mw::Shell::Thunks::supported_version = 1;
 
 mw::Shell::Shell(struct wl_resource* resource, Version<1>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -1849,13 +1798,8 @@ struct mw::ShellSurface::Thunks
 int const mw::ShellSurface::Thunks::supported_version = 1;
 
 mw::ShellSurface::ShellSurface(struct wl_resource* resource, Version<1>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -2194,13 +2138,8 @@ struct mw::Surface::Thunks
 int const mw::Surface::Thunks::supported_version = 4;
 
 mw::Surface::Surface(struct wl_resource* resource, Version<4>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -2421,13 +2360,8 @@ struct mw::Seat::Thunks
 int const mw::Seat::Thunks::supported_version = 8;
 
 mw::Seat::Seat(struct wl_resource* resource, Version<8>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -2592,13 +2526,8 @@ struct mw::Pointer::Thunks
 int const mw::Pointer::Thunks::supported_version = 8;
 
 mw::Pointer::Pointer(struct wl_resource* resource, Version<8>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -2863,13 +2792,8 @@ struct mw::Keyboard::Thunks
 int const mw::Keyboard::Thunks::supported_version = 8;
 
 mw::Keyboard::Keyboard(struct wl_resource* resource, Version<8>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -3011,13 +2935,8 @@ struct mw::Touch::Thunks
 int const mw::Touch::Thunks::supported_version = 8;
 
 mw::Touch::Touch(struct wl_resource* resource, Version<8>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -3211,13 +3130,8 @@ struct mw::Output::Thunks
 int const mw::Output::Thunks::supported_version = 3;
 
 mw::Output::Output(struct wl_resource* resource, Version<3>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -3429,13 +3343,8 @@ struct mw::Region::Thunks
 int const mw::Region::Thunks::supported_version = 1;
 
 mw::Region::Region(struct wl_resource* resource, Version<1>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -3554,13 +3463,8 @@ struct mw::Subcompositor::Thunks
 int const mw::Subcompositor::Thunks::supported_version = 1;
 
 mw::Subcompositor::Subcompositor(struct wl_resource* resource, Version<1>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 
@@ -3739,13 +3643,8 @@ struct mw::Subsurface::Thunks
 int const mw::Subsurface::Thunks::supported_version = 1;
 
 mw::Subsurface::Subsurface(struct wl_resource* resource, Version<1>)
-    : client{wl_resource_get_client(resource)},
-      resource{resource}
+    : Resource{resource}
 {
-    if (resource == nullptr)
-    {
-        BOOST_THROW_EXCEPTION((std::bad_alloc{}));
-    }
     wl_resource_set_implementation(resource, Thunks::request_vtable, this, &Thunks::resource_destroyed_thunk);
 }
 

--- a/tests/acceptance-tests/wayland-generator/expected.h
+++ b/tests/acceptance-tests/wayland-generator/expected.h
@@ -12,7 +12,8 @@
 #include "mir/fd.h"
 #include <wayland-server-core.h>
 
-#include "mir/wayland/wayland_base.h"
+#include "mir/wayland/resource.h"
+#include "mir/wayland/global.h"
 
 namespace mir
 {
@@ -54,9 +55,6 @@ public:
 
     void destroy_and_delete() const;
 
-    struct wl_client* const client;
-    struct wl_resource* const resource;
-
     struct Opcode
     {
         static uint32_t const done = 0;
@@ -80,9 +78,6 @@ public:
     virtual ~Compositor();
 
     void destroy_and_delete() const;
-
-    struct wl_client* const client;
-    struct wl_resource* const resource;
 
     struct Thunks;
 
@@ -115,9 +110,6 @@ public:
     ShmPool(struct wl_resource* resource, Version<1>);
     virtual ~ShmPool();
 
-    struct wl_client* const client;
-    struct wl_resource* const resource;
-
     struct Thunks;
 
     static bool is_instance(wl_resource* resource);
@@ -140,9 +132,6 @@ public:
     void send_format_event(uint32_t format) const;
 
     void destroy_and_delete() const;
-
-    struct wl_client* const client;
-    struct wl_resource* const resource;
 
     struct Error
     {
@@ -250,9 +239,6 @@ public:
 
     void send_release_event() const;
 
-    struct wl_client* const client;
-    struct wl_resource* const resource;
-
     struct Opcode
     {
         static uint32_t const release = 0;
@@ -282,9 +268,6 @@ public:
     bool version_supports_action();
     void send_action_event_if_supported(uint32_t dnd_action) const;
     void send_action_event(uint32_t dnd_action) const;
-
-    struct wl_client* const client;
-    struct wl_resource* const resource;
 
     struct Error
     {
@@ -335,9 +318,6 @@ public:
     void send_action_event_if_supported(uint32_t dnd_action) const;
     void send_action_event(uint32_t dnd_action) const;
 
-    struct wl_client* const client;
-    struct wl_resource* const resource;
-
     struct Error
     {
         static uint32_t const invalid_action_mask = 0;
@@ -380,9 +360,6 @@ public:
     void send_drop_event() const;
     void send_selection_event(std::optional<struct wl_resource*> const& id) const;
 
-    struct wl_client* const client;
-    struct wl_resource* const resource;
-
     struct Error
     {
         static uint32_t const role = 0;
@@ -418,9 +395,6 @@ public:
     virtual ~DataDeviceManager();
 
     void destroy_and_delete() const;
-
-    struct wl_client* const client;
-    struct wl_resource* const resource;
 
     struct DndAction
     {
@@ -463,9 +437,6 @@ public:
 
     void destroy_and_delete() const;
 
-    struct wl_client* const client;
-    struct wl_resource* const resource;
-
     struct Error
     {
         static uint32_t const role = 0;
@@ -506,9 +477,6 @@ public:
     void send_popup_done_event() const;
 
     void destroy_and_delete() const;
-
-    struct wl_client* const client;
-    struct wl_resource* const resource;
 
     struct Resize
     {
@@ -573,9 +541,6 @@ public:
     void send_enter_event(struct wl_resource* output) const;
     void send_leave_event(struct wl_resource* output) const;
 
-    struct wl_client* const client;
-    struct wl_resource* const resource;
-
     struct Error
     {
         static uint32_t const invalid_scale = 0;
@@ -618,9 +583,6 @@ public:
     bool version_supports_name();
     void send_name_event_if_supported(std::string const& name) const;
     void send_name_event(std::string const& name) const;
-
-    struct wl_client* const client;
-    struct wl_resource* const resource;
 
     struct Capability
     {
@@ -693,9 +655,6 @@ public:
     void send_axis_value120_event_if_supported(uint32_t axis, int32_t value120) const;
     void send_axis_value120_event(uint32_t axis, int32_t value120) const;
 
-    struct wl_client* const client;
-    struct wl_resource* const resource;
-
     struct Error
     {
         static uint32_t const role = 0;
@@ -762,9 +721,6 @@ public:
     void send_repeat_info_event_if_supported(int32_t rate, int32_t delay) const;
     void send_repeat_info_event(int32_t rate, int32_t delay) const;
 
-    struct wl_client* const client;
-    struct wl_resource* const resource;
-
     struct KeymapFormat
     {
         static uint32_t const no_keymap = 0;
@@ -816,9 +772,6 @@ public:
     void send_orientation_event_if_supported(int32_t id, double orientation) const;
     void send_orientation_event(int32_t id, double orientation) const;
 
-    struct wl_client* const client;
-    struct wl_resource* const resource;
-
     struct Opcode
     {
         static uint32_t const down = 0;
@@ -855,9 +808,6 @@ public:
     bool version_supports_scale();
     void send_scale_event_if_supported(int32_t factor) const;
     void send_scale_event(int32_t factor) const;
-
-    struct wl_client* const client;
-    struct wl_resource* const resource;
 
     struct Subpixel
     {
@@ -924,9 +874,6 @@ public:
     Region(struct wl_resource* resource, Version<1>);
     virtual ~Region();
 
-    struct wl_client* const client;
-    struct wl_resource* const resource;
-
     struct Thunks;
 
     static bool is_instance(wl_resource* resource);
@@ -945,9 +892,6 @@ public:
 
     Subcompositor(struct wl_resource* resource, Version<1>);
     virtual ~Subcompositor();
-
-    struct wl_client* const client;
-    struct wl_resource* const resource;
 
     struct Error
     {
@@ -983,9 +927,6 @@ public:
 
     Subsurface(struct wl_resource* resource, Version<1>);
     virtual ~Subsurface();
-
-    struct wl_client* const client;
-    struct wl_resource* const resource;
 
     struct Error
     {

--- a/tests/include/mir/test/doubles/mock_scene_session.h
+++ b/tests/include/mir/test/doubles/mock_scene_session.h
@@ -23,6 +23,7 @@
 #include "mir/input/mir_input_config.h"
 #include "mir/client_visible_error.h"
 #include "mir/shell/surface_specification.h"
+#include "mir/wayland/weak.h"
 
 #include <gmock/gmock.h>
 

--- a/tests/include/mir/test/doubles/mock_scene_session.h
+++ b/tests/include/mir/test/doubles/mock_scene_session.h
@@ -23,7 +23,6 @@
 #include "mir/input/mir_input_config.h"
 #include "mir/client_visible_error.h"
 #include "mir/shell/surface_specification.h"
-#include "mir/wayland/wayland_base.h"
 
 #include <gmock/gmock.h>
 

--- a/tests/integration-tests/input/test_single_seat_setup.cpp
+++ b/tests/integration-tests/input/test_single_seat_setup.cpp
@@ -48,7 +48,6 @@
 #include "mir/input/touch_visualizer.h"
 #include "mir/input/input_device_info.h"
 #include "mir/geometry/rectangles.h"
-#include "mir/wayland/wayland_base.h"
 #include "mir/test/input_config_matchers.h"
 #include "mir/test/fd_utils.h"
 

--- a/tests/integration-tests/test_surface_stack_with_compositor.cpp
+++ b/tests/integration-tests/test_surface_stack_with_compositor.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "mir/compositor/display_listener.h"
-#include "mir/wayland/wayland_base.h"
 #include "mir/renderer/renderer_factory.h"
 #include "src/server/report/null_report_factory.h"
 #include "src/server/scene/surface_stack.h"

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -25,7 +25,7 @@
 #include <mir/shell/focus_controller.h>
 #include <mir/shell/persistent_surface_store.h>
 #include "mir/graphics/display_configuration_observer.h"
-#include <mir/wayland/wayland_base.h>
+#include <mir/wayland/weak.h>
 
 #include <mir/test/doubles/stub_session.h>
 #include <mir/test/doubles/stub_surface.h>

--- a/tests/unit-tests/input/test_config_changer.cpp
+++ b/tests/unit-tests/input/test_config_changer.cpp
@@ -22,7 +22,6 @@
 #include "mir/scene/session_event_handler_register.h"
 #include "mir/input/input_device_observer.h"
 #include "mir/input/mir_touchscreen_config.h"
-#include "mir/wayland/wayland_base.h"
 
 #include "mir/test/doubles/mock_input_device_hub.h"
 #include "mir/test/doubles/mock_input_manager.h"

--- a/tests/unit-tests/input/test_default_input_manager.cpp
+++ b/tests/unit-tests/input/test_default_input_manager.cpp
@@ -22,7 +22,6 @@
 
 #include "mir/dispatch/multiplexing_dispatchable.h"
 #include "mir/dispatch/action_queue.h"
-#include "mir/wayland/weak.h"
 
 #include <sys/eventfd.h>
 

--- a/tests/unit-tests/input/test_default_input_manager.cpp
+++ b/tests/unit-tests/input/test_default_input_manager.cpp
@@ -22,6 +22,7 @@
 
 #include "mir/dispatch/multiplexing_dispatchable.h"
 #include "mir/dispatch/action_queue.h"
+#include "mir/wayland/weak.h"
 
 #include <sys/eventfd.h>
 

--- a/tests/unit-tests/input/test_seat_input_device_tracker.cpp
+++ b/tests/unit-tests/input/test_seat_input_device_tracker.cpp
@@ -28,6 +28,7 @@
 
 #include "mir/geometry/rectangles.h"
 #include "mir/cookie/authority.h"
+#include "mir/wayland/weak.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/tests/unit-tests/input/test_seat_input_device_tracker.cpp
+++ b/tests/unit-tests/input/test_seat_input_device_tracker.cpp
@@ -28,7 +28,6 @@
 
 #include "mir/geometry/rectangles.h"
 #include "mir/cookie/authority.h"
-#include "mir/wayland/weak.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/tests/unit-tests/scene/test_abstract_shell.cpp
+++ b/tests/unit-tests/scene/test_abstract_shell.cpp
@@ -22,6 +22,7 @@
 #include "mir/scene/session_container.h"
 #include "mir/scene/surface_factory.h"
 #include "mir/graphics/display_configuration_observer.h"
+#include "mir/wayland/weak.h"
 
 #include "src/server/report/null/shell_report.h"
 #include "src/include/server/mir/scene/session_event_sink.h"

--- a/tests/unit-tests/scene/test_mediating_display_changer.cpp
+++ b/tests/unit-tests/scene/test_mediating_display_changer.cpp
@@ -19,7 +19,6 @@
 #include "mir/graphics/display_configuration_policy.h"
 #include "src/server/scene/broadcasting_session_event_sink.h"
 #include "mir/server_action_queue.h"
-#include "mir/wayland/wayland_base.h"
 
 #include "mir/test/doubles/mock_display.h"
 #include "mir/test/doubles/mock_compositor.h"

--- a/tests/unit-tests/scene/test_session_manager.cpp
+++ b/tests/unit-tests/scene/test_session_manager.cpp
@@ -22,7 +22,6 @@
 #include "mir/graphics/display_configuration_observer.h"
 #include "mir/compositor/buffer_stream.h"
 #include "mir/scene/null_surface_observer.h"
-#include "mir/wayland/wayland_base.h"
 #include "src/server/scene/basic_surface.h"
 #include "src/include/server/mir/scene/session_event_sink.h"
 #include "src/server/report/null_report_factory.h"

--- a/tests/unit-tests/wayland/test_lifetime_tracker.cpp
+++ b/tests/unit-tests/wayland/test_lifetime_tracker.cpp
@@ -14,7 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "mir/wayland/wayland_base.h"
+#include "mir/wayland/lifetime_tracker.h"
+#include "mir/wayland/weak.h"
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>

--- a/tests/unit-tests/wayland/test_wayland_weak.cpp
+++ b/tests/unit-tests/wayland/test_wayland_weak.cpp
@@ -14,7 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "mir/wayland/wayland_base.h"
+#include "mir/wayland/lifetime_tracker.h"
+#include "mir/wayland/weak.h"
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>


### PR DESCRIPTION
Split up mirwayland header and source files. `wayland_base.h` is kept for API stability, but is not used internally. Also refactored `wayland::Resource` a bit to include `client` and `resource` members and null check (rather than the wrappers managing those things).