### PR TITLE
[mir-libs] bump timeout

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -12,7 +12,7 @@ jobs:
   mir-libs:
     runs-on: ubuntu-latest
 
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
     - name: Check out code


### PR DESCRIPTION
I've seen this "cancelled after 30 minutes" a few times.

Bumping the timeout