### PR TITLE
GitHub: Try to upload core files on failure

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -114,6 +114,8 @@ jobs:
         # Dump cores in a known directory, for later upload
         mkdir coredumps
         echo "$PWD/coredumps/corefile-%e-%p-%t" | sudo tee /proc/sys/kernel/core_pattern
+        # schroot runs suid, so we need to relax core dump security policies
+        sudo sysctl fs.suid_dumpable=2
 
         snap run spread-mir-ci.spread -v ${{ matrix.spread-task }}
 

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -74,7 +74,7 @@ jobs:
       run: |
         sudo snap install spread-mir-ci
         sudo snap connect spread-mir-ci:lxd lxd:lxd
-        lxc profile set default security.privileged=true security.nesting=true
+        lxc profile set default security.privileged=true security.nesting=true limits.kernel.core=unlimited
         sudo apt-get update
         sudo apt-get install --yes binfmt-support qemu-user-static
         echo "LXD_DIR=/var/snap/lxd/common/lxd" >> $GITHUB_ENV
@@ -111,8 +111,6 @@ jobs:
 
     - name: Run Spread task
       run: |
-        # Ensure core dumps can be generated
-        ulimit -c unlimited
         # Dump cores in a known directory, for later upload
         mkdir "${COREDUMPS_DIR}"
         echo "${COREDUMPS_DIR}/corefile-%e-%p-%t" | sudo tee /proc/sys/kernel/core_pattern

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -119,6 +119,10 @@ jobs:
 
         snap run spread-mir-ci.spread -v ${{ matrix.spread-task }}
 
+    - name: Own core dumps
+      if: failure()
+      run: sudo chown ${UID} ${COREDUMPS_DIR}/*
+
     - name: Upload core dumps (if generated)
       uses: actions/upload-artifact@v3
       if: failure()

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -108,7 +108,23 @@ jobs:
         echo "max_size = 800M" > ${CCACHE_DIR}/ccache.conf
 
     - name: Run Spread task
-      run: snap run spread-mir-ci.spread -v ${{ matrix.spread-task }}
+      run: |
+        # Ensure core dumps can be generated
+        ulimit -c unlimited
+        # Dump cores in a known directory, for later upload
+        mkdir coredumps
+        echo "$PWD/coredumps/corefile-%e-%p-%t" | sudo tee /proc/sys/kernel/core_pattern
+
+        snap run spread-mir-ci.spread -v ${{ matrix.spread-task }}
+
+    - name: Upload core dumps (if generated)
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: core-dumps
+        path: ./coredumps/*
+        retention-days: 5
+        if-no-files-found: ignore
 
     - name: CCache stats
       run: cat ${CCACHE_DIR}/ccache.stats

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -64,6 +64,7 @@ jobs:
       DEBEMAIL: "mir-ci-bot@canonical.com"
       SPREAD_PATH: "/tmp/spread"
       CCACHE_DIR: "/tmp/ccache"
+      COREDUMPS_DIR: "/tmp/coredumps"
 
     steps:
     - name: Set up LXD
@@ -88,6 +89,7 @@ jobs:
       run: |
         mkdir --parents ${CCACHE_DIR}
         /snap/bin/lxc profile device add default ccache disk source=${CCACHE_DIR} path=/root/.ccache
+        /snap/bin/lxc profile device add default coredumps disk source=${COREDUMPS_DIR} path=${COREDUMPS_DIR}
 
         # Find the merge base to avoid populating the cache with short lived cache entries
         # and evicting those we care for - from `main`
@@ -112,8 +114,8 @@ jobs:
         # Ensure core dumps can be generated
         ulimit -c unlimited
         # Dump cores in a known directory, for later upload
-        mkdir coredumps
-        echo "$PWD/coredumps/corefile-%e-%p-%t" | sudo tee /proc/sys/kernel/core_pattern
+        mkdir "${COREDUMPS_DIR}"
+        echo "${COREDUMPS_DIR}/corefile-%e-%p-%t" | sudo tee /proc/sys/kernel/core_pattern
         # schroot runs suid, so we need to relax core dump security policies
         sudo sysctl fs.suid_dumpable=2
 
@@ -124,7 +126,7 @@ jobs:
       if: failure()
       with:
         name: core-dumps
-        path: ./coredumps/*
+        path: ${{ env.COREDUMPS_DIR }}/*
         retention-days: 5
         if-no-files-found: ignore
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -50,6 +50,7 @@ environment:
     NOCHECK/asan,tsan,ubsan,asan_clang,tsan_clang,ubsan_clang: nocheck
     CTEST_OUTPUT_ON_FAILURE: 1
     CCACHE_DIR: /root/.ccache
+    COREDUMPS_DIR: /tmp/coredumps
     # Needed for precompiled headers (https://ccache.dev/manual/latest.html#_precompiled_headers)
     CCACHE_SLOPPINESS: time_macros,pch_defines,include_file_mtime,include_file_ctime
 

--- a/spread/build/sbuild/task.yaml
+++ b/spread/build/sbuild/task.yaml
@@ -28,7 +28,9 @@ execute: |
         schroot \
         ubuntu-dev-tools
 
-    printf "\$mailto = 'null@example.com';\n1;\n" > ~/.sbuildrc
+    printf "\$mailto = 'null@example.com';\n" > ~/.sbuildrc
+    printf "\$build_environment = { 'COREDUMPS_DIR' => '${COREDUMPS_DIR}' };\n" >> ~/.sbuildrc
+    printf "1;\n" >> ~/.sbuildrc
 
     adduser $USER sbuild
     # set host and build environment up

--- a/spread/build/sbuild/task.yaml
+++ b/spread/build/sbuild/task.yaml
@@ -87,6 +87,7 @@ execute: |
     echo "OVERRIDE_CONFIGURE_OPTIONS += -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> debian/opts.mk
 
     echo "${CCACHE_DIR} ${CCACHE_DIR} none rw,bind 0 0" >> /etc/schroot/sbuild/fstab
+    echo "${COREDUMPS_DIR} ${COREDUMPS_DIR} none rw,bind 0 0" >> /etc/schroot/sbuild/fstab
 
     # Running the tests under QEMU fails to entirely correctly support libwayland's SIGSEGV handler
     if [[ ${DEB_HOST_ARCH} == arm* ]]; then

--- a/tools/run_ctests.sh
+++ b/tools/run_ctests.sh
@@ -14,7 +14,7 @@ print_help_and_exit()
 }
 
 TEST_DIR=$(mktemp -d --tmpdir mir-ctests-XXXXX);
-trap "if [ -d \"$TEST_DIR\" ]; then rm -r \"$TEST_DIR\"; fi" INT TERM EXIT
+trap "if [ -d \"$COREDUMPS_DIR\" ]; then cp $TEST_DIR/qemu*.core $COREDUMPS_DIR/; fi; if [ -d \"$TEST_DIR\" ]; then rm -r \"$TEST_DIR\"; fi" INT TERM EXIT
 
 while [ $# -gt 0 ];
 do


### PR DESCRIPTION
Sometimes, tests fail with a crash. If we could get these tests to dump a core we could inspect later, that would be nice!