### PR TITLE
Rename ClipboardSource to DataExchangeSource

### DIFF
--- a/src/include/server/mir/scene/clipboard.h
+++ b/src/include/server/mir/scene/clipboard.h
@@ -17,34 +17,16 @@
 #ifndef MIR_SCENE_CLIPBOARD_H_
 #define MIR_SCENE_CLIPBOARD_H_
 
+#include "mir/scene/data_exchange.h"
+
 #include "mir/observer_registrar.h"
-#include "mir/fd.h"
 
 #include <memory>
-#include <vector>
 
 namespace mir
 {
 namespace scene
 {
-/// Interface representing a data source (such as an offer by a client to transfer data). Implemented by the
-/// frontend. Implementations must be threadsafe.
-class ClipboardSource
-{
-public:
-    ClipboardSource() = default;
-    virtual ~ClipboardSource() = default;
-
-    /// Returns the list of supported mime types.
-    virtual auto mime_types() const -> std::vector<std::string> const& = 0;
-
-    /// Instructs the source to start sending it's data in the given mime type to the given fd.
-    virtual void initiate_send(std::string const& mime_type, Fd const& target_fd) = 0;
-
-private:
-    ClipboardSource(ClipboardSource const&) = delete;
-    ClipboardSource& operator=(ClipboardSource const&) = delete;
-};
 
 /// Allows the frontend to listen for changes in the clipboard state
 class ClipboardObserver
@@ -56,7 +38,7 @@ public:
     /// The copy-paste data source has been set or cleared. If cleared, source is null. Note that the clipboard's mutex
     /// does not remain locked when notifying observers, so clipboard->paste_source() may return a different value than
     /// source.
-    virtual void paste_source_set(std::shared_ptr<ClipboardSource> const& source) = 0;
+    virtual void paste_source_set(std::shared_ptr<DataExchangeSource> const& source) = 0;
 
 private:
     ClipboardObserver(ClipboardObserver const&) = delete;
@@ -68,16 +50,16 @@ class Clipboard : public ObserverRegistrar<ClipboardObserver>
 {
 public:
     /// Get the current copy-paste source.
-    virtual auto paste_source() const -> std::shared_ptr<ClipboardSource> = 0;
+    virtual auto paste_source() const -> std::shared_ptr<DataExchangeSource> = 0;
 
     /// Sets the given source to be the current copy-paste source for all clients.
-    virtual void set_paste_source(std::shared_ptr<ClipboardSource> const& source) = 0;
+    virtual void set_paste_source(std::shared_ptr<DataExchangeSource> const& source) = 0;
 
     /// Clears the current copy-paste source
     virtual void clear_paste_source() = 0;
 
     /// Clears the current copy-paste source ONLY if it is the same as the given source, otherwise does nothing.
-    virtual void clear_paste_source(ClipboardSource const& source) = 0;
+    virtual void clear_paste_source(DataExchangeSource const& source) = 0;
 };
 }
 }

--- a/src/include/server/mir/scene/data_exchange.h
+++ b/src/include/server/mir/scene/data_exchange.h
@@ -17,9 +17,10 @@
 #ifndef MIR_SCENE_DATA_EXCHANGE_H_
 #define MIR_SCENE_DATA_EXCHANGE_H_
 
+#include "mir/fd.h"
+
 #include <vector>
 #include <string>
