### PR TITLE
Add support for cursor drag icons

### DIFF
--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -57,10 +57,11 @@ class CompositorReport;
 namespace frontend
 {
 class Connector;
-class SessionAuthorizer;
-class EventSink;
 class DisplayChanger;
+class DragIconController;
+class EventSink;
 class InputConfigurationChanger;
+class SessionAuthorizer;
 class SurfaceStack;
 }
 
@@ -252,6 +253,7 @@ public:
      *  @{ */
     virtual std::shared_ptr<frontend::SessionAuthorizer>      the_session_authorizer();
     virtual std::shared_ptr<frontend::DisplayChanger>         the_frontend_display_changer();
+    virtual std::shared_ptr<frontend::DragIconController>     the_drag_icon_controller();
     /** @name frontend configuration - internal dependencies
      * internal dependencies of frontend
      *  @{ */
@@ -363,6 +365,7 @@ protected:
     CachedPtr<frontend::Connector>   connector;
     CachedPtr<frontend::Connector>   wayland_connector;
     CachedPtr<frontend::Connector>   xwayland_connector;
+    CachedPtr<frontend::DragIconController> drag_icon_controller;
 
     CachedPtr<input::InputReport> input_report;
     CachedPtr<input::EventFilterChainDispatcher> event_filter_chain_dispatcher;

--- a/src/include/server/mir/frontend/drag_icon_controller.h
+++ b/src/include/server/mir/frontend/drag_icon_controller.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_FRONTEND_DRAG_ICON_CONTROLLER_H_
+#define MIR_FRONTEND_DRAG_ICON_CONTROLLER_H_
+
+#include <memory>
+
+namespace mir
+{
+namespace scene { class Surface; }
+
+namespace frontend
+{
+
+/// An interface for associating an image with the cursor
+class DragIconController
+{
+public:
+    virtual ~DragIconController() = default;
+
+    virtual void set_drag_icon(std::weak_ptr<scene::Surface> icon) = 0;
+
+protected:
+    DragIconController() = default;
+    DragIconController(DragIconController const&) = delete;
+    DragIconController& operator=(DragIconController const&) = delete;
+};
+
+}
+}
+
+#endif // MIR_FRONTEND_DRAG_ICON_CONTROLLER_H_

--- a/src/server/input/cursor_controller.h
+++ b/src/server/input/cursor_controller.h
@@ -18,6 +18,7 @@
 #define MIR_INPUT_CURSOR_CONTROLLER_H_
 
 #include "mir/input/cursor_listener.h"
+#include "mir/frontend/drag_icon_controller.h"
 #include "mir/geometry/point.h"
 
 #include <memory>
@@ -39,7 +40,7 @@ namespace input
 {
 class Scene;
 
-class CursorController : public CursorListener
+class CursorController : public CursorListener, public frontend::DragIconController
 {
 public:
     CursorController(std::shared_ptr<Scene> const& input_targets,
@@ -57,6 +58,8 @@ public:
 
     void pointer_unusable() override;
 
+    void set_drag_icon(std::weak_ptr<scene::Surface> icon) override;
+
 private:
     std::shared_ptr<Scene> const input_targets;
     std::shared_ptr<graphics::Cursor> const cursor;
@@ -67,6 +70,7 @@ private:
     geometry::Point cursor_location;
     std::shared_ptr<graphics::CursorImage> current_cursor;
     bool usable = false;
+    std::weak_ptr<scene::Surface> drag_icon;
 
     // Used only to serialize calls to pointer_usable()/pointer_unusable()
     std::mutex serialize_pointer_usable_unusable;

--- a/src/server/scene/default_configuration.cpp
+++ b/src/server/scene/default_configuration.cpp
@@ -16,14 +16,16 @@
 
 #include "mir/default_server_configuration.h"
 
+#include "mir/frontend/drag_icon_controller.h"
 #include "mir/graphics/display.h"
+#include "mir/input/cursor_listener.h"
+#include "mir/input/scene.h"
+#include "mir/main_loop.h"
 #include "mir/renderer/gl/context.h"
 #include "mir/renderer/gl/context_source.h"
-#include "mir/input/scene.h"
 #include "mir/scene/session.h"
 #include "mir/scene/session_container.h"
 #include "mir/shell/display_configuration_controller.h"
-#include "mir/main_loop.h"
 
 #include "broadcasting_session_event_sink.h"
 #include "mediating_display_changer.h"
@@ -150,6 +152,12 @@ std::shared_ptr<mf::DisplayChanger>
 mir::DefaultServerConfiguration::the_frontend_display_changer()
 {
     return the_mediating_display_changer();
+}
+
+std::shared_ptr<mf::DragIconController> mir::DefaultServerConfiguration::the_drag_icon_controller()
+{
+    return drag_icon_controller(
+        [this] { return std::dynamic_pointer_cast<mf::DragIconController>(the_cursor_listener()); });
 }
 
 std::shared_ptr<mir::DisplayChanger>

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -928,3 +928,10 @@ MIR_SERVER_2.11 {
       mir::DefaultServerConfiguration::the_primary_selection_clipboard*;
     };
 } MIR_SERVER_2.10;
+
+MIR_SERVER_2.14 {
+  global:
+    extern "C++" {
+      "mir::DefaultServerConfiguration::the_drag_icon_controller()";
+    };
+} MIR_SERVER_2.11;

--- a/tests/include/mir/test/doubles/mock_surface.h
+++ b/tests/include/mir/test/doubles/mock_surface.h
@@ -53,32 +53,38 @@ struct MockSurface : public scene::BasicSurface
                 {
                     BasicSurface::set_focus_state(focus_state);
                 }));
+        ON_CALL(*this, move_to(testing::_))
+            .WillByDefault(testing::Invoke([this](geometry::Point const& top_left)
+               {
+                    BasicSurface::move_to(top_left);
+               }));
     }
 
     ~MockSurface() noexcept {}
 
