### PR TITLE
Drop legacy workaround

### DIFF
--- a/src/platforms/gbm-kms/server/kms/cursor.cpp
+++ b/src/platforms/gbm-kms/server/kms/cursor.cpp
@@ -35,9 +35,6 @@ namespace geom = mir::geometry;
 
 namespace
 {
-const uint64_t fallback_cursor_size = 64;
-char const* const mir_drm_cursor_64x64 = "MIR_DRM_CURSOR_64x64";
-
 // Transforms a relative position within the display bounds described by \a rect which is rotated with \a orientation
 geom::Displacement transform(geom::Rectangle const& rect, geom::Displacement const& vector, MirOrientation orientation)
 {
@@ -54,35 +51,18 @@ geom::Displacement transform(geom::Rectangle const& rect, geom::Displacement con
         return vector;
     }
 }
-// support for older drm headers
-#ifndef DRM_CAP_CURSOR_WIDTH
-#define DRM_CAP_CURSOR_WIDTH            0x8
-#define DRM_CAP_CURSOR_HEIGHT           0x9
-#endif
 
-// In certain combinations of DRI backends and drivers GBM
-// returns a stride size that matches the requested buffers size,
-// instead of the underlying buffer:
-// https://bugs.freedesktop.org/show_bug.cgi?id=89164
 int get_drm_cursor_height(int fd)
 {
-    // on some older hardware drm incorrectly reports the cursor size
-    bool const force_64x64_cursor = getenv(mir_drm_cursor_64x64);
-
-    uint64_t height = fallback_cursor_size;
-    if (!force_64x64_cursor)
-       drmGetCap(fd, DRM_CAP_CURSOR_HEIGHT, &height);
+    uint64_t height;
+    drmGetCap(fd, DRM_CAP_CURSOR_HEIGHT, &height);
     return int(height);
 }
 
 int get_drm_cursor_width(int fd)
 {
-    // on some older hardware drm incorrectly reports the cursor size
-    bool const force_64x64_cursor = getenv(mir_drm_cursor_64x64);
-
-    uint64_t width = fallback_cursor_size;
-    if (!force_64x64_cursor)
-       drmGetCap(fd, DRM_CAP_CURSOR_WIDTH, &width);
+    uint64_t width;
+    drmGetCap(fd, DRM_CAP_CURSOR_WIDTH, &width);
     return int(width);
 }
 

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_cursor.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_cursor.cpp
@@ -383,23 +383,6 @@ TEST_F(MesaCursorTest, respects_drm_cap_cursor)
                            std::make_shared<StubCurrentConfiguration>(output_container)};
 }
 
-TEST_F(MesaCursorTest, can_force_64x64_cursor)
-{
-    auto const drm_buffer_size = 255;
-    ON_CALL(mock_drm, drmGetCap(_, DRM_CAP_CURSOR_WIDTH, _))
-        .WillByDefault(Invoke([](int , uint64_t , uint64_t *value) { *value = drm_buffer_size; return 0; }));
-
-    ON_CALL(mock_drm, drmGetCap(_, DRM_CAP_CURSOR_HEIGHT, _))
-        .WillByDefault(Invoke([](int , uint64_t , uint64_t *value) { *value = drm_buffer_size; return 0; }));
-
-    mir_test_framework::TemporaryEnvironmentValue mir_drm_cursor_64x64{"MIR_DRM_CURSOR_64x64", "on"};
-
-    EXPECT_CALL(mock_gbm, gbm_bo_create(_, 64, 64, _, _));
-
-    mgg::Cursor cursor_tmp{output_container,
-                           std::make_shared<StubCurrentConfiguration>(output_container)};
-}
-
 TEST_F(MesaCursorTest, show_cursor_writes_to_bo)
 {
     using namespace testing;


### PR DESCRIPTION
I remember having an old laptop (circa 2006) that needed the `MIR_DRM_CURSOR_64x64` workaround. But I don't think it we've encountered a need for this for a long time