### PR TITLE
ci: cancel previous merge groups

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -13,7 +13,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number && format('pr{0}', github.event.number) || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'merge_group' && 'merge_group'
+                                    || github.event.number && format('pr{0}', github.event.number)
+                                    || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
If we're triggered by a new `merge_group`, any previous groups are invalid already.