### PR TITLE
Move XKB modifier tracking from Wayland frontend to KeyMapper

### DIFF
--- a/include/core/mir_toolkit/events/enums.h
+++ b/include/core/mir_toolkit/events/enums.h
@@ -87,6 +87,8 @@ typedef enum {
     /* System policy has triggered a key repeat on a key
        which was already down */
     mir_keyboard_action_repeat,
+    /* Modifiers have been updated without a key event. keysym, scan_code and text are not set. */
+    mir_keyboard_action_modifiers,
 
     mir_keyboard_actions
 } MirKeyboardAction;

--- a/src/common/events/keyboard_event.cpp
+++ b/src/common/events/keyboard_event.cpp
@@ -76,3 +76,13 @@ void MirKeyboardEvent::set_keymap(std::shared_ptr<mir::input::Keymap> keymap)
 {
     keymap_ = std::move(keymap);
 }
+
+auto MirKeyboardEvent::xkb_modifiers() const -> std::optional<MirXkbModifiers>
+{
+    return xkb_modifiers_;
+}
+
+void MirKeyboardEvent::set_xkb_modifiers(std::optional<MirXkbModifiers> mods)
+{
+    xkb_modifiers_ = mods;
+}

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -534,3 +534,10 @@ MIR_COMMON_2.10 {
     MirTouchEvent::position*;
   };
 } MIR_COMMON_2.9;
+
+MIR_COMMON_2.11 {
+  extern "C++" {
+    MirKeyboardEvent::xkb_modifiers*;
+    MirKeyboardEvent::set_xkb_modifiers*;
+  };
+} MIR_COMMON_2.10;

--- a/src/include/common/mir/events/keyboard_event.h
+++ b/src/include/common/mir/events/keyboard_event.h
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include "mir/events/input_event.h"
+#include "mir/events/xkb_modifiers.h"
 
 namespace mir
 {
@@ -51,12 +52,16 @@ struct MirKeyboardEvent : MirInputEvent
     std::shared_ptr<mir::input::Keymap> keymap() const;
     void set_keymap(std::shared_ptr<mir::input::Keymap> keymap);
 
+    auto xkb_modifiers() const -> std::optional<MirXkbModifiers>;
+    void set_xkb_modifiers(std::optional<MirXkbModifiers> mods);
+
 private:
     MirKeyboardAction action_ = {};
     int32_t keysym_ = 0;
     int32_t scan_code_ = 0;
     std::string text_ = {};
     std::shared_ptr<mir::input::Keymap> keymap_;
+    std::optional<MirXkbModifiers> xkb_modifiers_;
 };
 
 #endif /* MIR_COMMON_KEYBOARD_EVENT_H_ */

--- a/src/include/common/mir/events/xkb_modifiers.h
+++ b/src/include/common/mir/events/xkb_modifiers.h
@@ -33,4 +33,9 @@ inline auto operator==(MirXkbModifiers const& lhs, MirXkbModifiers const& rhs) -
            lhs.effective_layout == rhs.effective_layout;
 }
 
+inline auto operator!=(MirXkbModifiers const& lhs, MirXkbModifiers const& rhs) -> bool
+{
+    return !(lhs == rhs);
+}
+
 #endif /* MIR_COMMON_XKB_MODIFIERS_H_ */

--- a/src/include/common/mir/events/xkb_modifiers.h
+++ b/src/include/common/mir/events/xkb_modifiers.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_COMMON_XKB_MODIFIERS_H_
+#define MIR_COMMON_XKB_MODIFIERS_H_
+
+struct MirXkbModifiers
+{
+    uint32_t depressed{0};
+    uint32_t latched{0};
+    uint32_t locked{0};
+    uint32_t effective_layout{0};
+};
+
+inline auto operator==(MirXkbModifiers const& lhs, MirXkbModifiers const& rhs) -> bool
+{
+    return lhs.depressed == rhs.depressed &&
+           lhs.latched == rhs.latched &&
+           lhs.locked == rhs.locked &&
+           lhs.effective_layout == rhs.effective_layout;
+}
+
+#endif /* MIR_COMMON_XKB_MODIFIERS_H_ */

--- a/src/include/common/mir/input/key_mapper.h
+++ b/src/include/common/mir/input/key_mapper.h
@@ -19,6 +19,7 @@
 
 #include "mir_toolkit/client_types.h"
 #include "mir_toolkit/event.h"
+#include "mir/events/xkb_modifiers.h"
 
 #include <vector>
 #include <memory>
