### PR TITLE
Add missing #include statements

### DIFF
--- a/include/miroil/miroil/edid.h
+++ b/include/miroil/miroil/edid.h
@@ -17,6 +17,7 @@
 #ifndef MIROIL_EDID_H
 #define MIROIL_EDID_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/platform/mir/graphics/egl_extensions.h
+++ b/include/platform/mir/graphics/egl_extensions.h
@@ -45,6 +45,7 @@
 #include <optional>
 #include <mutex>
 #include <atomic>
+#include <stdexcept>
 
 #include <boost/throw_exception.hpp>
 


### PR DESCRIPTION
- `<stdexcept>` for `std::logic_error`
- `<cstdint>` for `uint*_t`

Fixes failure to compile with GCC 13.