### PR TITLE
platform/DRMFormat: Add as_mir_format converter

### DIFF
--- a/include/platform/mir/graphics/drm_formats.h
+++ b/include/platform/mir/graphics/drm_formats.h
@@ -17,6 +17,7 @@
 #ifndef MIR_PLATFORM_GRAPHICS_DRM_FORMATS_H_
 #define MIR_PLATFORM_GRAPHICS_DRM_FORMATS_H_
 
+#include "mir_toolkit/common.h"
 #include <cstdint>
 #include <string>
 #include <optional>
@@ -48,6 +49,7 @@ public:
 
     operator uint32_t() const;
 
+    auto as_mir_format() const -> std::optional<MirPixelFormat>;
     struct FormatInfo;
 private:
     FormatInfo const* info;

--- a/src/platform/graphics/drm_formats.cpp
+++ b/src/platform/graphics/drm_formats.cpp
@@ -503,6 +503,33 @@ mg::DRMFormat::operator uint32_t() const
     return info->format;
 }
 
+auto mg::DRMFormat::as_mir_format() const -> std::optional<MirPixelFormat>
+{
+    switch (info->format)
+    {
+    case DRM_FORMAT_ARGB8888:
+        return mir_pixel_format_argb_8888;
+    case DRM_FORMAT_XRGB8888:
+        return mir_pixel_format_xrgb_8888;
+    case DRM_FORMAT_RGBA4444:
+        return mir_pixel_format_rgba_4444;
+    case DRM_FORMAT_RGBA5551:
+        return mir_pixel_format_rgba_5551;
+    case DRM_FORMAT_RGB565:
+        return mir_pixel_format_rgb_565;
+    case DRM_FORMAT_RGB888:
+        return mir_pixel_format_rgb_888;
+    case DRM_FORMAT_BGR888:
+        return mir_pixel_format_bgr_888;
+    case DRM_FORMAT_XBGR8888:
+        return mir_pixel_format_xbgr_8888;
+    case DRM_FORMAT_ABGR8888:
+        return mir_pixel_format_abgr_8888;
+    default:
+        return std::nullopt;
+    }
+}    
+
 auto mg::drm_modifier_to_string(uint64_t modifier) -> std::string
 {
 #ifdef MIR_HAVE_DRM_GET_MODIFIER_NAME

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -213,3 +213,10 @@ MIR_PLATFORM_2.8 {
     vtable?for?mir::graphics::common::EGLContextExecutor;
    };
 } MIRPLATFORM_2.7;
+
+MIR_PLATFORM_2.11 {
+ global:
+  extern "C++" {
+    mir::graphics::DRMFormat::as_mir_format*;
+  };
+} MIR_PLATFORM_2.8;


### PR DESCRIPTION
Ideally we would migrate to a world where `DRMFormat` is the canonical type for pixel formats; there are more of them, and the descriptor contains more useful information that code using `MirPixelFormat` has had to ad-hoc.

Make it possible to start doing this by adding a conversion from `DRMFormat` to `MirPixelFormat`. This is necessarily lossy, as there are a lot of `DRMFormat`s that have no corresponding `MirPixelFormat`, but that implies that *current* code couldn't have properly handled them, so it's OK.