### PR TITLE
Wayland platform: flush display before polling

### DIFF
--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -257,6 +257,8 @@ try
             }
         }
 
+        wl_display_flush(display);
+
         if (poll(fds, indices, -1) == -1)
         {
             wl_display_cancel_read(display);
@@ -289,7 +291,6 @@ try
                 lock.lock();
             }
             lock.unlock();
-            wl_display_flush(display);
         }
     }
 }

--- a/src/platforms/wayland/display.cpp
+++ b/src/platforms/wayland/display.cpp
@@ -257,7 +257,25 @@ try
             }
         }
 
-        wl_display_flush(display);
+        if (wl_display_flush(display) < 0)
+        {
+            // wl_display_flush may fail with errno == EAGAIN if the write buffer is full
+            if (errno == EAGAIN)
+            {
+                // In this case, we should also wake if the display_fd is writable, so we can
+                // finish flushing.
+                fds[display_fd].events |= POLLOUT;
+            }
+            else
+            {
+                BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to flush Wayland events"}));
+            }
+        }
+        else
+        {
+            // We've fully flushed our pending events to the server; we don't need to wake-on-writable
+            fds[display_fd].events &= ~POLLOUT;
+        }
 
         if (poll(fds, indices, -1) == -1)
         {


### PR DESCRIPTION
Fixes #2902, alternative to #2901, I've looked into #2903 but that seems a little more complicated (and tricky to test)