### PR TITLE
Drop legacy drag & drop code

### DIFF
--- a/include/miral/miral/window_manager_tools.h
+++ b/include/miral/miral/window_manager_tools.h
@@ -175,10 +175,13 @@ public:
      *
      * @param window_info source window
      * @param handle      drag handle
+     * \deprecated legacy of mirclient API
      */
+    [[deprecated("Not meaningful: legacy of mirclient API")]]
     void start_drag_and_drop(WindowInfo& window_info, std::vector<uint8_t> const& handle);
 
     /// End drag and drop
+    [[deprecated("Not meaningful: legacy of mirclient API")]]
     void end_drag_and_drop();
 
     /// Apply modifications to a window

--- a/src/include/server/mir/scene/null_surface_observer.h
+++ b/src/include/server/mir/scene/null_surface_observer.h
@@ -45,7 +45,6 @@ public:
     void cursor_image_removed(Surface const* surf) override;
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
     void input_consumed(Surface const* surf, std::shared_ptr<MirEvent const> const& event) override;
-    void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
     void application_id_set_to(Surface const* surf, std::string const& application_id) override;
 

--- a/src/include/server/mir/scene/surface.h
+++ b/src/include/server/mir/scene/surface.h
@@ -114,9 +114,8 @@ public:
     virtual MirPointerConfinementState confine_pointer_state() const = 0;
 
     virtual void placed_relative(geometry::Rectangle const& placement) = 0;
-    virtual void start_drag_and_drop(std::vector<uint8_t> const& handle) = 0;
-
     /// The depth layer the surface is on
+
     /// It will be kept above all surfaces on lower layers, and below surfaces on higher layers
     virtual auto depth_layer() const -> MirDepthLayer = 0;
     /// When the depth layer is changed, the surface becomes the top surface on that layer

--- a/src/include/server/mir/scene/surface_event_source.h
+++ b/src/include/server/mir/scene/surface_event_source.h
@@ -46,7 +46,6 @@ public:
     void client_surface_close_requested(Surface const* surf) override;
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
     void input_consumed(Surface const* surf, std::shared_ptr<MirEvent const> const& event) override;
-    void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
 
 private:
     frontend::SurfaceId const id;

--- a/src/include/server/mir/scene/surface_observer.h
+++ b/src/include/server/mir/scene/surface_observer.h
@@ -59,9 +59,8 @@ public:
     virtual void cursor_image_removed(Surface const* surf) = 0;
     virtual void placed_relative(Surface const* surf, geometry::Rectangle const& placement) = 0;
     virtual void input_consumed(Surface const* surf, std::shared_ptr<MirEvent const> const& event) = 0;
-    virtual void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) = 0;
-    virtual void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) = 0;
     virtual void application_id_set_to(Surface const* surf, std::string const& application_id) = 0;
+    virtual void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) = 0;
 
 protected:
     SurfaceObserver() = default;

--- a/src/include/server/mir/scene/surface_observers.h
+++ b/src/include/server/mir/scene/surface_observers.h
@@ -49,7 +49,6 @@ public:
     void cursor_image_removed(Surface const* surf) override;
     void placed_relative(Surface const* surf, geometry::Rectangle const& placement) override;
     void input_consumed(Surface const* surf, std::shared_ptr<MirEvent const> const& event) override;
-    void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override;
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override;
     void application_id_set_to(Surface const* surf, std::string const& application_id) override;
 };

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -941,17 +941,6 @@ void miral::BasicWindowManager::raise_tree(Window const& root)
     focus_controller->raise({begin(windows), end(windows)});
 }
 
