### PR TITLE
[Wayland] Don't kill bad clients

### DIFF
--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -191,6 +191,11 @@ private:
     void handle_close_request() override;
     void surface_destroyed() override;
 
+    void destroy_role() const override
+    {
+        wl_resource_destroy(resource);
+    }
+
     DoubleBuffered<uint32_t> exclusive_zone{0};
     DoubleBuffered<Anchors> anchors;
     DoubleBuffered<Margin> margin;

--- a/src/server/frontend_wayland/layer_shell_v1.cpp
+++ b/src/server/frontend_wayland/layer_shell_v1.cpp
@@ -670,15 +670,13 @@ void mf::LayerSurfaceV1::handle_close_request()
 
 void mf::LayerSurfaceV1::surface_destroyed()
 {
-    // Squeekboard (and possibly other purism apps) violate the protocol by destroying the surface before the role.
-    // Until it gets fixed we ignore this error for layer shell specifically.
-    // See: https://gitlab.gnome.org/World/Phosh/squeekboard/-/issues/285
-    try
+    if (!Resource::client->is_being_destroyed())
     {
-        WindowWlSurfaceRole::surface_destroyed();
-    }
-    catch (std::exception const& err)
-    {
-        log_warning("Ignoring layer shell protocol violation: %s", err.what());
+        // Squeekboard (and possibly other purism apps) violate the protocol by destroying the surface before the role.
+        // Until it gets fixed we ignore this error for layer shell specifically.
+        // See: https://gitlab.gnome.org/World/Phosh/squeekboard/-/issues/285
+        log_warning(
+            "Ignoring layer shell protocol violation: wl_surface destroyed before associated zwlr_layer_surface_v1@%d",
+            wl_resource_get_id(resource));
     }
 }

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -418,6 +418,10 @@ void mf::WindowWlSurfaceRole::surface_destroyed()
         log_warning("wl_surface@%s destroyed before associated role",
                     (surface ? std::to_string(wl_resource_get_id(surface.value().resource)) : "?").c_str());
 
+        // This isn't strictly correct (as it only applies to wl-shell) but is commonly assumed (e.g. by SDL2) and
+        // implemented (e.g. Mutter for xdg-shell)
+        // wl_shell_surface: "On the server side the object is automatically destroyed when the related wl_surface is
+        // destroyed"
         destroy_role();
     }
     else

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -410,13 +410,15 @@ void mf::WindowWlSurfaceRole::surface_destroyed()
 {
     if (!client->is_being_destroyed())
     {
+        mark_destroyed();
+
         // "When a client wants to destroy a wl_surface, they must destroy this 'role object' before the wl_surface"
         // NOTE: the wl_shell_surface specification seems contradictory, so this method is overridden in its implementation
         // NOTE: it's also overridden in layer shell, for reasons explained there
-        BOOST_THROW_EXCEPTION(std::runtime_error{
-            "wl_surface@" +
-            (surface ? std::to_string(wl_resource_get_id(surface.value().resource)) : "?") +
-            " destroyed before associated role"});
+        log_warning("wl_surface@%s destroyed before associated role",
+                    (surface ? std::to_string(wl_resource_get_id(surface.value().resource)) : "?").c_str());
+
+        delete this;
     }
     else
     {

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -418,7 +418,7 @@ void mf::WindowWlSurfaceRole::surface_destroyed()
         log_warning("wl_surface@%s destroyed before associated role",
                     (surface ? std::to_string(wl_resource_get_id(surface.value().resource)) : "?").c_str());
 
-        delete this;
+        destroy_role();
     }
     else
     {

--- a/src/server/frontend_wayland/window_wl_surface_role.h
+++ b/src/server/frontend_wayland/window_wl_surface_role.h
@@ -161,6 +161,9 @@ private:
     std::unique_ptr<shell::SurfaceSpecification> pending_changes;
 
     shell::SurfaceSpecification& spec();
+
+    // Ask the derived class to destroy the wayland role object (as only it can do that)
+    virtual void destroy_role() const = 0;
 };
 
 }

--- a/src/server/frontend_wayland/wl_shell.cpp
+++ b/src/server/frontend_wayland/wl_shell.cpp
@@ -50,15 +50,6 @@ public:
     ~WlShellSurface() = default;
 
 protected:
