### PR TITLE
Spike dynamic display configuration

### DIFF
--- a/debian/libmiral5.symbols
+++ b/debian/libmiral5.symbols
@@ -417,3 +417,5 @@ libmiral.so.5 libmiral5 #MINVER#
  (c++)"miral::MirRunner::register_signal_handler(std::initializer_list<int>, std::function<void (int)> const&)@MIRAL_3.7" 3.7.0
  (c++)"miral::MirRunner::register_fd_handler(mir::Fd, std::function<void (int)> const&)@MIRAL_3.7" 3.7.0
  (c++)"miral::FdHandle::~FdHandle()@MIRAL_3.7" 3.7.0
+ MIRAL_3.8@MIRAL_3.8 3.8.0
+ (c++)"miral::DynamicDisplayConfiguration::operator()(mir::Server&) const@MIRAL_3.8" 3.8.0

--- a/examples/miral-kiosk/kiosk_main.cpp
+++ b/examples/miral-kiosk/kiosk_main.cpp
@@ -15,8 +15,6 @@
  */
 
 #include "kiosk_window_manager.h"
-#include "miral/append_event_filter.h"
-#include "mir_toolkit/event.h"
 
 #include <miral/runner.h>
 #include <miral/application_authorizer.h>
@@ -110,35 +108,6 @@ int main(int argc, char const* argv[])
 
     DynamicDisplayConfiguration display_config{runner};
 
-    auto const reload_display_config = [&](MirEvent const* event)
-        {
-            if (mir_event_get_type(event) != mir_event_type_input)
-                return false;
-
-            MirInputEvent const* input_event = mir_event_get_input_event(event);
-            if (mir_input_event_get_type(input_event) != mir_input_event_type_key)
-                return false;
-
-            MirKeyboardEvent const* kev = mir_input_event_get_keyboard_event(input_event);
-            if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
-                return false;
-
-            MirInputEventModifiers mods = mir_keyboard_event_modifiers(kev);
-            if (!(mods & mir_input_event_modifier_alt) || !(mods & mir_input_event_modifier_ctrl))
-                return false;
-
-            switch (mir_keyboard_event_keysym(kev))
-            {
-            case XKB_KEY_r:
-            case XKB_KEY_R:display_config.reload();
-                return true;
-
-            default:
-                return false;
-            };
-        };
-
-
     ConfigurationOption show_splash{
         [&](bool show_splash) {splash.enable(show_splash); },
         "show-splash",
@@ -162,7 +131,6 @@ int main(int argc, char const* argv[])
             launcher,
             wayland_extensions,
             ConfigurationOption{run_startup_apps, "startup-apps", "Colon separated list of startup apps", ""},
-            StartupInternalClient{splash},
-            AppendEventFilter{reload_display_config}
+            StartupInternalClient{splash}
         });
 }

--- a/include/miral/miral/display_configuration.h
+++ b/include/miral/miral/display_configuration.h
@@ -54,8 +54,18 @@ public:
     auto operator=(DisplayConfiguration const&) -> DisplayConfiguration&;
 
 private:
+    friend class DynamicDisplayConfiguration;
     struct Self;
     std::shared_ptr<Self> self;
+};
+
+class DynamicDisplayConfiguration : public DisplayConfiguration
+{
+public:
+    using DisplayConfiguration::DisplayConfiguration;
+
+    void reload();
+    void operator()(mir::Server& server) const;
 };
 }
 

--- a/include/miral/miral/display_configuration.h
+++ b/include/miral/miral/display_configuration.h
@@ -64,7 +64,6 @@ class DynamicDisplayConfiguration : public DisplayConfiguration
 public:
     using DisplayConfiguration::DisplayConfiguration;
 
-    void reload();
     void operator()(mir::Server& server) const;
 };
 }

--- a/src/miral/display_configuration.cpp
+++ b/src/miral/display_configuration.cpp
@@ -20,6 +20,7 @@
 #include "static_display_config.h"
 
 #include <mir/server.h>
+#include "mir/shell/display_configuration_controller.h"
 #include <mir/log.h>
 
 #include <unistd.h>
@@ -31,6 +32,36 @@ struct miral::DisplayConfiguration::Self : StaticDisplayConfig
 {
     Self(std::string const& name) : name{name} {}
     std::string const name;
+    std::weak_ptr<mir::shell::DisplayConfigurationController> the_display_configuration_controller;
+
+    void find_and_load_config()
+    {
+        std::string config_roots;
+
+        if (auto config_home = getenv("XDG_CONFIG_HOME"))
+            (config_roots = config_home) += ":";
+        else if (auto home = getenv("HOME"))
+            (config_roots = home) += "/.config:";
+
+        if (auto config_dirs = getenv("XDG_CONFIG_DIRS"))
+            config_roots += config_dirs;
+        else
+            config_roots += "/etc/xdg";
+
+        std::istringstream config_stream(config_roots);
+
+        /* Read options from config files */
+        for (std::string config_root; getline(config_stream, config_root, ':');)
+        {
+            auto const& filename = config_root + "/" + name;
+
+            if (std::ifstream config_file{filename})
+            {
+                load_config(config_file, "ERROR: in display configuration file: '" + filename + "' : ");
+                break;
+            }
+        }
+    }
 
     void dump_config(std::function<void(std::ostream&)> const& print_template_config) override
     {
@@ -54,8 +85,10 @@ struct miral::DisplayConfiguration::Self : StaticDisplayConfig
                 std::ofstream out{filename};
                 print_template_config(out);
 
-                if (!out)
-                    mir::log_debug("Failed writing display configuration template: %s", filename.c_str());
+                mir::log_debug(
+                    "%s display configuration template: %s",
+                    out ? "Written" : "Failed writing",
+                    filename.c_str());
             }
         }
 
