### PR TITLE
Implement wp_primary_selection_unstable_v1

### DIFF
--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -177,7 +177,8 @@ public:
     std::shared_ptr<input::InputDispatcher> the_input_dispatcher() override;
     std::shared_ptr<EmergencyCleanup>       the_emergency_cleanup() override;
     std::shared_ptr<cookie::Authority>      the_cookie_authority() override;
-    std::shared_ptr<scene::Clipboard>       the_clipboard() override;
+    std::shared_ptr<scene::Clipboard>       the_main_clipboard() override;
+    std::shared_ptr<scene::Clipboard>       the_primary_selection_clipboard() override;
     std::shared_ptr<scene::TextInputHub>    the_text_input_hub() override;
     std::shared_ptr<scene::IdleHub>         the_idle_hub() override;
     std::shared_ptr<shell::IdleHandler>     the_idle_handler() override;

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -393,7 +393,8 @@ protected:
     CachedPtr<scene::SurfaceFactory> surface_factory;
     CachedPtr<scene::SessionContainer>  session_container;
     CachedPtr<scene::SessionListener> session_listener;
-    CachedPtr<scene::Clipboard>         clipboard;
+    CachedPtr<scene::Clipboard>         main_clipboard;
+    CachedPtr<scene::Clipboard>         primary_selection_clipboard;
     CachedPtr<scene::TextInputHub>      text_input_hub;
     CachedPtr<scene::IdleHub>           idle_hub;
     CachedPtr<shell::IdleHandler>       idle_handler;

--- a/src/include/server/mir/server_configuration.h
+++ b/src/include/server/mir/server_configuration.h
@@ -92,7 +92,8 @@ public:
     virtual std::shared_ptr<cookie::Authority> the_cookie_authority() = 0;
     virtual auto the_fatal_error_strategy() -> void (*)(char const* reason, ...) = 0;
     virtual std::shared_ptr<scene::ApplicationNotRespondingDetector> the_application_not_responding_detector() = 0;
-    virtual std::shared_ptr<scene::Clipboard> the_clipboard() = 0;
+    virtual std::shared_ptr<scene::Clipboard> the_main_clipboard() = 0;
+    virtual std::shared_ptr<scene::Clipboard> the_primary_selection_clipboard() = 0;
     virtual std::shared_ptr<scene::TextInputHub> the_text_input_hub() = 0;
     virtual std::shared_ptr<scene::IdleHub> the_idle_hub() = 0;
     virtual std::shared_ptr<shell::IdleHandler> the_idle_handler() = 0;

