### PR TITLE
Add a side-by-side layout to the .display configuration

### DIFF
--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -285,7 +285,7 @@ void miral::YamlFileDisplayConfig::apply_to(mg::DisplayConfiguration& conf)
     std::ostringstream out;
     out << "Display config:\n8>< ---------------------------------------------------\n";
     out << "layouts:"
-           "\n  default:                         # the default layout";
+           "\n  " << layout << ":                         # the current layout";
 
     serialize_configuration(out, conf);
     out << "8>< ---------------------------------------------------";
@@ -515,14 +515,13 @@ void miral::ReloadingYamlFileDisplayConfig::apply_to(mir::graphics::DisplayConfi
                    "\n# keys here are layout labels (used for atomically switching between them)."
                    "\n# The yaml anchor 'the_default' is used to alias the 'default' label"
                    "\n"
-                   "\n  all_at_00: &the_default          # outputs all at {0, 0}";
+                   "\n  default:                         # outputs all at {0, 0}";
             serialize_configuration(out, conf);
 
             out << "\n  side_by_side:                    # the side-by-side layout";
             serialize_configuration(out, *side_by_side_config);
 
-            out << "\n  default: *the_default"
-                   "\n";
+            out << "\n";
 
             mir::log_debug(
                 "%s display configuration template: %s",

--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -282,18 +282,22 @@ void miral::YamlFileDisplayConfig::apply_to(mg::DisplayConfiguration& conf)
             });
     }
 