@@ -78,6 +79,7 @@ public:
     virtual void map_event(MirEvent& event) = 0;
     virtual MirInputEventModifiers modifiers() const = 0;
     virtual MirInputEventModifiers device_modifiers(MirInputDeviceId id) const = 0;
+    virtual auto xkb_modifiers() const -> MirXkbModifiers = 0;
 
 protected:
     KeyMapper(KeyMapper const&) = delete;

--- a/src/include/server/mir/input/seat.h
+++ b/src/include/server/mir/input/seat.h
@@ -19,6 +19,7 @@
 
 #include "mir/geometry/rectangle.h"
 #include "mir/geometry/rectangles.h"
+#include "mir/events/xkb_modifiers.h"
 #include "mir_toolkit/event.h"
 
 #include <memory>
@@ -41,6 +42,7 @@ public:
     virtual void remove_device(Device const& device) = 0;
     virtual void dispatch_event(std::shared_ptr<MirEvent> const& event) = 0;
     virtual EventUPtr create_device_state() = 0;
+    virtual auto xkb_modifiers() const -> MirXkbModifiers = 0;
 
     virtual void set_key_state(Device const& dev, std::vector<uint32_t> const& scan_codes) = 0;
     virtual void set_pointer_state(Device const& dev, MirPointerButtons buttons) = 0;

--- a/src/server/frontend_wayland/input_method_grab_keyboard_v2.cpp
+++ b/src/server/frontend_wayland/input_method_grab_keyboard_v2.cpp
@@ -105,8 +105,13 @@ void mf::InputMethodGrabKeyboardV2::send_key(std::shared_ptr<MirKeyboardEvent co
     send_key_event(serial, timestamp, scancode, state);
 }
 
-void mf::InputMethodGrabKeyboardV2::send_modifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group)
+void mf::InputMethodGrabKeyboardV2::send_modifiers(MirXkbModifiers const& modifiers)
 {
     auto const serial = client->next_serial(nullptr);
-    send_modifiers_event(serial, depressed, latched, locked, group);
+    send_modifiers_event(
+        serial,
+        modifiers.depressed,
+        modifiers.latched,
+        modifiers.locked,
+        modifiers.effective_layout);
 }

--- a/src/server/frontend_wayland/input_method_grab_keyboard_v2.h
+++ b/src/server/frontend_wayland/input_method_grab_keyboard_v2.h
@@ -62,7 +62,7 @@ private:
     void send_repeat_info(int32_t rate, int32_t delay) override;
     void send_keymap_xkb_v1(mir::Fd const& fd, size_t length) override;
     void send_key(std::shared_ptr<MirKeyboardEvent const> const& event) override;
-    void send_modifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group) override;
+    void send_modifiers(MirXkbModifiers const& modifiers) override;
     /// @}
 };
 }

--- a/src/server/frontend_wayland/keyboard_helper.cpp
+++ b/src/server/frontend_wayland/keyboard_helper.cpp
@@ -105,18 +105,12 @@ void mf::KeyboardHelper::refresh_modifiers()
 void mf::KeyboardHelper::handle_keyboard_event(std::shared_ptr<MirKeyboardEvent const> const& event)
 {
     auto const action = mir_keyboard_event_action(event.get());
-    switch (action)
-    {
-    case mir_keyboard_action_down:
-    case mir_keyboard_action_up:
-        break;
-
-    default:
-        return;
-    }
 
     set_keymap(event->keymap());
-    callbacks->send_key(event);
+    if (action == mir_keyboard_action_down || action == mir_keyboard_action_up)
+    {
+        callbacks->send_key(event);
+    }
     if (auto const mods = event->xkb_modifiers())
     {
         set_modifiers(mods.value());

--- a/src/server/frontend_wayland/keyboard_helper.h
+++ b/src/server/frontend_wayland/keyboard_helper.h
@@ -18,6 +18,7 @@
 #define MIR_FRONTEND_KEYBOARD_HELPER_H
 
 #include "wayland_wrapper.h"
+#include "mir/events/xkb_modifiers.h"
 
 #include <vector>
 #include <functional>
@@ -49,7 +50,7 @@ public:
     virtual void send_repeat_info(int32_t rate, int32_t delay) = 0;
     virtual void send_keymap_xkb_v1(mir::Fd const& fd, size_t length) = 0;
     virtual void send_key(std::shared_ptr<MirKeyboardEvent const> const& event) = 0;
-    virtual void send_modifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group) = 0;
+    virtual void send_modifiers(MirXkbModifiers const& modifiers) = 0;
 
 private:
     KeyboardCallbacks(KeyboardCallbacks const&) = delete;
@@ -68,25 +69,21 @@ public:
     void handle_event(std::shared_ptr<MirEvent const> const& event);
 
     /// Returns the scancodes of pressed keys
-    auto refresh_internal_state() -> std::vector<uint32_t>;
+    auto pressed_key_scancodes() const -> std::vector<uint32_t>;
+    /// Updates the modifiers from the seat
+    void refresh_modifiers();
 
 private:
-    auto pressed_key_scancodes() const -> std::vector<uint32_t>;
     void handle_keyboard_event(std::shared_ptr<MirKeyboardEvent const> const& event);
     void set_keymap(std::shared_ptr<mir::input::Keymap> const& new_keymap);
-    void update_modifier_state();
+    void set_modifiers(MirXkbModifiers const& new_modifiers);
 
     KeyboardCallbacks* const callbacks;
     std::shared_ptr<input::Seat> const mir_seat;
+    std::optional<MirXkbModifiers> modifiers;
     std::shared_ptr<mir::input::Keymap> current_keymap;
     std::unique_ptr<xkb_keymap, void (*)(xkb_keymap *)> compiled_keymap;
-    std::unique_ptr<xkb_state, void (*)(xkb_state *)> state;
     std::unique_ptr<xkb_context, void (*)(xkb_context *)> const context;
-
-    uint32_t mods_depressed{0};
-    uint32_t mods_latched{0};
-    uint32_t mods_locked{0};
-    uint32_t group{0};
 };
 }
 }

