### PR TITLE
ThreadPoolExecutor: Drop std::binary_semaphore polyfill.

### DIFF
--- a/src/common/thread_pool_executor.cpp
+++ b/src/common/thread_pool_executor.cpp
@@ -24,61 +24,7 @@
 #include <list>
 #include <future>
 
-#include <version>
-
-#ifdef __cpp_lib_semaphore
 #include <semaphore>
-#else
-// Hello, there! This version of libstdc++ doesn't support the C++20 feature std::binary_semaphore
-// We shall, instead, open-code the simplest possible implementation of what we use here.
-namespace std
-{
-class binary_semaphore
-{
-public:
-    binary_semaphore(int initial)
-        : raised{initial == 1}
-    {
-    }
-
-    void release()
-    {
-        {
-            std::lock_guard lock{mutex};
-            raised = true;
-        }
-        cv.notify_all();
-    }
-
-    void acquire()
-    {
-        std::unique_lock lock{mutex};
-        if (raised)
-        {
-            raised = false;
-            return;
-        }
-        cv.wait(lock, [this]() { return raised; });
-        raised = false;
-    }
-
-    bool try_acquire()
-    {
-        std::lock_guard lock{mutex};
-        if (raised)
-        {
-            raised = false;
-            return true;
-        }
-        return false;
-    }
-private:
-    std::mutex mutex;
-    std::condition_variable cv;
-    bool raised;
-};
-}
-#endif
 
 namespace
 {


### PR DESCRIPTION
All targets we compile for should now support enough C++20 stdlib features to remove the need for us to provide a fallback.