### PR TITLE
Support scaled screenshots

### DIFF
--- a/include/platform/mir/renderer/sw/pixel_source.h
+++ b/include/platform/mir/renderer/sw/pixel_source.h
@@ -66,7 +66,7 @@ public:
 /**
  * A Buffer that can be mapped into CPU-accessible memory and directly written to.
  */
-class WriteMappableBuffer
+class WriteMappableBuffer : public virtual BufferDescriptor
 {
 public:
     virtual ~WriteMappableBuffer() = default;
@@ -88,7 +88,7 @@ public:
 /**
  * A Buffer that can be mapped into CPU-readable memory.
  */
-class ReadMappableBuffer
+class ReadMappableBuffer : public virtual BufferDescriptor
 {
 public:
     virtual ~ReadMappableBuffer() = default;

--- a/include/renderers/gl/mir/renderer/gl/basic_buffer_render_target.h
+++ b/include/renderers/gl/mir/renderer/gl/basic_buffer_render_target.h
@@ -38,6 +38,7 @@ public:
 
     void set_buffer(std::shared_ptr<software::WriteMappableBuffer> const& buffer) override;
 
+    auto size() const -> geometry::Size override;
     void make_current() override;
     void release_current() override;
     void swap_buffers() override;

--- a/include/renderers/gl/mir/renderer/gl/basic_buffer_render_target.h
+++ b/include/renderers/gl/mir/renderer/gl/basic_buffer_render_target.h
@@ -36,9 +36,7 @@ class BasicBufferRenderTarget: public BufferRenderTarget
 public:
     BasicBufferRenderTarget(std::shared_ptr<Context> const& ctx);
 
-    void set_buffer(
-        std::shared_ptr<software::WriteMappableBuffer> const& buffer,
-        geometry::Size const& size) override;
+    void set_buffer(std::shared_ptr<software::WriteMappableBuffer> const& buffer) override;
 
     void make_current() override;
     void release_current() override;

--- a/include/renderers/gl/mir/renderer/gl/buffer_render_target.h
+++ b/include/renderers/gl/mir/renderer/gl/buffer_render_target.h
@@ -37,9 +37,7 @@ namespace gl
 class BufferRenderTarget: public RenderTarget
 {
 public:
-    virtual void set_buffer(
-        std::shared_ptr<software::WriteMappableBuffer> const& buffer,
-        geometry::Size const& size) = 0;
+    virtual void set_buffer(std::shared_ptr<software::WriteMappableBuffer> const& buffer) = 0;
 };
 
 }

--- a/include/renderers/gl/mir/renderer/gl/render_target.h
+++ b/include/renderers/gl/mir/renderer/gl/render_target.h
@@ -17,6 +17,8 @@
 #ifndef MIR_RENDERER_GL_RENDER_TARGET_H_
 #define MIR_RENDERER_GL_RENDER_TARGET_H_
 
+#include <mir/geometry/forward.h>
+
 namespace mir
 {
 namespace renderer
@@ -29,6 +31,8 @@ class RenderTarget
 public:
     virtual ~RenderTarget() = default;
 
+    /** Returns the current size in pixels of the render target */
+    virtual auto size() const -> geometry::Size = 0;
     /** Makes GL render target current to calling thread */
     virtual void make_current() = 0;
     /** Releases the current GL render target. */

--- a/src/platform/graphics/cpu_buffers.cpp
+++ b/src/platform/graphics/cpu_buffers.cpp
@@ -118,6 +118,10 @@ auto mrs::as_read_mappable_buffer(
                     &noop>>(buffer);
         }
 
+        auto format() const -> MirPixelFormat override { return buffer->format(); }
+        auto stride() const -> geometry::Stride override { return buffer->stride(); }
+        auto size() const -> geometry::Size override { return buffer->size(); }
+
     private:
         std::shared_ptr<ReadTransferableBuffer> const buffer;
 
@@ -158,6 +162,10 @@ auto as_write_mappable_buffer(
                     &noop,
                     &write_to_buffer>>(buffer);
         }
+
+        auto format() const -> MirPixelFormat override { return buffer->format(); }
+        auto stride() const -> geom::Stride override { return buffer->stride(); }
+        auto size() const -> geom::Size override { return buffer->size(); }
 
     private:
         std::shared_ptr<mrs::WriteTransferableBuffer> const buffer;

--- a/src/platforms/common/server/buffer_from_wl_shm.cpp
+++ b/src/platforms/common/server/buffer_from_wl_shm.cpp
@@ -391,7 +391,7 @@ public:
 
             auto size() const -> mir::geometry::Size override
             {
-                return parent->ShmBuffer::size();
+                return parent->size();
             }
 
             auto data() -> T* override
@@ -463,7 +463,7 @@ public:
                 mir::geometry::Stride stride_;
             };
 
-            return std::make_unique<FallbackMapping>(pixel_format(), ShmBuffer::size(), stride_);
+            return std::make_unique<FallbackMapping>(pixel_format(), size(), stride_);
         }
     }
 