--- a/src/server/frontend_wayland/keyboard_helper.h
+++ b/src/server/frontend_wayland/keyboard_helper.h
@@ -80,7 +80,7 @@ private:
 
     KeyboardCallbacks* const callbacks;
     std::shared_ptr<input::Seat> const mir_seat;
-    std::optional<MirXkbModifiers> modifiers;
+    MirXkbModifiers modifiers;
     std::shared_ptr<mir::input::Keymap> current_keymap;
     std::unique_ptr<xkb_keymap, void (*)(xkb_keymap *)> compiled_keymap;
     std::unique_ptr<xkb_context, void (*)(xkb_context *)> const context;

--- a/src/server/frontend_wayland/virtual_keyboard_v1.cpp
+++ b/src/server/frontend_wayland/virtual_keyboard_v1.cpp
@@ -218,4 +218,11 @@ void mf::VirtualKeyboardV1::modifiers(
         mods_latched,
         mods_locked,
         group};
+    std::chrono::nanoseconds nano = std::chrono::steady_clock::now().time_since_epoch();
+    keyboard_device->if_started_then([&](input::InputSink* sink, input::EventBuilder* builder)
+        {
+            auto key_event = builder->key_event(nano, mir_keyboard_action_modifiers, 0, 0);
+            key_event->to_input()->to_keyboard()->set_xkb_modifiers(xkb_modifiers);
+            sink->handle_input(move(key_event));
+        });
 }

--- a/src/server/frontend_wayland/virtual_keyboard_v1.cpp
+++ b/src/server/frontend_wayland/virtual_keyboard_v1.cpp
@@ -24,6 +24,10 @@
 #include "mir/input/virtual_input_device.h"
 #include "mir/input/mir_keyboard_config.h"
 #include "mir/input/buffer_keymap.h"
+#include "mir/events/xkb_modifiers.h"
+#include "mir/events/event.h"
+#include "mir/events/input_event.h"
+#include "mir/events/keyboard_event.h"
 #include "mir/log.h"
 
 #include <cstring>
@@ -126,6 +130,7 @@ private:
     std::shared_ptr<VirtualKeyboardV1Ctx> const ctx;
     std::shared_ptr<input::VirtualInputDevice> const keyboard_device;
     std::weak_ptr<input::Device> const device_handle;
+    std::optional<MirXkbModifiers> xkb_modifiers;
 };
 }
 }
@@ -196,7 +201,9 @@ void mf::VirtualKeyboardV1::key(uint32_t time, uint32_t key, uint32_t state)
     std::chrono::nanoseconds nano = std::chrono::milliseconds{time};
     keyboard_device->if_started_then([&](input::InputSink* sink, input::EventBuilder* builder)
         {
-            sink->handle_input(builder->key_event(nano, mir_keyboard_action(state), 0, key));
+            auto key_event = builder->key_event(nano, mir_keyboard_action(state), 0, key);
+            key_event->to_input()->to_keyboard()->set_xkb_modifiers(xkb_modifiers);
+            sink->handle_input(move(key_event));
         });
 }
 
