### PR TITLE
Drop redundant eglmesaext.h include

### DIFF
--- a/include/platform/mir/graphics/egl_extensions.h
+++ b/include/platform/mir/graphics/egl_extensions.h
@@ -55,9 +55,6 @@
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 
-// For Wayland extensions
-#include <EGL/eglmesaext.h>
-
 /*
  * Just enough polyfill for RPi's EGL headers...
  */


### PR DESCRIPTION
The Wayland extensions aren't MESA-exclusive anymore (and haven't been for *some time*)