--- a/src/platforms/common/server/buffer_from_wl_shm.cpp
+++ b/src/platforms/common/server/buffer_from_wl_shm.cpp
@@ -37,6 +37,7 @@
 
 namespace mg = mir::graphics;
 namespace mgc = mir::graphics::common;
+namespace geom = mir::geometry;
 
 namespace mir
 {
@@ -390,7 +391,7 @@ public:
 
             auto size() const -> mir::geometry::Size override
             {
-                return parent->size();
+                return parent->ShmBuffer::size();
             }
 
             auto data() -> T* override
@@ -462,9 +463,13 @@ public:
                 mir::geometry::Stride stride_;
             };
 
-            return std::make_unique<FallbackMapping>(pixel_format(), size(), stride_);
+            return std::make_unique<FallbackMapping>(pixel_format(), ShmBuffer::size(), stride_);
         }
     }
+
+    auto format() const -> MirPixelFormat override { return ShmBuffer::pixel_format(); }
+    auto stride() const -> geom::Stride override { return stride_; }
+    auto size() const -> geom::Size override { return ShmBuffer::size(); }
 
 private:
     void notify_consumed()

--- a/src/platforms/common/server/shm_buffer.h
+++ b/src/platforms/common/server/shm_buffer.h
@@ -90,6 +90,10 @@ public:
 
     void bind() override;
 
+    auto format() const -> MirPixelFormat override { return ShmBuffer::pixel_format(); }
+    auto stride() const -> geometry::Stride override { return stride_; }
+    auto size() const -> geometry::Size override { return ShmBuffer::size(); }
+
     MemoryBackedShmBuffer(MemoryBackedShmBuffer const&) = delete;
     MemoryBackedShmBuffer& operator=(MemoryBackedShmBuffer const&) = delete;
 private:

--- a/src/platforms/eglstream-kms/server/display.cpp
+++ b/src/platforms/eglstream-kms/server/display.cpp
@@ -139,6 +139,7 @@ public:
           layer{output.output_layer()},
           crtc_id{output.crtc_id()},
           view_area_{output.extents()},
+          output_size{output.size()},
           transform{output.transformation()},
           drm_node{std::move(drm_node)},
           event_handler{std::move(event_handler)},
@@ -172,8 +173,8 @@ public:
         };
 
         EGLint const surface_attribs[] = {
-            EGL_WIDTH, output.size().width.as_int(),
-            EGL_HEIGHT, output.size().height.as_int(),
+            EGL_WIDTH, output_size.width.as_int(),
+            EGL_HEIGHT, output_size.height.as_int(),
             EGL_NONE,
         };
         surface = eglCreateStreamProducerSurfaceKHR(dpy, config, output_stream, surface_attribs);
@@ -193,6 +194,11 @@ public:
     }
 
     /* gl::RenderTarget */
+    auto size() const -> mir::geometry::Size override
+    {
+        return output_size;
+    }
+
     void make_current() override
     {
         if (eglMakeCurrent(dpy, surface, surface, ctx) != EGL_TRUE)
@@ -285,6 +291,7 @@ private:
     EGLOutputLayerEXT layer;
     uint32_t crtc_id;
     mir::geometry::Rectangle const view_area_;
+    mir::geometry::Size const output_size;
     glm::mat2 const transform;
     EGLStreamKHR output_stream;
     EGLSurface surface;

--- a/src/platforms/gbm-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.cpp
@@ -729,6 +729,11 @@ void mgg::DisplayBuffer::wait_for_page_flip()
     }
 }
 
