### PR TITLE
Use wayland::Weak in place of raw pointers in XDG surfaces

### DIFF
--- a/src/server/frontend_wayland/xdg_shell_stable.h
+++ b/src/server/frontend_wayland/xdg_shell_stable.h
@@ -89,7 +89,7 @@ private:
     std::optional<geometry::Size> cached_size;
 
     std::shared_ptr<shell::Shell> const shell;
-    XdgSurfaceStable* const xdg_surface;
+    wayland::Weak<XdgSurfaceStable> const xdg_surface;
     geometry::Rectangle aux_rect;
     geometry::Displacement aux_rect_offset;
 };


### PR DESCRIPTION
While poking around in WLCS I noticed that we have some potential for use-after-free in XDG surfaces. This clears those issues up.