### PR TITLE
platform/Display: Remove register_pause_resume_handlers

### DIFF
--- a/include/platform/mir/graphics/display.h
+++ b/include/platform/mir/graphics/display.h
@@ -140,17 +140,6 @@ public:
         DisplayConfigurationChangeHandler const& conf_change_handler) = 0;
 
     /**
-     * Registers handlers for pausing and resuming the display subsystem.
-     *
-     * The implementation should use the functionality provided by the EventHandlerRegister
-     * to register the handlers in a way appropriate for the platform.
-     */
-    virtual void register_pause_resume_handlers(
-        EventHandlerRegister& handlers,
-        DisplayPauseHandler const& pause_handler,
-        DisplayResumeHandler const& resume_handler) = 0;
-
-    /**
      * Pauses the display.
      *
      * This method may temporarily (until resumed) release any resources

--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -172,6 +172,7 @@ public:
     std::shared_ptr<MainLoop>               the_main_loop() override;
     std::shared_ptr<ServerStatusListener>   the_server_status_listener() override;
     std::shared_ptr<DisplayChanger>         the_display_changer() override;
+    std::shared_ptr<ConsoleServices>        the_console_services() override;
     std::vector<std::shared_ptr<graphics::DisplayPlatform>> const& the_display_platforms() override;
     auto the_rendering_platforms() -> std::vector<std::shared_ptr<graphics::RenderingPlatform>> const& override;
     std::shared_ptr<input::InputDispatcher> the_input_dispatcher() override;
@@ -335,7 +336,6 @@ public:
     virtual std::shared_ptr<ServerActionQueue> the_server_action_queue();
     virtual std::shared_ptr<SharedLibraryProberReport>  the_shared_library_prober_report();
 
-    virtual std::shared_ptr<ConsoleServices> the_console_services();
     auto default_reports() -> std::shared_ptr<void>;
 
 protected:

--- a/src/include/server/mir/server_configuration.h
+++ b/src/include/server/mir/server_configuration.h
@@ -70,6 +70,7 @@ class MainLoop;
 class ServerStatusListener;
 class DisplayChanger;
 class EmergencyCleanup;
+class ConsoleServices;
 
 class ServerConfiguration
 {
@@ -86,6 +87,7 @@ public:
     virtual std::shared_ptr<MainLoop> the_main_loop() = 0;
     virtual std::shared_ptr<ServerStatusListener> the_server_status_listener() = 0;
     virtual std::shared_ptr<DisplayChanger> the_display_changer() = 0;
+    virtual auto the_console_services() -> std::shared_ptr<ConsoleServices> = 0;
     virtual auto the_display_platforms() -> std::vector<std::shared_ptr<graphics::DisplayPlatform>> const& = 0;
     virtual auto the_rendering_platforms() -> std::vector<std::shared_ptr<graphics::RenderingPlatform>> const& = 0;
     virtual std::shared_ptr<EmergencyCleanup> the_emergency_cleanup() = 0;

--- a/src/platforms/eglstream-kms/server/display.cpp
+++ b/src/platforms/eglstream-kms/server/display.cpp
@@ -416,13 +416,6 @@ void mge::Display::register_configuration_change_handler(
             }));
 }
 
-void mge::Display::register_pause_resume_handlers(
-    EventHandlerRegister& /*handlers*/,
-    DisplayPauseHandler const& /*pause_handler*/,
-    DisplayResumeHandler const& /*resume_handler*/)
-{
-}
-
 void mge::Display::pause()
 {
 

--- a/src/platforms/eglstream-kms/server/display.h
+++ b/src/platforms/eglstream-kms/server/display.h
@@ -57,9 +57,6 @@ public:
     void register_configuration_change_handler(EventHandlerRegister& handlers,
         DisplayConfigurationChangeHandler const& conf_change_handler) override;
 
-    void register_pause_resume_handlers(EventHandlerRegister& handlers,
-        DisplayPauseHandler const& pause_handler, DisplayResumeHandler const& resume_handler) override;
-
     void pause() override;
 
     void resume() override;

--- a/src/platforms/gbm-kms/server/kms/display.cpp
+++ b/src/platforms/gbm-kms/server/kms/display.cpp
@@ -173,14 +173,12 @@ void log_drm_details(std::vector<std::shared_ptr<mgg::helpers::DRMHelper>> const
 
 mgg::Display::Display(std::vector<std::shared_ptr<helpers::DRMHelper>> const& drm,
                       std::shared_ptr<helpers::GBMHelper> const& gbm,
-                      std::shared_ptr<ConsoleServices> const& vt,
                       mgg::BypassOption bypass_option,
                       std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
                       std::shared_ptr<GLConfig> const& gl_config,
                       std::shared_ptr<DisplayReport> const& listener)
     : drm{drm},
       gbm(gbm),
-      vt(vt),
       listener(listener),
       monitor(mir::udev::Context()),
       shared_egl{*gl_config},

--- a/src/platforms/gbm-kms/server/kms/display.cpp
+++ b/src/platforms/gbm-kms/server/kms/display.cpp
@@ -282,14 +282,6 @@ void mgg::Display::register_configuration_change_handler(
             }));
 }
 
