### PR TITLE
Fix MediatingDisplayChanger::set_power_mode()

### DIFF
--- a/src/include/server/mir/display_changer.h
+++ b/src/include/server/mir/display_changer.h
@@ -31,8 +31,7 @@ class DisplayChanger
 public:
     virtual ~DisplayChanger() = default;
 
-    virtual void configure_for_hardware_change(
-        std::shared_ptr<graphics::DisplayConfiguration> const& conf) = 0;
+    virtual void configure(std::shared_ptr<graphics::DisplayConfiguration> const& conf) = 0;
 
     virtual void pause_display_config_processing() = 0;
     virtual void resume_display_config_processing() = 0;

--- a/src/server/display_server.cpp
+++ b/src/server/display_server.cpp
@@ -188,7 +188,7 @@ struct mir::DisplayServer::Private
         std::shared_ptr<graphics::DisplayConfiguration> conf =
             display->configuration();
 
-        display_changer->configure_for_hardware_change(conf);
+        display_changer->configure(conf);
     }
 
     std::shared_ptr<EmergencyCleanup> const emergency_cleanup; // Hold this so it does not get freed prematurely

--- a/src/server/scene/mediating_display_changer.cpp
+++ b/src/server/scene/mediating_display_changer.cpp
@@ -288,8 +288,7 @@ ms::MediatingDisplayChanger::base_configuration()
     return base_configuration_->clone();
 }
 
-void ms::MediatingDisplayChanger::configure_for_hardware_change(
-    std::shared_ptr<graphics::DisplayConfiguration> const& conf)
+void ms::MediatingDisplayChanger::configure(std::shared_ptr<graphics::DisplayConfiguration> const& conf)
 {
     {
         std::lock_guard lg{pending_configuration_mutex};
@@ -534,11 +533,7 @@ void ms::MediatingDisplayChanger::set_power_mode(MirPowerMode new_power_mode)
         }
         power_mode = new_power_mode;
     }
-    decltype(base_configuration_) const config = [this]
-        {
-            std::lock_guard lg{configuration_mutex};
-            return base_configuration_->clone();
-        }();
+    auto const config = base_configuration();
 
     config->for_each_output([&](mg::UserDisplayConfigurationOutput &output)
     {
@@ -547,6 +542,6 @@ void ms::MediatingDisplayChanger::set_power_mode(MirPowerMode new_power_mode)
             output.power_mode = new_power_mode;
         }
     });
-    configure_for_hardware_change(config);
+    configure(config);
 }
 

--- a/src/server/scene/mediating_display_changer.h
+++ b/src/server/scene/mediating_display_changer.h
@@ -79,8 +79,7 @@ public:
         std::shared_ptr<graphics::DisplayConfiguration> const& confirmed_conf) override;
 
     /* From mir::DisplayChanger */
-    void configure_for_hardware_change(
-        std::shared_ptr<graphics::DisplayConfiguration> const& conf) override;
+    void configure(std::shared_ptr<graphics::DisplayConfiguration> const& conf) override;
 
     void pause_display_config_processing() override;
     void resume_display_config_processing() override;
@@ -121,7 +120,7 @@ private:
 
     /// Mutex protecting pending_configuration
     std::mutex pending_configuration_mutex;
-    /// See configure_for_hardware_change(). The config that will be applied by a currently in-flight server action.
+    /// See configure(). The config that will be applied by a currently in-flight server action.
     /// If null, there is no config to apply or hardware config server action queued.
     std::shared_ptr<graphics::DisplayConfiguration> pending_configuration;
 

--- a/tests/unit-tests/scene/test_mediating_display_changer.cpp
+++ b/tests/unit-tests/scene/test_mediating_display_changer.cpp
@@ -145,21 +145,25 @@ TEST_F(MediatingDisplayChangerTest, power_mode_can_be_set)
             mock_display.config->for_each_output([&](mg::DisplayConfigurationOutput const& output)
                 {
                     has_output = true;
-                    EXPECT_THAT(output.power_mode, Eq(expected));
+                    if (output.used) { EXPECT_THAT(output.power_mode, Eq(expected)); }
                 });
             EXPECT_THAT(has_output, Eq(true));
         };
 
-    mock_display.config->for_each_output([&](mg::UserDisplayConfigurationOutput& output)
-        {
-            output.used = true;
-        });
     changer->set_power_mode(mir_power_mode_off);
     expect_power_mode_eq(mir_power_mode_off);
     changer->set_power_mode(mir_power_mode_standby);
     expect_power_mode_eq(mir_power_mode_standby);
     changer->set_power_mode(mir_power_mode_on);
     expect_power_mode_eq(mir_power_mode_on);
+}
+
+TEST_F(MediatingDisplayChangerTest, power_mode_sets_base_configuration)
+{
+    EXPECT_CALL(display_configuration_observer, base_configuration_updated(_)).Times(3);
+    changer->set_power_mode(mir_power_mode_off);
+    changer->set_power_mode(mir_power_mode_standby);
+    changer->set_power_mode(mir_power_mode_on);
 }
 
 TEST_F(MediatingDisplayChangerTest, pauses_system_when_applying_new_configuration_for_focused_session_would_invalidate_display_buffers)

