### PR TITLE
Multiplexing display

### DIFF
--- a/include/platform/mir/graphics/display.h
+++ b/include/platform/mir/graphics/display.h
@@ -98,6 +98,12 @@ public:
      */
     virtual std::unique_ptr<DisplayConfiguration> configuration() const = 0;
 
+
+    class IncompleteConfigurationApplied : public std::runtime_error
+    {
+    public:
+        using runtime_error::runtime_error;
+    };
     /**
      * Applying a display configuration only if it will not invalidate existing DisplayBuffers
      *
@@ -113,6 +119,8 @@ public:
      *
      * \param conf [in] Configuration to possibly apply.
      * \return      \c true if \p conf has been applied as the new output configuration.
+     * \throws     IncompleteConfigurationApplied if the configuration has been partially applied.
+     *             Users should fall back to a full configure() to return to a consistent state.
      */
     virtual bool apply_if_configuration_preserves_display_buffers(DisplayConfiguration const& conf) = 0;
 

--- a/src/server/graphics/CMakeLists.txt
+++ b/src/server/graphics/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(
   display_configuration_observer_multiplexer.h
   platform_probe.cpp
   platform_probe.h
+  multiplexing_display.h
+  multiplexing_display.cpp
 )
 
 target_link_libraries(mirgraphics

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -111,7 +111,7 @@ auto mg::MultiplexingDisplay::apply_if_configuration_preserves_display_buffers(
                 if (!i->first->apply_if_configuration_preserves_display_buffers(*i->second))
                 {
                     BOOST_THROW_EXCEPTION((
-                        std::runtime_error{"Failure attempting to undo partially-applied configuration"}));
+                        mg::Display::IncompleteConfigurationApplied{"Failure attempting to undo partially-applied configuration"}));
                 }
             }
             return false;

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "multiplexing_display.h"
+#include "mir/graphics/display_configuration.h"
+#include "mir/renderer/gl/context.h"
+#include <functional>
+
+namespace mg = mir::graphics;
+
+mg::MultiplexingDisplay::MultiplexingDisplay(std::vector<std::unique_ptr<Display>> displays)
+    : displays{std::move(displays)}
+{
+}
+
+mg::MultiplexingDisplay::~MultiplexingDisplay() = default;
+
+void mg::MultiplexingDisplay::for_each_display_sync_group(
+    std::function<void(DisplaySyncGroup&)> const& f)
+{
+    for (auto const& display: displays)
+    {
+        display->for_each_display_sync_group(f);
+    }
+}
+
+namespace
+{
+class CompositeDisplayConfiguration : public mg::DisplayConfiguration
+{
+public:
+    CompositeDisplayConfiguration(std::vector<std::unique_ptr<mg::DisplayConfiguration>> confs)
+        : components{std::move(confs)}
+    {
+    }
+
+    void for_each_output(std::function<void(mg::DisplayConfigurationOutput const&)> functor) const override
+    {
+        for (auto const& conf : components)
+        {
+            conf->for_each_output(functor);
+        }
+    }
+
+    void for_each_output(std::function<void(mg::UserDisplayConfigurationOutput&)> functor) override
+    {
+        for (auto const& conf : components)
+        {
+            conf->for_each_output(functor);
+        }
+    }
+
+    auto clone() const -> std::unique_ptr<DisplayConfiguration> override
+    {
+        std::vector<std::unique_ptr<mg::DisplayConfiguration>> cloned_conf;
+        for (auto const& conf : components)
+        {
+            cloned_conf.push_back(conf->clone());
+        }
+        return std::make_unique<CompositeDisplayConfiguration>(std::move(cloned_conf));
+    }
+
+    // Public so that MultiplexingDisplay can pull the components back out later.
+    // TODO: Should configure() be a method on *DisplayConfiguration* rather than Display?
+    std::vector<std::unique_ptr<mg::DisplayConfiguration>> const components;
+};
+}
+
+auto mg::MultiplexingDisplay::configuration() const -> std::unique_ptr<DisplayConfiguration>
+{
+    std::vector<std::unique_ptr<mg::DisplayConfiguration>> cloned_conf;
+    for (auto const& display : displays)
+    {
+        cloned_conf.push_back(display->configuration());
+    }
+    return std::make_unique<CompositeDisplayConfiguration>(std::move(cloned_conf));
+}
+
+auto mg::MultiplexingDisplay::apply_if_configuration_preserves_display_buffers(
+    DisplayConfiguration const& conf) -> bool
+{
+    auto const& real_conf = dynamic_cast<CompositeDisplayConfiguration const&>(conf);
+
+    for (auto i = 0u; i < displays.size(); ++i)
+    {
+        displays[i]->apply_if_configuration_preserves_display_buffers(*real_conf.components[i]);
+    }
+    return true;
+}
+
+void mg::MultiplexingDisplay::configure(DisplayConfiguration const& conf)
+{
+    auto const& real_conf = dynamic_cast<CompositeDisplayConfiguration const&>(conf);
+    for (auto i = 0u; i < displays.size(); ++i)
+    {
+        displays[i]->configure(*real_conf.components[i]);
+    }
+}
+
+void mg::MultiplexingDisplay::register_configuration_change_handler(
+    EventHandlerRegister& /*handlers*/,
+    DisplayConfigurationChangeHandler const& /*conf_change_handler*/)
+{
+}
+
+void mg::MultiplexingDisplay::register_pause_resume_handlers(
+    EventHandlerRegister& /*handlers*/,
+    DisplayPauseHandler const& /*pause_handler*/,
+    DisplayResumeHandler const& /*resume_handler*/)
+{
+}
+
+void mg::MultiplexingDisplay::pause()
+{
+}
+
+void mg::MultiplexingDisplay::resume()
+{
+}
+
+auto mg::MultiplexingDisplay::create_hardware_cursor() -> std::shared_ptr<Cursor>
+{
+    return {};
+}
+
+auto mg::MultiplexingDisplay::last_frame_on(unsigned /*output_id*/) const -> Frame
+{
+    return {};
+}
+
+auto mg::MultiplexingDisplay::create_gl_context() const -> std::unique_ptr<renderer::gl::Context>
+{
+    // This will disappear in the New Platform API™; just return the first underlying Display's context for now.
+    return displays[0]->create_gl_context();
+}

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -130,9 +130,20 @@ void mg::MultiplexingDisplay::configure(DisplayConfiguration const& conf)
 }
 
 void mg::MultiplexingDisplay::register_configuration_change_handler(
-    EventHandlerRegister& /*handlers*/,
-    DisplayConfigurationChangeHandler const& /*conf_change_handler*/)
+    EventHandlerRegister& handlers,
+    DisplayConfigurationChangeHandler const& conf_change_handler)
 {
+    /* We don't need to, and can't reasonably, do any aggregation here.
+     *
+     * The conf_change_handler is called by the Display if/when a hardware change
+     * is detected on the hardware it controls; if multiple Displays detect a hardware
+     * change the conf_change_handler will be called once per change, but that's not
+     * actually different to today.
+     */
+    for (auto& display : displays)
+    {
+        display->register_configuration_change_handler(handlers, conf_change_handler);
+    }
 }
 
 void mg::MultiplexingDisplay::pause()

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -231,9 +231,9 @@ auto mg::MultiplexingDisplay::apply_if_configuration_preserves_display_buffers(
             // We don't need to revert the last change; that didn't succeed.
             previous_configs.pop_back();
 
-            for (auto i = previous_configs.crbegin() ; i != previous_configs.crend(); ++i)
+            for (auto saved_config = previous_configs.crbegin(); saved_config != previous_configs.crend(); ++saved_config)
             {
-                if (!i->first->apply_if_configuration_preserves_display_buffers(*i->second))
+                if (!saved_config->first->apply_if_configuration_preserves_display_buffers(*saved_config->second))
                 {
                     BOOST_THROW_EXCEPTION((
                         mg::Display::IncompleteConfigurationApplied{"Failure attempting to undo partially-applied configuration"}));

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -165,6 +165,16 @@ private:
         std::vector<mg::DisplayConfigurationOutput>& backing_store;
         struct OutputInfo
         {
+            OutputInfo(
+                mg::DisplayConfiguration* owner,
+                mg::DisplayConfigurationOutputId internal_id,
+                size_t output_index)
+                : owner{owner},
+                  internal_id{internal_id},
+                  output_index{output_index}
+            {
+            }
+
             mg::DisplayConfiguration* const owner;
             mg::DisplayConfigurationOutputId const internal_id;
             size_t const output_index;

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 Canonical Ltd.
+ * Copyright © Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -23,9 +23,14 @@
 
 namespace mg = mir::graphics;
 
-mg::MultiplexingDisplay::MultiplexingDisplay(std::vector<std::unique_ptr<Display>> displays)
+mg::MultiplexingDisplay::MultiplexingDisplay(
+    std::vector<std::unique_ptr<Display>> displays,
+    DisplayConfigurationPolicy& initial_configuration_policy)
     : displays{std::move(displays)}
 {
+    auto conf = configuration();
+    initial_configuration_policy.apply_to(*conf);
+    configure(*conf);
 }
 
 mg::MultiplexingDisplay::~MultiplexingDisplay() = default;

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -258,10 +258,18 @@ void mg::MultiplexingDisplay::register_configuration_change_handler(
 
 void mg::MultiplexingDisplay::pause()
 {
+    for (auto& display : displays)
+    {
+        display->pause();
+    }
 }
 
 void mg::MultiplexingDisplay::resume()
 {
+    for (auto& display : displays)
+    {
+        display->resume();
+    }
 }
 
 auto mg::MultiplexingDisplay::create_hardware_cursor() -> std::shared_ptr<Cursor>

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -116,13 +116,6 @@ void mg::MultiplexingDisplay::register_configuration_change_handler(
 {
 }
 
-void mg::MultiplexingDisplay::register_pause_resume_handlers(
-    EventHandlerRegister& /*handlers*/,
-    DisplayPauseHandler const& /*pause_handler*/,
-    DisplayResumeHandler const& /*resume_handler*/)
-{
-}
-
 void mg::MultiplexingDisplay::pause()
 {
 }

--- a/src/server/graphics/multiplexing_display.h
+++ b/src/server/graphics/multiplexing_display.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir/graphics/display.h"
+
+#include <vector>
+#include <memory>
+
+namespace mir::graphics
+{
+class MultiplexingDisplay : public Display
+{
+public:
+    MultiplexingDisplay(std::vector<std::unique_ptr<Display>> displays);
+    ~MultiplexingDisplay() override;
+
+    void for_each_display_sync_group(std::function<void(DisplaySyncGroup&)> const& f) override;
+
+    auto configuration() const -> std::unique_ptr<DisplayConfiguration> override;
+
+    auto apply_if_configuration_preserves_display_buffers(DisplayConfiguration const& conf) -> bool override;
+
+    void configure(DisplayConfiguration const& conf) override;
+
+    void register_configuration_change_handler(
+        EventHandlerRegister& handlers,
+        DisplayConfigurationChangeHandler const& conf_change_handler) override;
+
+    void register_pause_resume_handlers(
+        EventHandlerRegister& handlers,
+        DisplayPauseHandler const& pause_handler,
+        DisplayResumeHandler const& resume_handler) override;
+
+    void pause() override;
+
+    void resume() override;
+
+    auto create_hardware_cursor() -> std::shared_ptr<Cursor> override;
+
+    auto last_frame_on(unsigned output_id) const -> Frame override;
+
+    auto create_gl_context() const -> std::unique_ptr<renderer::gl::Context> override;
+private:
+    std::vector<std::unique_ptr<Display>> const displays;
+};
+}

--- a/src/server/graphics/multiplexing_display.h
+++ b/src/server/graphics/multiplexing_display.h
@@ -39,11 +39,6 @@ public:
         EventHandlerRegister& handlers,
         DisplayConfigurationChangeHandler const& conf_change_handler) override;
 
-    void register_pause_resume_handlers(
-        EventHandlerRegister& handlers,
-        DisplayPauseHandler const& pause_handler,
-        DisplayResumeHandler const& resume_handler) override;
-
     void pause() override;
 
     void resume() override;

--- a/src/server/graphics/multiplexing_display.h
+++ b/src/server/graphics/multiplexing_display.h
@@ -15,6 +15,7 @@
  */
 
 #include "mir/graphics/display.h"
+#include "mir/graphics/display_configuration_policy.h"
 
 #include <vector>
 #include <memory>
@@ -24,7 +25,9 @@ namespace mir::graphics
 class MultiplexingDisplay : public Display
 {
 public:
-    MultiplexingDisplay(std::vector<std::unique_ptr<Display>> displays);
+    MultiplexingDisplay(
+        std::vector<std::unique_ptr<Display>> displays,
+        DisplayConfigurationPolicy& initial_configuration_policy);
     ~MultiplexingDisplay() override;
 
     void for_each_display_sync_group(std::function<void(DisplaySyncGroup&)> const& f) override;

--- a/src/server/graphics/multiplexing_display.h
+++ b/src/server/graphics/multiplexing_display.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 Canonical Ltd.
+ * Copyright © Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,

--- a/src/server/scene/mediating_display_changer.cpp
+++ b/src/server/scene/mediating_display_changer.cpp
@@ -397,8 +397,20 @@ void ms::MediatingDisplayChanger::apply_config(
     auto existing_configuration = display->configuration();
     try
     {
+        auto interruption_free_configuration_successful =
+            [&]()
+            {
+                try
+                {
+                    return display->apply_if_configuration_preserves_display_buffers(*conf);
+                }
+                catch (mg::Display::IncompleteConfigurationApplied const&)
+                {
+                    return false;
+                }
+            };
         if (configuration_has_new_outputs_enabled(*display->configuration(), *conf) ||
-            !display->apply_if_configuration_preserves_display_buffers(*conf))
+            !interruption_free_configuration_successful())
         {
             ApplyNowAndRevertOnScopeExit comp{
                 [this] { compositor->stop(); },

--- a/tests/include/mir/test/doubles/mock_display.h
+++ b/tests/include/mir/test/doubles/mock_display.h
@@ -18,6 +18,7 @@
 #define MIR_TEST_DOUBLES_MOCK_DISPLAY_H_
 
 #include "mir/graphics/display.h"
+#include "mir/graphics/display_configuration.h"
 #include "mir/renderer/gl/context.h"
 #include "mir/main_loop.h"
 #include <gmock/gmock.h>

--- a/tests/include/mir/test/doubles/mock_display.h
+++ b/tests/include/mir/test/doubles/mock_display.h
@@ -32,19 +32,16 @@ namespace doubles
 struct MockDisplay : public graphics::Display
 {
 public:
-    MOCK_METHOD1(for_each_display_sync_group, void (std::function<void(graphics::DisplaySyncGroup&)> const&));
-    MOCK_CONST_METHOD0(configuration, std::unique_ptr<graphics::DisplayConfiguration>());
-    MOCK_METHOD1(apply_if_configuration_preserves_display_buffers, bool(graphics::DisplayConfiguration const&));
-    MOCK_METHOD1(configure, void(graphics::DisplayConfiguration const&));
-    MOCK_METHOD2(register_configuration_change_handler,
-                 void(graphics::EventHandlerRegister&, graphics::DisplayConfigurationChangeHandler const&));
-
-    MOCK_METHOD0(pause, void());
-    MOCK_METHOD0(resume, void());
-    MOCK_METHOD0(create_hardware_cursor, std::shared_ptr<graphics::Cursor>());
-    MOCK_CONST_METHOD1(last_frame_on, graphics::Frame(unsigned));
-
-    MOCK_CONST_METHOD0(create_gl_context, std::unique_ptr<mir::renderer::gl::Context>());
+    MOCK_METHOD(void, for_each_display_sync_group, (std::function<void(graphics::DisplaySyncGroup&)> const&), (override));
+    MOCK_METHOD(std::unique_ptr<graphics::DisplayConfiguration>, configuration, (), (const override));
+    MOCK_METHOD(bool, apply_if_configuration_preserves_display_buffers, (graphics::DisplayConfiguration const&), (override));
+    MOCK_METHOD(void, configure, (graphics::DisplayConfiguration const&), (override));
+    MOCK_METHOD(void, register_configuration_change_handler, (graphics::EventHandlerRegister&, graphics::DisplayConfigurationChangeHandler const&), (override));
+    MOCK_METHOD(void, pause, (), (override));
+    MOCK_METHOD(void, resume, (), (override));
+    MOCK_METHOD(std::unique_ptr<renderer::gl::Context>, create_gl_context, (), (const override));
+    MOCK_METHOD(std::shared_ptr<graphics::Cursor>, create_hardware_cursor, (), (override));
+    MOCK_METHOD(graphics::Frame, last_frame_on, (unsigned), (const override));
 };
 
 }

--- a/tests/unit-tests/graphics/CMakeLists.txt
+++ b/tests/unit-tests/graphics/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND UNIT_TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test_software_cursor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_anonymous_shm_file.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_shm_buffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_multiplexing_display.cpp
 )
 
 list(APPEND UMOCK_UNIT_TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_platform_prober.cpp)

--- a/tests/unit-tests/graphics/test_multiplexing_display.cpp
+++ b/tests/unit-tests/graphics/test_multiplexing_display.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "mir/graphics/display_configuration.h"
+#include "mir/test/doubles/mock_display.h"
+
+#include "mir_toolkit/common.h"
+#include "src/server/graphics/multiplexing_display.h"
+
+
+namespace mtd = mir::test::doubles;
+namespace mg = mir::graphics;
+namespace geom = mir::geometry;
+
+namespace
+{
+
+
+mg::DisplayConfigurationOutput const hidpi_laptop {
+
+    mg::DisplayConfigurationOutputId{3},
+    mg::DisplayConfigurationCardId{2},
+    mg::DisplayConfigurationLogicalGroupId{1},
+    mg::DisplayConfigurationOutputType::edp,
+    {
+        mir_pixel_format_argb_8888,
+        mir_pixel_format_xrgb_8888
+    },
+    {
+        {geom::Size{3840, 2160}, 59.98},
+    },
+    0,
+    geom::Size{340, 190},
+    true,
+    true,
+    geom::Point{0,0},
+    0,
+    mir_pixel_format_xrgb_8888,
+    mir_power_mode_on,
+    mir_orientation_normal,
+    2.0f,
+    mir_form_factor_monitor,
+    mir_subpixel_arrangement_horizontal_rgb,
+    {},
+    mir_output_gamma_unsupported,
+    {},
+    {}
+};
+}
+
+TEST(MultiplexingDisplay, forwards_for_each_display_sync_group)
+{
+    using namespace testing;
+
+    std::vector<std::unique_ptr<mg::Display>> displays;
+
+    for (int i = 0u; i < 2; ++i)
+    {
+        auto mock_display = std::make_unique<NiceMock<mtd::MockDisplay>>();
+        EXPECT_CALL(*mock_display, for_each_display_sync_group(_)).Times(1);
+        displays.push_back(std::move(mock_display));
+    }
+
+    mg::MultiplexingDisplay display{std::move(displays)};
+
+    display.for_each_display_sync_group([](auto const&) {});
+}

--- a/tests/unit-tests/graphics/test_multiplexing_display.cpp
+++ b/tests/unit-tests/graphics/test_multiplexing_display.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 Canonical Ltd.
+ * Copyright © Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3,

--- a/tests/unit-tests/graphics/test_multiplexing_display.cpp
+++ b/tests/unit-tests/graphics/test_multiplexing_display.cpp
@@ -29,6 +29,8 @@ namespace mtd = mir::test::doubles;
 namespace mg = mir::graphics;
 namespace geom = mir::geometry;
 
+using namespace testing;
+
 namespace
 {
 
@@ -88,8 +90,6 @@ private:
 
 TEST(MultiplexingDisplay, forwards_for_each_display_sync_group)
 {
-    using namespace testing;
-
     std::vector<std::unique_ptr<mg::Display>> displays;
 
     for (int i = 0u; i < 2; ++i)
@@ -106,8 +106,6 @@ TEST(MultiplexingDisplay, forwards_for_each_display_sync_group)
 
 TEST(MultiplexingDisplay, configuration_is_union_of_all_displays)
 {
-    using namespace testing;
-
     std::vector<mg::DisplayConfigurationOutput> first_display_conf, second_display_conf, third_display_conf;
 
     DisplayConfigurationOutputGenerator card_one{1}, card_two{3}, card_three{42};
@@ -162,8 +160,6 @@ TEST(MultiplexingDisplay, configuration_is_union_of_all_displays)
 
 TEST(MultiplexingDisplay, dispatches_configure_to_associated_platform)
 {
-    using namespace testing;
-
     DisplayConfigurationOutputGenerator gen1{5}, gen2{42};
 
     auto d1 = std::make_unique<NiceMock<mtd::MockDisplay>>();
@@ -206,8 +202,6 @@ MATCHER_P(IsConfigurationOfCard, cardid, "")
 
 TEST(MultiplexingDisplay, apply_if_confguration_preserves_display_buffers_succeeds_if_all_succeed)
 {
-    using namespace testing;
-
     DisplayConfigurationOutputGenerator gen1{5}, gen2{42};
 
     auto d1 = std::make_unique<NiceMock<mtd::MockDisplay>>();
@@ -248,8 +242,6 @@ TEST(MultiplexingDisplay, apply_if_confguration_preserves_display_buffers_succee
 
 TEST(MultiplexingDisplay, apply_if_confguration_preserves_display_buffers_fails_if_any_fail)
 {
-    using namespace testing;
-
     DisplayConfigurationOutputGenerator gen1{5}, gen2{42};
 
     auto d1 = std::make_unique<NiceMock<mtd::MockDisplay>>();
@@ -290,8 +282,6 @@ TEST(MultiplexingDisplay, apply_if_confguration_preserves_display_buffers_fails_
 
 TEST(MultiplexingDisplay, apply_if_configuration_preserves_display_buffers_fails_to_previous_configuration)
 {
-    using namespace testing;
-
     DisplayConfigurationOutputGenerator gen1{5}, gen2{42};
 
     auto d1 = std::make_unique<NiceMock<mtd::MockDisplay>>();
@@ -361,8 +351,6 @@ TEST(MultiplexingDisplay, apply_if_configuration_preserves_display_buffers_fails
 
 TEST(MultiplexingDisplay, apply_if_configuration_preserves_display_buffers_throws_on_unrecoverable_error)
 {
-    using namespace testing;
-
     DisplayConfigurationOutputGenerator gen1{5}, gen2{42};
 
     auto d1 = std::make_unique<NiceMock<mtd::MockDisplay>>();

--- a/tests/unit-tests/graphics/test_multiplexing_display.cpp
+++ b/tests/unit-tests/graphics/test_multiplexing_display.cpp
@@ -19,6 +19,7 @@
 
 #include "mir/graphics/display_configuration.h"
 #include "mir/test/doubles/mock_display.h"
+#include "mir/test/doubles/mock_main_loop.h"
 #include "mir/test/doubles/stub_display_configuration.h"
 
 #include "mir_toolkit/common.h"
@@ -416,4 +417,21 @@ TEST(MultiplexingDisplay, apply_if_configuration_preserves_display_buffers_throw
     EXPECT_THROW(
         { display.apply_if_configuration_preserves_display_buffers(*changed_conf); },
         mg::Display::IncompleteConfigurationApplied);
+}
+
+TEST(MultiplexingDisplay, delegates_registering_configuration_change_handlers)
+{
+    std::vector<std::unique_ptr<mg::Display>> mock_displays;
+
+    for (auto i = 0; i < 5 ; ++i)
+    {
+        auto mock_display = std::make_unique<NiceMock<mtd::MockDisplay>>();
+        EXPECT_CALL(*mock_display, register_configuration_change_handler(_,_));
+        mock_displays.push_back(std::move(mock_display));
+    }
+
+    mg::MultiplexingDisplay display{std::move(mock_displays)};
+
+    mtd::MockMainLoop ml;
+    display.register_configuration_change_handler(ml, [](){});
 }

--- a/tests/unit-tests/graphics/test_multiplexing_display.cpp
+++ b/tests/unit-tests/graphics/test_multiplexing_display.cpp
@@ -589,3 +589,22 @@ TEST(MultiplexingDisplay, delegates_last_frame_on_to_appropriate_platform)
             display.last_frame_on(output.id.as_value());
         });
 }
+
+TEST(MultiplexingDisplay, delegates_pause_resume_to_underlying_platforms)
+{
+    std::vector<std::unique_ptr<mg::Display>> mock_displays;
+
+    for (auto i = 0; i < 5 ; ++i)
+    {
+        auto mock_display = std::make_unique<NiceMock<mtd::MockDisplay>>();
+        InSequence seq;
+        EXPECT_CALL(*mock_display, pause);
+        EXPECT_CALL(*mock_display, resume);
+        mock_displays.push_back(std::move(mock_display));
+    }
+
+    mg::MultiplexingDisplay display{std::move(mock_displays)};
+
+    display.pause();
+    display.resume();
+}


### PR DESCRIPTION
In the brave New Platform API™ world, each `DisplayPlatform` drives
a single set of display hardware.

This means, for multi-GPU cases, Mir needs to aggregate multiple
`Display`s into a single, combined configuration.

`MultiplexingDisplay` does this.