### PR TITLE
Wayland platform: flush connection after sending pong

### DIFF
--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -655,6 +655,7 @@ void mgw::DisplayClient::remove_global(
 void mgw::DisplayClient::shell_ping(xdg_wm_base* shell, uint32_t serial)
 {
     xdg_wm_base_pong(shell, serial);
+    wl_display_flush(display);
 }
 
 void mgw::DisplayClient::keyboard_keymap(wl_keyboard* /*keyboard*/, uint32_t format, int32_t fd, uint32_t size)

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -626,7 +626,7 @@ void mgw::DisplayClient::new_global(
     else if (strcmp(interface, xdg_wm_base_interface.name) == 0)
     {
         static xdg_wm_base_listener const shell_listener{
-            [](void*, xdg_wm_base* shell, uint32_t serial){ xdg_wm_base_pong(shell, serial); },
+            [](void* self, auto... args) { static_cast<DisplayClient*>(self)->shell_ping(args...); },
         };
         self->shell = static_cast<decltype(self->shell)>(
             wl_registry_bind(registry, id, &xdg_wm_base_interface, std::min(version, 1u)));
@@ -650,6 +650,11 @@ void mgw::DisplayClient::remove_global(
         self->on_display_config_changed();
     }
     // TODO: We should probably also delete any other globals we've bound to that disappear.
+}
+
+void mgw::DisplayClient::shell_ping(xdg_wm_base* shell, uint32_t serial)
+{
+    xdg_wm_base_pong(shell, serial);
 }
 
 void mgw::DisplayClient::keyboard_keymap(wl_keyboard* /*keyboard*/, uint32_t format, int32_t fd, uint32_t size)

--- a/src/platforms/wayland/displayclient.h
+++ b/src/platforms/wayland/displayclient.h
@@ -63,6 +63,8 @@ protected:
     auto display_configuration() const -> std::unique_ptr<DisplayConfiguration>;
     void for_each_display_sync_group(const std::function<void(DisplaySyncGroup&)>& f);
 
+    void shell_ping(xdg_wm_base* shell, uint32_t serial);
+
     virtual void keyboard_keymap(wl_keyboard* keyboard, uint32_t format, int32_t fd, uint32_t size);
     virtual void keyboard_enter(wl_keyboard* keyboard, uint32_t serial, wl_surface* surface, wl_array* keys);
     virtual void keyboard_leave(wl_keyboard* keyboard, uint32_t serial, wl_surface* surface);


### PR DESCRIPTION
Seems to fix #2876, at least on the Wayland platform.