### PR TITLE
Close all Wayland clients on server stop

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -407,6 +407,12 @@ void mf::WaylandConnector::stop()
     {
         mir::log_warning("WaylandConnector::stop() called on not-running connector?");
     }
+    wl_list* client_list = wl_display_get_client_list(display.get());
+    wl_client* client;
+    wl_client_for_each(client, client_list)
+    {
+        wl_client_destroy(client);
+    }
 }
 
 int mf::WaylandConnector::client_socket_fd() const

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -209,10 +209,6 @@ auto mir::frontend::WaylandExtensions::get_extension(std::string const& name) co
     return {};
 }
 
-void mf::WaylandExtensions::run_builders(wl_display*, std::function<void(std::function<void()>&& work)> const&)
-{
-}
-
 mf::WaylandConnector::WaylandConnector(
     std::shared_ptr<msh::Shell> const& shell,
     std::shared_ptr<time::Clock> const& clock,

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -146,7 +146,13 @@ namespace
 {
 int halt_eventloop(int fd, uint32_t /*mask*/, void* data)
 {
-    auto display = reinterpret_cast<wl_display*>(data);
+    auto const display = reinterpret_cast<wl_display*>(data);
+    wl_list* const client_list = wl_display_get_client_list(display);
+    wl_client* client;
+    wl_client_for_each(client, client_list)
+    {
+        wl_client_destroy(client);
+    }
     wl_display_terminate(display);
 
     eventfd_t ignored;
@@ -406,12 +412,6 @@ void mf::WaylandConnector::stop()
     else
     {
         mir::log_warning("WaylandConnector::stop() called on not-running connector?");
-    }
-    wl_list* client_list = wl_display_get_client_list(display.get());
-    wl_client* client;
-    wl_client_for_each(client, client_list)
-    {
-        wl_client_destroy(client);
     }
 }
 

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -98,7 +98,9 @@ public:
     WaylandExtensions(WaylandExtensions const&) = delete;
     WaylandExtensions& operator=(WaylandExtensions const&) = delete;
 
-    virtual void run_builders(wl_display* display, std::function<void(std::function<void()>&& work)> const& run_on_wayland_mainloop);
+    virtual void run_builders(
+        wl_display* display,
+        std::function<void(std::function<void()>&& work)> const& run_on_wayland_mainloop) = 0;
 
     void init(Context const& context);
 


### PR DESCRIPTION
By closing clients explicitly instead of waiting for the destruction of the display to do it, clients do not see all globals disappear (which they may not be designed to handle)