### PR TITLE
gbm-kms: Improve Display platform probing

### DIFF
--- a/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
@@ -226,10 +226,8 @@ auto probe_display_platform(
                         "Probe failed to query GL renderer");
                 }
 
-                if (strncmp(
-                    "llvmpipe",
-                    renderer_string,
-                    strlen("llvmpipe")) == 0)
+                using namespace std::literals::string_literals;
+                if ("llvmpipe"s == renderer_string)
                 {
                     mir::log_info("KMS device only has associated software renderer: %s, device unsuitable", renderer_string);
                     supported_devices.back().support_level = mg::PlatformPriority::unsupported;

--- a/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
@@ -264,6 +264,11 @@ auto probe_display_platform(
                             // It supports KMS *and* can drive at least one physical output! Top hole!
                             supported_devices.back().support_level = mg::PlatformPriority::best;
                         }
+                        else
+                        {
+                            mir::log_info("KMS support found, but device has no output hardware.");
+                            mir::log_info("This is probably a render-only hybrid graphics device");
+                        }
                         break;
 
                     case ENOSYS:


### PR DESCRIPTION
Ensure that a candidate device has the hardware to support at least one physical display. It's not a very useful `DisplayPlatform` without at least one display :grin:

Also ensure that the device supports hardware EGL; this is (currently) a requirement for the gbm-kms `DisplayPlatform`.

Fixes: #2258