### PR TITLE
XWaylandClipboardSource: do not clear source just before a new one is set

### DIFF
--- a/src/server/frontend_xwayland/xwayland_clipboard_source.cpp
+++ b/src/server/frontend_xwayland/xwayland_clipboard_source.cpp
@@ -337,9 +337,8 @@ void mf::XWaylandClipboardSource::xfixes_selection_notify_event(xcb_xfixes_selec
     {
         if (verbose_xwayland_logging_enabled())
         {
-            log_info("Clearing old X11 clipboard source");
+            log_info("Invalidating X11 clipboard source");
         }
-        clipboard->clear_paste_source(*source_to_reset);
         source_to_reset->invalidate_owner();
     }
 }


### PR DESCRIPTION
Fixes #2677? I'm not quite sure the cause of the originally described bug (copying up to the last `\n`, nor have I observed that behavior specifically. However this does seem to fix the CLion/Intellij copy/paste bugs I'm seeing.

The problem is that when we got a new paste source we cleared the old one, but since setting up an X11 paste is a multi-step process and paste source observations are non-blocking, both the clearing and new source setup were happening at an arbitrary time and racing. With this PR the old paste source is invalidated (so nothing can paste from it), but it's not cleared. It will instead be replaced by the future paste source that will be created. If something goes wrong in the setup process, the worst that can happen is apps see an expired paste source, but trying to paste from it safely fails.