### PR TITLE
Allow "attached" windows to be "restored" by drag gesture

### DIFF
--- a/src/miral/minimal_window_manager.cpp
+++ b/src/miral/minimal_window_manager.cpp
@@ -286,6 +286,7 @@ bool miral::MinimalWindowManager::Impl::prepare_for_gesture(
         case mir_window_state_maximized:
         case mir_window_state_vertmaximized:
         case mir_window_state_horizmaximized:
+        case mir_window_state_attached:
         {
             WindowSpecification mods;
             mods.state() = mir_window_state_restored;


### PR DESCRIPTION
We introduced "attached" windows to support layer-shell. But the window manager can use them to support docked applications. But docked applications should be dragged into a restored state. (See https://github.com/Miriway/Miriway/pull/28 for an example of this)

I don't think this affects the layer-shell support as these windows won't initiate a drag gesture.