### PR TITLE
gbm-kms/quirks: Quirk off AST devices

### DIFF
--- a/src/platforms/gbm-kms/server/kms/quirks.cpp
+++ b/src/platforms/gbm-kms/server/kms/quirks.cpp
@@ -155,7 +155,7 @@ public:
 private:
     // Mir's gbm-kms support isn't (yet) working with nvidia
     // Mir's gbm-kms support isn't (yet) working with evdi
-    std::unordered_set<std::string> drivers_to_skip = { "nvidia", "evdi" };
+    std::unordered_set<std::string> drivers_to_skip = { "nvidia", "evdi", "ast" };
     std::unordered_set<std::string> devnodes_to_skip;
     // We know this is currently useful for virtio_gpu, vc4-drm and v3d
     std::unordered_set<std::string> skip_modesetting_support = { "virtio_gpu", "vc4-drm", "v3d" };


### PR DESCRIPTION
These are basic 2D output devices built into motherboards (particularly server MBs). They have no 3D hardware, and they have no DRI drivers. Unfortunately, bug #2678 means that this causes Mir to fail to come up on a system with AST hardware.

Like evdi, this hardware *should* be supportable in the New Platform API™, but for now quirking it off is the appropriate response.