-void miral::BasicWindowManager::start_drag_and_drop(WindowInfo& window_info, std::vector<uint8_t> const& handle)
-{
-    std::shared_ptr<scene::Surface>(window_info.window())->start_drag_and_drop(handle);
-    focus_controller->set_drag_and_drop_handle(handle);
-}
-
-void miral::BasicWindowManager::end_drag_and_drop()
-{
-    focus_controller->clear_drag_and_drop_handle();
-}
-
 void miral::BasicWindowManager::move_tree(miral::WindowInfo& root, mir::geometry::Displacement movement)
 {
     if (movement == mir::geometry::Displacement{})

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -182,9 +182,6 @@ public:
     auto active_application_zone() -> Zone override;
 
     void raise_tree(Window const& root) override;
-    void start_drag_and_drop(WindowInfo& window_info, std::vector<uint8_t> const& handle) override;
-    void end_drag_and_drop() override;
-
     void modify_window(WindowInfo& window_info, WindowSpecification const& modifications) override;
 
     auto info_for_window_id(std::string const& id) const -> WindowInfo& override;

--- a/src/miral/window_management_trace.cpp
+++ b/src/miral/window_management_trace.cpp
@@ -585,24 +585,6 @@ try {
 }
 MIRAL_TRACE_EXCEPTION
 
-void miral::WindowManagementTrace::start_drag_and_drop(miral::WindowInfo& window_info, std::vector<uint8_t> const& handle)
-try {
-    log_input();
-    mir::log_info("%s window_info=%s", __func__, dump_of(window_info).c_str());
-    trace_count++;
-    wrapped.start_drag_and_drop(window_info, handle);
-}
-MIRAL_TRACE_EXCEPTION
-
-void miral::WindowManagementTrace::end_drag_and_drop()
-try {
-    log_input();
-    mir::log_info("%s", __func__);
-    trace_count++;
-    wrapped.end_drag_and_drop();
-}
-MIRAL_TRACE_EXCEPTION
-
 void miral::WindowManagementTrace::modify_window(
     miral::WindowInfo& window_info, miral::WindowSpecification const& modifications)
 try {

--- a/src/miral/window_management_trace.h
+++ b/src/miral/window_management_trace.h
@@ -70,8 +70,6 @@ private:
     virtual void focus_prev_within_application() override;
 
     virtual void raise_tree(Window const& root) override;
-    virtual void start_drag_and_drop(WindowInfo& window_info, std::vector<uint8_t> const& handle) override;
-    virtual void end_drag_and_drop() override;
 
     virtual void modify_window(WindowInfo& window_info, WindowSpecification const& modifications) override;
 

--- a/src/miral/window_manager_tools.cpp
+++ b/src/miral/window_manager_tools.cpp
@@ -85,11 +85,11 @@ auto miral::WindowManagerTools::active_application_zone() const -> Zone
 void miral::WindowManagerTools::raise_tree(Window const& root)
 { tools->raise_tree(root); }
 
-void miral::WindowManagerTools::start_drag_and_drop(WindowInfo& window_info, std::vector<uint8_t> const& handle)
-{ tools->start_drag_and_drop(window_info, handle); }
+void miral::WindowManagerTools::start_drag_and_drop(WindowInfo& /*window_info*/, std::vector<uint8_t> const& /*handle*/)
+{ }
 
 void miral::WindowManagerTools::end_drag_and_drop()
-{ tools->end_drag_and_drop(); }
+{ }
 
 void miral::WindowManagerTools::modify_window(WindowInfo& window_info, WindowSpecification const& modifications)
 { tools->modify_window(window_info,modifications); }

--- a/src/miral/window_manager_tools_implementation.h
+++ b/src/miral/window_manager_tools_implementation.h
@@ -67,8 +67,6 @@ public:
     virtual auto active_output() -> mir::geometry::Rectangle const = 0;
     virtual auto active_application_zone() -> Zone = 0;
     virtual void raise_tree(Window const& root) = 0;
-    virtual void start_drag_and_drop(WindowInfo& window_info, std::vector<uint8_t> const& handle) = 0;
-    virtual void end_drag_and_drop() = 0;
     virtual void modify_window(WindowInfo& window_info, WindowSpecification const& modifications) = 0;
     virtual auto info_for_window_id(std::string const& id) const -> WindowInfo& = 0;
     virtual auto id_for_window(Window const& window) const -> std::string = 0;

--- a/src/miroil/surface.cpp
+++ b/src/miroil/surface.cpp
@@ -54,8 +54,6 @@ public:
   reception_mode_set_to(mir::scene::Surface const * /*surf*/,
                         mir::input::InputReceptionMode /*mode*/) override{};
   void renamed(mir::scene::Surface const *surf, std::string const& name) override;
-  void start_drag_and_drop(mir::scene::Surface const *surf,
-                           std::vector<uint8_t> const &handle) override;
   void transformation_set_to(mir::scene::Surface const *surf,
                              glm::mat4 const &t) override;
   void window_resized_to(mir::scene::Surface const *surf,
@@ -148,11 +146,6 @@ void miroil::SurfaceObserverImpl::placed_relative(mir::scene::Surface const* sur
 void miroil::SurfaceObserverImpl::renamed(mir::scene::Surface const* surf, std::string const& name)
 {
     listener->renamed(surf, name.c_str());
-}
-
-void miroil::SurfaceObserverImpl::start_drag_and_drop(mir::scene::Surface const* surf, std::vector<uint8_t> const& handle)
-{
-    listener->start_drag_and_drop(surf, handle);
 }
 
 void miroil::SurfaceObserverImpl::transformation_set_to(mir::scene::Surface const* surf, glm::mat4 const& t)

--- a/src/server/scene/basic_surface.cpp
+++ b/src/server/scene/basic_surface.cpp
@@ -130,11 +130,6 @@ public:
         for_each_observer(&SurfaceObserver::input_consumed, surf, event);
     }
 
-    void start_drag_and_drop(Surface const* surf, std::vector<uint8_t> const& handle) override
-    {
-        for_each_observer(&SurfaceObserver::start_drag_and_drop, surf, handle);
-    }
-
     void depth_layer_set_to(Surface const* surf, MirDepthLayer depth_layer) override
     {
         for_each_observer(&SurfaceObserver::depth_layer_set_to, surf, depth_layer);
@@ -820,11 +815,6 @@ MirPointerConfinementState ms::BasicSurface::confine_pointer_state() const
 void ms::BasicSurface::placed_relative(geometry::Rectangle const& placement)
 {
     observers->placed_relative(this, placement);
-}
-
-void mir::scene::BasicSurface::start_drag_and_drop(std::vector<uint8_t> const& handle)
-{
-    observers->start_drag_and_drop(this, handle);
 }
 
 auto mir::scene::BasicSurface::depth_layer() const -> MirDepthLayer

--- a/src/server/scene/basic_surface.h
+++ b/src/server/scene/basic_surface.h
@@ -141,7 +141,6 @@ public:
     void set_confine_pointer_state(MirPointerConfinementState state) override;
     MirPointerConfinementState confine_pointer_state() const override;
     void placed_relative(geometry::Rectangle const& placement) override;
-    void start_drag_and_drop(std::vector<uint8_t> const& handle) override;
 
     auto depth_layer() const -> MirDepthLayer override;
     void set_depth_layer(MirDepthLayer depth_layer) override;

--- a/src/server/scene/null_surface_observer.cpp
+++ b/src/server/scene/null_surface_observer.cpp
@@ -35,6 +35,5 @@ void ms::NullSurfaceObserver::renamed(Surface const*, std::string const&) {}
 void ms::NullSurfaceObserver::cursor_image_removed(Surface const*) {}
 void ms::NullSurfaceObserver::placed_relative(Surface const*, geometry::Rectangle const&) {}
 void ms::NullSurfaceObserver::input_consumed(Surface const*, std::shared_ptr<MirEvent const> const&) {}
-void ms::NullSurfaceObserver::start_drag_and_drop(Surface const*, std::vector<uint8_t> const&) {}
 void ms::NullSurfaceObserver::depth_layer_set_to(Surface const*, MirDepthLayer) {}
 void ms::NullSurfaceObserver::application_id_set_to(Surface const*, std::string const&) {}

--- a/src/server/scene/surface_event_source.cpp
+++ b/src/server/scene/surface_event_source.cpp
@@ -86,8 +86,3 @@ void ms::SurfaceEventSource::input_consumed(Surface const*, std::shared_ptr<MirE
     mev::set_window_id(*ev, id.as_value());
     event_sink->handle_event(std::move(ev));
 }
-
-void ms::SurfaceEventSource::start_drag_and_drop(Surface const*, std::vector<uint8_t> const& handle)
-{
-    event_sink->handle_event(mev::make_start_drag_and_drop_event(id, handle));
-}

--- a/tests/include/mir/test/doubles/stub_surface.h
+++ b/tests/include/mir/test/doubles/stub_surface.h
@@ -71,7 +71,6 @@ struct StubSurface : scene::Surface
     void set_confine_pointer_state(MirPointerConfinementState) override {}
     MirPointerConfinementState confine_pointer_state() const override { return mir_pointer_unconfined; }
     void placed_relative(geometry::Rectangle const&) override {}
-    void start_drag_and_drop(std::vector<uint8_t> const&) override {}
     MirDepthLayer depth_layer() const override { return mir_depth_layer_application; }
     void set_depth_layer(MirDepthLayer) override {}
     std::optional<geometry::Rectangle> clip_area() const override { return std::nullopt; }


### PR DESCRIPTION
This is not functional without the mirclient API and content-hub, and not useful as a framework for further development.

There are miral and miroil APIs that mention drag and drop. For ABI stability these are retained and deprecated, but do nothing.