@@ -66,31 +99,7 @@ struct miral::DisplayConfiguration::Self : StaticDisplayConfig
 miral::DisplayConfiguration::DisplayConfiguration(MirRunner const& mir_runner) :
     self{std::make_shared<Self>(mir_runner.display_config_file())}
 {
-    std::string config_roots;
-
-    if (auto config_home = getenv("XDG_CONFIG_HOME"))
-        (config_roots = config_home) += ":";
-    else if (auto home = getenv("HOME"))
-        (config_roots = home) += "/.config:";
-
-    if (auto config_dirs = getenv("XDG_CONFIG_DIRS"))
-        config_roots += config_dirs;
-    else
-        config_roots += "/etc/xdg";
-
-    std::istringstream config_stream(config_roots);
-
-    /* Read options from config files */
-    for (std::string config_root; getline(config_stream, config_root, ':');)
-    {
-        auto const& filename = config_root + "/" + self->name;
-
-        if (std::ifstream config_file{filename})
-        {
-            self->load_config(config_file, "ERROR: in display configuration file: '" + filename + "' : ");
-            break;
-        }
-    }
+    self->find_and_load_config();
 }
 
 void miral::DisplayConfiguration::select_layout(std::string const& layout)
@@ -129,3 +138,24 @@ miral::DisplayConfiguration::~DisplayConfiguration() = default;
 miral::DisplayConfiguration::DisplayConfiguration(miral::DisplayConfiguration const&) = default;
 
 auto miral::DisplayConfiguration::operator=(miral::DisplayConfiguration const&) -> miral::DisplayConfiguration& = default;
+
+void miral::DynamicDisplayConfiguration::reload()
+{
+    self->find_and_load_config();
+
+    if (auto const the_display_configuration_controller = self->the_display_configuration_controller.lock())
+    {
+        auto config = the_display_configuration_controller->base_configuration();
+        self->apply_to(*config);
+        the_display_configuration_controller->set_base_configuration(config);
+    }
+}
+
+void miral::DynamicDisplayConfiguration::operator()(mir::Server& server) const
+{
+    server.add_init_callback([self=self, &server]
+        {
+            self->the_display_configuration_controller = server.the_display_configuration_controller();
+        });
+    DisplayConfiguration::operator()(server);
+}

--- a/src/miral/display_configuration.cpp
+++ b/src/miral/display_configuration.cpp
@@ -175,6 +175,7 @@ public:
 
                         if (inotify_buffer.event.mask & (IN_CLOSE_WRITE | IN_CREATE)
                             && inotify_buffer.event.name == basename)
+                        try
                         {
                             find_and_load_config();
                             if (auto const dcc = the_display_configuration_controller())
@@ -183,6 +184,10 @@ public:
                                 apply_to(*config);
                                 dcc->set_base_configuration(config);
                             }
+                        }
+                        catch (mir::AbnormalExit const& except)
+                        {
+                            mir::log_warning("Failed to reload display configuration: %s", except.what());
                         }
                     });
             }

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -471,3 +471,11 @@ global:
     miral::FdHandle::?FdHandle*;
   };
 } MIRAL_3.6;
+
+MIRAL_3.8 {
+global:
+  extern "C++" {
+    "miral::DynamicDisplayConfiguration::reload()";
+    "miral::DynamicDisplayConfiguration::operator()(mir::Server&) const";
+  };
+} MIRAL_3.7;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -475,7 +475,6 @@ global:
 MIRAL_3.8 {
 global:
   extern "C++" {
-    "miral::DynamicDisplayConfiguration::reload()";
     "miral::DynamicDisplayConfiguration::operator()(mir::Server&) const";
   };
 } MIRAL_3.7;

--- a/tests/acceptance-tests/server_configuration_options.cpp
+++ b/tests/acceptance-tests/server_configuration_options.cpp
@@ -74,7 +74,7 @@ struct ServerConfigurationOptions : mir_test_framework::HeadlessTest
 
     static constexpr char const* const not_found = "not found";
     std::string const config_filename{"test.config"};
-    static constexpr char const* const test_config_key = "config_dir";
+    static constexpr char const* const test_config_key = "config_path";
 
     void create_config_file_in(std::string const& dir)
     {


### PR DESCRIPTION
This isn't necessarily something we want to land in this form.

But it automatically applies changes to the `.display` config file. (At least for the modified miral-kiosk))

I won't be working on it over the holidays, but shared as a draft in case there's interest