### PR TITLE
Prevent freetype from linking in an older glib

### DIFF
--- a/examples/example-server-lib/CMakeLists.txt
+++ b/examples/example-server-lib/CMakeLists.txt
@@ -19,4 +19,4 @@ target_include_directories(example-shell-lib
     PRIVATE
         ${FREETYPE_INCLUDE_DIRS}
 )
-target_link_libraries(example-shell-lib PUBLIC miral PRIVATE ${WAYLAND_CLIENT_LDFLAGS} ${FREETYPE_LDFLAGS})
+target_link_libraries(example-shell-lib PUBLIC miral PRIVATE ${WAYLAND_CLIENT_LDFLAGS} ${FREETYPE_LIBRARIES})


### PR DESCRIPTION
This should fix https://github.com/MirServer/mir/issues/2854