### PR TITLE
wayland: Add missing cstdint includes

### DIFF
--- a/include/wayland/mir/wayland/protocol_error.h
+++ b/include/wayland/mir/wayland/protocol_error.h
@@ -18,6 +18,7 @@
 #define MIR_WAYLAND_PROTOCOL_ERROR_H_
 
 #include <stdexcept>
+#include <cstdint>
 
 struct wl_resource;
 struct wl_client;


### PR DESCRIPTION
This fixes building for Fedora Linux 38, which ships GCC 13.