### PR TITLE
platforms/evdev: Handle libinput device rejections better.

### DIFF
--- a/src/platforms/evdev/platform.cpp
+++ b/src/platforms/evdev/platform.cpp
@@ -187,7 +187,6 @@ public:
                 &device_watchers = device_watchers
             ]() mutable
             {
-                auto raw_fd = static_cast<int>(fd);
                 device_fds.store_fd(devnode.c_str(), std::move(fd));
 
                 auto pending_iter = pending_devices.find(devnum);
@@ -199,8 +198,10 @@ public:
 
                 if (!libinput_path_add_device(lib.get(), devnode.c_str()))
                 {
-                    // Oops, libinput didn't want this after all.
-                    device_fds.remove_fd(raw_fd);
+                    /* Oops, libinput didn't want this after all.
+                     * libinput will have closed the FD as a part of failing to add
+                     * the device, so we only need to release our Device handle.
+                     */
                     device_watchers.erase(devnum);
                 }
             });


### PR DESCRIPTION
When libinput fails to add a device via `libinput_path_add_device` it will already have called the close-fd hook we provide. We should not try to remove it from the `FdStore` ourselves; that will (at best) result in `FdStore` generating a warning, or, if the fatal stars align *just right*, will result in us closing a newly-acquired FD to an unrelated input device.

Fixes log warnings of the form:
```
[2023-05-15 10:43:48.442256] < -warning- > evdev-input: Attempted to remove unmanaged fd 73
```