-void mgg::Display::register_pause_resume_handlers(
-    EventHandlerRegister& handlers,
-    DisplayPauseHandler const& pause_handler,
-    DisplayResumeHandler const& resume_handler)
-{
-    vt->register_switch_handlers(handlers, pause_handler, resume_handler);
-}
-
 void mgg::Display::pause()
 {
     if (auto c = cursor.lock()) c->suspend();

--- a/src/platforms/gbm-kms/server/kms/display.h
+++ b/src/platforms/gbm-kms/server/kms/display.h
@@ -31,7 +31,6 @@
 
 namespace mir
 {
-class ConsoleServices;
 namespace graphics
 {
 
@@ -59,7 +58,6 @@ class Display : public graphics::Display
 public:
     Display(std::vector<std::shared_ptr<helpers::DRMHelper>> const& drm,
             std::shared_ptr<helpers::GBMHelper> const& gbm,
-            std::shared_ptr<ConsoleServices> const& vt,
             BypassOption bypass_option,
             std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
             std::shared_ptr<GLConfig> const& gl_config,
@@ -93,7 +91,6 @@ private:
     mutable std::mutex configuration_mutex;
     std::vector<std::shared_ptr<helpers::DRMHelper>> const drm;
     std::shared_ptr<helpers::GBMHelper> const gbm;
-    std::shared_ptr<ConsoleServices> const vt;
     std::shared_ptr<DisplayReport> const listener;
     mir::udev::Monitor monitor;
     helpers::EGLHelper shared_egl;

--- a/src/platforms/gbm-kms/server/kms/display.h
+++ b/src/platforms/gbm-kms/server/kms/display.h
@@ -78,11 +78,6 @@ public:
         EventHandlerRegister& handlers,
         DisplayConfigurationChangeHandler const& conf_change_handler) override;
 
-    void register_pause_resume_handlers(
-        EventHandlerRegister& handlers,
-        DisplayPauseHandler const& pause_handler,
-        DisplayResumeHandler const& resume_handler) override;
-
     void pause() override;
     void resume() override;
 

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -31,19 +31,18 @@ namespace mgg = mg::gbm;
 namespace mgmh = mgg::helpers;
 
 mgg::Platform::Platform(std::shared_ptr<DisplayReport> const& listener,
-                        std::shared_ptr<ConsoleServices> const& vt,
+                        ConsoleServices& vt,
                         EmergencyCleanupRegistry&,
                         BypassOption bypass_option,
                         std::unique_ptr<Quirks> quirks)
     : udev{std::make_shared<mir::udev::Context>()},
-      drm{helpers::DRMHelper::open_all_devices(udev, *vt, *quirks)},
+      drm{helpers::DRMHelper::open_all_devices(udev, vt, *quirks)},
       // We assume the first DRM device is the boot GPU, and arbitrarily pick it as our
       // shell renderer.
       //
       // TODO: expose multiple rendering GPUs to the shell.
       gbm{std::make_shared<mgmh::GBMHelper>(drm.front()->fd)},
       listener{listener},
-      vt{vt},
       bypass_option_{bypass_option}
 {
 }
@@ -66,7 +65,6 @@ mir::UniqueModulePtr<mg::Display> mgg::Platform::create_display(
     return make_module_ptr<mgg::Display>(
         drm,
         gbm,
-        vt,
         bypass_option_,
         initial_conf_policy,
         gl_config,

--- a/src/platforms/gbm-kms/server/kms/platform.h
+++ b/src/platforms/gbm-kms/server/kms/platform.h
@@ -37,7 +37,7 @@ class Platform : public graphics::DisplayPlatform
 {
 public:
     explicit Platform(std::shared_ptr<DisplayReport> const& reporter,
-                      std::shared_ptr<ConsoleServices> const& vt,
+                      ConsoleServices& vt,
                       EmergencyCleanupRegistry& emergency_cleanup_registry,
                       BypassOption bypass_option,
                       std::unique_ptr<Quirks> quirks);
@@ -52,7 +52,6 @@ public:
     std::shared_ptr<helpers::GBMHelper> const gbm;
 
     std::shared_ptr<DisplayReport> const listener;
-    std::shared_ptr<ConsoleServices> const vt;
 
     BypassOption bypass_option() const;
 private:

--- a/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform_symbols.cpp
@@ -74,7 +74,7 @@ mir::UniqueModulePtr<mg::DisplayPlatform> create_display_platform(
     auto quirks = std::make_unique<mgg::Quirks>(*options);
 
     return mir::make_module_ptr<mgg::Platform>(
-        report, console, *emergency_cleanup_registry, bypass_option, std::move(quirks));
+        report, *console, *emergency_cleanup_registry, bypass_option, std::move(quirks));
 }
 
 auto create_rendering_platform(

--- a/src/platforms/rpi-dispmanx/display.cpp
+++ b/src/platforms/rpi-dispmanx/display.cpp
@@ -241,13 +241,6 @@ void mg::rpi::Display::register_configuration_change_handler(
 {
 }
 
-void mg::rpi::Display::register_pause_resume_handlers(
-    mg::EventHandlerRegister&,
-    mg::DisplayPauseHandler const&,
-    mg::DisplayResumeHandler const&)
-{
-}
-
 void mg::rpi::Display::pause()
 {
 }

--- a/src/platforms/rpi-dispmanx/display.h
+++ b/src/platforms/rpi-dispmanx/display.h
@@ -47,10 +47,6 @@ public:
     void configure(graphics::DisplayConfiguration const& conf) override;
     void register_configuration_change_handler(
         EventHandlerRegister& handlers, DisplayConfigurationChangeHandler const& conf_change_handler) override;
-    void register_pause_resume_handlers(
-        EventHandlerRegister& handlers,
-        DisplayPauseHandler const& pause_handler,
-        DisplayResumeHandler const& resume_handler) override;
     void pause() override;
     void resume() override;
     std::shared_ptr<Cursor> create_hardware_cursor() override;

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -129,13 +129,6 @@ void mgw::Display::register_configuration_change_handler(
     config_change_handlers.push_back(conf_change_handler);
 }
 
-void mgw::Display::register_pause_resume_handlers(
-    EventHandlerRegister& /*handlers*/,
-    DisplayPauseHandler const& /*pause_handler*/,
-    DisplayResumeHandler const& /*resume_handler*/)
-{
-}
-
 void mgw::Display::pause()
 {
    BOOST_THROW_EXCEPTION(std::runtime_error("'Display::pause()' not yet supported on wayland platform"));

--- a/src/platforms/wayland/display.h
+++ b/src/platforms/wayland/display.h
@@ -80,9 +80,6 @@ public:
     void register_configuration_change_handler(EventHandlerRegister& handlers,
         DisplayConfigurationChangeHandler const& conf_change_handler) override;
 
-    void register_pause_resume_handlers(EventHandlerRegister& handlers,
-        DisplayPauseHandler const& pause_handler, DisplayResumeHandler const& resume_handler) override;
-
     void pause() override;
 
     void resume() override;

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -271,13 +271,6 @@ void mgx::Display::register_configuration_change_handler(
     config_change_handlers.push_back(change_handler);
 }
 
-void mgx::Display::register_pause_resume_handlers(
-    EventHandlerRegister& /*handlers*/,
-    DisplayPauseHandler const& /*pause_handler*/,
-    DisplayResumeHandler const& /*resume_handler*/)
-{
-}
-
 void mgx::Display::pause()
 {
     BOOST_THROW_EXCEPTION(std::runtime_error("'Display::pause()' not yet supported on x11 platform"));

--- a/src/platforms/x11/graphics/display.h
+++ b/src/platforms/x11/graphics/display.h
@@ -86,11 +86,6 @@ public:
         EventHandlerRegister& handlers,
         DisplayConfigurationChangeHandler const& conf_change_handler) override;
 
-    void register_pause_resume_handlers(
-        EventHandlerRegister& handlers,
-        DisplayPauseHandler const& pause_handler,
-        DisplayResumeHandler const& resume_handler) override;
-
     void pause() override;
     void resume() override;
 

--- a/src/server/display_server.cpp
+++ b/src/server/display_server.cpp
@@ -19,6 +19,7 @@
 #include "mir/main_loop.h"
 #include "mir/server_status_listener.h"
 #include "mir/display_changer.h"
+#include "mir/console_services.h"
 
 #include "mir/compositor/compositor.h"
 #include "mir/frontend/connector.h"
@@ -82,13 +83,14 @@ struct mir::DisplayServer::Private
           server_status_listener{config.the_server_status_listener()},
           display_changer{config.the_display_changer()},
           idle_handler{config.the_idle_handler()},
-          stop_callback{config.the_stop_callback()}
+          stop_callback{config.the_stop_callback()},
+          console_services{config.the_console_services()}
     {
         display->register_configuration_change_handler(
             *main_loop,
             [this] { return configure_display(); });
 
-        display->register_pause_resume_handlers(
+        console_services->register_switch_handlers(
             *main_loop,
             [this] { return pause(); },
             [this] { return resume(); });
@@ -204,7 +206,7 @@ struct mir::DisplayServer::Private
     std::shared_ptr<mir::DisplayChanger> const display_changer;
     std::shared_ptr<msh::IdleHandler> const idle_handler;
     std::function<void()> const stop_callback;
-
+    std::shared_ptr<mir::ConsoleServices> const console_services;
 };
 
 mir::DisplayServer::DisplayServer(ServerConfiguration& config) :

--- a/tests/include/mir/test/doubles/mock_console_services.h
+++ b/tests/include/mir/test/doubles/mock_console_services.h
@@ -31,20 +31,23 @@ namespace doubles
 class MockConsoleServices : public ConsoleServices
 {
 public:
-    MOCK_METHOD3(register_switch_handlers,
-                 void(graphics::EventHandlerRegister&,
-                      std::function<bool()> const&,
-                      std::function<bool()> const&));
-    MOCK_METHOD0(restore, void());
-    MOCK_METHOD3(
+    MOCK_METHOD(
+        void,
+         register_switch_handlers, 
+        (graphics::EventHandlerRegister&,
+         std::function<bool()> const&,
+         std::function<bool()> const&),
+        (override));
+    MOCK_METHOD(void, restore, (), (override));
+    MOCK_METHOD(
+        std::unique_ptr<Device>,
         acquire_device_immediate,
-        std::unique_ptr<Device>(
-            int,int,
-            Device::Observer*));
+        (int, int, Device::Observer*),
+        ());
 
     std::future<std::unique_ptr<Device>> acquire_device(
         int major, int minor,
-        std::unique_ptr<Device::Observer> observer  )
+        std::unique_ptr<Device::Observer> observer) override
     {
         std::promise<std::unique_ptr<Device>> promise;
         try

--- a/tests/include/mir/test/doubles/mock_console_services.h
+++ b/tests/include/mir/test/doubles/mock_console_services.h
@@ -39,6 +39,7 @@ public:
          std::function<bool()> const&),
         (override));
     MOCK_METHOD(void, restore, (), (override));
+    MOCK_METHOD(std::unique_ptr<VTSwitcher>, create_vt_switcher, (), (override));
     MOCK_METHOD(
         std::unique_ptr<Device>,
         acquire_device_immediate,

--- a/tests/include/mir/test/doubles/mock_display.h
+++ b/tests/include/mir/test/doubles/mock_display.h
@@ -39,9 +39,6 @@ public:
     MOCK_METHOD2(register_configuration_change_handler,
                  void(graphics::EventHandlerRegister&, graphics::DisplayConfigurationChangeHandler const&));
 
-    MOCK_METHOD3(register_pause_resume_handlers, void(graphics::EventHandlerRegister&,
-                                                      graphics::DisplayPauseHandler const&,
-                                                      graphics::DisplayResumeHandler const&));
     MOCK_METHOD0(pause, void());
     MOCK_METHOD0(resume, void());
     MOCK_METHOD0(create_hardware_cursor, std::shared_ptr<graphics::Cursor>());

--- a/tests/include/mir/test/doubles/null_display.h
+++ b/tests/include/mir/test/doubles/null_display.h
@@ -53,11 +53,6 @@ class NullDisplay : public graphics::Display
         graphics::DisplayConfigurationChangeHandler const&) override
     {
     }
-    void register_pause_resume_handlers(graphics::EventHandlerRegister&,
-                                        graphics::DisplayPauseHandler const&,
-                                        graphics::DisplayResumeHandler const&) override
-    {
-    }
     void pause() override{}
     void resume() override {}
 

--- a/tests/integration-tests/test_display_server_main_loop_events.cpp
+++ b/tests/integration-tests/test_display_server_main_loop_events.cpp
@@ -237,7 +237,7 @@ public:
     {
         if (!mock_console_services)
         {
-            mock_console_services = std::make_shared<MockConsoleServices>(pause_signal, resume_signal);
+            mock_console_services = std::make_shared<testing::NiceMock<MockConsoleServices>>(pause_signal, resume_signal);
         }
         return mock_console_services;
     }

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_buffer_allocator.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_buffer_allocator.cpp
@@ -86,7 +86,7 @@ protected:
 
         platform = std::make_shared<mgg::Platform>(
                 mir::report::null_display_report(),
-                std::make_shared<mtd::StubConsoleServices>(),
+                *std::make_shared<mtd::StubConsoleServices>(),
                 *std::make_shared<mtd::NullEmergencyCleanup>(),
                 mgg::BypassOption::allowed,
                 std::make_unique<mgg::Quirks>(mo::ProgramOption{}));

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display.cpp
@@ -119,7 +119,7 @@ public:
     {
         return std::make_shared<mgg::Platform>(
                mir::report::null_display_report(),
-               std::make_shared<mtd::StubConsoleServices>(),
+               *std::make_shared<mtd::StubConsoleServices>(),
                *std::make_shared<mtd::NullEmergencyCleanup>(),
                mgg::BypassOption::allowed,
                std::make_unique<mgg::Quirks>(mir::options::ProgramOption{}));
@@ -131,7 +131,6 @@ public:
         return std::make_shared<mgg::Display>(
             platform->drm,
             platform->gbm,
-            platform->vt,
             platform->bypass_option(),
             std::make_shared<mg::CloneDisplayConfigurationPolicy>(),
             std::make_shared<mtd::StubGLConfig>(),
@@ -634,7 +633,6 @@ TEST_F(MesaDisplayTest, successful_creation_of_display_reports_successful_setup_
     auto display = std::make_shared<mgg::Display>(
                         platform->drm,
                         platform->gbm,
-                        platform->vt,
                         platform->bypass_option(),
                         std::make_shared<mg::CloneDisplayConfigurationPolicy>(),
                         std::make_shared<mtd::StubGLConfig>(),
@@ -855,7 +853,6 @@ TEST_F(MesaDisplayTest, respects_gl_config)
     mgg::Display display{
         platform->drm,
         platform->gbm,
-        platform->vt,
         platform->bypass_option(),
         std::make_shared<mg::CloneDisplayConfigurationPolicy>(),
         mir::test::fake_shared(mock_gl_config),
@@ -883,7 +880,6 @@ TEST_F(MesaDisplayTest, uses_xrgb8888_framebuffer_when_argb8888_is_not_supported
     mgg::Display display{
         platform->drm,
         platform->gbm,
-        platform->vt,
         platform->bypass_option(),
         std::make_shared<mg::CloneDisplayConfigurationPolicy>(),
         std::make_shared<NiceMock<mtd::MockGLConfig>>(),
@@ -911,7 +907,6 @@ TEST_F(MesaDisplayTest, uses_argb8888_framebuffer_when_xrgb8888_is_not_supported
     mgg::Display display{
         platform->drm,
         platform->gbm,
-        platform->vt,
         platform->bypass_option(),
         std::make_shared<mg::CloneDisplayConfigurationPolicy>(),
         std::make_shared<NiceMock<mtd::MockGLConfig>>(),

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_configuration.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_configuration.cpp
@@ -126,7 +126,7 @@ public:
     {
         return std::make_shared<mgg::Platform>(
                mir::report::null_display_report(),
-               std::make_shared<mtd::StubConsoleServices>(),
+               *std::make_shared<mtd::StubConsoleServices>(),
                *std::make_shared<mtd::NullEmergencyCleanup>(),
                mgg::BypassOption::allowed,
                std::make_unique<mgg::Quirks>(mir::options::ProgramOption{}));

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_generic.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_generic.cpp
@@ -85,7 +85,7 @@ public:
     {
         auto const platform = std::make_shared<mgg::Platform>(
                 mir::report::null_display_report(),
-                std::make_shared<mtd::StubConsoleServices>(),
+                *std::make_shared<mtd::StubConsoleServices>(),
                 *std::make_shared<mtd::NullEmergencyCleanup>(),
                 mgg::BypassOption::allowed,
                 std::make_unique<mgg::Quirks>(mir::options::ProgramOption{}));

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
@@ -149,7 +149,7 @@ public:
     {
         return std::make_shared<mgg::Platform>(
                mir::report::null_display_report(),
-               std::make_shared<mtd::StubConsoleServices>(),
+               *std::make_shared<mtd::StubConsoleServices>(),
                *std::make_shared<mtd::NullEmergencyCleanup>(),
                mgg::BypassOption::allowed,
                std::make_unique<mgg::Quirks>(mir::options::ProgramOption{}));

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_platform.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_platform.cpp
@@ -81,7 +81,7 @@ public:
     {
         return std::make_shared<mgg::Platform>(
                 mir::report::null_display_report(),
-                std::make_shared<mtd::StubConsoleServices>(),
+                *std::make_shared<mtd::StubConsoleServices>(),
                 *std::make_shared<mtd::NullEmergencyCleanup>(),
                 mgg::BypassOption::allowed,
                 std::make_unique<mgg::Quirks>(mir::options::ProgramOption{}));


### PR DESCRIPTION
The `ConsoleServices` is a singleton, and which the `DisplayPlatform` only needs
to interact with during construction (in order to `acquire_device`).

There's no need to force the `Display` to keep a reference to the `ConsoleServices`
purely so that it can forward `register_pause_resume_handlers` to it.