### PR TITLE
Server/run_mir: Improve warning message.

### DIFF
--- a/src/server/run_mir.cpp
+++ b/src/server/run_mir.cpp
@@ -158,7 +158,7 @@ extern "C" [[noreturn]] void fatal_signal_cleanup(int sig, siginfo_t* info, void
          * Since we're crashing *anyway*, start with a log that *is* signal-safe, and
          * then cross our fingers for the rest.
          */
-        constexpr char const* warning = "!!! Fatal signal received. Attempting cleanup, but deadlock may occur";
+        constexpr char const* warning = "!!! Fatal signal received. Attempting cleanup, but deadlock may occur\n";
         constexpr size_t len = std::char_traits<char>::length(warning);
         // We cannot possibly do anything sensible if this write fails, so ignore the return value.
         // Note: static_cast<void>() is *not* sufficient to silence this warning on all compilers,


### PR DESCRIPTION
Oops. We should probably add a newline after our “it's all going to hell” warning.