-#include "mir/fd.h"
 
 namespace mir
 {

--- a/src/include/server/mir/scene/data_exchange.h
+++ b/src/include/server/mir/scene/data_exchange.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_SCENE_DATA_EXCHANGE_H_
+#define MIR_SCENE_DATA_EXCHANGE_H_
+
+#include <vector>
+#include <string>
+#include "mir/fd.h"
+
+namespace mir
+{
+namespace scene
+{
+/// Interface representing a data source (such as an offer by a client to transfer data). Implemented by the
+/// frontend. Implementations must be threadsafe.
+class DataExchangeSource
+{
+public:
+    DataExchangeSource() = default;
+    virtual ~DataExchangeSource() = default;
+
+    /// Returns the list of supported mime types.
+    virtual auto mime_types() const -> std::vector<std::string> const& = 0;
+
+    /// Instructs the source to start sending it's data in the given mime type to the given fd.
+    virtual void initiate_send(std::string const& mime_type, Fd const& target_fd) = 0;
+
+private:
+    DataExchangeSource(DataExchangeSource const&) = delete;
+    DataExchangeSource& operator=(DataExchangeSource const&) = delete;
+};
+}
+}
+#endif //MIR_SCENE_DATA_EXCHANGE_H_

--- a/src/server/frontend_wayland/primary_selection_v1.cpp
+++ b/src/server/frontend_wayland/primary_selection_v1.cpp
@@ -29,7 +29,7 @@ namespace
 class PrimarySelectionSource : public mw::PrimarySelectionSourceV1
 {
 private:
-class Source : public ms::DataExchangeSource
+    class Source : public ms::DataExchangeSource
     {
     public:
         Source(

--- a/src/server/frontend_wayland/primary_selection_v1.cpp
+++ b/src/server/frontend_wayland/primary_selection_v1.cpp
@@ -29,7 +29,7 @@ namespace
 class PrimarySelectionSource : public mw::PrimarySelectionSourceV1
 {
 private:
-    class Source : public ms::ClipboardSource
+class Source : public ms::DataExchangeSource
     {
     public:
         Source(
@@ -81,7 +81,7 @@ public:
         mime_types.push_back(mime_type);
     }
 
-    auto make_source() const -> std::shared_ptr<ms::ClipboardSource>
+    auto make_source() const -> std::shared_ptr<ms::DataExchangeSource>
     {
         return std::make_shared<Source>(this, wayland_executor, mime_types);
     }
@@ -90,7 +90,7 @@ public:
 class PrimarySelectionOffer : public mw::PrimarySelectionOfferV1
 {
 public:
-    PrimarySelectionOffer(mw::PrimarySelectionDeviceV1& parent, std::shared_ptr<ms::ClipboardSource> source)
+    PrimarySelectionOffer(mw::PrimarySelectionDeviceV1& parent, std::shared_ptr<ms::DataExchangeSource> source)
         : PrimarySelectionOfferV1{parent},
           source{std::move(source)}
     {
@@ -101,7 +101,7 @@ public:
         source->initiate_send(mime_type, fd);
     }
 
-    std::shared_ptr<ms::ClipboardSource> const source;
+    std::shared_ptr<ms::DataExchangeSource> const source;
 };
 
 class PrimarySelectionDevice : public mw::PrimarySelectionDeviceV1, public mf::WlSeat::FocusListener
@@ -115,7 +115,7 @@ private:
         }
 
     private:
-        void paste_source_set(std::shared_ptr<ms::ClipboardSource> const& source) override
+        void paste_source_set(std::shared_ptr<ms::DataExchangeSource> const& source) override
         {
             if (owner)
             {
@@ -175,7 +175,7 @@ private:
         paste_source_set(primary_selection_clipboard->paste_source());
     }
 
-    void paste_source_set(std::shared_ptr<ms::ClipboardSource> const& source)
+    void paste_source_set(std::shared_ptr<ms::DataExchangeSource> const& source)
     {
         if (pending.source == source)
         {
@@ -211,7 +211,7 @@ private:
     }
 
     struct Selection {
-        std::shared_ptr<ms::ClipboardSource> source;
+        std::shared_ptr<ms::DataExchangeSource> source;
         mw::Weak<PrimarySelectionSource> wrapper;
     };
 

--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -31,7 +31,7 @@ public:
     }
 
 private:
-    void paste_source_set(std::shared_ptr<ms::ClipboardSource> const& source) override
+    void paste_source_set(std::shared_ptr<ms::DataExchangeSource> const& source) override
     {
         if (device)
         {
@@ -45,7 +45,7 @@ private:
 class mf::WlDataDevice::Offer : public wayland::DataOffer
 {
 public:
-    Offer(WlDataDevice* device, std::shared_ptr<scene::ClipboardSource> const& source);
+    Offer(WlDataDevice* device, std::shared_ptr<ms::DataExchangeSource> const& source);
 
     void accept(uint32_t serial, std::optional<std::string> const& mime_type) override
     {
@@ -66,10 +66,10 @@ public:
 private:
     friend mf::WlDataDevice;
     wayland::Weak<WlDataDevice> const device;
-    std::shared_ptr<scene::ClipboardSource> const source;
+    std::shared_ptr<ms::DataExchangeSource> const source;
 };
 
-mf::WlDataDevice::Offer::Offer(WlDataDevice* device, std::shared_ptr<scene::ClipboardSource> const& source) :
+mf::WlDataDevice::Offer::Offer(WlDataDevice* device, std::shared_ptr<ms::DataExchangeSource> const& source) :
     mw::DataOffer(*device),
     device{device},
     source{source}
@@ -131,7 +131,7 @@ void mf::WlDataDevice::focus_on(WlSurface* surface)
     paste_source_set(clipboard.paste_source());
 }
 
-void mf::WlDataDevice::paste_source_set(std::shared_ptr<scene::ClipboardSource> const& source)
+void mf::WlDataDevice::paste_source_set(std::shared_ptr<ms::DataExchangeSource> const& source)
 {
     if (source && has_focus)
     {

--- a/src/server/frontend_wayland/wl_data_device.h
+++ b/src/server/frontend_wayland/wl_data_device.h
@@ -26,7 +26,7 @@ class Executor;
 namespace scene
 {
 class Clipboard;
-class ClipboardSource;
+class DataExchangeSource;
 }
 
 namespace frontend
@@ -60,7 +60,7 @@ private:
     void focus_on(WlSurface* surface) override;
 
     /// Called by the clipboard observer
-    void paste_source_set(std::shared_ptr<scene::ClipboardSource> const& source);
+    void paste_source_set(std::shared_ptr<scene::DataExchangeSource> const& source);
 
     scene::Clipboard& clipboard;
     WlSeat& seat;

--- a/src/server/frontend_wayland/wl_data_source.cpp
+++ b/src/server/frontend_wayland/wl_data_source.cpp
@@ -33,7 +33,7 @@ public:
     }
 
 private:
-    void paste_source_set(std::shared_ptr<ms::ClipboardSource> const& source) override
+    void paste_source_set(std::shared_ptr<ms::DataExchangeSource> const& source) override
     {
         if (owner)
         {
@@ -44,7 +44,7 @@ private:
     wayland::Weak<WlDataSource> const owner;
 };
 
-class mf::WlDataSource::Source : public ms::ClipboardSource
+class mf::WlDataSource::Source : public ms::DataExchangeSource
 {
 public:
     Source(WlDataSource& wl_data_source)
@@ -73,7 +73,7 @@ public:
 private:
     std::shared_ptr<Executor> const wayland_executor;
     wayland::Weak<WlDataSource> const wl_data_source;
-    std::vector<std::string> types;
+    std::vector<std::string> const types;
 };
 
 mf::WlDataSource::WlDataSource(
@@ -119,7 +119,7 @@ void mf::WlDataSource::offer(std::string const& mime_type)
     mime_types.push_back(mime_type);
 }
 
-void mf::WlDataSource::paste_source_set(std::shared_ptr<scene::ClipboardSource> const& source)
+void mf::WlDataSource::paste_source_set(std::shared_ptr<ms::DataExchangeSource> const& source)
 {
     if (source && source == paste_source.lock())
     {

--- a/src/server/frontend_wayland/wl_data_source.h
+++ b/src/server/frontend_wayland/wl_data_source.h
@@ -25,7 +25,7 @@ class Executor;
 namespace scene
 {
 class Clipboard;
-class ClipboardSource;
+class DataExchangeSource;
 }
 
 namespace frontend
@@ -56,13 +56,13 @@ private:
     class ClipboardObserver;
     class Source;
 
-    void paste_source_set(std::shared_ptr<scene::ClipboardSource> const& source);
+    void paste_source_set(std::shared_ptr<scene::DataExchangeSource> const& source);
 
     std::shared_ptr<Executor> const wayland_executor;
     scene::Clipboard& clipboard;
     std::shared_ptr<ClipboardObserver> const clipboard_observer;
     std::vector<std::string> mime_types;
-    std::weak_ptr<scene::ClipboardSource> paste_source;
+    std::weak_ptr<scene::DataExchangeSource> paste_source;
     bool clipboards_paste_source_is_ours{false};
 };
 }

--- a/src/server/frontend_xwayland/xwayland_clipboard_provider.cpp
+++ b/src/server/frontend_xwayland/xwayland_clipboard_provider.cpp
@@ -281,7 +281,7 @@ public:
     {
     }
 
-    void paste_source_set(std::shared_ptr<ms::ClipboardSource> const& source) override
+    void paste_source_set(std::shared_ptr<ms::DataExchangeSource> const& source) override
     {
         owner->paste_source_set(source);
     }
@@ -471,7 +471,7 @@ void mf::XWaylandClipboardProvider::send_data(
         target));
 }
 
-void mf::XWaylandClipboardProvider::paste_source_set(std::shared_ptr<ms::ClipboardSource> const& source)
+void mf::XWaylandClipboardProvider::paste_source_set(std::shared_ptr<ms::DataExchangeSource> const& source)
 {
     std::unique_lock lock{mutex};
 

--- a/src/server/frontend_xwayland/xwayland_clipboard_provider.h
+++ b/src/server/frontend_xwayland/xwayland_clipboard_provider.h
@@ -18,6 +18,7 @@
 #define MIR_FRONTEND_XWAYLAND_CLIPBOARD_PROVIDER_H_
 
 #include "xcb_connection.h"
+#include "mir/scene/data_exchange.h"
 
 #include <map>
 
@@ -28,7 +29,7 @@ namespace mir
 namespace scene
 {
 class Clipboard;
-class ClipboardSource;
+class DataExchangeSource;
 }
 namespace dispatch
 {
@@ -92,7 +93,7 @@ private:
         std::string const& mime_type);
 
     /// Called by the observer, indicates the paste source has been set by someone (could be us or Wayland)
-    void paste_source_set(std::shared_ptr<scene::ClipboardSource> const& source);
+    void paste_source_set(std::shared_ptr<scene::DataExchangeSource> const& source);
 
     /// Called by the sender, indicates sending should resume when the sender's property is deleted
     void defer_incremental_send(std::shared_ptr<SelectionSender> sender, xcb_window_t window, xcb_atom_t property);
@@ -109,7 +110,7 @@ private:
     /// received the event we need to set it.
     xcb_timestamp_t clipboard_ownership_timestamp{XCB_TIME_CURRENT_TIME};
     /// The source X11 clients can paste from. Should never be a source from this XWayland connection. Can be null
-    std::shared_ptr<scene::ClipboardSource> current_source;
+    std::shared_ptr<scene::DataExchangeSource> current_source;
     /// Maps window/property pairs to SelectionSender's that are waiting for those properties to be deleted in order to
     /// continue an incremental send.
     std::map<std::pair<xcb_window_t, xcb_atom_t>, std::shared_ptr<SelectionSender>> pending_incremental_sends;

--- a/src/server/frontend_xwayland/xwayland_clipboard_source.cpp
+++ b/src/server/frontend_xwayland/xwayland_clipboard_source.cpp
@@ -69,7 +69,7 @@ auto map2vec(std::map<std::string, xcb_atom_t> const& map) -> std::vector<std::s
 }
 }
 
-class mf::XWaylandClipboardSource::ClipboardSource : public scene::ClipboardSource
+class mf::XWaylandClipboardSource::ClipboardSource : public ms::DataExchangeSource
 {
 public:
     ClipboardSource(std::map<std::string, xcb_atom_t>&& mime_types_map, XWaylandClipboardSource* owner)
@@ -197,7 +197,7 @@ mf::XWaylandClipboardSource::XWaylandClipboardSource(
 {
 }
 
-auto mf::XWaylandClipboardSource::source_is_from(ms::ClipboardSource* source, XCBConnection& connection) -> bool
+auto mf::XWaylandClipboardSource::source_is_from(ms::DataExchangeSource* source, XCBConnection& connection) -> bool
 {
     if (auto const xwayland_source = dynamic_cast<ClipboardSource*>(source))
     {

--- a/src/server/frontend_xwayland/xwayland_clipboard_source.h
+++ b/src/server/frontend_xwayland/xwayland_clipboard_source.h
@@ -26,7 +26,7 @@ namespace mir
 namespace scene
 {
 class Clipboard;
-class ClipboardSource;
+class DataExchangeSource;
 }
 namespace dispatch
 {
@@ -47,7 +47,7 @@ public:
     /// Return's if the given clipboard source is an XWayland source for the given connection. This is used to prevent
     /// stealing the X11 clipboard when the source is from X11. It must check if the connection is the same because
     /// if we're running multiple XWaylands sources coming from different ones should be treated like any other.
-    static auto source_is_from(scene::ClipboardSource* source, XCBConnection& connection) -> bool;
+    static auto source_is_from(scene::DataExchangeSource* source, XCBConnection& connection) -> bool;
 
     /// Called by the source, indicates the XWayland buffer needs to be sent to the given fd
     void initiate_send(xcb_atom_t target_type, Fd const& receiver_fd);

--- a/src/server/scene/basic_clipboard.cpp
+++ b/src/server/scene/basic_clipboard.cpp
@@ -20,13 +20,13 @@
 
 namespace ms = mir::scene;
 
-auto ms::BasicClipboard::paste_source() const -> std::shared_ptr<ClipboardSource>
+auto ms::BasicClipboard::paste_source() const -> std::shared_ptr<DataExchangeSource>
 {
     std::lock_guard lock{paste_mutex};
     return paste_source_;
 }
 
-void ms::BasicClipboard::set_paste_source(std::shared_ptr<ClipboardSource> const& source)
+void ms::BasicClipboard::set_paste_source(std::shared_ptr<DataExchangeSource> const& source)
 {
     if (!source)
     {
@@ -64,7 +64,7 @@ void ms::BasicClipboard::clear_paste_source()
     }
 }
 
-void ms::BasicClipboard::clear_paste_source(ClipboardSource const& source)
+void ms::BasicClipboard::clear_paste_source(DataExchangeSource const& source)
 {
     bool notify{false};
     {

--- a/src/server/scene/basic_clipboard.h
+++ b/src/server/scene/basic_clipboard.h
@@ -34,7 +34,7 @@ public:
     {
     }
 
-    void paste_source_set(std::shared_ptr<ClipboardSource> const& source) override
+    void paste_source_set(std::shared_ptr<DataExchangeSource> const& source) override
     {
         for_each_observer(&ClipboardObserver::paste_source_set, source);
     }
@@ -44,10 +44,10 @@ public:
 class BasicClipboard : public Clipboard
 {
 public:
-    auto paste_source() const -> std::shared_ptr<ClipboardSource> override;
-    void set_paste_source(std::shared_ptr<ClipboardSource> const& source) override;
+    auto paste_source() const -> std::shared_ptr<DataExchangeSource> override;
+    void set_paste_source(std::shared_ptr<DataExchangeSource> const& source) override;
     void clear_paste_source() override;
-    void clear_paste_source(ClipboardSource const& source) override;
+    void clear_paste_source(DataExchangeSource const& source) override;
 
     /// Implement ObserverRegistrar<ClipboardObserver>
     /// @{
@@ -69,7 +69,7 @@ private:
     ClipboardObserverMultiplexer multiplexer;
 
     std::mutex mutable paste_mutex;
-    std::shared_ptr<ClipboardSource> paste_source_; ///< Can be null
+    std::shared_ptr<DataExchangeSource> paste_source_; ///< Can be null
 };
 }
 }

--- a/tests/unit-tests/scene/test_basic_clipboard.cpp
+++ b/tests/unit-tests/scene/test_basic_clipboard.cpp
@@ -25,7 +25,7 @@ using namespace testing;
 namespace ms = mir::scene;
 namespace mt = mir::test;
 
-struct MockClipboardSource : ms::ClipboardSource
+struct MockClipboardSource : ms::DataExchangeSource
 {
     auto mime_types() const -> std::vector<std::string> const& override
     {
@@ -41,7 +41,7 @@ struct MockClipboardSource : ms::ClipboardSource
 
 struct MockClipboardObserver : ms::ClipboardObserver
 {
-    MOCK_METHOD1(paste_source_set, void(std::shared_ptr<ms::ClipboardSource> const&));
+    MOCK_METHOD(void, paste_source_set, (std::shared_ptr<ms::DataExchangeSource> const&));
 };
 
 struct BasicClipboardTest : Test


### PR DESCRIPTION
Extract and rename data exchange interface that is common between cut & paste, select & paste, and drag and drop.