### PR TITLE
Add some logging to terminate_with_current_exception()

### DIFF
--- a/src/server/terminate_with_current_exception.cpp
+++ b/src/server/terminate_with_current_exception.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "mir/terminate_with_current_exception.h"
+#include "mir/log.h"
 
 #include <unistd.h>
 #include <csignal>
@@ -47,6 +48,12 @@ void mir::terminate_with_current_exception()
     if (!termination_exception)
     {
         termination_exception = std::current_exception();
+
+        log(logging::Severity::critical,
+            MIR_LOG_COMPONENT,
+            termination_exception,
+            "terminate_with_current_exception()");
+
         kill(getpid(), SIGTERM);
     }
 }


### PR DESCRIPTION
We've encountered a few issues recently where we think we're trying to terminate, but don't have clear diagnostic information.

This ensures we log the "current exception" before trying to terminate.