### PR TITLE
ci: bump actions/checkout version

### DIFF
--- a/.github/workflows/ppa-upload.yml
+++ b/.github/workflows/ppa-upload.yml
@@ -31,7 +31,7 @@ jobs:
         gpg-private-key: ${{ secrets.MIR_BOT_GPG_PRIVATE_KEY }}
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # Need full history for version determination
         fetch-depth: 0

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0  # needed for version determination
 
@@ -47,7 +47,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ${{ matrix.snap }}
         ref: mir-build-snap

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -89,7 +89,7 @@ jobs:
         fi
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Run Spread task
       env:


### PR DESCRIPTION
Because Node.js 12 actions are getting deprecated:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/