### PR TITLE
ci: cancel previous PR runs

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-pr${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   mir-core20:
     runs-on: ubuntu-latest

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number && format('pr{0}', github.event.number) || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   GetMatrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ref.:

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

This will cancel any pending runs for a PR, avoiding wasted work and speeding up results when we get throttled down.