-    void surface_destroyed() override
-    {
-        // The spec is a little contradictory:
-        // wl_surface: When a client wants to destroy a wl_surface, they must destroy this 'role object' before the wl_surface
-        // wl_shell_surface: On the server side the object is automatically destroyed when the related wl_surface is destroyed
-        // Without a destroy request, it seems the latter must be correct, so that is what we implement
-        destroy_and_delete();
-    }
-
     void set_toplevel() override
     {
     }

--- a/src/server/frontend_wayland/wl_shell.cpp
+++ b/src/server/frontend_wayland/wl_shell.cpp
@@ -207,6 +207,11 @@ protected:
     void set_class(std::string const& /*class_*/) override
     {
     }
+
+    void destroy_role() const override
+    {
+        wl_resource_destroy(resource);
+    }
 };
 
 class WlShell : public wayland::Shell::Global

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -104,6 +104,7 @@ public:
 private:
     static XdgToplevelStable* from(wl_resource* surface);
     void send_toplevel_configure();
+    void destroy_role() const override;
 
     XdgSurfaceStable* const xdg_surface;
 };
@@ -386,6 +387,11 @@ auto mf::XdgPopupStable::from(wl_resource* resource) -> XdgPopupStable*
     return popup;
 }
 
+void mf::XdgPopupStable::destroy_role() const
+{
+    wl_resource_destroy(resource);
+}
+
 // XdgToplevelStable
 
 mf::XdgToplevelStable::XdgToplevelStable(wl_resource* new_resource, XdgSurfaceStable* xdg_surface, WlSurface* surface)
@@ -590,6 +596,11 @@ mf::XdgToplevelStable* mf::XdgToplevelStable::from(wl_resource* surface)
 {
     auto* tmp = wl_resource_get_user_data(surface);
     return static_cast<XdgToplevelStable*>(static_cast<mw::XdgToplevel*>(tmp));
+}
+
+void mf::XdgToplevelStable::destroy_role() const
+{
+    wl_resource_destroy(resource);
 }
 
 // XdgPositionerStable

--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -83,6 +83,8 @@ public:
     static auto from(wl_resource* resource) -> XdgPopupStable*;
 
 private:
+    void destroy_role() const override;
+
     std::optional<geometry::Point> cached_top_left;
     std::optional<geometry::Size> cached_size;
 

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -93,6 +93,8 @@ private:
     std::optional<geom::Size> cached_size;
 
     XdgSurfaceV6* const xdg_surface;
+
+    void destroy_role() const override;
 };
 
 class XdgToplevelV6 : mw::XdgToplevelV6, public WindowWlSurfaceRole
@@ -125,6 +127,7 @@ public:
 private:
     static XdgToplevelV6* from(wl_resource* surface);
     void send_toplevel_configure();
+    void destroy_role() const override;
 
     XdgSurfaceV6* const xdg_surface;
 };
@@ -343,6 +346,11 @@ void mf::XdgPopupV6::handle_close_request()
     send_popup_done_event();
 }
 
+void mf::XdgPopupV6::destroy_role() const
+{
+    wl_resource_destroy(resource);
+}
+
 // XdgToplevelV6
 
 mf::XdgToplevelV6::XdgToplevelV6(struct wl_resource* new_resource, XdgSurfaceV6* xdg_surface, WlSurface* surface)
@@ -546,6 +554,11 @@ mf::XdgToplevelV6* mf::XdgToplevelV6::from(wl_resource* surface)
 {
     auto* tmp = wl_resource_get_user_data(surface);
     return static_cast<XdgToplevelV6*>(static_cast<mw::XdgToplevelV6*>(tmp));
+}
+
+void mf::XdgToplevelV6::destroy_role() const
+{
+    wl_resource_destroy(resource);
 }
 
 // XdgPositionerV6


### PR DESCRIPTION
Some toolkits & clients are not deleting the surface role before deleting the surface. 

Killing the connection when they do this is too harsh: Wayland servers are not conformance test suites, and can be flexible in what they expect.

There is text in wl-shell that directs that, despite the client not being allowed to do this, the server should delete the role object. And we already handled that case this way. Mutter does the same with xdg-shell, so there is prior art for what is proposed here.

We have a different workaround in layer-shell, as squeekboard doesn't delete the surface role before the surface, but also crashes if the role object is destroyed by the server.