### PR TITLE
Drive-by cleanup

### DIFF
--- a/include/miroil/miroil/event_builder.h
+++ b/include/miroil/miroil/event_builder.h
@@ -18,12 +18,7 @@
 #define MIROIL_EVENT_BUILDER_H
 
 #include <mir_toolkit/mir_input_device_types.h>
-#include <miral/version.h>
-#if MIRAL_VERSION >= MIR_VERSION_NUMBER(3, 0, 0)
 #include <miral/toolkit_event.h>
-#else
-#include <mir_toolkit/event.h>
-#endif
 
 #include <chrono>
 #include <memory>

--- a/src/miroil/input_device.cpp
+++ b/src/miroil/input_device.cpp
@@ -45,11 +45,7 @@ void miroil::InputDevice::apply_keymap(std::string const& layout, std::string co
     if (auto const kbd_conf = device->keyboard_configuration())
     {
         // TODO work out how to support this functionality on OSK etc.
-#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(2, 5, 0)
         if (auto const old_keymap = std::dynamic_pointer_cast<ParameterKeymap const>(kbd_conf.value().device_keymap()))
-#else
-        if (auto const* const old_keymap = dynamic_cast<ParameterKeymap const*>(&kbd_conf.value().device_keymap()))
-#endif
         {
             // preserve the model and options
             device->apply_keyboard_configuration(MirKeyboardConfig{old_keymap->with_layout(layout, variant)});

--- a/src/miroil/mir_server_hooks.cpp
+++ b/src/miroil/mir_server_hooks.cpp
@@ -67,9 +67,6 @@ struct HiddenCursorWrapper : mg::Cursor
 {
     HiddenCursorWrapper(std::shared_ptr<mg::Cursor> const& wrapped) :
         wrapped{wrapped} { wrapped->hide(); }
-#if MIR_SERVER_VERSION < MIR_VERSION_NUMBER(2, 3, 0)
-    void show() override { }
-#endif
     void show(mg::CursorImage const&) override { }
     void hide() override { wrapped->hide(); }
 


### PR DESCRIPTION
There's no longer any point in keeping miroil source-compatibile between 1.x and 2.x. It has been introduced and used in both places