--- a/tests/unit-tests/scene/test_mediating_display_changer.cpp
+++ b/tests/unit-tests/scene/test_mediating_display_changer.cpp
@@ -250,7 +250,7 @@ TEST_F(MediatingDisplayChangerTest, returns_updated_base_configuration_after_har
 
     mtd::StubDisplayConfig conf{2};
 
-    changer->configure_for_hardware_change(
+    changer->configure(
         mt::fake_shared(conf));
 
     auto const base_conf = changer->base_configuration();
@@ -271,7 +271,7 @@ TEST_F(MediatingDisplayChangerTest, handles_hardware_change_when_display_buffers
     EXPECT_CALL(mock_display, configure(Ref(conf)));
     EXPECT_CALL(mock_compositor, start());
 
-    changer->configure_for_hardware_change(mt::fake_shared(conf));
+    changer->configure(mt::fake_shared(conf));
 }
 
 TEST_F(MediatingDisplayChangerTest, handles_error_when_applying_hardware_change)
@@ -287,7 +287,7 @@ TEST_F(MediatingDisplayChangerTest, handles_error_when_applying_hardware_change)
     auto const previous_base_config = changer->base_configuration();
     ASSERT_THAT(conf, Not(mt::DisplayConfigMatches(std::cref(*previous_base_config))));
 
-    changer->configure_for_hardware_change(mt::fake_shared(conf));
+    changer->configure(mt::fake_shared(conf));
 
     EXPECT_THAT(*changer->base_configuration(), mt::DisplayConfigMatches(std::cref(*previous_base_config)));
 }
@@ -308,7 +308,7 @@ TEST_F(MediatingDisplayChangerTest, handles_hardware_change_when_display_buffers
     EXPECT_CALL(mock_display, configure(_)).Times(0);
     EXPECT_CALL(mock_compositor, start()).Times(0);
 
-    changer->configure_for_hardware_change(mt::fake_shared(conf));
+    changer->configure(mt::fake_shared(conf));
 }
 
 TEST_F(MediatingDisplayChangerTest, handles_hardware_change_when_display_buffers_are_preserved_but_new_outputs_are_enabled)
@@ -341,7 +341,7 @@ TEST_F(MediatingDisplayChangerTest, handles_hardware_change_when_display_buffers
     EXPECT_CALL(mock_display, configure(Ref(*conf)));
     EXPECT_CALL(mock_compositor, start()).Times(1);
 
-    changer->configure_for_hardware_change(conf);
+    changer->configure(conf);
 }
 
 TEST_F(MediatingDisplayChangerTest, hardware_change_doesnt_apply_base_config_if_per_session_config_is_active)
@@ -362,7 +362,7 @@ TEST_F(MediatingDisplayChangerTest, hardware_change_doesnt_apply_base_config_if_
     EXPECT_CALL(mock_display, configure(_)).Times(0);
     EXPECT_CALL(mock_compositor, start()).Times(0);
 
-    changer->configure_for_hardware_change(conf);
+    changer->configure(conf);
 }
 
 TEST_F(MediatingDisplayChangerTest, notifies_all_sessions_on_hardware_config_change)
@@ -377,7 +377,7 @@ TEST_F(MediatingDisplayChangerTest, notifies_all_sessions_on_hardware_config_cha
     EXPECT_CALL(display_configuration_observer, configuration_updated_for_session(Eq(mt::fake_shared(mock_session1)), _));
     EXPECT_CALL(display_configuration_observer, configuration_updated_for_session(Eq(mt::fake_shared(mock_session2)), _));
 
-    changer->configure_for_hardware_change(mt::fake_shared(conf));
+    changer->configure(mt::fake_shared(conf));
 }
 
 TEST_F(MediatingDisplayChangerTest, notifies_all_sessions_when_hardware_config_change_fails)
@@ -410,7 +410,7 @@ TEST_F(MediatingDisplayChangerTest, notifies_all_sessions_when_hardware_config_c
             Eq(mt::fake_shared(mock_session2)),
             mt::DisplayConfigMatches(std::cref(*previous_base_config))));
 
-    changer->configure_for_hardware_change(mt::fake_shared(conf));
+    changer->configure(mt::fake_shared(conf));
 }
 
 TEST_F(MediatingDisplayChangerTest, focusing_a_session_with_db_preserving_attached_config_applies_config)
@@ -615,7 +615,7 @@ TEST_F(MediatingDisplayChangerTest, hardware_change_invalidates_session_configs)
     session_container.insert_session(session1);
     changer->configure(session1, conf);
 
-    changer->configure_for_hardware_change(conf);
+    changer->configure(conf);
 
     Mock::VerifyAndClearExpectations(&mock_compositor);
     Mock::VerifyAndClearExpectations(&mock_display);
@@ -687,7 +687,7 @@ TEST_F(MediatingDisplayChangerTest, uses_server_action_queue_for_configuration_a
     Mock::VerifyAndClearExpectations(&mock_server_action_queue);
 
     EXPECT_CALL(mock_server_action_queue, enqueue(owner, _));
-    display_changer.configure_for_hardware_change(conf);
+    display_changer.configure(conf);
     Mock::VerifyAndClearExpectations(&mock_server_action_queue);
 
     EXPECT_CALL(mock_server_action_queue, enqueue(owner, _));


### PR DESCRIPTION
The MediatingDisplayChanger will in many scenarios revert to the base_configuration which means this must be kept up to date.

Fixes: #2695
Fixes: #2757

It may be worth revisiting  #2632, but I am entirely unclear how to reproduce or test that.