-    MOCK_CONST_METHOD0(type, MirWindowType());
-    MOCK_METHOD0(hide, void());
-    MOCK_METHOD0(show, void());
-    MOCK_CONST_METHOD0(visible, bool());
+    MOCK_METHOD(MirWindowType, type, (), (const));
+    MOCK_METHOD(void, hide, ());
+    MOCK_METHOD(void, show, ());
+    MOCK_METHOD(bool, visible, (), (const));
+    MOCK_METHOD(void, move_to, (geometry::Point const& ));
 
-    MOCK_METHOD0(force_requests_to_complete, void());
-    MOCK_METHOD0(advance_client_buffer, std::shared_ptr<graphics::Buffer>());
+    MOCK_METHOD(void, force_requests_to_complete, ());
+    MOCK_METHOD(std::shared_ptr<graphics::Buffer>, advance_client_buffer, ());
 
-    MOCK_CONST_METHOD0(size, geometry::Size());
-    MOCK_CONST_METHOD0(pixel_format, MirPixelFormat());
+    MOCK_METHOD(geometry::Size, size, (), (const));
+    MOCK_METHOD(MirPixelFormat, pixel_format, (), (const));
 
-    MOCK_METHOD0(request_client_surface_close, void());
-    MOCK_CONST_METHOD0(parent, std::shared_ptr<scene::Surface>());
-    MOCK_METHOD2(configure, int(MirWindowAttrib, int));
-    MOCK_METHOD1(register_interest, void(std::weak_ptr<scene::SurfaceObserver> const&));
-    MOCK_METHOD1(unregister_interest, void(scene::SurfaceObserver const&));
-    MOCK_METHOD1(consume, void(std::shared_ptr<MirEvent const> const& event));
+    MOCK_METHOD(void, request_client_surface_close, ());
+    MOCK_METHOD(std::shared_ptr<scene::Surface>, parent, (), (const));
+    MOCK_METHOD(int, configure, (MirWindowAttrib, int));
+    MOCK_METHOD(void, register_interest, (std::weak_ptr<scene::SurfaceObserver> const&));
+    MOCK_METHOD(void, unregister_interest, (scene::SurfaceObserver const&));
+    MOCK_METHOD(void, consume, (std::shared_ptr<MirEvent const> const& event));
 
-    MOCK_CONST_METHOD0(primary_buffer_stream, std::shared_ptr<frontend::BufferStream>());
-    MOCK_METHOD1(set_streams, void(std::list<scene::StreamInfo> const&));
+    MOCK_METHOD(std::shared_ptr<frontend::BufferStream>, primary_buffer_stream, (), (const));
+    MOCK_METHOD(void, set_streams, (std::list<scene::StreamInfo> const&));
 
-    MOCK_METHOD1(set_focus_state, void(MirWindowFocusState));
+    MOCK_METHOD(void, set_focus_state, (MirWindowFocusState));
 
     std::shared_ptr<MockBufferStream> const stream;
 };


### PR DESCRIPTION
This is a prerequisite for drag & drop support. (It isn't connected up to anything yet, so doesn't impact visible behaviour.)

Fixes: #640