### PR TITLE
Disconnected hardware has no modes: invent a size

### DIFF
--- a/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
+++ b/src/platforms/gbm-kms/server/kms/real_kms_output.cpp
@@ -129,6 +129,10 @@ void mgg::RealKMSOutput::reset()
 
 geom::Size mgg::RealKMSOutput::size() const
 {
+    // Disconnected hardware has no modes: invent a size
+    if (connector->connection == DRM_MODE_DISCONNECTED)
+        return {0, 0};
+
     drmModeModeInfo const& mode(connector->modes[mode_index]);
     return {mode.hdisplay, mode.vdisplay};
 }


### PR DESCRIPTION
In #2690, we're segfaulting trying to access the size of an output. Maybe this "fixes" it?

Marked as "draft" as it is experimental
