### PR TITLE
[miral] Provide output names

### DIFF
--- a/debian/libmiral5.symbols
+++ b/debian/libmiral5.symbols
@@ -416,3 +416,5 @@ libmiral.so.5 libmiral5 #MINVER#
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&, MirInputEventModifier)@MIRAL_3.7" 3.7.0
  (c++)"miral::MirRunner::register_signal_handler(std::initializer_list<int>, std::function<void (int)> const&)@MIRAL_3.7" 3.7.0
  (c++)"miral::MirRunner::register_fd_handler(mir::Fd, std::function<void (int)> const&)@MIRAL_3.7" 3.7.0
+ MIRAL_3.8@MIRAL_3.8 3.8.0
+ (c++)"miral::Output::name[abi:cxx11]() const@MIRAL_3.8" 3.8.0

--- a/include/miral/miral/output.h
+++ b/include/miral/miral/output.h
@@ -97,6 +97,10 @@ public:
     /// mostly useful for matching against a miral::WindowInfo::output_id
     auto id() const -> int;
 
+    /// The output name. This matches that suppled to clients through wl_output
+    /// \remark Since MirAL 3.8
+    auto name() const -> std::string;
+
     auto valid() const -> bool;
 
     auto is_same_output(Output const& other) const -> bool;

--- a/src/miral/output.cpp
+++ b/src/miral/output.cpp
@@ -103,6 +103,11 @@ auto miral::Output::logical_group_id() const -> int
     return self->logical_group_id.as_value();
 }
 
+auto miral::Output::name() const -> std::string
+{
+    return self->name;
+}
+
 bool miral::operator==(Output::PhysicalSizeMM const& lhs, Output::PhysicalSizeMM const& rhs)
 {
     return lhs.width == rhs.width && lhs.height == rhs.height;

--- a/src/miral/regenerate-miral-symbols-map.py
+++ b/src/miral/regenerate-miral-symbols-map.py
@@ -549,9 +549,15 @@ MIRAL_3.7 {
 global:
   extern "C++" {
     "miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&, MirInputEventModifier)";
-  };'''
+    miral::MirRunner::register_signal_handler*;
+    miral::MirRunner::register_fd_handler*;
+  };
+} MIRAL_3.6;
 
-END_NEW_STANZA = '} MIRAL_3.6;'
+MIRAL_3.8 {
+global:'''
+
+END_NEW_STANZA = '} MIRAL_3.7;'
 
 def _print_report():
     print(OLD_STANZAS)

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -470,3 +470,14 @@ global:
     miral::MirRunner::register_fd_handler*;
   };
 } MIRAL_3.6;
+
+MIRAL_3.8 {
+global:
+  extern "C++" {
+    miral::FdHandle::?FdHandle*;
+    miral::Output::name*;
+    non-virtual?thunk?to?miral::FdHandle::?FdHandle*;
+    typeinfo?for?miral::FdHandle;
+    vtable?for?miral::FdHandle;
+  };
+} MIRAL_3.7;


### PR DESCRIPTION
These are useful for compositors (e.g. Frame) that want to do lexical matching (e.g. HDMI-1: "Kodi")