@@ -206,10 +213,9 @@ void mf::VirtualKeyboardV1::modifiers(
     uint32_t mods_locked,
     uint32_t group)
 {
-    (void)mods_depressed;
-    (void)mods_latched;
-    (void)mods_locked;
-    (void)group;
-    log_info("Ignoring zwp_virtual_keyboard_v1.modifiers()");
-    // Currently we keep track of and send modifiers in the Wayland frontend, so handling this is not needed
+    xkb_modifiers = MirXkbModifiers{
+        mods_depressed,
+        mods_latched,
+        mods_locked,
+        group};
 }

--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -57,7 +57,7 @@ void mf::WlKeyboard::focus_on(WlSurface* surface)
     {
         // TODO: Send the surface's keymap here
 
-        auto const pressed_keys = helper->refresh_internal_state();
+        auto const pressed_keys = helper->pressed_key_scancodes();
 
         wl_array key_state;
         wl_array_init(&key_state);
@@ -83,7 +83,7 @@ void mf::WlKeyboard::focus_on(WlSurface* surface)
         auto const serial = client->next_serial(nullptr);
         send_enter_event(serial, surface->raw_resource(), &key_state);
         wl_array_release(&key_state);
-        send_modifiers_event(serial, depressed_modifiers, latched_modifiers, locked_modifiers, group_modifiers);
+        helper->refresh_modifiers();
     }
 
     focused_surface = mw::make_weak(surface);
@@ -108,16 +108,16 @@ void mf::WlKeyboard::send_key(std::shared_ptr<MirKeyboardEvent const> const& eve
     send_key_event(serial, timestamp, scancode, state);
 }
 
-void mf::WlKeyboard::send_modifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group)
+void mf::WlKeyboard::send_modifiers(MirXkbModifiers const& modifiers)
 {
-    depressed_modifiers = depressed;
-    latched_modifiers = latched;
-    locked_modifiers = locked;
-    group_modifiers = group;
-
     if (focused_surface)
     {
         auto const serial = client->next_serial(nullptr);
-        send_modifiers_event(serial, depressed, latched, locked, group);
+        send_modifiers_event(
+            serial,
+            modifiers.depressed,
+            modifiers.latched,
+            modifiers.locked,
+            modifiers.effective_layout);
     }
 }

--- a/src/server/frontend_wayland/wl_keyboard.h
+++ b/src/server/frontend_wayland/wl_keyboard.h
@@ -47,17 +47,12 @@ private:
     std::unique_ptr<KeyboardHelper> const helper;
     wayland::Weak<WlSurface> focused_surface;
 
-    uint32_t depressed_modifiers = 0;
-    uint32_t latched_modifiers = 0;
-    uint32_t locked_modifiers = 0;
-    uint32_t group_modifiers = 0;
-
     /// KeyboardCallbacks overrides
     /// @{
     void send_repeat_info(int32_t rate, int32_t delay) override;
     void send_keymap_xkb_v1(mir::Fd const& fd, size_t length) override;
     void send_key(std::shared_ptr<MirKeyboardEvent const> const& event) override;
-    void send_modifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group) override;
+    void send_modifiers(MirXkbModifiers const& modifiers) override;
     /// @}
 };
 }

--- a/src/server/input/basic_seat.cpp
+++ b/src/server/input/basic_seat.cpp
@@ -217,6 +217,11 @@ mir::EventUPtr mi::BasicSeat::create_device_state()
     return input_state_tracker.create_device_state();
 }
 
