### PR TITLE
Clean up copy/paste messages

### DIFF
--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -85,7 +85,7 @@ void mf::WlDataDevice::Offer::receive(std::string const& mime_type, mir::Fd fd)
 {
     if (device && device.value().current_offer.is(*this))
     {
-        source->initiate_send(mime_type, fd);;
+        source->initiate_send(mime_type, fd);
     }
 }
 

--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -78,12 +78,14 @@ mf::WlDataDevice::Offer::Offer(WlDataDevice* device, std::shared_ptr<scene::Clip
     {
         send_offer_event(type);
     }
-    device->send_selection_event(resource);
 }
 
 void mf::WlDataDevice::Offer::receive(std::string const& mime_type, mir::Fd fd)
 {
-    source->initiate_send(mime_type, fd);
+    if (device && device.value().current_offer.is(*this))
+    {
+        source->initiate_send(mime_type, fd);;
+    }
 }
 
 mf::WlDataDevice::WlDataDevice(


### PR DESCRIPTION
Before we were sending multiple null sections in a row, and may have been allowing clients to paste after they were unfocused. This PR cleans up that logic so that clients can only paste from the currently active offer and events are sent only as necessary.