### PR TITLE
doc: better removal of existing docs

### DIFF
--- a/cmake/Doxygen.cmake
+++ b/cmake/Doxygen.cmake
@@ -27,7 +27,7 @@ if(DOXYGEN_FOUND)
     set(ALL "ALL")
   endif()
   add_custom_target(doc ${ALL}
-                    COMMAND rm -f  ${CMAKE_BINARY_DIR}/doc/html/{*,search}
+                    COMMAND find ${CMAKE_BINARY_DIR}/doc/html/ -mindepth 1 -maxdepth 1 -not -name cppguide -exec rm -rf {} +
                     COMMAND rm -rf ${CMAKE_BINARY_DIR}/doc/xml
                     COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile
                     SOURCES ${PROJECT_BINARY_DIR}/Doxyfile


### PR DESCRIPTION
`rm -f dir` doesn't do.

Fixes: #2800