### PR TITLE
cmake: Fix ptest target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,7 @@ CMAKE_DEPENDENT_OPTION(
   MIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN "Expect WLCS BadBuffer tests to fail" OFF
   "MIR_RUN_WLCS_TESTS" OFF
 )
+SET(MIR_EXCLUDE_TESTS "" CACHE STRING "Semicolon-separated list of tests to exclude (wildcards accepted)")
 
 
 foreach(platform IN LISTS MIR_PLATFORM)

--- a/cmake/MirCommon.cmake
+++ b/cmake/MirCommon.cmake
@@ -66,7 +66,7 @@ function (mir_discover_tests_internal EXECUTABLE TEST_ENV_OPTIONS DETECT_FD_LEAK
       set(test_name ${EXECUTABLE})
   endif()
   set(test_no_memcheck_filter)
-  set(test_exclusion_filter)
+  list(APPEND test_exclusion_filter ${MIR_EXCLUDE_TESTS})
 
   if(ENABLE_MEMCHECK_OPTION)
     set(test_cmd ${VALGRIND_CMD} ${test_cmd_no_memcheck})

--- a/cmake/MirCommon.cmake
+++ b/cmake/MirCommon.cmake
@@ -70,7 +70,7 @@ function (mir_discover_tests_internal EXECUTABLE TEST_ENV_OPTIONS DETECT_FD_LEAK
 
   if(ENABLE_MEMCHECK_OPTION)
     set(test_cmd ${VALGRIND_CMD} ${test_cmd_no_memcheck})
-    set(test_no_memcheck_filter "*DeathTest.*" "ClientLatency.*")
+    list(APPEND test_no_memcheck_filter "*DeathTest.*" "ClientLatency.*")
   endif()
 
   if(cmake_build_type_lower MATCHES "threadsanitizer")

--- a/spread/build/sbuild/task.yaml
+++ b/spread/build/sbuild/task.yaml
@@ -74,7 +74,7 @@ execute: |
         # Running the tests under QEMU fails to entirely correctly support libwayland's SIGSEGV handler
         echo "OVERRIDE_CONFIGURE_OPTIONS += -DMIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN=ON" >> debian/opts.mk
         # This test inexplicably tends to die under qemu (MirServer/mir#2748)
-        echo "OVERRIDE_CONFIGURE_OPTIONS += -DMIR_EXCLUDE_TEST=Anchor/LayerSurfaceLayoutTest.*" >> debian/opts.mk
+        echo "OVERRIDE_CONFIGURE_OPTIONS += -DMIR_EXCLUDE_TESTS=Anchor/LayerSurfaceLayoutTest.*" >> debian/opts.mk
       fi
     fi
 

--- a/spread/build/sbuild/task.yaml
+++ b/spread/build/sbuild/task.yaml
@@ -69,6 +69,13 @@ execute: |
       # Quirk for the eglexternalplatform-dev build dependency
       sed -i 's/\(eglexternalplatform-dev\)/\1:all/' debian/control
       SCHROOT_NAME="${SCHROOT_NAME}-${DEB_HOST_ARCH}"
+
+      if [[ ${DEB_HOST_ARCH} == arm* ]]; then
+        # Running the tests under QEMU fails to entirely correctly support libwayland's SIGSEGV handler
+        echo "OVERRIDE_CONFIGURE_OPTIONS += -DMIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN=ON" >> debian/opts.mk
+        # This test inexplicably tends to die under qemu (MirServer/mir#2748)
+        echo "OVERRIDE_CONFIGURE_OPTIONS += -DMIR_EXCLUDE_TEST=Anchor/LayerSurfaceLayoutTest.*" >> debian/opts.mk
+      fi
     fi
 
     # If release not in yet
@@ -87,11 +94,6 @@ execute: |
     echo "OVERRIDE_CONFIGURE_OPTIONS += -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> debian/opts.mk
 
     echo "${CCACHE_DIR} ${CCACHE_DIR} none rw,bind 0 0" >> /etc/schroot/sbuild/fstab
-
-    # Running the tests under QEMU fails to entirely correctly support libwayland's SIGSEGV handler
-    if [[ ${DEB_HOST_ARCH} == arm* ]]; then
-      echo "OVERRIDE_CONFIGURE_OPTIONS += -DMIR_BAD_BUFFER_TEST_ENVIRONMENT_BROKEN=ON" >> debian/opts.mk
-    fi
 
     sbuild "${SBUILD_OPTS[@]}"
 

--- a/tools/discover_gtests.sh
+++ b/tools/discover_gtests.sh
@@ -91,12 +91,7 @@ then
     testname=$(basename $test_binary)
 fi
 
-if [ -z "$includes" ];
-then
-    discover_filter="-$excludes"
-else
-    discover_filter="$includes:-$excludes"
-fi
+discover_filter="${includes:+$includes:}-$excludes"
 
 tests=$($test_binary --gtest_list_tests --gtest_filter=$discover_filter | grep -v '^ ' | cut -d' ' -f1 | grep '\.' | sed 's/$/*/')
 

--- a/tools/discover_gtests.sh
+++ b/tools/discover_gtests.sh
@@ -13,13 +13,25 @@ print_help_and_exit()
     echo "                                    if not specified, the last element of \`cmds\` is used."
     echo "      --env=ENV                     add ENV to the environment of the tests"
     echo "      --gtest-exclude FILTER        Exclude tests matching FILTER (may be specified multiple times)"
+    echo "      --gtest-include FILTER        Include only tests matching FILTER (may be specified multiple times)"
     echo "  -h, --help                        display this help and exit"
+    echo ""
+    echo "WARNING: --gtest_filter passed in through <cmds> will not work; to avoid accidental misuse,"
+    echo "         $prog will exit with an error if --gtest_filter is discovered in specified command"
     echo ""
     echo "Example: $prog path/to/mir_unit_tests"
     echo "Example: $prog --env LD_PRELOAD=p.so -- valgrind --trace-children=yes path/to/mir_unit_tests"
     echo "Example: $prog --gtest-executable path/to/mir_unit_tests -- path/to/mir_unit_tests make_explode_with_delight"
 
     exit 0
+}
+
+print_filter_error_and_exit()
+{
+    echo "ERROR: Detected --gtest_filter as a part of <cmds>"
+    echo "       --gtest_filter in the command will not do what you want; to avoid accidental misuse"
+    echo "       $prog will now exit."
+    exit 1
 }
 
 add_env()
@@ -32,14 +44,14 @@ add_cmd()
     cmd="$cmd \"$1\""
 }
 
