### PR TITLE
examples/miral-kiosk/fake-mir-kiosk.sh: Contains bashisms, thus use /…

### DIFF
--- a/examples/miral-kiosk/fake-mir-kiosk.sh
+++ b/examples/miral-kiosk/fake-mir-kiosk.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 bindir=$(dirname $0)
 if [ "${bindir}" != "" ]; then bindir="${bindir}/"; fi


### PR DESCRIPTION
…bin/bash in shebang.

 This is the quick and easy solution. Better approach might be
 de-bash'ing the fake-mir-kiosk.sh shell script.