### PR TITLE
More tidy-up of the display configuration

### DIFF
--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -514,8 +514,6 @@ void miral::ReloadingYamlFileDisplayConfig::config_path(std::string newpath)
 
 void miral::ReloadingYamlFileDisplayConfig::apply_to(mir::graphics::DisplayConfiguration& conf)
 {
-    YamlFileDisplayConfig::apply_to(conf);
-
     if (!config_path_)
     {
         mir::log_debug("Nowhere to write display configuration template: Neither XDG_CONFIG_HOME or HOME is set");
@@ -550,6 +548,8 @@ void miral::ReloadingYamlFileDisplayConfig::apply_to(mir::graphics::DisplayConfi
                 filename.c_str());
         }
     }
+
+    YamlFileDisplayConfig::apply_to(conf);
 }
 
 auto miral::ReloadingYamlFileDisplayConfig::the_main_loop() const -> std::shared_ptr<mir::MainLoop>

--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -300,6 +300,7 @@ void miral::YamlFileDisplayConfig::apply_to(mg::DisplayConfiguration& conf)
     else
     {
         mir::log_warning("Display config does not contain layout '%s'", layout.c_str());
+        mir::log_debug("Display config using layout strategy: 'default'");
         apply_default_configuration(conf);
     }
 

--- a/src/miral/static_display_config.cpp
+++ b/src/miral/static_display_config.cpp
@@ -261,6 +261,7 @@ try
         new_config[ll.first.Scalar()] = layout_config;
     }
 
+    std::lock_guard lock{mutex};
     config = new_config;
     mir::log_debug("Loaded display configuration file: %s", filename.c_str());
 }
@@ -271,6 +272,7 @@ catch (YAML::Exception const& x)
 
 void miral::YamlFileDisplayConfig::apply_to(mg::DisplayConfiguration& conf)
 {
+    std::lock_guard lock{mutex};
     auto const current_config = config.find(layout);
 
     if (current_config != end(config))
@@ -463,6 +465,7 @@ void miral::YamlFileDisplayConfig::apply_to_output(mg::UserDisplayConfigurationO
 
 void miral::YamlFileDisplayConfig::select_layout(std::string const& layout)
 {
+    std::lock_guard lock{mutex};
     this->layout = layout;
 }
 
@@ -470,6 +473,7 @@ auto miral::YamlFileDisplayConfig::list_layouts() const -> std::vector<std::stri
 {
     std::vector<std::string> result;
 
+    std::lock_guard lock{mutex};
     for (auto const& c: config)
     {
         result.push_back(c.first);

--- a/src/miral/static_display_config.h
+++ b/src/miral/static_display_config.h
@@ -51,6 +51,8 @@ public:
 
     static void serialize_configuration(std::ostream& out, mir::graphics::DisplayConfiguration& conf);
 
+    static void apply_default_configuration(mir::graphics::DisplayConfiguration& conf);
+
 private:
     std::mutex mutable mutex;
     std::string layout = "default";

--- a/src/miral/static_display_config.h
+++ b/src/miral/static_display_config.h
@@ -52,6 +52,7 @@ public:
     static void serialize_configuration(std::ostream& out, mir::graphics::DisplayConfiguration& conf);
 
 private:
+    std::mutex mutable mutex;
     std::string layout = "default";
     struct Config
     {


### PR DESCRIPTION
* Roll the "default" layout into the `layout_strategies` table
* Write the .display configuration file before applying the selected layout to preserve the default settings
* If an output "appears" after the .display configuration is written apply the named strategy (if found) and use those values by default
