### PR TITLE
Replace input::Scene::for_each() with input_surface_at()

### DIFF
--- a/src/include/server/mir/input/scene.h
+++ b/src/include/server/mir/input/scene.h
@@ -20,6 +20,8 @@
 #include <memory>
 #include <functional>
 
+#include "mir/geometry/point.h"
+
 namespace mir
 {
 namespace scene
@@ -40,7 +42,7 @@ class Scene
 public:
     virtual ~Scene() = default;
 
-    virtual void for_each(std::function<void(std::shared_ptr<input::Surface> const&)> const& callback) = 0;
+    virtual auto input_surface_at(geometry::Point point) const -> std::shared_ptr<input::Surface> = 0;
 
     virtual void add_observer(std::shared_ptr<scene::Observer> const& observer) = 0;
     virtual void remove_observer(std::weak_ptr<scene::Observer> const& observer) = 0;

--- a/src/server/input/cursor_controller.cpp
+++ b/src/server/input/cursor_controller.cpp
@@ -176,19 +176,6 @@ private:
     std::map<ms::Surface*, std::shared_ptr<ms::SurfaceObserver>> surface_observers;
 };
 
-std::shared_ptr<mi::Surface> topmost_surface_containing_point(
-    std::shared_ptr<mi::Scene> const& targets, geom::Point const& point)
-{
-    std::shared_ptr<mi::Surface> top_surface_at_point;
-    targets->for_each([&top_surface_at_point, &point]
-        (std::shared_ptr<mi::Surface> const& surface) 
-        {
-            if (surface->input_area_contains(point))
-                top_surface_at_point = surface;
-        });
-    return top_surface_at_point;
-}
-
 bool is_empty(std::shared_ptr<mg::CursorImage> const& image)
 {
     auto const size = image->size();
@@ -248,8 +235,7 @@ void mi::CursorController::set_cursor_image_locked(std::unique_lock<std::mutex>&
 
 void mi::CursorController::update_cursor_image_locked(std::unique_lock<std::mutex>& lock)
 {
-    auto surface = topmost_surface_containing_point(input_targets, cursor_location);
-    if (surface)
+    if (auto const surface = input_targets->input_surface_at(cursor_location))
     {
         set_cursor_image_locked(lock, surface->cursor_image());
     }

--- a/src/server/input/surface_input_dispatcher.h
+++ b/src/server/input/surface_input_dispatcher.h
@@ -79,8 +79,6 @@ private:
     void send_enter_exit_event(std::shared_ptr<input::Surface> const& surface,
         MirPointerEvent const* triggering_ev, MirPointerAction action);
 
-    std::shared_ptr<input::Surface> find_target_surface(geometry::Point const& target);
-
     void set_focus_locked(std::lock_guard<std::mutex> const&, std::shared_ptr<input::Surface> const&);
 
     void surface_removed(std::shared_ptr<scene::Surface> surface);

--- a/src/server/scene/surface_stack.cpp
+++ b/src/server/scene/surface_stack.cpp
@@ -339,16 +339,9 @@ auto ms::SurfaceStack::surface_at(geometry::Point cursor) const
     return {};
 }
 
-void ms::SurfaceStack::for_each(std::function<void(std::shared_ptr<mi::Surface> const&)> const& callback)
+auto ms::SurfaceStack::input_surface_at(geometry::Point point) const -> std::shared_ptr<input::Surface>
 {
-    RecursiveReadLock lg(guard);
-    for (auto const& layer : surface_layers)
-    {
-        for (auto const& surface : layer)
-        {
-            callback(surface);
-        }
-    }
+    return surface_at(point);
 }
 
 void ms::SurfaceStack::raise(Surface const* surface)

--- a/src/server/scene/surface_stack.h
+++ b/src/server/scene/surface_stack.h
@@ -82,7 +82,7 @@ public:
     void unregister_compositor(compositor::CompositorID id) override;
 
     // From Scene
-    void for_each(std::function<void(std::shared_ptr<input::Surface> const&)> const& callback) override;
+    auto input_surface_at(geometry::Point point) const -> std::shared_ptr<input::Surface> override;
 
     virtual void remove_surface(std::weak_ptr<Surface> const& surface) override;
 

--- a/tests/include/mir/test/doubles/stub_input_scene.h
+++ b/tests/include/mir/test/doubles/stub_input_scene.h
@@ -28,8 +28,9 @@ namespace doubles
 
 class StubInputScene : public input::Scene
 {
-    void for_each(std::function<void(std::shared_ptr<input::Surface> const&)> const& ) override
+    auto input_surface_at(geometry::Point) const -> std::shared_ptr<input::Surface> override
     {
+        return nullptr;
     }
     void add_observer(std::shared_ptr<scene::Observer> const& /* observer */) override
     {

--- a/tests/unit-tests/input/test_cursor_controller.cpp
+++ b/tests/unit-tests/input/test_cursor_controller.cpp
@@ -205,12 +205,6 @@ struct StubScene : public mtd::StubInputScene
     {
     }
 
-    void for_each(std::function<void(std::shared_ptr<mi::Surface> const&)> const& callback) override
-    {
-        for (auto const& target : targets)
-            callback(target);
-    }
-
     void add_observer(std::shared_ptr<ms::Observer> const& observer) override
     {
         observers.add(observer);

--- a/tests/unit-tests/input/test_cursor_controller.cpp
+++ b/tests/unit-tests/input/test_cursor_controller.cpp
@@ -205,6 +205,19 @@ struct StubScene : public mtd::StubInputScene
     {
     }
 
+    auto input_surface_at(geom::Point point) const -> std::shared_ptr<mi::Surface> override
+    {
+        std::shared_ptr<mi::Surface> result;
+        for (auto target : targets)
+        {
+            if (target->input_area_contains(point))
+            {
+                result = target;
+            }
+        }
+        return result;
+    }
+
     void add_observer(std::shared_ptr<ms::Observer> const& observer) override
     {
         observers.add(observer);

--- a/tests/unit-tests/input/test_surface_input_dispatcher.cpp
+++ b/tests/unit-tests/input/test_surface_input_dispatcher.cpp
@@ -89,6 +89,19 @@ struct StubInputScene : public mtd::StubInputScene
         return add_surface({{0, 0}, {1, 1}});
     }
 
+    auto input_surface_at(geom::Point point) const -> std::shared_ptr<mi::Surface> override
+    {
+        std::shared_ptr<mi::Surface> result;
+        surfaces.for_each([&](auto surface)
+            {
+                if (surface->input_area_contains(point))
+                {
+                    result = surface;
+                }
+            });
+        return result;
+    }
+
     void add_observer(std::shared_ptr<ms::Observer> const& new_observer) override
     {
         assert(observer == nullptr);
@@ -105,7 +118,7 @@ struct StubInputScene : public mtd::StubInputScene
         observer.reset();
     }
     
-    mir::ThreadSafeList<std::shared_ptr<ms::Surface>> surfaces;
+    mir::ThreadSafeList<std::shared_ptr<ms::Surface>> mutable surfaces;
 
     std::shared_ptr<ms::Observer> observer;
 };

--- a/tests/unit-tests/input/test_surface_input_dispatcher.cpp
+++ b/tests/unit-tests/input/test_surface_input_dispatcher.cpp
@@ -88,13 +88,6 @@ struct StubInputScene : public mtd::StubInputScene
     {
         return add_surface({{0, 0}, {1, 1}});
     }
-    
-    void for_each(std::function<void(std::shared_ptr<mi::Surface> const&)> const& exec) override
-    {
-	surfaces.for_each([&exec](std::shared_ptr<mi::Surface> const& surface) {
-            exec(surface);
-        });
-    }
 
     void add_observer(std::shared_ptr<ms::Observer> const& new_observer) override
     {


### PR DESCRIPTION
`for_each()` was only being used to implement finding the topmost input surface. Our `input::Scene` implementation already has a more performant function to find the topmost surface.