### PR TITLE
Continue building ppa debs for kinetic

### DIFF
--- a/.github/workflows/ppa-upload.yml
+++ b/.github/workflows/ppa-upload.yml
@@ -16,6 +16,7 @@ jobs:
         release:
         - "20.04"
         - "22.04"
+        - "22.10"
         - "devel"
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ppa-upload.yml
+++ b/.github/workflows/ppa-upload.yml
@@ -17,7 +17,7 @@ jobs:
         - "20.04"
         - "22.04"
         - "22.10"
-        - "devel"
+        - "23.04"
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Hello :) This should allow for kinetic ppa debs to continue now that kinetic is no longer 'devel'. I have also taken the liberty to stop using 'devel' in this context and explicitly name lunar (=23.04) as it would seem much better for any debs which are being built to continue being built (and then adding the latest development release when needed), rather than the latest release debs stopping as soon as there is a new development release. I appreciate there might be a good reason to use 'devel', but (with my limited knowledge) I couldn't see anything immediately obvious. Thanks a lot!