### PR TITLE
Do not abort when nothing is wrong

### DIFF
--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -1412,19 +1412,6 @@ mf::XWaylandSurface::XWaylandSurfaceObserverManager::~XWaylandSurfaceObserverMan
     {
         scene_surface->unregister_interest(*surface_observer);
     }
-
-    if (surface_observer)
-    {
-        // make sure surface observer is deleted and will not spew any more events
-        std::weak_ptr<XWaylandSurfaceObserver> const weak_observer{surface_observer};
-        surface_observer.reset();
-        if (auto const should_be_dead_observer = weak_observer.lock())
-        {
-            fatal_error(
-                "surface observer should have been deleted, but was not (use count %d)",
-                should_be_dead_observer.use_count());
-        }
-    }
 }
 
 auto mf::XWaylandSurface::XWaylandSurfaceObserverManager::try_get_resize_event()


### PR DESCRIPTION
We need to ensure that no further callbacks occur after `~XWaylandSurfaceObserverManager()` executes, and this is guaranteed by `ObserverRegistrar::unregister_interest()`:

     * It is guaranteed that once unregister_interest() returns that no
     * other thread is in, or will receive, observations from this
     * ObserverRegistrar. If the thread calling unregister_interest()
     * is currently in an Observer call that call will complete, but
     * no further ones will be dispatched.

What is not guaranteed though is that there will be no remaining `shared_ptr` to `observer`.

In practice, that is not so as `WeakObserver::spawn()` may still hold `live_observer` after `WeakObserver::invoke()` has returned.

As the check is both redundant and wrong remove it.

Fixes: #2790