--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -47,6 +47,7 @@ set(
   idle_inhibit_v1.cpp           idle_inhibit_v1.h
   wlr_screencopy_v1.cpp         wlr_screencopy_v1.h
   text_input_v1.cpp             text_input_v1.h
+  primary_selection_v1.cpp      primary_selection_v1.h
   ${PROJECT_SOURCE_DIR}/src/include/server/mir/frontend/wayland.h
   ${CMAKE_CURRENT_BINARY_DIR}/wayland_frontend.tp.c
   ${CMAKE_CURRENT_BINARY_DIR}/wayland_frontend.tp.h

--- a/src/server/frontend_wayland/primary_selection_v1.cpp
+++ b/src/server/frontend_wayland/primary_selection_v1.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "primary_selection_v1.h"
+
+namespace mf = mir::frontend;
+namespace mw = mir::wayland;
+
+namespace
+{
+class PrimarySelectionSource : public mw::PrimarySelectionSourceV1
+{
+public:
+    PrimarySelectionSource(wl_resource* resource)
+        : PrimarySelectionSourceV1{resource, Version<1>()}
+    {
+    }
+
+    void offer(std::string const& mime_type) override
+    {
+        (void)mime_type;
+    }
+};
+
+class PrimarySelectionDevice : public mw::PrimarySelectionDeviceV1
+{
+public:
+    PrimarySelectionDevice(wl_resource* resource)
+        : PrimarySelectionDeviceV1{resource, Version<1>()}
+    {
+    }
+
+    void set_selection(std::optional<struct wl_resource*> const& source, uint32_t serial) override
+    {
+        (void)source;
+        (void)serial;
+    }
+};
+
+class PrimarySelectionManager : public mw::PrimarySelectionDeviceManagerV1
+{
+public:
+    PrimarySelectionManager(wl_resource* manager)
+        : PrimarySelectionDeviceManagerV1{manager, Version<1>()}
+    {
+    }
+
+    void create_source(struct wl_resource* id) override
+    {
+        new PrimarySelectionSource{id};
+    }
+
+    void get_device(struct wl_resource* id, struct wl_resource* seat) override
+    {
+        new PrimarySelectionDevice{id};
+        (void)seat;
+    }
+};
+
+class PrimarySelectionGlobal : public mw::PrimarySelectionDeviceManagerV1::Global
+{
+public:
+    PrimarySelectionGlobal(wl_display* display)
+        : Global{display, Version<1>()}
+    {
+    }
+
+    void bind(wl_resource* manager) override
+    {
+        new PrimarySelectionManager{manager};
+    }
+};
+}
+
+auto mf::create_primary_selection_device_manager_v1(wl_display* display)
+-> std::shared_ptr<mw::PrimarySelectionDeviceManagerV1::Global>
+{
+    return std::make_shared<PrimarySelectionGlobal>(display);
+}

--- a/src/server/frontend_wayland/primary_selection_v1.cpp
+++ b/src/server/frontend_wayland/primary_selection_v1.cpp
@@ -15,6 +15,10 @@
  */
 
 #include "primary_selection_v1.h"
+#include "wl_seat.h"
+#include "mir/scene/clipboard.h"
+#include "mir/wayland/weak.h"
+#include "mir/executor.h"
 
 namespace mf = mir::frontend;
 namespace mw = mir::wayland;
@@ -24,78 +28,256 @@ namespace
 {
 class PrimarySelectionSource : public mw::PrimarySelectionSourceV1
 {
+private:
+    class Source : public ms::ClipboardSource
+    {
+    public:
+        Source(
+            PrimarySelectionSource const* owner,
+            std::shared_ptr<mir::Executor> wayland_executor,
+            std::vector<std::string> types)
+            : owner{std::move(owner)},
+              wayland_executor{move(wayland_executor)},
+              types{move(types)}
+        {
+        }
+
+        auto mime_types() const -> std::vector<std::string> const& override
+        {
+            return types;
+        }
+
+        void initiate_send(std::string const& mime_type, mir::Fd const& target_fd) override
+        {
+            wayland_executor->spawn([owner=owner, mime_type, target_fd]()
+                {
+                    if (owner)
+                    {
+                        owner.value().send_send_event(mime_type, target_fd);
+                    }
+                });
+        }
+
+    private:
+        mw::Weak<PrimarySelectionSource const> const owner;
+        std::shared_ptr<mir::Executor> const wayland_executor;
+        std::vector<std::string> const types;
+    };
+
+    std::vector<std::string> mime_types;
+    std::shared_ptr<mir::Executor> const wayland_executor;
+
 public:
-    PrimarySelectionSource(wl_resource* resource)
-        : PrimarySelectionSourceV1{resource, Version<1>()}
+    PrimarySelectionSource(
+        wl_resource* resource,
+        std::shared_ptr<mir::Executor> wayland_executor)
+        : PrimarySelectionSourceV1{resource, Version<1>()},
+          wayland_executor{move(wayland_executor)}
     {
     }
 
     void offer(std::string const& mime_type) override
     {
-        (void)mime_type;
+        mime_types.push_back(mime_type);
     }
+
+    auto make_source() const -> std::shared_ptr<ms::ClipboardSource>
+    {
+        return std::make_shared<Source>(this, wayland_executor, mime_types);
+    }
+};
+
+class PrimarySelectionOffer : public mw::PrimarySelectionOfferV1
+{
+public:
+    PrimarySelectionOffer(mw::PrimarySelectionDeviceV1& parent, std::shared_ptr<ms::ClipboardSource> source)
+        : PrimarySelectionOfferV1{parent},
+          source{move(source)}
+    {
+    }
+
+    void receive(std::string const& mime_type, mir::Fd fd) override
+    {
+        source->initiate_send(mime_type, fd);
+    }
+
+    std::shared_ptr<ms::ClipboardSource> const source;
 };
 
 class PrimarySelectionDevice : public mw::PrimarySelectionDeviceV1
 {
-public:
-    PrimarySelectionDevice(wl_resource* resource)
-        : PrimarySelectionDeviceV1{resource, Version<1>()}
+private:
+    class ClipboardObserver : public ms::ClipboardObserver
     {
+    public:
+        ClipboardObserver(PrimarySelectionDevice* owner) : owner{owner}
+        {
+        }
+
+    private:
+        void paste_source_set(std::shared_ptr<ms::ClipboardSource> const& source) override
+        {
+            if (owner)
+            {
+                owner.value().paste_source_set(source);
+            }
+        }
+
+        mw::Weak<PrimarySelectionDevice> const owner;
+    };
+
+public:
+    PrimarySelectionDevice(
+        wl_resource* resource,
+        std::shared_ptr<ms::Clipboard> primary_selection_clipboard,
+        mf::WlSeat& seat)
+        : PrimarySelectionDeviceV1{resource, Version<1>()},
+          clipboard_observer{std::make_shared<ClipboardObserver>(this)},
+          primary_selection_clipboard{move(primary_selection_clipboard)},
+          seat{seat}
+    {
+        this->primary_selection_clipboard->register_interest(clipboard_observer, mir::immediate_executor);
     }
 
-    void set_selection(std::optional<struct wl_resource*> const& source, uint32_t serial) override
+    ~PrimarySelectionDevice()
     {
-        (void)source;
-        (void)serial;
+        primary_selection_clipboard->unregister_interest(*clipboard_observer);
+        if (current.source)
+        {
+            primary_selection_clipboard->clear_paste_source(*current.source);
+        }
     }
+
+private:
+    void set_selection(std::optional<wl_resource*> const& source, uint32_t serial) override
+    {
+        (void)serial;
+        auto const source_wrapper = mw::make_weak(source ?
+            dynamic_cast<PrimarySelectionSource*>(mw::PrimarySelectionSourceV1::from(source.value())) :
+            nullptr);
+        if (source_wrapper)
+        {
+            pending = {source_wrapper.value().make_source(), source_wrapper};
+            primary_selection_clipboard->set_paste_source(pending.source);
+        }
+        else
+        {
+            pending = {};
+            primary_selection_clipboard->clear_paste_source();
+        }
+    }
+
+    void paste_source_set(std::shared_ptr<ms::ClipboardSource> const& source)
+    {
+        if (pending.source == source)
+        {
+            if (current.wrapper && pending.wrapper != current.wrapper)
+            {
+                current.wrapper.value().send_cancelled_event();
+            }
+            current = std::move(pending);
+            pending = {};
+        }
+        if (source)
+        {
+            if (!current_offer || current_offer.value().source != source)
+            {
+                auto const offer = new PrimarySelectionOffer{*this, source};
+                current_offer = mw::make_weak(offer);
+                send_data_offer_event(offer->resource);
+                for (auto const& type : source->mime_types())
+                {
+                    offer->send_offer_event(type);
+                }
+                send_selection_event(current_offer.value().resource);
+            }
+        }
+        else
+        {
+            if (current_offer)
+            {
+                current_offer = {};
+                send_selection_event(std::nullopt);
+            }
+        }
+    }
+
+    struct Selection {
+        std::shared_ptr<ms::ClipboardSource> source;
+        mw::Weak<PrimarySelectionSource> wrapper;
+    };
+
+    Selection pending, current;
+    mw::Weak<PrimarySelectionOffer> current_offer;
+    std::shared_ptr<ClipboardObserver> clipboard_observer;
+    std::shared_ptr<ms::Clipboard> const primary_selection_clipboard;
+    mf::WlSeat& seat;
 };
 
 class PrimarySelectionManager : public mw::PrimarySelectionDeviceManagerV1
 {
 public:
-    PrimarySelectionManager(wl_resource* manager, std::shared_ptr<ms::Clipboard> primary_selection_clipboard)
+    PrimarySelectionManager(
+        wl_resource* manager,
+        std::shared_ptr<mir::Executor> wayland_executor,
+        std::shared_ptr<ms::Clipboard> primary_selection_clipboard)
         : PrimarySelectionDeviceManagerV1{manager, Version<1>()},
+          wayland_executor{move(wayland_executor)},
           primary_selection_clipboard{move(primary_selection_clipboard)}
     {
     }
 
     void create_source(struct wl_resource* id) override
     {
-        new PrimarySelectionSource{id};
+        new PrimarySelectionSource{id, wayland_executor};
     }
 
     void get_device(struct wl_resource* id, struct wl_resource* seat) override
     {
-        new PrimarySelectionDevice{id};
-        (void)seat;
+        auto const wl_seat = mf::WlSeat::from(seat);
+        if (!wl_seat)
+        {
+            BOOST_THROW_EXCEPTION(std::runtime_error(
+                "client provided incorrect seat to zwp_primary_selection_device_manager_v1.get_device"));
+        }
+        new PrimarySelectionDevice{id, primary_selection_clipboard, *wl_seat};
     }
 
+    std::shared_ptr<mir::Executor> const wayland_executor;
     std::shared_ptr<ms::Clipboard> const primary_selection_clipboard;
 };
 
 class PrimarySelectionGlobal : public mw::PrimarySelectionDeviceManagerV1::Global
 {
 public:
-    PrimarySelectionGlobal(wl_display* display, std::shared_ptr<ms::Clipboard> primary_selection_clipboard)
+    PrimarySelectionGlobal(
+        wl_display* display,
+        std::shared_ptr<mir::Executor> wayland_executor,
+        std::shared_ptr<ms::Clipboard> primary_selection_clipboard)
         : Global{display, Version<1>()},
-          clipboard{move(primary_selection_clipboard)}
+          wayland_executor{move(wayland_executor)},
+          primary_selection_clipboard{move(primary_selection_clipboard)}
     {
     }
 
     void bind(wl_resource* manager) override
     {
-        new PrimarySelectionManager{manager, clipboard};
+        new PrimarySelectionManager{manager, wayland_executor, primary_selection_clipboard};
     }
 
-    std::shared_ptr<ms::Clipboard> const clipboard;
+    std::shared_ptr<mir::Executor> const wayland_executor;
+    std::shared_ptr<ms::Clipboard> const primary_selection_clipboard;
 };
 }
 
 auto mf::create_primary_selection_device_manager_v1(
     wl_display* display,
+    std::shared_ptr<Executor> wayland_executor,
     std::shared_ptr<ms::Clipboard> primary_selection_clipboard)
 -> std::shared_ptr<mw::PrimarySelectionDeviceManagerV1::Global>
 {
-    return std::make_shared<PrimarySelectionGlobal>(display, move(primary_selection_clipboard));
+    return std::make_shared<PrimarySelectionGlobal>(
+        display,
+        move(wayland_executor),
+        move(primary_selection_clipboard));
 }

--- a/src/server/frontend_wayland/primary_selection_v1.cpp
+++ b/src/server/frontend_wayland/primary_selection_v1.cpp
@@ -54,9 +54,9 @@ public:
 class PrimarySelectionManager : public mw::PrimarySelectionDeviceManagerV1
 {
 public:
-    PrimarySelectionManager(wl_resource* manager, std::shared_ptr<ms::Clipboard> clipboard)
+    PrimarySelectionManager(wl_resource* manager, std::shared_ptr<ms::Clipboard> primary_selection_clipboard)
         : PrimarySelectionDeviceManagerV1{manager, Version<1>()},
-          clipboard{move(clipboard)}
+          primary_selection_clipboard{move(primary_selection_clipboard)}
     {
     }
 
@@ -71,15 +71,15 @@ public:
         (void)seat;
     }
 
-    std::shared_ptr<ms::Clipboard> const clipboard;
+    std::shared_ptr<ms::Clipboard> const primary_selection_clipboard;
 };
 
 class PrimarySelectionGlobal : public mw::PrimarySelectionDeviceManagerV1::Global
 {
 public:
-    PrimarySelectionGlobal(wl_display* display, std::shared_ptr<ms::Clipboard> clipboard)
+    PrimarySelectionGlobal(wl_display* display, std::shared_ptr<ms::Clipboard> primary_selection_clipboard)
         : Global{display, Version<1>()},
-          clipboard{move(clipboard)}
+          clipboard{move(primary_selection_clipboard)}
     {
     }
 
@@ -94,8 +94,8 @@ public:
 
 auto mf::create_primary_selection_device_manager_v1(
     wl_display* display,
-    std::shared_ptr<ms::Clipboard> clipboard)
+    std::shared_ptr<ms::Clipboard> primary_selection_clipboard)
 -> std::shared_ptr<mw::PrimarySelectionDeviceManagerV1::Global>
 {
-    return std::make_shared<PrimarySelectionGlobal>(display, move(clipboard));
+    return std::make_shared<PrimarySelectionGlobal>(display, move(primary_selection_clipboard));
 }

