### PR TITLE
Fixup unqualified `std::move` warnings

### DIFF
--- a/src/server/frontend_wayland/primary_selection_v1.cpp
+++ b/src/server/frontend_wayland/primary_selection_v1.cpp
@@ -37,8 +37,8 @@ private:
             std::shared_ptr<mir::Executor> wayland_executor,
             std::vector<std::string> types)
             : owner{std::move(owner)},
-              wayland_executor{move(wayland_executor)},
-              types{move(types)}
+              wayland_executor{std::move(wayland_executor)},
+              types{std::move(types)}
         {
         }
 
@@ -72,7 +72,7 @@ public:
         wl_resource* resource,
         std::shared_ptr<mir::Executor> wayland_executor)
         : PrimarySelectionSourceV1{resource, Version<1>()},
-          wayland_executor{move(wayland_executor)}
+          wayland_executor{std::move(wayland_executor)}
     {
     }
 
@@ -92,7 +92,7 @@ class PrimarySelectionOffer : public mw::PrimarySelectionOfferV1
 public:
     PrimarySelectionOffer(mw::PrimarySelectionDeviceV1& parent, std::shared_ptr<ms::ClipboardSource> source)
         : PrimarySelectionOfferV1{parent},
-          source{move(source)}
+          source{std::move(source)}
     {
     }
 
@@ -133,7 +133,7 @@ public:
         mf::WlSeat& seat)
         : PrimarySelectionDeviceV1{resource, Version<1>()},
           clipboard_observer{std::make_shared<ClipboardObserver>(this)},
-          primary_selection_clipboard{move(primary_selection_clipboard)},
+          primary_selection_clipboard{std::move(primary_selection_clipboard)},
           seat{seat}
     {
         this->primary_selection_clipboard->register_interest(clipboard_observer, mir::immediate_executor);
@@ -231,8 +231,8 @@ public:
         std::shared_ptr<mir::Executor> wayland_executor,
         std::shared_ptr<ms::Clipboard> primary_selection_clipboard)
         : PrimarySelectionDeviceManagerV1{manager, Version<1>()},
-          wayland_executor{move(wayland_executor)},
-          primary_selection_clipboard{move(primary_selection_clipboard)}
+          wayland_executor{std::move(wayland_executor)},
+          primary_selection_clipboard{std::move(primary_selection_clipboard)}
     {
     }
 
@@ -264,8 +264,8 @@ public:
         std::shared_ptr<mir::Executor> wayland_executor,
         std::shared_ptr<ms::Clipboard> primary_selection_clipboard)
         : Global{display, Version<1>()},
-          wayland_executor{move(wayland_executor)},
-          primary_selection_clipboard{move(primary_selection_clipboard)}
+          wayland_executor{std::move(wayland_executor)},
+          primary_selection_clipboard{std::move(primary_selection_clipboard)}
     {
     }
 
@@ -287,6 +287,6 @@ auto mf::create_primary_selection_device_manager_v1(
 {
     return std::make_shared<PrimarySelectionGlobal>(
         display,
-        move(wayland_executor),
-        move(primary_selection_clipboard));
+        std::move(wayland_executor),
+        std::move(primary_selection_clipboard));
 }

--- a/src/server/frontend_wayland/virtual_keyboard_v1.cpp
+++ b/src/server/frontend_wayland/virtual_keyboard_v1.cpp
@@ -203,7 +203,7 @@ void mf::VirtualKeyboardV1::key(uint32_t time, uint32_t key, uint32_t state)
         {
             auto key_event = builder->key_event(nano, mir_keyboard_action(state), 0, key);
             key_event->to_input()->to_keyboard()->set_xkb_modifiers(xkb_modifiers);
-            sink->handle_input(move(key_event));
+            sink->handle_input(std::move(key_event));
         });
 }
 
@@ -223,6 +223,6 @@ void mf::VirtualKeyboardV1::modifiers(
         {
             auto key_event = builder->key_event(nano, mir_keyboard_action_modifiers, 0, 0);
             key_event->to_input()->to_keyboard()->set_xkb_modifiers(xkb_modifiers);
-            sink->handle_input(move(key_event));
+            sink->handle_input(std::move(key_event));
         });
 }

--- a/src/server/frontend_wayland/wl_client.cpp
+++ b/src/server/frontend_wayland/wl_client.cpp
@@ -164,7 +164,7 @@ void mf::WlClient::handle_client_created(wl_listener* listener, void* data)
     client_context->destroy_listener.notify = &handle_client_destroyed;
     wl_client_add_destroy_listener(client, &client_context->destroy_listener);
 
-    client_context->client->owned_self = move(shared);
+    client_context->client->owned_self = std::move(shared);
 
     (*construction_context->client_created_callback)(*client_context->client);
 }


### PR DESCRIPTION
Clang warns about calling `std::move` as an unqualified call to `move`, and is reasonable to do so because Argument Dependent Lookup *could* cause the compiler to resolve `bar::T baz; move(baz)` to some other `bar::move(baz)` if there happens to be a `bar::move(T)` implementation in the same namespace as `T` is defined.

Closes: #2742