### PR TITLE
[snaps workflow] Fix Frame build

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         snapcraft-token: ${{ secrets.SNAPCRAFT_TOKEN }}
         publish: ${{ github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name }}
-        publish-channel: edge/pr${{ github.event.number }}
+        publish-channel: 22/edge/pr${{ github.event.number }}
 
   snap:
     # Only run if we have access to secrets.

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Tweak the stage snap
       run: |
-        sed -i 's@- mir-libs@\0/latest/edge/pr${{ github.event.number }}@' snap/snapcraft.yaml
+        sed -i 's@- mir-libs.*$@\0/pr${{ github.event.number }}@' snap/snapcraft.yaml
 
     - name: Build and publish the snap
       uses: canonical/actions/build-snap@release


### PR DESCRIPTION
The mir-libs-build branches now contain the track and risk. Just add the branch

Fixes: #2877