--- a/src/server/frontend_wayland/primary_selection_v1.h
+++ b/src/server/frontend_wayland/primary_selection_v1.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_FRONTEND_PRIMARY_SELECTION_V1_H
+#define MIR_FRONTEND_PRIMARY_SELECTION_V1_H
+
+#include "primary-selection-unstable-v1_wrapper.h"
+
+namespace mir
+{
+namespace frontend
+{
+auto create_primary_selection_device_manager_v1(wl_display* display)
+-> std::shared_ptr<wayland::PrimarySelectionDeviceManagerV1::Global>;
+}
+}
+
+#endif // MIR_FRONTEND_PRIMARY_SELECTION_V1_H

--- a/src/server/frontend_wayland/primary_selection_v1.h
+++ b/src/server/frontend_wayland/primary_selection_v1.h
@@ -21,9 +21,15 @@
 
 namespace mir
 {
+namespace scene
+{
+class Clipboard;
+}
 namespace frontend
 {
-auto create_primary_selection_device_manager_v1(wl_display* display)
+auto create_primary_selection_device_manager_v1(
+    wl_display* display,
+    std::shared_ptr<scene::Clipboard> clipboard)
 -> std::shared_ptr<wayland::PrimarySelectionDeviceManagerV1::Global>;
 }
 }