-    dump_config([&conf](std::ostream& out){ serialize_configuration(out, conf); });
+    dump_config([&conf](std::ostream& out)
+        {
+            out << "layouts:"
+                   "\n# keys here are layout labels (used for atomically switching between them)"
+                   "\n# when enabling displays, surfaces should be matched in reverse recency order"
+                   "\n"
+                   "\n  default:                         # the default layout"
+                   "\n";
+
+            serialize_configuration(out, conf);
+        });
 }
 
 void miral::YamlFileDisplayConfig::serialize_configuration(std::ostream& out, mg::DisplayConfiguration& conf)
 {
-    out << "layouts:"
-           "\n# keys here are layout labels (used for atomically switching between them)"
-           "\n# when enabling displays, surfaces should be matched in reverse recency order"
-           "\n"
-           "\n  default:                         # the default layout"
-           "\n"
-           "\n    cards:"
+    out << "\n    cards:"
            "\n    # a list of cards (currently matched by card-id)";
 
     std::map<mg::DisplayConfigurationCardId, std::ostringstream> card_map;

--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -504,16 +504,7 @@ void miral::ReloadingYamlFileDisplayConfig::apply_to(mir::graphics::DisplayConfi
     {
         auto const filename = config_path_.value() + "/" + basename;
 
-        // We don't want to write a .display config if running on an X11 or Wayland platform
-        // (We can not configure those this way). We guess the platform based on the output names
-        // because KMS sets realistic names.
-        bool all_fake_outputs = true;
-        conf.for_each_output([&all_fake_outputs](mg::UserDisplayConfigurationOutput const& conf_output)
-            {
-                all_fake_outputs &= conf_output.name.starts_with("OUT-");
-            });
-
-        if (!all_fake_outputs && access(filename.c_str(), F_OK))
+        if (access(filename.c_str(), F_OK))
         {
             auto const side_by_side_config = conf.clone();
             mg::SideBySideDisplayConfigurationPolicy{}.apply_to(*side_by_side_config);

--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -285,11 +285,7 @@ void miral::YamlFileDisplayConfig::apply_to(mg::DisplayConfiguration& conf)
     std::ostringstream out;
     out << "Display config:\n8>< ---------------------------------------------------\n";
     out << "layouts:"
-           "\n# keys here are layout labels (used for atomically switching between them)"
-           "\n# when enabling displays, surfaces should be matched in reverse recency order"
-           "\n"
-           "\n  default:                         # the default layout"
-           "\n";
+           "\n  default:                         # the default layout";
 
     serialize_configuration(out, conf);
     out << "8>< ---------------------------------------------------";
@@ -510,16 +506,23 @@ void miral::ReloadingYamlFileDisplayConfig::apply_to(mir::graphics::DisplayConfi
 
         if (access(filename.c_str(), F_OK))
         {
+            auto const side_by_side_config = conf.clone();
+            mg::SideBySideDisplayConfigurationPolicy{}.apply_to(*side_by_side_config);
+
             std::ofstream out{filename};
 
             out << "layouts:"
-                   "\n# keys here are layout labels (used for atomically switching between them)"
-                   "\n# when enabling displays, surfaces should be matched in reverse recency order"
+                   "\n# keys here are layout labels (used for atomically switching between them)."
+                   "\n# The yaml anchor 'the_default' is used to alias the 'default' label"
                    "\n"
-                   "\n  default:                         # the default layout"
-                   "\n";
-
+                   "\n  all_at_00: &the_default          # outputs all at {0, 0}";
             serialize_configuration(out, conf);
+
+            out << "\n  side_by_side:                    # the side-by-side layout";
+            serialize_configuration(out, *side_by_side_config);
+
+            out << "\n  default: *the_default"
+                   "\n";
 
             mir::log_debug(
                 "%s display configuration template: %s",

--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -506,28 +506,40 @@ void miral::ReloadingYamlFileDisplayConfig::apply_to(mir::graphics::DisplayConfi
 
         if (access(filename.c_str(), F_OK))
         {
-            auto const side_by_side_config = conf.clone();
-            mg::SideBySideDisplayConfigurationPolicy{}.apply_to(*side_by_side_config);
+            // We don't want to write a .display config if running on an X11 or Wayland platform
+            // (We can not configure those this way). We guess the platform based on the output names
+            // because KMS sets realistic names.
+            bool all_fake_outputs = true;
+            conf.for_each_output([&all_fake_outputs](mg::UserDisplayConfigurationOutput const& conf_output)
+                {
+                    all_fake_outputs &= conf_output.name.starts_with("OUT-");
+                });
 
-            std::ofstream out{filename};
+            if (!all_fake_outputs)
+            {
+                auto const side_by_side_config = conf.clone();
+                mg::SideBySideDisplayConfigurationPolicy{}.apply_to(*side_by_side_config);
 
-            out << "layouts:"
-                   "\n# keys here are layout labels (used for atomically switching between them)."
-                   "\n# The yaml anchor 'the_default' is used to alias the 'default' label"
-                   "\n"
-                   "\n  all_at_00: &the_default          # outputs all at {0, 0}";
-            serialize_configuration(out, conf);
+                std::ofstream out{filename};
 
-            out << "\n  side_by_side:                    # the side-by-side layout";
-            serialize_configuration(out, *side_by_side_config);
+                out << "layouts:"
+                       "\n# keys here are layout labels (used for atomically switching between them)."
+                       "\n# The yaml anchor 'the_default' is used to alias the 'default' label"
+                       "\n"
+                       "\n  all_at_00: &the_default          # outputs all at {0, 0}";
+                serialize_configuration(out, conf);
 
-            out << "\n  default: *the_default"
-                   "\n";
+                out << "\n  side_by_side:                    # the side-by-side layout";
+                serialize_configuration(out, *side_by_side_config);
 
-            mir::log_debug(
-                "%s display configuration template: %s",
-                out ? "Wrote" : "Failed writing",
-                filename.c_str());
+                out << "\n  default: *the_default"
+                       "\n";
+
+                mir::log_debug(
+                    "%s display configuration template: %s",
+                    out ? "Wrote" : "Failed writing",
+                    filename.c_str());
+            }
         }
     }
 }

--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -330,19 +330,19 @@ void miral::YamlFileDisplayConfig::serialize_output_configuration(
                "\n        # Uncomment the following to enforce the selected configuration."
                "\n        # Or amend as desired."
                "\n        #"
-               "\n        # state: " << (conf_output.used ? state_enabled : state_disabled)
+               "\n        state: " << (conf_output.used ? state_enabled : state_disabled)
             << "\t# {enabled, disabled}, defaults to enabled";
 
         if (conf_output.used) // The following are only set when used
         {
-            out << "\n        # mode: " << conf_output.modes[conf_output.current_mode_index]
+            out << "\n        mode: " << conf_output.modes[conf_output.current_mode_index]
                 << "\t# Defaults to preferred mode"
-                   "\n        # position: [" << conf_output.top_left.x << ", " << conf_output.top_left.y << ']'
+                   "\n        position: [" << conf_output.top_left.x << ", " << conf_output.top_left.y << ']'
                 << "\t# Defaults to [0, 0]"
-                   "\n        # orientation: " << as_string(conf_output.orientation)
+                   "\n        orientation: " << as_string(conf_output.orientation)
                 << "\t# {normal, left, right, inverted}, defaults to normal"
-                   "\n        # scale: " << conf_output.scale
-                << "\n        # group: " << conf_output.logical_group_id.as_value()
+                   "\n        scale: " << conf_output.scale
+                << "\n        group: " << conf_output.logical_group_id.as_value()
                 << "\t# Outputs with the same non-zero value are treated as a single display";
         }
     }

--- a/src/miral/static_display_config.h
+++ b/src/miral/static_display_config.h
@@ -43,13 +43,13 @@ class YamlFileDisplayConfig : public mir::graphics::DisplayConfigurationPolicy
 public:
     void load_config(std::istream& config_file, std::string const& filename);
 
-    virtual void apply_to(mir::graphics::DisplayConfiguration& conf);
-
-    virtual void dump_config(std::function<void(std::ostream&)> const& print_template_config);
+    void apply_to(mir::graphics::DisplayConfiguration& conf) override;
 
     void select_layout(std::string const& layout);
 
     auto list_layouts() const -> std::vector<std::string>;
+
+    static void serialize_configuration(std::ostream& out, mir::graphics::DisplayConfiguration& conf);
 
 private:
     std::string layout = "default";
@@ -72,8 +72,6 @@ private:
 
     static void serialize_output_configuration(
         std::ostream& out, mir::graphics::UserDisplayConfigurationOutput const& conf_output);
-
-    static void serialize_configuration(std::ostream& out, mir::graphics::DisplayConfiguration& conf);
 };
 
 class ReloadingYamlFileDisplayConfig : public YamlFileDisplayConfig
@@ -87,7 +85,7 @@ public:
 
     void config_path(std::string newpath);
 
-    void dump_config(std::function<void(std::ostream&)> const& print_template_config) override;
+    void apply_to(mir::graphics::DisplayConfiguration& conf) override;
 
 private:
     auto the_main_loop() const -> std::shared_ptr<mir::MainLoop>;


### PR DESCRIPTION
When creating a .display configuration include multiple layouts (`all_at_00` and `side_by_side`)