### PR TITLE
More refactoring of display configuration

### DIFF
--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -266,58 +266,53 @@ void miral::YamlFileDisplayConfig::apply_to(mg::DisplayConfiguration& conf)
     if (current_config != end(config))
     {
         mir::log_debug("Display config using layout: '%s'", layout.c_str());
+
+        conf.for_each_output([&config=current_config->second](mg::UserDisplayConfigurationOutput& conf_output)
+            {
+                apply_to_output(conf_output, config[conf_output.name]);
+            });
     }
     else
     {
         mir::log_warning("Display config does not contain layout '%s'", layout.c_str());
+
+        conf.for_each_output([config=Config{}](mg::UserDisplayConfigurationOutput& conf_output)
+            {
+                apply_to_output(conf_output, config);
+            });
     }
 
-    struct card_data
-    {
-        std::ostringstream out;
-    };
-    std::map<mg::DisplayConfigurationCardId, card_data> card_map;
+    dump_config([&conf](std::ostream& out){ serialize_configuration(out, conf); });
+}
 
-    conf.for_each_output([&](mg::UserDisplayConfigurationOutput& conf_output)
+void miral::YamlFileDisplayConfig::serialize_configuration(std::ostream& out, mg::DisplayConfiguration& conf)
+{
+    out << "layouts:"
+           "\n# keys here are layout labels (used for atomically switching between them)"
+           "\n# when enabling displays, surfaces should be matched in reverse recency order"
+           "\n"
+           "\n  default:                         # the default layout"
+           "\n"
+           "\n    cards:"
+           "\n    # a list of cards (currently matched by card-id)";
+
+    std::map<mg::DisplayConfigurationCardId, std::ostringstream> card_map;
+
+    conf.for_each_output([&card_map](mg::UserDisplayConfigurationOutput const& conf_output)
         {
-            auto& card_data = card_map[conf_output.card_id];
-
-            if (current_config != end(config))
-            {
-                apply_to_output(conf_output, current_config->second[conf_output.name]);
-            }
-            else
-            {
-                apply_to_output(conf_output, Config{});
-            }
-
-            serialize_output_configuration(card_data.out, conf_output);
+            serialize_output_configuration(card_map[conf_output.card_id], conf_output);
         });
 
-    auto print_template_config = [&card_map](std::ostream& out)
-        {
-            out << "layouts:"
-                   "\n# keys here are layout labels (used for atomically switching between them)"
-                   "\n# when enabling displays, surfaces should be matched in reverse recency order"
-                   "\n"
-                   "\n  default:                         # the default layout"
-                   "\n"
-                   "\n    cards:"
-                   "\n    # a list of cards (currently matched by card-id)";
-
-            for (auto const& co : card_map)
-            {
-                out << "\n"
-                       "\n    - card-id: " << co.first.as_value()
-                    << co.second.out.str();
-            }
-        };
-
-    dump_config(print_template_config);
+    for (auto const& co : card_map)
+    {
+        out << "\n"
+               "\n    - card-id: " << co.first.as_value()
+            << co.second.str();
+    }
 }
 
 void miral::YamlFileDisplayConfig::serialize_output_configuration(
-    std::ostream& out, mg::UserDisplayConfigurationOutput& conf_output)
+    std::ostream& out, mg::UserDisplayConfigurationOutput const& conf_output)
 {
     out << "\n      " << conf_output.name << ':';
 

--- a/src/miral/static_display_config.h
+++ b/src/miral/static_display_config.h
@@ -63,11 +63,10 @@ private:
         mir::optional_value<MirOrientation>  orientation;
         mir::optional_value<int> group_id;
     };
-    using Id = std::tuple<mir::graphics::DisplayConfigurationCardId, MirOutputType, int>;
 
-    using Id2Config = std::map<Id, Config>;
-    using Layout2Id2Config = std::map<std::string, Id2Config>;
-    Layout2Id2Config config;
+    using Port2Config = std::map<std::string, Config>;
+    using Layout2Port2Config = std::map<std::string, Port2Config>;
+    Layout2Port2Config config;
 
     static void apply_to_output(mir::graphics::UserDisplayConfigurationOutput& conf_output, Config const& conf);
 

--- a/src/miral/static_display_config.h
+++ b/src/miral/static_display_config.h
@@ -71,7 +71,9 @@ private:
     static void apply_to_output(mir::graphics::UserDisplayConfigurationOutput& conf_output, Config const& conf);
 
     static void serialize_output_configuration(
-        std::ostream& out, mir::graphics::UserDisplayConfigurationOutput& conf_output);
+        std::ostream& out, mir::graphics::UserDisplayConfigurationOutput const& conf_output);
+
+    static void serialize_configuration(std::ostream& out, mir::graphics::DisplayConfiguration& conf);
 };
 
 class ReloadingYamlFileDisplayConfig : public YamlFileDisplayConfig

--- a/src/platforms/gbm-kms/server/kms/real_kms_display_configuration.cpp
+++ b/src/platforms/gbm-kms/server/kms/real_kms_display_configuration.cpp
@@ -133,17 +133,17 @@ void populate_default_mir_config(mg::DisplayConfigurationOutput& to_populate)
 
 void name_outputs(std::vector<std::pair<mg::DisplayConfigurationOutput, std::shared_ptr<mgg::KMSOutput>>>& outputs)
 {
-    std::map<mg::DisplayConfigurationCardId, std::map<MirOutputType, int>> card_map;
+    std::map<mg::DisplayConfigurationCardId, std::map<mg::DisplayConfigurationOutputType, int>> card_map;
 
     for (auto& output_pair : outputs)
     {
         auto& conf_output = output_pair.first;
-        auto const type = static_cast<MirOutputType>(conf_output.type);
+        auto const type = conf_output.type;
         auto const index_by_type = ++card_map[conf_output.card_id][type];
 
         std::ostringstream out;
 
-        out << mir::output_type_name(type);
+        out << mir::output_type_name(static_cast<unsigned>(type));
         if (conf_output.card_id.as_value() > 0)
             out << '-' << conf_output.card_id.as_value();
         out << '-' << index_by_type;

--- a/tests/miral/static_display_config.cpp
+++ b/tests/miral/static_display_config.cpp
@@ -65,6 +65,7 @@ struct StaticDisplayConfig : Test
         vga1.modes.push_back(another_mode);
         vga1.power_mode = mir_power_mode_on;
         vga1.orientation = mir_orientation_normal;
+        vga1.name = "VGA-1";
 
         hdmi1.id = mg::DisplayConfigurationOutputId{1};
         hdmi1.card_id = mg::DisplayConfigurationCardId{0};
@@ -78,6 +79,7 @@ struct StaticDisplayConfig : Test
         hdmi1.modes.push_back(another_mode);
         hdmi1.power_mode = mir_power_mode_on;
         hdmi1.orientation = mir_orientation_normal;
+        hdmi1.name = "HDMI-A-1";
 
         EXPECT_CALL(dc, for_each_output(_)).WillRepeatedly(DoAll(
             InvokeArgument<0>(mg::UserDisplayConfigurationOutput{vga1}),


### PR DESCRIPTION
* Refactor YamlFileDisplayConfig::apply_to() more
* use the unique output name as an identifier (instead of a weird tuple)
* Some drive-by tidy up