+auto mgg::DisplayBuffer::size() const -> geometry::Size
+{
+    return surface.size();
+}
+
 void mgg::DisplayBuffer::make_current()
 {
     surface.make_current();
@@ -777,6 +782,10 @@ mgg::GBMOutputSurface::GBMOutputSurface(GBMOutputSurface&& from)
 {
 }
 
+auto mgg::GBMOutputSurface::GBMOutputSurface::size() const -> geometry::Size
+{
+    return {width, height};
+}
 
 void mgg::GBMOutputSurface::make_current()
 {

--- a/src/platforms/gbm-kms/server/kms/display_buffer.h
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.h
@@ -76,6 +76,7 @@ public:
     GBMOutputSurface(GBMOutputSurface&& from);
 
     // gl::RenderTarget
+    auto size() const -> geometry::Size override;
     void make_current() override;
     void release_current() override;
     void swap_buffers() override;
@@ -83,7 +84,6 @@ public:
 
     FrontBuffer lock_front();
     void report_egl_configuration(std::function<void(EGLDisplay, EGLConfig)> const& to);
-    geometry::Size size() const { return {width, height}; }
 private:
     int const drm_fd;
     uint32_t width, height;
@@ -106,6 +106,7 @@ public:
     ~DisplayBuffer();
 
     geometry::Rectangle view_area() const override;
+    auto size() const -> geometry::Size override;
     void make_current() override;
     void release_current() override;
     void swap_buffers() override;

--- a/src/platforms/rpi-dispmanx/display_buffer.cpp
+++ b/src/platforms/rpi-dispmanx/display_buffer.cpp
@@ -324,6 +324,11 @@ mg::NativeDisplayBuffer* mg::rpi::DisplayBuffer::native_display_buffer()
     return this;
 }
 
+auto mg::rpi::DisplayBuffer::size() const -> geometry::Size
+{
+    return view.size;
+}
+
 void mg::rpi::DisplayBuffer::make_current()
 {
     if (eglMakeCurrent(dpy, surface, surface, ctx) != EGL_TRUE)

--- a/src/platforms/rpi-dispmanx/display_buffer.h
+++ b/src/platforms/rpi-dispmanx/display_buffer.h
@@ -53,6 +53,7 @@ public:
     glm::mat2 transformation() const override;
     NativeDisplayBuffer* native_display_buffer() override;
 
+    auto size() const -> geometry::Size override;
     void make_current() override;
     void release_current() override;
     void swap_buffers() override;

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -182,6 +182,7 @@ mgx::Display::Display(std::shared_ptr<mir::X::X11Resources> const& x11_resources
             configuration->id,
             *window,
             configuration->extents(),
+            actual_size,
             shared_egl.context(),
             last_frame,
             report,
@@ -342,7 +343,8 @@ void mgx::Display::OutputInfo::set_size(geometry::Size const& size)
         return;
     }
     config->modes[0].size = size;
-    display_buffer->set_view_area({display_buffer->view_area().top_left, size});
+    display_buffer->set_size(size);
+    display_buffer->set_view_area(config->extents());
     auto const handlers = owner->config_change_handlers;
 
     lock.unlock();

--- a/src/platforms/x11/graphics/display_buffer.cpp
+++ b/src/platforms/x11/graphics/display_buffer.cpp
@@ -30,12 +30,14 @@ mgx::DisplayBuffer::DisplayBuffer(::Display* const x_dpy,
                                   DisplayConfigurationOutputId output_id,
                                   xcb_window_t win,
                                   geometry::Rectangle const& view_area,
+                                  geometry::Size const& window_size,
                                   EGLContext const shared_context,
                                   std::shared_ptr<AtomicFrame> const& f,
                                   std::shared_ptr<DisplayReport> const& r,
                                   GLConfig const& gl_config)
                                   : report{r},
                                     area{view_area},
+                                    window_size{window_size},
                                     transform(1),
                                     egl{gl_config, x_dpy, win, shared_context},
                                     last_frame{f},
@@ -82,6 +84,11 @@ mgx::DisplayBuffer::DisplayBuffer(::Display* const x_dpy,
 geom::Rectangle mgx::DisplayBuffer::view_area() const
 {
     return area;
+}
+
+auto mgx::DisplayBuffer::size() const -> geom::Size
+{
+    return window_size;
 }
 
 void mgx::DisplayBuffer::make_current()
@@ -150,6 +157,11 @@ glm::mat2 mgx::DisplayBuffer::transformation() const
 void mgx::DisplayBuffer::set_view_area(geom::Rectangle const& a)
 {
     area = a;
+}
+
+void mgx::DisplayBuffer::set_size(geom::Size const& size)
+{
+    window_size = size;
 }
 
 void mgx::DisplayBuffer::set_transformation(glm::mat2 const& t)

--- a/src/platforms/x11/graphics/display_buffer.h
+++ b/src/platforms/x11/graphics/display_buffer.h
@@ -49,18 +49,21 @@ public:
             DisplayConfigurationOutputId output_id,
             xcb_window_t win,
             geometry::Rectangle const& view_area,
+            geometry::Size const& window_size,
             EGLContext const shared_context,
             std::shared_ptr<AtomicFrame> const& f,
             std::shared_ptr<DisplayReport> const& r,
             GLConfig const& gl_config);
 
     geometry::Rectangle view_area() const override;
+    auto size() const -> geometry::Size override;
     void make_current() override;
     void release_current() override;
     void swap_buffers() override;
     void bind() override;
     bool overlay(RenderableList const& renderlist) override;
     void set_view_area(geometry::Rectangle const& a);
+    void set_size(geometry::Size const& size);
     void set_transformation(glm::mat2 const& t);
 
     void for_each_display_buffer(
@@ -74,6 +77,7 @@ public:
 private:
     std::shared_ptr<DisplayReport> const report;
     geometry::Rectangle area;
+    geometry::Size window_size;
     glm::mat2 transform;
     helpers::EGLHelper const egl;
     std::shared_ptr<AtomicFrame> const last_frame;

--- a/src/renderers/gl/basic_buffer_render_target.cpp
+++ b/src/renderers/gl/basic_buffer_render_target.cpp
@@ -113,17 +113,15 @@ mrg::BasicBufferRenderTarget::BasicBufferRenderTarget(std::shared_ptr<Context> c
 {
 }
 
-void mrg::BasicBufferRenderTarget::set_buffer(
-    std::shared_ptr<software::WriteMappableBuffer> const& buffer,
-    geometry::Size const& size)
+void mrg::BasicBufferRenderTarget::set_buffer(std::shared_ptr<software::WriteMappableBuffer> const& buffer)
 {
     this->buffer = buffer;
-    if (framebuffer && framebuffer->size == size)
+    if (framebuffer && framebuffer->size == buffer->size())
     {
         return;
     }
     framebuffer.reset();
-    framebuffer.emplace(size);
+    framebuffer.emplace(buffer->size());
 }
 
 void mrg::BasicBufferRenderTarget::make_current()

--- a/src/renderers/gl/basic_buffer_render_target.cpp
+++ b/src/renderers/gl/basic_buffer_render_target.cpp
@@ -124,6 +124,18 @@ void mrg::BasicBufferRenderTarget::set_buffer(std::shared_ptr<software::WriteMap
     framebuffer.emplace(buffer->size());
 }
 
+auto mrg::BasicBufferRenderTarget::size() const -> geometry::Size
+{
+    if (framebuffer)
+    {
+        return framebuffer.value().size;
+    }
+    else
+    {
+        return {};
+    }
+}
+
 void mrg::BasicBufferRenderTarget::make_current()
 {
     ctx->make_current();

--- a/src/renderers/gl/renderer.cpp
+++ b/src/renderers/gl/renderer.cpp
@@ -602,33 +602,31 @@ void mrg::Renderer::update_gl_viewport()
      * the logical viewport aspect ratio doesn't match the display aspect.
      * This keeps pixels square. Note "black"-bars are really glClearColor.
      */
-    render_target.ensure_current();
+
+    auto const buf_size = render_target.size();
+    GLint const buf_width = buf_size.width.as_value(), buf_height = buf_size.height.as_value();
+    if (!buf_width || !buf_height)
+    {
+        return;
+    }
 
     auto transformed_viewport = display_transform *
                                 glm::vec4(viewport.size.width.as_int(),
                                           viewport.size.height.as_int(), 0, 1);
     auto viewport_width = fabs(transformed_viewport[0]);
     auto viewport_height = fabs(transformed_viewport[1]);
-    auto dpy = eglGetCurrentDisplay();
-    auto surf = eglGetCurrentSurface(EGL_DRAW);
-    EGLint buf_width = 0, buf_height = 0;
 
-    if (viewport_width > 0.0f && viewport_height > 0.0f &&
-        eglQuerySurface(dpy, surf, EGL_WIDTH, &buf_width) && buf_width > 0 &&
-        eglQuerySurface(dpy, surf, EGL_HEIGHT, &buf_height) && buf_height > 0)
-    {
-        GLint reduced_width = buf_width, reduced_height = buf_height;
-        // if viewport_aspect_ratio >= buf_aspect_ratio
-        if (viewport_width * buf_height >= buf_width * viewport_height)
-            reduced_height = buf_width * viewport_height / viewport_width;
-        else
-            reduced_width = buf_height * viewport_width / viewport_height;
+    GLint reduced_width = buf_width, reduced_height = buf_height;
+    // if viewport_aspect_ratio >= buf_aspect_ratio
+    if (viewport_width * buf_height >= buf_width * viewport_height)
+        reduced_height = buf_width * viewport_height / viewport_width;
+    else
+        reduced_width = buf_height * viewport_width / viewport_height;
 
-        GLint offset_x = (buf_width - reduced_width) / 2;
-        GLint offset_y = (buf_height - reduced_height) / 2;
+    GLint offset_x = (buf_width - reduced_width) / 2;
+    GLint offset_y = (buf_height - reduced_height) / 2;
 
-        glViewport(offset_x, offset_y, reduced_width, reduced_height);
-    }
+    glViewport(offset_x, offset_y, reduced_width, reduced_height);
 }
 
 void mrg::Renderer::set_output_transform(glm::mat2 const& t)
@@ -644,4 +642,3 @@ void mrg::Renderer::set_output_transform(glm::mat2 const& t)
 void mrg::Renderer::suspend()
 {
 }
-

--- a/src/renderers/gl/renderer.cpp
+++ b/src/renderers/gl/renderer.cpp
@@ -55,6 +55,11 @@ mrg::CurrentRenderTarget::~CurrentRenderTarget()
     render_target->release_current();
 }
 
+auto mrg::CurrentRenderTarget::size() const -> geom::Size
+{
+    return render_target->size();
+}
+
 void mrg::CurrentRenderTarget::ensure_current()
 {
     render_target->make_current();

--- a/src/renderers/gl/renderer.h
+++ b/src/renderers/gl/renderer.h
@@ -43,6 +43,7 @@ public:
     CurrentRenderTarget(RenderTarget& render_target);
     ~CurrentRenderTarget();
 
+    auto size() const -> geometry::Size;
     void ensure_current();
     void bind();
     void swap_buffers();

--- a/src/server/compositor/basic_screen_shooter.cpp
+++ b/src/server/compositor/basic_screen_shooter.cpp
@@ -62,7 +62,6 @@ auto mc::BasicScreenShooter::Self::render(
     render_target->set_buffer(buffer, area.size);
 
     render_target->bind();
-    renderer->set_output_transform(glm::mat2{1});
     renderer->set_viewport(area);
     renderer->render(renderable_list);
 

--- a/src/server/compositor/basic_screen_shooter.cpp
+++ b/src/server/compositor/basic_screen_shooter.cpp
@@ -59,7 +59,7 @@ auto mc::BasicScreenShooter::Self::render(
     scene_elements.clear();
 
     render_target->make_current();
-    render_target->set_buffer(buffer, area.size);
+    render_target->set_buffer(buffer);
 
     render_target->bind();
     renderer->set_viewport(area);

--- a/src/server/frontend_wayland/wlr_screencopy_v1.h
+++ b/src/server/frontend_wayland/wlr_screencopy_v1.h
@@ -56,12 +56,20 @@ class WlrScreencopyV1DamageTracker : public wayland::LifetimeTracker
 public:
     struct FrameParams
     {
-        geometry::Rectangle area;
         wl_resource* output;
+        geometry::Rectangle output_space_area;
+        geometry::Size buffer_size;
 
         auto operator==(FrameParams const& other) const -> bool
         {
-            return area == other.area && output == other.output;
+            return output == other.output &&
+                   output_space_area == other.output_space_area &&
+                   buffer_size == other.buffer_size;
+        }
+
+        auto full_buffer_space_damage() const -> geometry::Rectangle
+        {
+            return {{}, buffer_size};
         }
     };
 
@@ -71,7 +79,7 @@ public:
         virtual ~Frame() = default;
         virtual auto destroyed_flag() const -> std::shared_ptr<bool const> = 0;
         virtual auto parameters() const -> FrameParams const& = 0;
-        virtual void capture(std::optional<geometry::Rectangle> const& damage) = 0;
+        virtual void capture(geometry::Rectangle buffer_space_damage) = 0;
     };
 
     WlrScreencopyV1DamageTracker(Executor& wayland_executor, SurfaceStack& surface_stack);

--- a/tests/include/mir/test/doubles/mock_gl_display_buffer.h
+++ b/tests/include/mir/test/doubles/mock_gl_display_buffer.h
@@ -31,10 +31,11 @@ class MockGLDisplayBuffer : public MockDisplayBuffer,
                             public renderer::gl::RenderTarget
 {
 public:
-    MOCK_METHOD0(make_current, void());
-    MOCK_METHOD0(release_current, void());
-    MOCK_METHOD0(swap_buffers, void());
-    MOCK_METHOD0(bind, void());
+    MOCK_METHOD(geometry::Size, size, (), (const, override));
+    MOCK_METHOD(void, make_current, (), (override));
+    MOCK_METHOD(void, release_current, (), (override));
+    MOCK_METHOD(void, swap_buffers, (), (override));
+    MOCK_METHOD(void, bind, (), (override));
 };
 
 }

--- a/tests/include/mir/test/doubles/stub_buffer.h
+++ b/tests/include/mir/test/doubles/stub_buffer.h
@@ -126,6 +126,10 @@ public:
 
     virtual MirPixelFormat pixel_format() const override { return buf_pixel_format; }
 
+    auto format() const -> MirPixelFormat override { return buf_pixel_format; }
+
+    auto stride() const -> geometry::Stride override { return buf_stride; }
+
     template<typename T>
     class Mapping : public mir::renderer::software::Mapping<T>
     {

--- a/tests/include/mir/test/doubles/stub_gl_display_buffer.h
+++ b/tests/include/mir/test/doubles/stub_gl_display_buffer.h
@@ -34,6 +34,7 @@ public:
     using StubDisplayBuffer::StubDisplayBuffer;
     StubGLDisplayBuffer(StubGLDisplayBuffer const& s) : StubDisplayBuffer(s) {}
 
+    auto size() const -> geometry::Size override { return {}; }
     void make_current() override {}
     void release_current() override {}
     void swap_buffers() override {}

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -47,6 +47,7 @@ class MockBufferRenderTarget: public mrg::BufferRenderTarget
 {
 public:
     MOCK_METHOD(void, set_buffer, (std::shared_ptr<mrs::WriteMappableBuffer> const& buffer), (override));
+    MOCK_METHOD(geom::Size, size, (), (const, override));
     MOCK_METHOD(void, make_current, (), (override));
     MOCK_METHOD(void, release_current, (), (override));
     MOCK_METHOD(void, swap_buffers, (), (override));

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -130,7 +130,6 @@ TEST_F(BasicScreenShooter, sets_viewport_correctly_before_render)
             callback.Call(time);
         });
     Sequence a, b;
-    EXPECT_CALL(renderer, set_output_transform(Eq(glm::mat2{1}))).InSequence(a);
     EXPECT_CALL(renderer, set_viewport(Eq(viewport_rect))).InSequence(b);
     EXPECT_CALL(renderer, render(_)).InSequence(a, b);
     EXPECT_CALL(callback, Call(std::make_optional(clock.now()))).InSequence(a, b);

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -46,9 +46,7 @@ namespace
 class MockBufferRenderTarget: public mrg::BufferRenderTarget
 {
 public:
-    MOCK_METHOD(void, set_buffer, (
-        std::shared_ptr<mrs::WriteMappableBuffer> const& buffer,
-        geom::Size const& size), (override));
+    MOCK_METHOD(void, set_buffer, (std::shared_ptr<mrs::WriteMappableBuffer> const& buffer), (override));
     MOCK_METHOD(void, make_current, (), (override));
     MOCK_METHOD(void, release_current, (), (override));
     MOCK_METHOD(void, swap_buffers, (), (override));
@@ -146,7 +144,7 @@ TEST_F(BasicScreenShooter, sets_buffer_before_render)
         });
     InSequence seq;
     EXPECT_CALL(render_target, make_current());
-    EXPECT_CALL(render_target, set_buffer(Eq(mt::fake_shared(buffer)), Eq(viewport_rect.size)));
+    EXPECT_CALL(render_target, set_buffer(Eq(mt::fake_shared(buffer))));
     EXPECT_CALL(render_target, bind());
     EXPECT_CALL(renderer, render(_));
     EXPECT_CALL(render_target, release_current());

--- a/tests/unit-tests/renderers/gl/test_basic_buffer_render_target.cpp
+++ b/tests/unit-tests/renderers/gl/test_basic_buffer_render_target.cpp
@@ -55,7 +55,7 @@ TEST_F(BasicBufferRenderTarget, set_buffer_always_allocs_correct_storage)
 {
     mrg::BasicBufferRenderTarget render_target{mt::fake_shared(ctx)};
     EXPECT_CALL(mock_gl, glRenderbufferStorage(_, _, reasonable_width, reasonable_height));
-    render_target.set_buffer(mt::fake_shared(reasonable_buffer), reasonable_size);
+    render_target.set_buffer(mt::fake_shared(reasonable_buffer));
     render_target.swap_buffers();
     Mock::VerifyAndClearExpectations(&mock_gl);
     int const other_width = 124, other_height = 88;
@@ -64,7 +64,7 @@ TEST_F(BasicBufferRenderTarget, set_buffer_always_allocs_correct_storage)
         reasonable_pixel_format,
         mg::BufferUsage::software}};
     EXPECT_CALL(mock_gl, glRenderbufferStorage(_, _, other_width, other_height));
-    render_target.set_buffer(mt::fake_shared(other_buffer), {other_width, other_height});
+    render_target.set_buffer(mt::fake_shared(other_buffer));
     render_target.swap_buffers();
 }
 
@@ -72,7 +72,7 @@ TEST_F(BasicBufferRenderTarget, sets_gl_viewport_on_buffer_size_change)
 {
     mrg::BasicBufferRenderTarget render_target{mt::fake_shared(ctx)};
     EXPECT_CALL(mock_gl, glViewport(0, 0, reasonable_width, reasonable_height));
-    render_target.set_buffer(mt::fake_shared(reasonable_buffer), reasonable_size);
+    render_target.set_buffer(mt::fake_shared(reasonable_buffer));
     Mock::VerifyAndClearExpectations(&mock_gl);
     int const other_width = 124, other_height = 88;
     mtd::StubBuffer other_buffer{{
@@ -80,7 +80,7 @@ TEST_F(BasicBufferRenderTarget, sets_gl_viewport_on_buffer_size_change)
         reasonable_pixel_format,
         mg::BufferUsage::software}};
     EXPECT_CALL(mock_gl, glViewport(0, 0, other_width, other_height));
-    render_target.set_buffer(mt::fake_shared(other_buffer), {other_width, other_height});
+    render_target.set_buffer(mt::fake_shared(other_buffer));
 }
 
 TEST_F(BasicBufferRenderTarget, cleans_up_framebuffers_and_renderbuffers)
@@ -110,7 +110,7 @@ TEST_F(BasicBufferRenderTarget, cleans_up_framebuffers_and_renderbuffers)
     {
         mrg::BasicBufferRenderTarget render_target{mt::fake_shared(ctx)};
         render_target.make_current();
-        render_target.set_buffer(mt::fake_shared(reasonable_buffer), reasonable_size);
+        render_target.set_buffer(mt::fake_shared(reasonable_buffer));
         render_target.bind();
         render_target.swap_buffers();
         int const other_width = 124, other_height = 88;
@@ -118,7 +118,7 @@ TEST_F(BasicBufferRenderTarget, cleans_up_framebuffers_and_renderbuffers)
             {other_width, other_height},
             reasonable_pixel_format,
             mg::BufferUsage::software}};
