### PR TITLE
Fix compilation failure with GCC-12 (missing headers)

### DIFF
--- a/src/client/rpc/mir_protobuf_rpc_channel.cpp
+++ b/src/client/rpc/mir_protobuf_rpc_channel.cpp
@@ -47,6 +47,7 @@
 
 #include <stdexcept>
 #include <cstring>
+#include <array>
 
 namespace mf = mir::frontend;
 namespace mev = mir::events;

--- a/src/renderers/gl/renderer.h
+++ b/src/renderers/gl/renderer.h
@@ -32,6 +32,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <array>
 
 namespace mir
 {

--- a/src/server/glib_main_loop_sources.cpp
+++ b/src/server/glib_main_loop_sources.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <array>
 #include <system_error>
 #include <sstream>
 

--- a/tests/acceptance-tests/test_presentation_chain.cpp
+++ b/tests/acceptance-tests/test_presentation_chain.cpp
@@ -33,6 +33,7 @@
 #include "mir/raii.h"
 
 #include <atomic>
+#include <array>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 

--- a/tests/acceptance-tests/test_prompt_session_client_api.cpp
+++ b/tests/acceptance-tests/test_prompt_session_client_api.cpp
@@ -38,6 +38,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <atomic>
+#include <array>
 
 namespace mtd = mir::test::doubles;
 namespace mtf = mir_test_framework;

--- a/tests/unit-tests/compositor/test_multi_monitor_arbiter.cpp
+++ b/tests/unit-tests/compositor/test_multi_monitor_arbiter.cpp
@@ -23,6 +23,7 @@
 #include "src/server/compositor/schedule.h"
 
 #include <gtest/gtest.h>
+#include <array>
 using namespace testing;
 namespace mt = mir::test;
 namespace mtd = mir::test::doubles;

--- a/tests/unit-tests/scene/test_application_session.cpp
+++ b/tests/unit-tests/scene/test_application_session.cpp
@@ -44,6 +44,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <array>
 
 namespace mc = mir::compositor;
 namespace mf = mir::frontend;

--- a/tests/unit-tests/scene/test_basic_surface.cpp
+++ b/tests/unit-tests/scene/test_basic_surface.cpp
@@ -39,6 +39,7 @@
 #include <future>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <array>
 
 namespace mc = mir::compositor;
 namespace mf = mir::frontend;

--- a/tests/unit-tests/test_glib_main_loop.cpp
+++ b/tests/unit-tests/test_glib_main_loop.cpp
@@ -32,6 +32,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include <array>
 #include <thread>
 
 namespace mt = mir::test;

--- a/tests/unit-tests/test_posix_rw_mutex.cpp
+++ b/tests/unit-tests/test_posix_rw_mutex.cpp
@@ -26,6 +26,7 @@
 #include <shared_mutex>
 #include <thread>
 #include <atomic>
+#include <array>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Adding missing headers, needed for compilation with GCC-12.