+auto mi::BasicSeat::xkb_modifiers() const -> MirXkbModifiers
+{
+    return input_state_tracker.xkb_modifiers();
+}
+
 void mi::BasicSeat::set_key_state(Device const& dev, std::vector<uint32_t> const& scan_codes)
 {
     input_state_tracker.set_key_state(dev.id(), scan_codes);

--- a/src/server/input/basic_seat.h
+++ b/src/server/input/basic_seat.h
@@ -60,6 +60,7 @@ public:
     geometry::Rectangle bounding_rectangle() const override;
     input::OutputInfo output_info(uint32_t output_id) const override;
     EventUPtr create_device_state() override;
+    auto xkb_modifiers() const -> MirXkbModifiers override;
     void set_confinement_regions(geometry::Rectangles const& regions) override;
     void reset_confinement_regions() override;
 

--- a/src/server/input/key_repeat_dispatcher.cpp
+++ b/src/server/input/key_repeat_dispatcher.cpp
@@ -222,6 +222,8 @@ void mi::KeyRepeatDispatcher::handle_key_input(MirInputDeviceId id, MirKeyboardE
     case mir_keyboard_action_repeat:
         // Should we consume existing repeats?
         break;
+    case mir_keyboard_action_modifiers:
+        break;
     default:
         BOOST_THROW_EXCEPTION(std::logic_error("Unexpected key event action"));
     }

--- a/src/server/input/seat_input_device_tracker.cpp
+++ b/src/server/input/seat_input_device_tracker.cpp
@@ -316,6 +316,11 @@ mir::EventUPtr mi::SeatInputDeviceTracker::create_device_state() const
     return out_ev;
 }
 
+auto mi::SeatInputDeviceTracker::xkb_modifiers() const -> MirXkbModifiers
+{
+    return key_mapper->xkb_modifiers();
+}
+
 void mi::SeatInputDeviceTracker::DeviceData::update_scan_codes(MirKeyboardEvent const* event)
 {
     auto const action = mir_keyboard_event_action(event);

--- a/src/server/input/seat_input_device_tracker.cpp
+++ b/src/server/input/seat_input_device_tracker.cpp
@@ -389,6 +389,11 @@ void mir::input::SeatInputDeviceTracker::remove_pointing_device()
 bool mi::SeatInputDeviceTracker::DeviceData::allowed_scan_code_action(MirKeyboardEvent const* event) const
 {
     auto const action = mir_keyboard_event_action(event);
+    if (action == mir_keyboard_action_modifiers)
+    {
+        return true;
+    }
+
     auto const scan_code = mir_keyboard_event_scan_code(event);
     bool found = find(begin(scan_codes), end(scan_codes), scan_code) != end(scan_codes);
 

--- a/src/server/input/seat_input_device_tracker.h
+++ b/src/server/input/seat_input_device_tracker.h
@@ -23,6 +23,7 @@
 #include "mir/geometry/size.h"
 #include "mir/optional_value.h"
 #include "mir_toolkit/event.h"
+#include "mir/events/xkb_modifiers.h"
 
 #include <atomic>
 #include <unordered_map>
@@ -69,6 +70,7 @@ public:
     MirPointerButtons button_state() const;
 
     EventUPtr create_device_state() const;
+    auto xkb_modifiers() const -> MirXkbModifiers;
 
     void set_key_state(MirInputDeviceId id, std::vector<uint32_t> const& scan_codes);
     void set_pointer_state(MirInputDeviceId id, MirPointerButtons buttons);

--- a/tests/include/mir/test/doubles/mock_input_seat.h
+++ b/tests/include/mir/test/doubles/mock_input_seat.h
@@ -35,6 +35,7 @@ struct MockInputSeat : input::Seat
     MOCK_METHOD1(remove_device, void(input::Device const& device));
     MOCK_METHOD1(dispatch_event, void(std::shared_ptr<MirEvent> const& event));
     MOCK_METHOD0(create_device_state, mir::EventUPtr());
+    MOCK_CONST_METHOD0(xkb_modifiers, MirXkbModifiers());
     MOCK_METHOD2(set_key_state, void(input::Device const&, std::vector<uint32_t> const&));
     MOCK_METHOD2(set_pointer_state, void (input::Device const&, MirPointerButtons));
     MOCK_METHOD2(set_cursor_position, void (float, float));

--- a/tests/include/mir/test/doubles/mock_key_mapper.h
+++ b/tests/include/mir/test/doubles/mock_key_mapper.h
@@ -38,8 +38,8 @@ struct MockKeyMapper : input::KeyMapper
     MOCK_METHOD1(map_event, void(MirEvent& event));
     MOCK_CONST_METHOD0(modifiers, MirInputEventModifiers());
     MOCK_CONST_METHOD1(device_modifiers, MirInputEventModifiers(MirInputDeviceId));
+    MOCK_CONST_METHOD0(xkb_modifiers, MirXkbModifiers());
 };
-
 
 }
 }


### PR DESCRIPTION
Instead of the long-standing hacky solution of maintaining an XKB state in the Wayland frontend, this PR uses the state already maintained in the KeyMapper. XKB modifiers are now passes as part of key events so they are available for the frontend to send to clients. With these changes in place it was possible to add support for virtual keyboard modifiers.

Fixes #2720
Fixes #2145