### PR TITLE
Don't use "wayland-host" as command line option example

### DIFF
--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -115,7 +115,7 @@ std::string description_text(char const* program, std::string const& config_file
 
     if (!config_file.empty())
         result +=
-        "Config file entries are long form (e.g. \"--wayland-extensions=wl_shell\").\n"
+        "Config file entries are long form (e.g. \"wayland-extensions=wl_shell\").\n"
         "The config file (" + config_file + ") is located via the XDG Base Directory Specification.\n"
         "($XDG_CONFIG_HOME or $HOME/.config followed by $XDG_CONFIG_DIRS)\n\n";
 

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -106,16 +106,16 @@ namespace
 std::string description_text(char const* program, std::string const& config_file)
 {
     std::string result{
-        "Command-line options (e.g. \"--wayland-host=wayland-0\").\n\n"
+        "Command-line options (e.g. \"--wayland-extensions=wl_shell\").\n\n"
         "Environment variables capitalise long form with prefix \"MIR_SERVER_\" and \"_\" in place of \"-\".\n"
-        "(E.g. \"MIR_SERVER_WAYLAND_HOST=wayland-0\")\n\n"};
+        "(E.g. \"MIR_SERVER_WAYLAND_EXTENSIONS=wl_shell\")\n\n"};
 
     if (program)
         result = std::string{"usage: "} + program + " [options]\n\n" + result;
 
     if (!config_file.empty())
         result +=
-        "Config file entries are long form (e.g. \"wayland-host=wayland-0\").\n"
+        "Config file entries are long form (e.g. \"--wayland-extensions=wl_shell\").\n"
         "The config file (" + config_file + ") is located via the XDG Base Directory Specification.\n"
         "($XDG_CONFIG_HOME or $HOME/.config followed by $XDG_CONFIG_DIRS)\n\n";
 


### PR DESCRIPTION
Since `--wayland-host` is an option only provided by the Wayland platform, it makes more sense to present an example option that is existent on all platforms. This uses `--wayland-extensions` instead as an example. Fixes #2687