### PR TITLE
WaylandConnector: Fix use-after-free

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -234,13 +234,13 @@ mf::WaylandConnector::WaylandConnector(
     std::unique_ptr<WaylandExtensions> extensions_,
     WaylandProtocolExtensionFilter const& extension_filter,
     bool enable_key_repeat)
-    : display{wl_display_create(), &cleanup_display},
+    : extension_filter{extension_filter},
+      display{wl_display_create(), &cleanup_display},
       pause_signal{eventfd(0, EFD_CLOEXEC | EFD_SEMAPHORE)},
       executor{std::make_shared<WaylandExecutor>(wl_display_get_event_loop(display.get()))},
       allocator{allocator_for_display(allocator, display.get(), executor)},
       shell{shell},
-      extensions{std::move(extensions_)},
-      extension_filter{extension_filter}
+      extensions{std::move(extensions_)}
 {
     if (pause_signal == mir::Fd::invalid)
     {

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -164,6 +164,17 @@ private:
     bool wl_display_global_filter_func(wl_client const* client, wl_global const* global) const;
     static bool wl_display_global_filter_func_thunk(wl_client const* client, wl_global const* global, void* data);
 
+    /* The wayland global filter is called during wl_global_remove
+     * (libwayland needs to know if it should broadcast the removal)
+     *
+     * This means the filter needs to outlive any extension object
+     * that provides a wl_global (which is all of them).
+     *
+     * For safety, just ensure it outlives the wl_display. libwayland
+     * cannot *possibly* call it after then :)
+     */
+    WaylandProtocolExtensionFilter const extension_filter;
+
     std::unique_ptr<wl_display, void(*)(wl_display*)> const display;
     mir::Fd const pause_signal;
     std::unique_ptr<WlCompositor> compositor_global;
@@ -178,8 +189,6 @@ private:
     std::thread dispatch_thread;
     wl_event_source* pause_source;
     std::string wayland_display;
-
-    WaylandProtocolExtensionFilter const extension_filter;
 
     // Only accessed on event loop
     std::unordered_map<int, std::function<void(std::shared_ptr<scene::Session> const& session)>> mutable connect_handlers;


### PR DESCRIPTION
The libwayland global filter is called during wl_global_remove (sensibly, as it needs to know whether or not the client knows about the global that's being removed).

This means that the filter will be called from the destructor of any extension object that publishes a global (ie: all of them).

Ensure it lives long enough to avoid UAF.