### PR TITLE
Bump mirplatform soname

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -75,7 +75,7 @@ Description: Display server for Ubuntu - server library
  .
  Contains the shared library needed by server applications for Mir.
 
-Package: libmirplatform24
+Package: libmirplatform25
 Section: libs
 Architecture: linux-any
 Multi-Arch: same
@@ -123,7 +123,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libmirplatform24 (= ${binary:Version}),
+Depends: libmirplatform25 (= ${binary:Version}),
          libmircommon-dev (= ${binary:Version}),
          libboost-program-options-dev,
          ${misc:Depends},

--- a/debian/libmirplatform24.install
+++ b/debian/libmirplatform24.install
@@ -1,1 +1,0 @@
-usr/lib/*/libmirplatform.so.24

--- a/debian/libmirplatform25.install
+++ b/debian/libmirplatform25.install
@@ -1,0 +1,1 @@
+usr/lib/*/libmirplatform.so.25

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # We need MIRPLATFORM_ABI in both libmirplatform and the platform implementations.
-set(MIRPLATFORM_ABI 24)
+set(MIRPLATFORM_ABI 25)
 
 set(MIRAL_VERSION_MAJOR 3)
 set(MIRAL_VERSION_MINOR 8)


### PR DESCRIPTION
We've introduced members to mir::graphics::Display, DisplayConfigurationOutput and UserDisplayConfigurationOutput that break ABI