### PR TITLE
(Sophie's) reimplementation of idle_inhibit_unstable_v1

### DIFF
--- a/src/server/frontend_wayland/idle_inhibit_v1.cpp
+++ b/src/server/frontend_wayland/idle_inhibit_v1.cpp
@@ -29,6 +29,8 @@ namespace mf = mir::frontend;
 namespace mw = mir::wayland;
 namespace ms = mir::scene;
 
+namespace
+{
 struct IdleInhibitV1Ctx
 {
     std::shared_ptr<mir::Executor> const wayland_executor;
@@ -56,6 +58,31 @@ private:
 
     std::shared_ptr<IdleInhibitV1Ctx> const ctx;
 };
+
+class IdleInhibitorV1 : public mw::IdleInhibitorV1
+{
+public:
+    IdleInhibitorV1(wl_resource *resource, std::shared_ptr<IdleInhibitV1Ctx> const& ctx, mf::WlSurface* surface);
+    ~IdleInhibitorV1();
+
+private:
+    class VisibilityObserver;
+
+    void notify(std::optional<bool> visible, std::optional<bool> hidden);
+    void finalize(); ///< May be safely called multiple times
+
+    std::shared_ptr<IdleInhibitV1Ctx> const ctx;
+    mw::Weak<mf::WlSurface> const wl_surface;
+    mw::DestroyListenerId const surface_destroyed_listener_id;
+    std::shared_ptr<VisibilityObserver> const visibility_observer;
+
+    bool visible = false;
+    bool hidden = false;
+    bool finalized = false;
+    std::shared_ptr<ms::IdleHub::WakeLock> wake_lock;
+    std::weak_ptr<ms::Surface> scene_surface;
+};
+}
 
 auto mf::create_idle_inhibit_manager_v1(
     wl_display* display,
@@ -92,32 +119,115 @@ IdleInhibitManagerV1::IdleInhibitManagerV1(
 
 void IdleInhibitManagerV1::create_inhibitor(struct wl_resource* id, struct wl_resource* surface)
 {
-    auto inhibitor = new mf::IdleInhibitorV1{id, ctx->idle_hub};
-
-    mf::WlSurface::from(surface)->idle_inhibitor(mw::Weak{inhibitor});
+    new IdleInhibitorV1{id, ctx, mf::WlSurface::from(surface)};
 }
 
-mf::IdleInhibitorV1::IdleInhibitorV1(wl_resource *resource, std::shared_ptr<scene::IdleHub> idle_hub)
-    : mw::IdleInhibitorV1{resource, Version<1>()},
-      idle_hub{std::move(idle_hub)}
+class IdleInhibitorV1::VisibilityObserver : public mir::scene::NullSurfaceObserver
 {
-}
-
-mf::IdleInhibitorV1::~IdleInhibitorV1()
-{
-}
-
-void mf::IdleInhibitorV1::exposed()
-{
-    std::lock_guard lock{mutex};
-    if (!wake_lock)
+public:
+    VisibilityObserver(
+        mw::Weak<IdleInhibitorV1> inhibitor,
+        std::shared_ptr<mir::Executor> const executor)
+        : executor{std::move(executor)},
+          inhibitor{std::move(inhibitor)}
     {
-        wake_lock = idle_hub->inhibit_idle();
+    }
+
+    void attrib_changed(mir::scene::Surface const*, MirWindowAttrib attrib, int value) override
+    {
+        if (attrib == mir_window_attrib_visibility)
+        {
+            executor->spawn([inhibitor=inhibitor, value]
+                {
+                    if (inhibitor)
+                    {
+                        inhibitor.value().notify(value == mir_window_visibility_exposed, std::nullopt);
+                    }
+                });
+        }
+    }
+
+    void hidden_set_to(const mir::scene::Surface*, bool hide) override
+    {
+        executor->spawn([inhibitor=inhibitor, hide]
+            {
+                if (inhibitor)
+                {
+                    inhibitor.value().notify(std::nullopt, hide);
+                }
+            });
+    }
+
+private:
+    std::shared_ptr<mir::Executor> const executor;
+    mw::Weak<IdleInhibitorV1> const inhibitor;
+};
+
+IdleInhibitorV1::IdleInhibitorV1(
+    wl_resource *resource,
+    std::shared_ptr<IdleInhibitV1Ctx> const& ctx,
+    mf::WlSurface* wl_surface)
+    : mw::IdleInhibitorV1{resource, Version<1>()},
+      ctx{ctx},
+      wl_surface{wl_surface},
+      surface_destroyed_listener_id{wl_surface->add_destroy_listener([this]()
+          {
+              finalize();
+          })},
+      visibility_observer{std::make_shared<VisibilityObserver>(mw::make_weak(this), this->ctx->wayland_executor)}
+{
+    wl_surface->on_scene_surface_created(
+        [weak_self=mw::make_weak(this)](std::shared_ptr<ms::Surface> scene_surface)
+        {
+            if (weak_self)
+            {
+                // Use immediate_executor so uninteresting observations are processed quickly, we punt interesting
+                // observations to an executor ourselves
+                scene_surface->register_interest(weak_self.value().visibility_observer, mir::immediate_executor);
+                weak_self.value().notify(
+                    scene_surface->query(mir_window_attrib_visibility) == mir_window_visibility_exposed,
+                    std::nullopt);
+            }
+        });
+}
+
+IdleInhibitorV1::~IdleInhibitorV1()
+{
+    finalize();
+}
+
+void IdleInhibitorV1::notify(std::optional<bool> new_visible, std::optional<bool> new_hidden)
+{
+    if (finalized)
+    {
+        return;
+    }
+    visible = new_visible.value_or(visible);
+    hidden = new_hidden.value_or(this->hidden);
+    if (visible && !hidden)
+    {
+        if (!wake_lock)
+        {
+            wake_lock = ctx->idle_hub->inhibit_idle();
+        }
+    }
+    else
+    {
+        wake_lock.reset();
     }
 }
 
-void mf::IdleInhibitorV1::occluded()
+void IdleInhibitorV1::finalize()
 {
-    std::lock_guard lock{mutex};
+    finalized = true;
+    if (auto const surface = scene_surface.lock())
+    {
+        surface->unregister_interest(*visibility_observer);
+    }
+    scene_surface.reset();
+    if (wl_surface)
+    {
+        wl_surface.value().remove_destroy_listener(surface_destroyed_listener_id);
+    }
     wake_lock.reset();
 }

--- a/src/server/frontend_wayland/idle_inhibit_v1.cpp
+++ b/src/server/frontend_wayland/idle_inhibit_v1.cpp
@@ -103,15 +103,7 @@ IdleInhibitManagerV1::IdleInhibitManagerV1(
 
 void IdleInhibitManagerV1::create_inhibitor(struct wl_resource* id, struct wl_resource* surface)
 {
-    auto wl_surface = mf::WlSurface::from(surface);
-
-    if (auto const scene_surface = wl_surface->scene_surface())
-    {
-        if (scene_surface.value()->focus_state() != mir_window_focus_state_unfocused)
-        {
-            new IdleInhibitorV1{id, ctx};
-        }
-    }
+    new IdleInhibitorV1{id, ctx};
 }
 
 IdleInhibitorV1::IdleInhibitorV1(wl_resource *resource, std::shared_ptr<IdleInhibitV1Ctx> const& ctx)

--- a/src/server/frontend_wayland/idle_inhibit_v1.h
+++ b/src/server/frontend_wayland/idle_inhibit_v1.h
@@ -36,6 +36,22 @@ auto create_idle_inhibit_manager_v1(
     std::shared_ptr<Executor> wayland_executor,
     std::shared_ptr<scene::IdleHub> idle_hub)
 -> std::shared_ptr<wayland::IdleInhibitManagerV1::Global>;
+
+class IdleInhibitorV1 : public mir::wayland::IdleInhibitorV1
+{
+public:
+    IdleInhibitorV1(wl_resource *resource, std::shared_ptr<scene::IdleHub> idle_hub);
+    ~IdleInhibitorV1();
+
+    void exposed();
+    void occluded();
+
+private:
+    std::shared_ptr<scene::IdleHub> const idle_hub;
+
+    std::mutex mutex;
+    std::shared_ptr<scene::IdleHub::WakeLock> wake_lock;
+};
 }
 }
 

--- a/src/server/frontend_wayland/idle_inhibit_v1.h
+++ b/src/server/frontend_wayland/idle_inhibit_v1.h
@@ -21,6 +21,7 @@
 #include "mir/scene/idle_hub.h"
 
 #include <memory>
+#include <mutex>
 
 namespace mir
 {

--- a/src/server/frontend_wayland/idle_inhibit_v1.h
+++ b/src/server/frontend_wayland/idle_inhibit_v1.h
@@ -21,15 +21,10 @@
 #include "mir/scene/idle_hub.h"
 
 #include <memory>
-#include <mutex>
 
 namespace mir
 {
 class Executor;
-namespace scene
-{
-class IdleHub;
-}
 namespace frontend
 {
 auto create_idle_inhibit_manager_v1(
@@ -37,22 +32,6 @@ auto create_idle_inhibit_manager_v1(
     std::shared_ptr<Executor> wayland_executor,
     std::shared_ptr<scene::IdleHub> idle_hub)
 -> std::shared_ptr<wayland::IdleInhibitManagerV1::Global>;
-
-class IdleInhibitorV1 : public mir::wayland::IdleInhibitorV1
-{
-public:
-    IdleInhibitorV1(wl_resource *resource, std::shared_ptr<scene::IdleHub> idle_hub);
-    ~IdleInhibitorV1();
-
-    void exposed();
-    void occluded();
-
-private:
-    std::shared_ptr<scene::IdleHub> const idle_hub;
-
-    std::mutex mutex;
-    std::shared_ptr<scene::IdleHub::WakeLock> wake_lock;
-};
 }
 }
 

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -22,24 +22,22 @@
 #include "wl_region.h"
 #include "shm.h"
 #include "deleted_for_resource.h"
-#include "idle_inhibit_v1.h"
 
 #include "wayland_wrapper.h"
 
 #include "wayland_frontend.tp.h"
 
+#include "mir/wayland/protocol_error.h"
+#include "mir/wayland/client.h"
+#include "mir/graphics/buffer_properties.h"
+#include "mir/scene/session.h"
+#include "mir/frontend/wayland.h"
 #include "mir/compositor/buffer_stream.h"
 #include "mir/executor.h"
-#include "mir/frontend/wayland.h"
-#include "mir/graphics/buffer_properties.h"
 #include "mir/graphics/graphic_buffer_allocator.h"
-#include "mir/log.h"
-#include "mir/scene/null_surface_observer.h"
-#include "mir/scene/session.h"
 #include "mir/scene/surface.h"
 #include "mir/shell/surface_specification.h"
-#include "mir/wayland/client.h"
-#include "mir/wayland/protocol_error.h"
+#include "mir/log.h"
 
 #include <chrono>
 #include <boost/throw_exception.hpp>
@@ -104,8 +102,6 @@ mf::WlSurface::WlSurface(
 
 mf::WlSurface::~WlSurface()
 {
-    unregister_visibility_observer();
-
     // We can't use a function try block as we want to access `client`:
     // "Before any catch clauses of a function-try-block on a destructor are entered,
     // all bases and non-variant members have already been destroyed."
@@ -152,6 +148,18 @@ auto mf::WlSurface::subsurface_at(geom::Point point) -> std::optional<WlSurface*
 auto mf::WlSurface::scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>>
 {
     return role->scene_surface();
+}
+
+void mf::WlSurface::on_scene_surface_created(SceneSurfaceCreatedCallback&& callback)
+{
+    if (auto const surface = scene_surface(); surface && surface.value())
+    {
+        callback(surface.value());
+    }
+    else
+    {
+        scene_surface_created_callbacks.push_back(std::move(callback));
+    }
 }
 
 void mf::WlSurface::set_role(WlSurfaceRole* role_)
@@ -421,7 +429,17 @@ void mf::WlSurface::commit()
     pending = WlSurfaceState();
     role->commit(state);
 
-    register_visibility_observer();
+    if (scene_surface_created_callbacks.size())
+    {
+        if (auto const surface = scene_surface(); surface && surface.value())
+        {
+            for (auto const& callback : scene_surface_created_callbacks)
+            {
+                callback(surface.value());
+            }
+            scene_surface_created_callbacks.clear();
+        }
+    }
 }
 
 void mf::WlSurface::set_buffer_transform(int32_t transform)
@@ -446,100 +464,6 @@ auto mf::WlSurface::confine_pointer_state() const -> MirPointerConfinementState
     }
 
     return mir_pointer_unconfined;
-}
-
-class mf::WlSurface::VisibilityObserver : public mir::scene::NullSurfaceObserver
-{
-public:
-    VisibilityObserver(wayland::Weak<IdleInhibitorV1> inhibitor, std::shared_ptr<mir::Executor> const executor) :
-        executor{std::move(executor)},
-        inhibitor{std::move(inhibitor)} {}
-
-    void attrib_changed(mir::scene::Surface const*, MirWindowAttrib attrib, int value) override
-    {
-        if (attrib == mir_window_attrib_visibility)
-        {
-            {
-                std::lock_guard lock{mutex};
-                visible = value == mir_window_visibility_exposed;
-            }
-
-            executor->spawn([this] { notify(); });
-        }
-    }
-
-    void hidden_set_to(const mir::scene::Surface*, bool hide) override
-    {
-        {
-            std::lock_guard lock{mutex};
-            hidden = hide;
-        }
-
-        executor->spawn([this] { notify(); });
-    }
-
-    void notify() const
-    {
-        if (inhibitor)
-        {
-            std::lock_guard lock{mutex};
-            if (visible && !hidden)
-            {
-                inhibitor.value().exposed();
-            }
-            else
-            {
-                inhibitor.value().occluded();
-            }
-        }
-    }
-
-private:
-    std::shared_ptr<mir::Executor> const executor;
-    wayland::Weak<IdleInhibitorV1> const inhibitor;
-
-    std::mutex mutable mutex;
-    bool visible = true;
-    bool hidden = false;
-};
-
-void mf::WlSurface::idle_inhibitor(wayland::Weak<IdleInhibitorV1> inhibitor)
-{
-    unregister_visibility_observer();
-    visibility_observer = std::make_shared<VisibilityObserver>(std::move(inhibitor), frame_callback_executor);
-    register_visibility_observer();
-}
-
-void mf::WlSurface::unregister_visibility_observer()
-{
-    if (visibility_observer_registered && visibility_observer)
-    {
-        if (auto const maybe_scene_surface = scene_surface())
-        {
-            if (auto const scene_surface = *maybe_scene_surface)
-            {
-                scene_surface->unregister_interest(*visibility_observer);
-            }
-        }
-    }
-
-    visibility_observer_registered = false;
-    visibility_observer.reset();
-}
-
-void mf::WlSurface::register_visibility_observer()
-{
-    if (!visibility_observer_registered && visibility_observer)
-    {
-        if (auto const maybe_scene_surface = scene_surface())
-        {
-            if (auto const scene_surface = *maybe_scene_surface)
-            {
-                scene_surface->register_interest(visibility_observer);
-                visibility_observer_registered = true;
-            }
-        }
-    }
 }
 
 mf::NullWlSurfaceRole::NullWlSurfaceRole(WlSurface* surface) :

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -54,6 +54,7 @@ namespace frontend
 {
 class WlSurface;
 class WlSubsurface;
+class IdleInhibitorV1;
 
 struct WlSurfaceState
 {
@@ -131,6 +132,7 @@ public:
                                geometry::Displacement const& parent_offset) const;
     void commit(WlSurfaceState const& state);
     auto confine_pointer_state() const -> MirPointerConfinementState;
+    void idle_inhibitor(wayland::Weak<IdleInhibitorV1> inhibitor);
 
     std::shared_ptr<scene::Session> const session;
     std::shared_ptr<compositor::BufferStream> const stream;
@@ -151,6 +153,9 @@ private:
     std::optional<geometry::Size> buffer_size_;
     std::vector<wayland::Weak<WlSurfaceState::Callback>> frame_callbacks;
     std::optional<std::vector<mir::geometry::Rectangle>> input_shape;
+    class VisibilityObserver;
+    std::shared_ptr<VisibilityObserver> visibility_observer;
+    bool visibility_observer_registered = false;
 
     void send_frame_callbacks();
 
@@ -163,6 +168,8 @@ private:
     void damage_buffer(int32_t x, int32_t y, int32_t width, int32_t height) override;
     void set_buffer_transform(int32_t transform) override;
     void set_buffer_scale(int32_t scale) override;
+    void unregister_visibility_observer();
+    void register_visibility_observer();
 };
 }
 }


### PR DESCRIPTION
Based on and alternative to #2839. I put the visibility observer in idle_inhibit_v1.cpp to avoid cluttering wl_surface.cpp. Draft since there's still some issues I've observed and want to sort out. Not yet clear if they're also in our current implementation and/or Alan's implementation.

Fixes #2838
Fixes #2836