### PR TITLE
Server/run_mir: Fix build failure.

### DIFF
--- a/src/server/run_mir.cpp
+++ b/src/server/run_mir.cpp
@@ -160,7 +160,9 @@ extern "C" [[noreturn]] void fatal_signal_cleanup(int sig, siginfo_t* info, void
          */
         constexpr char const* warning = "!!! Fatal signal received. Attempting cleanup, but deadlock may occur";
         constexpr size_t len = std::char_traits<char>::length(warning);
-        static_cast<void>(write(STDERR_FILENO, warning, len));
+        // We cannot possibly do anything sensible if this write fails, so ignore the return value.
+        // Note: static_cast<void>() is *not* sufficient to silence this warning on all compilers
+        (void)write(STDERR_FILENO, warning, len);
     }
     perform_emergency_cleanup();
 


### PR DESCRIPTION
*Of course* there exist compilers for which `static_cast<void>(foo)` does not disable the “must-use return value” warning for `write()`…

Fixes: #2663