### PR TITLE
spread/sbuild: Don't purge the schroot session, more for local runs

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -76,3 +76,5 @@ path:
 
 exclude:
     - .git
+    - build-*
+    - install-*

--- a/spread/build/sbuild/task.yaml
+++ b/spread/build/sbuild/task.yaml
@@ -49,6 +49,7 @@ execute: |
       --dist=${RELEASE}
       --build=${DEB_BUILD_ARCH}
       --host=${DEB_HOST_ARCH}
+      --purge=never
     )
 
     SCHROOT_NAME="${RELEASE}-${DEB_BUILD_ARCH}"

--- a/spread/build/sbuild/task.yaml
+++ b/spread/build/sbuild/task.yaml
@@ -68,7 +68,7 @@ execute: |
       MKSBUILD_OPTS+=("--arch=${DEB_BUILD_ARCH}" "--target=${DEB_HOST_ARCH}")
 
       # Quirk for the eglexternalplatform-dev build dependency
-      sed -i 's/\(eglexternalplatform-dev\)/\1:all/' debian/control
+      sed -i '/:all,$/n; s/\(eglexternalplatform-dev\)/\1:all/' debian/control
       SCHROOT_NAME="${SCHROOT_NAME}-${DEB_HOST_ARCH}"
 
       if [[ ${DEB_HOST_ARCH} == armhf ]]; then
@@ -84,7 +84,8 @@ execute: |
       ln -vs "${DEBOOTSTRAP_SCRIPTS}/gutsy" "${DEBOOTSTRAP_SCRIPTS}/${RELEASE}"
     fi
 
-    sg sbuild -c "${MKSBUILD_OPTS[*]}"
+    # Build the schroot, if it doesn't already exist
+    [ -f /etc/schroot/chroot.d/sbuild-${SCHROOT_NAME} ] || sg sbuild -c "${MKSBUILD_OPTS[*]}"
 
     echo "export XDG_RUNTIME_DIR=/tmp" >> debian/opts.mk
 
@@ -94,6 +95,7 @@ execute: |
     echo "OVERRIDE_CONFIGURE_OPTIONS += -DCMAKE_C_COMPILER_LAUNCHER=ccache" >> debian/opts.mk
     echo "OVERRIDE_CONFIGURE_OPTIONS += -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> debian/opts.mk
 
+    mkdir --parents ${CCACHE_DIR}
     echo "${CCACHE_DIR} ${CCACHE_DIR} none rw,bind 0 0" >> /etc/schroot/sbuild/fstab
 
     sbuild "${SBUILD_OPTS[@]}"

--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -12,7 +12,7 @@ summary: Build Ubuntu packages
 execute: |
     cd $SPREAD_PATH
 
-    apt-get update
+    apt-get install --yes software-properties-common
 
     # Add Mir dev PPA for any out-of-archive packages needed
     # (Currently: a newer version of WLCS)


### PR DESCRIPTION
This is both a (tiny) CI optimisation - we're running sbuild inside an ephemeral LXD container, so there's no point in spending time cleaning up the schroot - and also makes for easier debugging, as you can run `spread -debug` to stop after sbuild fails and still have the build available in the preserved schroot session.