-        render_target.set_buffer(mt::fake_shared(other_buffer), {other_width, other_height});
+        render_target.set_buffer(mt::fake_shared(other_buffer));
         render_target.bind();
         render_target.swap_buffers();
     }
@@ -131,7 +131,7 @@ TEST_F(BasicBufferRenderTarget, cleans_up_framebuffers_and_renderbuffers)
 TEST_F(BasicBufferRenderTarget, reads_pixels)
 {
     mrg::BasicBufferRenderTarget render_target{mt::fake_shared(ctx)};
-    render_target.set_buffer(mt::fake_shared(reasonable_buffer), reasonable_size);
+    render_target.set_buffer(mt::fake_shared(reasonable_buffer));
     EXPECT_CALL(mock_gl, glReadPixels(0, 0, reasonable_width, reasonable_height, _, _, _));
     render_target.swap_buffers();
 }
@@ -141,18 +141,10 @@ TEST_F(BasicBufferRenderTarget, throws_on_invalid_buffer)
     mrg::BasicBufferRenderTarget render_target{mt::fake_shared(ctx)};
     EXPECT_THROW({
         mtd::StubBuffer buffer({
-            {55, 66}, // wrong size
-            reasonable_pixel_format,
-            mg::BufferUsage::software});
-        render_target.set_buffer(mt::fake_shared(buffer), {10, 20});
-        render_target.swap_buffers();
-    }, std::logic_error);
-    EXPECT_THROW({
-        mtd::StubBuffer buffer({
             reasonable_size,
             mir_pixel_format_abgr_8888, // wrong format
             mg::BufferUsage::software});
-        render_target.set_buffer(mt::fake_shared(buffer), reasonable_size);
+        render_target.set_buffer(mt::fake_shared(buffer));
         render_target.swap_buffers();
     }, std::logic_error);
 }