--- a/src/server/frontend_wayland/primary_selection_v1.h
+++ b/src/server/frontend_wayland/primary_selection_v1.h
@@ -29,7 +29,7 @@ namespace frontend
 {
 auto create_primary_selection_device_manager_v1(
     wl_display* display,
-    std::shared_ptr<scene::Clipboard> clipboard)
+    std::shared_ptr<scene::Clipboard> primary_selection_clipboard)
 -> std::shared_ptr<wayland::PrimarySelectionDeviceManagerV1::Global>;
 }
 }

--- a/src/server/frontend_wayland/primary_selection_v1.h
+++ b/src/server/frontend_wayland/primary_selection_v1.h
@@ -21,6 +21,7 @@
 
 namespace mir
 {
+class Executor;
 namespace scene
 {
 class Clipboard;
@@ -29,6 +30,7 @@ namespace frontend
 {
 auto create_primary_selection_device_manager_v1(
     wl_display* display,
+    std::shared_ptr<Executor> wayland_executor,
     std::shared_ptr<scene::Clipboard> primary_selection_clipboard)
 -> std::shared_ptr<wayland::PrimarySelectionDeviceManagerV1::Global>;
 }

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -227,7 +227,8 @@ mf::WaylandConnector::WaylandConnector(
     std::shared_ptr<mf::SessionAuthorizer> const& session_authorizer,
     std::shared_ptr<SurfaceStack> const& surface_stack,
     std::shared_ptr<ObserverRegistrar<graphics::DisplayConfigurationObserver>> const& display_config_registrar,
-    std::shared_ptr<ms::Clipboard> const& clipboard,
+    std::shared_ptr<ms::Clipboard> const& main_clipboard,
+    std::shared_ptr<ms::Clipboard> const& primary_selection_clipboard,
     std::shared_ptr<ms::TextInputHub> const& text_input_hub,
     std::shared_ptr<ms::IdleHub> const& idle_hub,
     std::shared_ptr<mc::ScreenShooter> const& screen_shooter,
@@ -292,13 +293,14 @@ mf::WaylandConnector::WaylandConnector(
         executor,
         display_config_registrar);
 
-    data_device_manager_global = std::make_unique<WlDataDeviceManager>(display.get(), executor, clipboard);
+    data_device_manager_global = std::make_unique<WlDataDeviceManager>(display.get(), executor, main_clipboard);
 
     extensions->init(WaylandExtensions::Context{
         display.get(),
         executor,
         shell,
-        clipboard,
+        main_clipboard,
+        primary_selection_clipboard,
         text_input_hub,
         idle_hub,
         seat_global.get(),

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -81,7 +81,8 @@ public:
         wl_display* display;
         std::shared_ptr<Executor> wayland_executor;
         std::shared_ptr<shell::Shell> shell;
-        std::shared_ptr<scene::Clipboard> clipboard;
+        std::shared_ptr<scene::Clipboard> main_clipboard;
+        std::shared_ptr<scene::Clipboard> primary_selection_clipboard;
         std::shared_ptr<scene::TextInputHub> text_input_hub;
         std::shared_ptr<scene::IdleHub> idle_hub;
         WlSeat* seat;
@@ -132,7 +133,8 @@ public:
         std::shared_ptr<SessionAuthorizer> const& session_authorizer,
         std::shared_ptr<SurfaceStack> const& surface_stack,
         std::shared_ptr<ObserverRegistrar<graphics::DisplayConfigurationObserver>> const& display_config_registrar,
-        std::shared_ptr<scene::Clipboard> const& clipboard,
+        std::shared_ptr<scene::Clipboard> const& main_clipboard,
+        std::shared_ptr<scene::Clipboard> const& primary_selection_clipboard,
         std::shared_ptr<scene::TextInputHub> const& text_input_hub,
         std::shared_ptr<scene::IdleHub> const& idle_hub,
         std::shared_ptr<compositor::ScreenShooter> const& screen_shooter,

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -36,6 +36,7 @@
 #include "input_method_v2.h"
 #include "idle_inhibit_v1.h"
 #include "wlr_screencopy_v1.h"
+#include "primary_selection_v1.h"
 
 #include "mir/graphics/platform.h"
 #include "mir/options/default_configuration.h"
@@ -167,6 +168,10 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
                 ctx.graphic_buffer_allocator,
                 ctx.screen_shooter,
                 ctx.surface_stack);
+        }),
+    make_extension_builder<mw::PrimarySelectionDeviceManagerV1>([](auto const& ctx)
+        {
+            return mf::create_primary_selection_device_manager_v1(ctx.display);
         }),
 };
 

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -171,7 +171,7 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
         }),
     make_extension_builder<mw::PrimarySelectionDeviceManagerV1>([](auto const& ctx)
         {
-            return mf::create_primary_selection_device_manager_v1(ctx.display);
+            return mf::create_primary_selection_device_manager_v1(ctx.display, ctx.primary_selection_clipboard);
         }),
 };
 
