### PR TITLE
Deactivate text input in destructor for v1 and v2 protocols

### DIFF
--- a/src/server/frontend_wayland/text_input_v1.cpp
+++ b/src/server/frontend_wayland/text_input_v1.cpp
@@ -259,6 +259,7 @@ TextInputV1::~TextInputV1()
 
     on_new_input_field = false;
     pending_state.reset();
+    ctx->text_input_hub->deactivate_handler(handler);
 }
 
 void TextInputV1::send_text_change(ms::TextInputChange const& change)

--- a/src/server/frontend_wayland/text_input_v2.cpp
+++ b/src/server/frontend_wayland/text_input_v2.cpp
@@ -265,6 +265,7 @@ mf::TextInputV2::TextInputV2(
 mf::TextInputV2::~TextInputV2()
 {
     seat.remove_focus_listener(client, this);
+    ctx->text_input_hub->deactivate_handler(handler);
 }
 
 void mf::TextInputV2::send_text_change(ms::TextInputChange const& change)


### PR DESCRIPTION
~~Fixes #2651,~~ should have been included in #2270