--- a/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
+++ b/tests/unit-tests/renderers/gl/test_gl_renderer.cpp
@@ -345,12 +345,8 @@ TEST_F(GLRenderer, unchanged_viewport_avoids_gl_calls)
     int const screen_height = 1080;
     mir::geometry::Rectangle const view_area{{0,0}, {1920,1080}};
 
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_WIDTH,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_width),
-                             Return(EGL_TRUE)));
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_HEIGHT,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_height),
-                             Return(EGL_TRUE)));
+    ON_CALL(mock_display_buffer, size())
+        .WillByDefault(Return(mir::geometry::Size{screen_width, screen_height}));
 
     mrg::Renderer renderer(mock_display_buffer);
 
@@ -367,12 +363,8 @@ TEST_F(GLRenderer, unchanged_viewport_updates_gl_if_rotated)
     int const screen_height = 1080;
     mir::geometry::Rectangle const view_area{{0,0}, {1920,1080}};
 
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_WIDTH,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_width),
-                             Return(EGL_TRUE)));
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_HEIGHT,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_height),
-                             Return(EGL_TRUE)));
+    ON_CALL(mock_display_buffer, size())
+        .WillByDefault(Return(mir::geometry::Size{screen_width, screen_height}));
 
     mrg::Renderer renderer(mock_display_buffer);
 