@@ -181,7 +181,7 @@ ExtensionBuilder const xwayland_builder {
             return std::make_shared<mf::XWaylandWMShell>(
                 ctx.wayland_executor,
                 ctx.shell,
-                ctx.clipboard,
+                ctx.main_clipboard,
                 *ctx.seat,
                 ctx.surface_stack);
         }
@@ -310,7 +310,8 @@ std::shared_ptr<mf::Connector>
                 the_session_authorizer(),
                 the_frontend_surface_stack(),
                 the_display_configuration_observer_registrar(),
-                the_clipboard(),
+                the_main_clipboard(),
+                the_primary_selection_clipboard(),
                 the_text_input_hub(),
                 the_idle_hub(),
                 the_screen_shooter(),

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -171,7 +171,7 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
         }),
     make_extension_builder<mw::PrimarySelectionDeviceManagerV1>([](auto const& ctx)
         {
-            return mf::create_primary_selection_device_manager_v1(ctx.display, ctx.primary_selection_clipboard);
+            return mf::create_primary_selection_device_manager_v1(ctx.display, ctx.wayland_executor, ctx.primary_selection_clipboard);
         }),
 };
 

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -34,12 +34,6 @@ mf::WlKeyboard::WlKeyboard(wl_resource* new_resource, WlSeat& seat)
       seat{seat},
       helper{seat.make_keyboard_helper(this)}
 {
-    seat.add_focus_listener(client, this);
-}
-
-mf::WlKeyboard::~WlKeyboard()
-{
-    seat.remove_focus_listener(client, this);
 }
 
 void mf::WlKeyboard::handle_event(std::shared_ptr<MirEvent const> const& event)

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -31,7 +31,6 @@ namespace mi = mir::input;
 
 mf::WlKeyboard::WlKeyboard(wl_resource* new_resource, WlSeat& seat)
     : wayland::Keyboard{new_resource, Version<8>()},
-      seat{seat},
       helper{seat.make_keyboard_helper(this)}
 {
 }

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -35,15 +35,13 @@ class WlSurface;
 
 class WlKeyboard
     : public wayland::Keyboard,