-add_filter()
-{
-    filter="$filter $1"
-}
-
 add_exclude()
 {
     excludes="$excludes:$1"
+}
+
+add_include()
+{
+    includes="$includes:$1"
 }
 
 while [ $# -gt 0 ];
@@ -50,6 +62,7 @@ do
         --help|-h) print_help_and_exit;;
         --gtest-executable) shift; test_binary="$1";;
         --gtest-exclude) shift; add_exclude "$1";;
+        --gtest-include) shift; add_include "$1";;
         --) shift; break;;
         --*) print_help_and_exit;;
         *) break;;
@@ -60,7 +73,7 @@ done
 while [ $# -gt 0 ];
 do
     case "$1" in
-        --gtest_filter*) add_filter "$1";;
+        --gtest_filter*) print_filter_error_and_exit ;;
         --*) ;;
         *) last_cmd="$1";;
     esac
@@ -78,7 +91,14 @@ then
     testname=$(basename $test_binary)
 fi
 
-tests=$($test_binary --gtest_list_tests --gtest_filter=-$excludes | grep -v '^ ' | cut -d' ' -f1 | grep '\.' | sed 's/$/*/')
+if [ -z "$includes" ];
+then
+    discover_filter="-$excludes"
+else
+    discover_filter="$includes:-$excludes"
+fi
+
+tests=$($test_binary --gtest_list_tests --gtest_filter=$discover_filter | grep -v '^ ' | cut -d' ' -f1 | grep '\.' | sed 's/$/*/')
 
 for t in $tests;
 do


### PR DESCRIPTION
We've been accidentally misusing `tools/discover-gtests.sh` by trying to pass `--gtest_filter` through. Due to the way GTest parses `--gtest_filter` (specifically, that it only respects the *last* `--gtest_filter` on the command line, ignoring any others), this results in any filter we were *trying* to pass in being ignored.

Instead, add a `--gtest-includes` option to `tools/discover-gtests.sh`, error out if the command contains `--gtest_filter`, use this in test discovery infrastructure, and explicitly pass tests we don't expect to run as `--gtest-excludes`.