@@ -392,12 +384,8 @@ TEST_F(GLRenderer, sets_viewport_unscaled_exact)
     int const screen_height = 1080;
     mir::geometry::Rectangle const view_area{{0,0}, {1920,1080}};
 
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_WIDTH,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_width),
-                             Return(EGL_TRUE)));
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_HEIGHT,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_height),
-                             Return(EGL_TRUE)));
+    ON_CALL(mock_display_buffer, size())
+        .WillByDefault(Return(mir::geometry::Size{screen_width, screen_height}));
 
     EXPECT_CALL(mock_gl, glViewport(0, 0, screen_width, screen_height));
 
@@ -411,12 +399,8 @@ TEST_F(GLRenderer, sets_viewport_upscaled_exact)
     int const screen_height = 1080;
     mir::geometry::Rectangle const view_area{{0,0}, {1280,720}};
 
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_WIDTH,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_width),
-                             Return(EGL_TRUE)));
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_HEIGHT,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_height),
-                             Return(EGL_TRUE)));
+    ON_CALL(mock_display_buffer, size())
+        .WillByDefault(Return(mir::geometry::Size{screen_width, screen_height}));
 
     EXPECT_CALL(mock_gl, glViewport(0, 0, screen_width, screen_height));
 
@@ -430,12 +414,8 @@ TEST_F(GLRenderer, sets_viewport_downscaled_exact)
     int const screen_height = 720;
     mir::geometry::Rectangle const view_area{{0,0}, {1920,1080}};
 
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_WIDTH,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_width),
-                             Return(EGL_TRUE)));
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_HEIGHT,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_height),
-                             Return(EGL_TRUE)));
+    ON_CALL(mock_display_buffer, size())
+        .WillByDefault(Return(mir::geometry::Size{screen_width, screen_height}));
 
     EXPECT_CALL(mock_gl, glViewport(0, 0, screen_width, screen_height));
 