-      private WlSeat::FocusListener,
       private KeyboardCallbacks
 {
 public:
     WlKeyboard(wl_resource* new_resource, WlSeat& seat);
 
-    ~WlKeyboard();
-
     void handle_event(std::shared_ptr<MirEvent const> const& event);
+    void focus_on(WlSurface* surface);
 
 private:
     WlSeat& seat;
@@ -54,9 +52,6 @@ private:
     uint32_t latched_modifiers = 0;
     uint32_t locked_modifiers = 0;
     uint32_t group_modifiers = 0;
-
-    /// WlSeat::FocusListener override
-    void focus_on(WlSurface* surface) override;
 
     /// KeyboardCallbacks overrides
     /// @{

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -44,7 +44,6 @@ public:
     void focus_on(WlSurface* surface);
 
 private:
-    WlSeat& seat;
     std::unique_ptr<KeyboardHelper> const helper;
     wayland::Weak<WlSurface> focused_surface;
 

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -263,6 +263,10 @@ void mf::WlSeat::set_focus_to(WlSurface* new_surface)
     auto const new_client = new_surface ? new_surface->client : nullptr;
     if (new_client != focused_client)
     {
+        keyboard_listeners->for_each(focused_client, [](WlKeyboard* keyboard)
+            {
+                keyboard->focus_on(nullptr);
+            });
         focus_listeners->for_each(focused_client, [](FocusListener* listener)
             {
                 listener->focus_on(nullptr);
@@ -286,6 +290,10 @@ void mf::WlSeat::set_focus_to(WlSurface* new_surface)
     {
         focused_surface_destroy_listener_id = {};
     }
+    keyboard_listeners->for_each(focused_client, [&](WlKeyboard* keyboard)
+        {
+            keyboard->focus_on(new_surface);
+        });
     focus_listeners->for_each(new_client, [&](FocusListener* listener)
         {
             listener->focus_on(new_surface);

--- a/src/server/scene/default_configuration.cpp
+++ b/src/server/scene/default_configuration.cpp
@@ -190,7 +190,17 @@ mir::DefaultServerConfiguration::the_prompt_session_manager()
         });
 }
 
-auto mir::DefaultServerConfiguration::the_clipboard()
+auto mir::DefaultServerConfiguration::the_main_clipboard()
+-> std::shared_ptr<ms::Clipboard>
+{
+    return clipboard(
+        []()
+        {
+            return std::make_shared<ms::BasicClipboard>();
+        });
+}
+
+auto mir::DefaultServerConfiguration::the_primary_selection_clipboard()
 -> std::shared_ptr<ms::Clipboard>
 {
     return clipboard(

--- a/src/server/scene/default_configuration.cpp
+++ b/src/server/scene/default_configuration.cpp
@@ -193,7 +193,7 @@ mir::DefaultServerConfiguration::the_prompt_session_manager()
 auto mir::DefaultServerConfiguration::the_main_clipboard()
 -> std::shared_ptr<ms::Clipboard>
 {
-    return clipboard(
+    return main_clipboard(
         []()
         {
             return std::make_shared<ms::BasicClipboard>();
@@ -203,7 +203,7 @@ auto mir::DefaultServerConfiguration::the_main_clipboard()
 auto mir::DefaultServerConfiguration::the_primary_selection_clipboard()
 -> std::shared_ptr<ms::Clipboard>
 {
-    return clipboard(
+    return primary_selection_clipboard(
         []()
         {
             return std::make_shared<ms::BasicClipboard>();

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -918,5 +918,7 @@ MIR_SERVER_2.10 {
   global:
     extern "C++" {
       mir::shell::ShellWrapper::set_popup_grab_tree*;
+      mir::DefaultServerConfiguration::the_main_clipboard*;
+      mir::DefaultServerConfiguration::the_primary_selection_clipboard*;
     };
 } MIR_SERVER_2.9;

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -918,7 +918,13 @@ MIR_SERVER_2.10 {
   global:
     extern "C++" {
       mir::shell::ShellWrapper::set_popup_grab_tree*;
+    };
+} MIR_SERVER_2.9;
+
+MIR_SERVER_2.11 {
+  global:
+    extern "C++" {
       mir::DefaultServerConfiguration::the_main_clipboard*;
       mir::DefaultServerConfiguration::the_primary_selection_clipboard*;
     };
-} MIR_SERVER_2.9;
+} MIR_SERVER_2.10;

--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -30,6 +30,7 @@ mir_generate_protocol_wrapper(mirwayland "zwp_"  protocol/text-input-unstable-v2
 mir_generate_protocol_wrapper(mirwayland "zwp_"  protocol/text-input-unstable-v1.xml)
 mir_generate_protocol_wrapper(mirwayland "zwp_"  protocol/input-method-unstable-v2.xml)
 mir_generate_protocol_wrapper(mirwayland "zwp_"  protocol/idle-inhibit-unstable-v1.xml)
+mir_generate_protocol_wrapper(mirwayland "zwp_"  protocol/primary-selection-unstable-v1.xml)
 mir_generate_protocol_wrapper(mirwayland "z"     protocol/wlr-screencopy-unstable-v1.xml)
 mir_generate_protocol_wrapper(mirwayland "zwlr_" protocol/wlr-virtual-pointer-unstable-v1.xml)
 

--- a/src/wayland/protocol/primary-selection-unstable-v1.xml
+++ b/src/wayland/protocol/primary-selection-unstable-v1.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wp_primary_selection_unstable_v1">
+  <copyright>
+    Copyright © 2015, 2016 Red Hat
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Primary selection protocol">
+    This protocol provides the ability to have a primary selection device to
+    match that of the X server. This primary selection is a shortcut to the
+    common clipboard selection, where text just needs to be selected in order
+    to allow copying it elsewhere. The de facto way to perform this action
+    is the middle mouse button, although it is not limited to this one.
+
+    Clients wishing to honor primary selection should create a primary
+    selection source and set it as the selection through
+    wp_primary_selection_device.set_selection whenever the text selection
+    changes. In order to minimize calls in pointer-driven text selection,
+    it should happen only once after the operation finished. Similarly,
+    a NULL source should be set when text is unselected.
+
+    wp_primary_selection_offer objects are first announced through the
+    wp_primary_selection_device.data_offer event. Immediately after this event,
+    the primary data offer will emit wp_primary_selection_offer.offer events
+    to let know of the mime types being offered.
+
+    When the primary selection changes, the client with the keyboard focus
+    will receive wp_primary_selection_device.selection events. Only the client
+    with the keyboard focus will receive such events with a non-NULL
+    wp_primary_selection_offer. Across keyboard focus changes, previously
+    focused clients will receive wp_primary_selection_device.events with a
+    NULL wp_primary_selection_offer.
+
+    In order to request the primary selection data, the client must pass
+    a recent serial pertaining to the press event that is triggering the
+    operation, if the compositor deems the serial valid and recent, the
+    wp_primary_selection_source.send event will happen in the other end
+    to let the transfer begin. The client owning the primary selection
+    should write the requested data, and close the file descriptor
+    immediately.
+
+    If the primary selection owner client disappeared during the transfer,
+    the client reading the data will receive a
+    wp_primary_selection_device.selection event with a NULL
+    wp_primary_selection_offer, the client should take this as a hint
+    to finish the reads related to the no longer existing offer.
+
+    The primary selection owner should be checking for errors during
+    writes, merely cancelling the ongoing transfer if any happened.
+  </description>
+
+  <interface name="zwp_primary_selection_device_manager_v1" version="1">
+    <description summary="X primary selection emulation">
+      The primary selection device manager is a singleton global object that
+      provides access to the primary selection. It allows to create
+      wp_primary_selection_source objects, as well as retrieving the per-seat
+      wp_primary_selection_device objects.
+    </description>
+
+    <request name="create_source">
+      <description summary="create a new primary selection source">
+        Create a new primary selection source.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_primary_selection_source_v1"/>
+    </request>
+
+    <request name="get_device">
+      <description summary="create a new primary selection device">
+        Create a new data device for a given seat.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_primary_selection_device_v1"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the primary selection device manager">
+        Destroy the primary selection device manager.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwp_primary_selection_device_v1" version="1">
+    <request name="set_selection">
+      <description summary="set the primary selection">
+        Replaces the current selection. The previous owner of the primary
+        selection will receive a wp_primary_selection_source.cancelled event.
+
+        To unset the selection, set the source to NULL.
+      </description>
+      <arg name="source" type="object" interface="zwp_primary_selection_source_v1" allow-null="true"/>
+      <arg name="serial" type="uint" summary="serial of the event that triggered this request"/>
+    </request>
+
+    <event name="data_offer">
+      <description summary="introduce a new wp_primary_selection_offer">
+        Introduces a new wp_primary_selection_offer object that may be used
+        to receive the current primary selection. Immediately following this
+        event, the new wp_primary_selection_offer object will send
+        wp_primary_selection_offer.offer events to describe the offered mime
+        types.
+      </description>
+      <arg name="offer" type="new_id" interface="zwp_primary_selection_offer_v1"/>
+    </event>
+
+    <event name="selection">
+      <description summary="advertise a new primary selection">
+        The wp_primary_selection_device.selection event is sent to notify the
+        client of a new primary selection. This event is sent after the
+        wp_primary_selection.data_offer event introducing this object, and after
+        the offer has announced its mimetypes through
+        wp_primary_selection_offer.offer.
+
+        The data_offer is valid until a new offer or NULL is received
+        or until the client loses keyboard focus. The client must destroy the
+        previous selection data_offer, if any, upon receiving this event.
+      </description>
+      <arg name="id" type="object" interface="zwp_primary_selection_offer_v1" allow-null="true"/>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the primary selection device">
+        Destroy the primary selection device.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwp_primary_selection_offer_v1" version="1">
+    <description summary="offer to transfer primary selection contents">
+      A wp_primary_selection_offer represents an offer to transfer the contents
+      of the primary selection clipboard to the client. Similar to
+      wl_data_offer, the offer also describes the mime types that the data can
+      be converted to and provides the mechanisms for transferring the data
+      directly to the client.
+    </description>
+
+    <request name="receive">
+      <description summary="request that the data is transferred">
+        To transfer the contents of the primary selection clipboard, the client
+        issues this request and indicates the mime type that it wants to
+        receive. The transfer happens through the passed file descriptor
+        (typically created with the pipe system call). The source client writes
+        the data in the mime type representation requested and then closes the
+        file descriptor.
+
+        The receiving client reads from the read end of the pipe until EOF and
+        closes its end, at which point the transfer is complete.
+      </description>
+      <arg name="mime_type" type="string"/>
+      <arg name="fd" type="fd"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the primary selection offer">
+        Destroy the primary selection offer.
+      </description>
+    </request>
+
+    <event name="offer">
+      <description summary="advertise offered mime type">
+        Sent immediately after creating announcing the
+        wp_primary_selection_offer through
+        wp_primary_selection_device.data_offer. One event is sent per offered
+        mime type.
+      </description>
+      <arg name="mime_type" type="string"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_primary_selection_source_v1" version="1">
+    <description summary="offer to replace the contents of the primary selection">
+      The source side of a wp_primary_selection_offer, it provides a way to
+      describe the offered data and respond to requests to transfer the
+      requested contents of the primary selection clipboard.
+    </description>
+
+    <request name="offer">
+      <description summary="add an offered mime type">
+        This request adds a mime type to the set of mime types advertised to
+        targets. Can be called several times to offer multiple types.
+      </description>
+      <arg name="mime_type" type="string"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the primary selection source">
+        Destroy the primary selection source.
+      </description>
+    </request>
+
+    <event name="send">
+      <description summary="send the primary selection contents">
+        Request for the current primary selection contents from the client.
+        Send the specified mime type over the passed file descriptor, then
+        close it.
+      </description>
+      <arg name="mime_type" type="string"/>
+      <arg name="fd" type="fd"/>
+    </event>
+
+    <event name="cancelled">
+      <description summary="request for primary selection contents was canceled">
+        This primary selection source is no longer valid. The client should
+        clean up and destroy this primary selection source.
+      </description>
+    </event>
+  </interface>
+</protocol>

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -537,5 +537,31 @@ global:
     mir::wayland::Client::register_client*;
     mir::wayland::Client::unregister_client*;
     virtual?thunk?to?mir::wayland::Resource::?Resource*;
+
+    mir::wayland::PrimarySelectionDeviceManagerV1::*;
+    non-virtual?thunk?to?mir::wayland::PrimarySelectionDeviceManagerV1::*;
+    typeinfo?for?mir::wayland::PrimarySelectionDeviceManagerV1;
+    vtable?for?mir::wayland::PrimarySelectionDeviceManagerV1;
+    typeinfo?for?mir::wayland::PrimarySelectionDeviceManagerV1::Global;
+    vtable?for?mir::wayland::PrimarySelectionDeviceManagerV1::Global;
+    virtual?thunk?to?mir::wayland::PrimarySelectionDeviceManagerV1::?PrimarySelectionDeviceManagerV1*;
+
+    mir::wayland::PrimarySelectionDeviceV1::*;
+    non-virtual?thunk?to?mir::wayland::PrimarySelectionDeviceV1::*;
+    typeinfo?for?mir::wayland::PrimarySelectionDeviceV1;
+    vtable?for?mir::wayland::PrimarySelectionDeviceV1;
+    virtual?thunk?to?mir::wayland::PrimarySelectionDeviceV1::?PrimarySelectionDeviceV1*;
+
+    mir::wayland::PrimarySelectionOfferV1::*;
+    non-virtual?thunk?to?mir::wayland::PrimarySelectionOfferV1::*;
+    typeinfo?for?mir::wayland::PrimarySelectionOfferV1;
+    vtable?for?mir::wayland::PrimarySelectionOfferV1;
+    virtual?thunk?to?mir::wayland::PrimarySelectionOfferV1::?PrimarySelectionOfferV1*;
+
+    mir::wayland::PrimarySelectionSourceV1::*;
+    non-virtual?thunk?to?mir::wayland::PrimarySelectionSourceV1::*;
+    typeinfo?for?mir::wayland::PrimarySelectionSourceV1;
+    vtable?for?mir::wayland::PrimarySelectionSourceV1;
+    virtual?thunk?to?mir::wayland::PrimarySelectionSourceV1::?PrimarySelectionSourceV1*;
   };
 } MIRWAYLAND_2.9;

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -537,7 +537,12 @@ global:
     mir::wayland::Client::register_client*;
     mir::wayland::Client::unregister_client*;
     virtual?thunk?to?mir::wayland::Resource::?Resource*;
+  };
+} MIRWAYLAND_2.9;
 
+MIRWAYLAND_2.11 {
+global:
+  extern "C++" {
     mir::wayland::PrimarySelectionDeviceManagerV1::*;
     non-virtual?thunk?to?mir::wayland::PrimarySelectionDeviceManagerV1::*;
     typeinfo?for?mir::wayland::PrimarySelectionDeviceManagerV1;
@@ -564,4 +569,4 @@ global:
     vtable?for?mir::wayland::PrimarySelectionSourceV1;
     virtual?thunk?to?mir::wayland::PrimarySelectionSourceV1::?PrimarySelectionSourceV1*;
   };
-} MIRWAYLAND_2.9;
+} MIRWAYLAND_2.10;

--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -97,6 +97,12 @@ set(EXPECTED_FAILURES
   XdgPopupUnstableV6/XdgPopupTest.grabbed_popup_gets_keyboard_focus/0
   XdgPopupStable/XdgPopupTest.grabbed_popup_gets_keyboard_focus/0
   LayerShellPopup/XdgPopupTest.grabbed_popup_gets_keyboard_focus/0
+
+  # Fixed by https://github.com/MirServer/wlcs/pull/245
+  PrimarySelection.source_sees_request
+  PrimarySelection.source_can_supply_request
+  PrimarySelection.sink_can_request
+  PrimarySelection.sink_can_listen
 )
 
 if (MIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN)


### PR DESCRIPTION
Needs to be enabled with `--add-wayland-extensions zwp_primary_selection_device_manager_v1`. GTK doesn't seem to consistently work outside of one app, possibly due to environment variable/settings problem? Qt works. Without a check that the receiving client has a focused surface it passes WLCS, but with that check it needs https://github.com/MirServer/wlcs/pull/245 (so I disabled the relevant tests until that's resolved).

Fixes #2699 
Fixes #2583.