@@ -449,12 +429,8 @@ TEST_F(GLRenderer, sets_viewport_upscaled_narrow)
     int const screen_height = 1080;
     mir::geometry::Rectangle const view_area{{0,0}, {640,480}};
 
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_WIDTH,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_width),
-                             Return(EGL_TRUE)));
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_HEIGHT,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_height),
-                             Return(EGL_TRUE)));
+    ON_CALL(mock_display_buffer, size())
+        .WillByDefault(Return(mir::geometry::Size{screen_width, screen_height}));
 
     EXPECT_CALL(mock_gl, glViewport(240, 0, 1440, 1080));
 
@@ -468,12 +444,8 @@ TEST_F(GLRenderer, sets_viewport_downscaled_wide)
     int const screen_height = 480;
     mir::geometry::Rectangle const view_area{{0,0}, {1920,1080}};
 
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_WIDTH,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_width),
-                             Return(EGL_TRUE)));
-    ON_CALL(mock_egl, eglQuerySurface(_,_,EGL_HEIGHT,_))
-        .WillByDefault(DoAll(SetArgPointee<3>(screen_height),
-                             Return(EGL_TRUE)));
+    ON_CALL(mock_display_buffer, size())
+        .WillByDefault(Return(mir::geometry::Size{screen_width, screen_height}));
 
     EXPECT_CALL(mock_gl, glViewport(0, 60, 640, 360));
 


### PR DESCRIPTION
Fixes #2653, a few systems needed to be refactored. With this PR software buffers now expose their properties without being mapped, render targets expose their size so the renderer doesn't have to query the current EGL surface (something that never worked for screenshots), and our wlr-screencopy implementation requests clients use buffers of the full output resolution rather than the logical size.