### PR TITLE
Event local positions take 2

### DIFF
--- a/include/common/mir/events/event_builders.h
+++ b/include/common/mir/events/event_builders.h
@@ -198,12 +198,15 @@ EventUPtr make_touch_event(
     std::vector<TouchContact> const& contacts);
 
 EventUPtr clone_event(MirEvent const& event);
-void transform_positions(MirEvent& event, mir::geometry::Displacement const& movement);
-void scale_positions(MirEvent& event, float scale);
 void set_window_id(MirEvent& event, int window_id);
 
 EventUPtr make_start_drag_and_drop_event(frontend::SurfaceId const& surface_id, std::vector<uint8_t> const& handle);
 void set_drag_and_drop_handle(MirEvent& event, std::vector<uint8_t> const& handle);
+
+[[deprecated("Internally functions from event_helpers.h should be used, externally this should not be needed")]]
+void transform_positions(MirEvent& event, mir::geometry::Displacement const& movement);
+[[deprecated("Internally functions from event_helpers.h should be used, externally this should not be needed")]]
+void scale_positions(MirEvent& event, float scale);
 }
 }
 

--- a/include/common/mir/events/touch_contact.h
+++ b/include/common/mir/events/touch_contact.h
@@ -21,6 +21,8 @@
 #include "contact_state.h"
 #include "mir/geometry/point.h"
 
+#include <optional>
+
 namespace mir
 {
 namespace events
@@ -92,6 +94,7 @@ struct TouchContactV2
     MirTouchAction action;
     MirTouchTooltype tooltype;
     geometry::PointF position;
+    std::optional<geometry::PointF> local_position;
     float pressure;
     float touch_major;
     float touch_minor;

--- a/src/common/events/CMakeLists.txt
+++ b/src/common/events/CMakeLists.txt
@@ -27,6 +27,7 @@ set(EVENT_SOURCES
   orientation_event.cpp
   resize_event.cpp
   window_output_event.cpp
+  event_helpers.cpp
   window_placement_event.cpp ${PROJECT_SOURCE_DIR}/src/include/common/mir/events/window_placement_event.h
 )
 

--- a/src/common/events/event_helpers.cpp
+++ b/src/common/events/event_helpers.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2023 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir/events/event_helpers.h"
+#include "mir/events/input_event.h"
+#include "mir/events/pointer_event.h"
+#include "mir/events/touch_event.h"
+
+namespace mev = mir::events;
+namespace geom = mir::geometry;
+
+void mev::map_positions(MirEvent& event, MapPositionFunc const& func)
+{
+    if (event.type() == mir_event_type_input)
+    {
+        auto const input_type = event.to_input()->input_type();
+        if (input_type == mir_input_event_type_pointer)
+        {
+            auto pev = event.to_input()->to_pointer();
+            auto const global = pev->position();
+            if (global)
+            {
+                auto const updated = func(global.value(), pev->local_position());
+                pev->set_position(updated.first);
+                pev->set_local_position(updated.second);
+            }
+        }
+        else if (input_type == mir_input_event_type_touch)
+        {
+            auto tev = event.to_input()->to_touch();
+            for (unsigned i = 0; i < tev->pointer_count(); i++)
+            {
+                auto const updated = func(tev->position(i), tev->local_position(i));
+                tev->set_position(i, updated.first);
+                tev->set_local_position(i, updated.second);
+            }
+        }
+    }
+}

--- a/src/common/events/pointer_event.cpp
+++ b/src/common/events/pointer_event.cpp
@@ -74,6 +74,16 @@ void MirPointerEvent::set_position(std::optional<mir::geometry::PointF> value)
     position_ = value;
 }
 
+auto MirPointerEvent::local_position() const -> std::optional<mir::geometry::PointF>
+{
+    return local_position_;
+}
+
+void MirPointerEvent::set_local_position(std::optional<mir::geometry::PointF> value)
+{
+    local_position_ = value;
+}
+
 auto MirPointerEvent::motion() const -> mir::geometry::DisplacementF
 {
     return motion_;

--- a/src/common/events/touch_event.cpp
+++ b/src/common/events/touch_event.cpp
@@ -84,6 +84,20 @@ void MirTouchEvent::set_position(size_t index, geom::PointF position)
     contacts[index].position = position;
 }
 
+std::optional<geom::PointF> MirTouchEvent::local_position(size_t index) const
+{
+    throw_if_out_of_bounds(index);
+
+    return contacts[index].local_position;
+}
+
+void MirTouchEvent::set_local_position(size_t index, std::optional<geom::PointF> position)
+{
+    throw_if_out_of_bounds(index);
+
+    contacts[index].local_position = position;
+}
+
 float MirTouchEvent::touch_major(size_t index) const
 {
     throw_if_out_of_bounds(index);

--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -541,3 +541,13 @@ MIR_COMMON_2.11 {
     MirKeyboardEvent::set_xkb_modifiers*;
   };
 } MIR_COMMON_2.10;
+
+MIR_COMMON_2.14 {
+  extern "C++" {
+    MirTouchEvent::set_local_position*;
+    MirTouchEvent::local_position*;
+    MirPointerEvent::set_local_position*;
+    MirPointerEvent::local_position*;
+    mir::events::map_positions*;
+  };
+} MIR_COMMON_2.11;

--- a/src/include/common/mir/events/event_helpers.h
+++ b/src/include/common/mir/events/event_helpers.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2023 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_COMMON_EVENT_HELPERS_H_
+#define MIR_COMMON_EVENT_HELPERS_H_
+
+#include "event.h"
+
+#include <functional>
+
+namespace mir
+{
+namespace events
+{
+/// A function that takes and returns a global and optional local position
+using MapPositionFunc = std::function<
+    std::pair<geometry::PointF, std::optional<geometry::PointF>>(
+        geometry::PointF global,
+        std::optional<geometry::PointF> local)>;
+
+/// Calls the given function for all positions in the event (could be multiple in the case of touch events) and updates
+/// the local and global positions based on the returned values.
+void map_positions(MirEvent& event, MapPositionFunc const& func);
+}
+}
+
+#endif // MIR_COMMON_EVENT_HELPERS_H_

--- a/src/include/common/mir/events/pointer_event.h
+++ b/src/include/common/mir/events/pointer_event.h
@@ -47,6 +47,9 @@ struct MirPointerEvent : MirInputEvent
     auto position() const -> std::optional<mir::geometry::PointF>;
     void set_position(std::optional<mir::geometry::PointF> value);
 
+    auto local_position() const -> std::optional<mir::geometry::PointF>;
+    void set_local_position(std::optional<mir::geometry::PointF> value);
+
     auto motion() const -> mir::geometry::DisplacementF;
     void set_motion(mir::geometry::DisplacementF value);
 
@@ -66,6 +69,7 @@ struct MirPointerEvent : MirInputEvent
     MirBlob* dnd_handle() const;
 
 private:
+    std::optional<mir::geometry::PointF> local_position_;
     std::optional<mir::geometry::PointF> position_;
     mir::geometry::DisplacementF motion_;
     MirPointerAxisSource axis_source_;

--- a/src/include/common/mir/events/touch_event.h
+++ b/src/include/common/mir/events/touch_event.h
@@ -41,6 +41,9 @@ struct MirTouchEvent : MirInputEvent
     mir::geometry::PointF position(size_t index) const;
     void set_position(size_t index, mir::geometry::PointF position);
 
+    std::optional<mir::geometry::PointF> local_position(size_t index) const;
+    void set_local_position(size_t index, std::optional<mir::geometry::PointF> position);
+
     float touch_major(size_t index) const;
     void set_touch_major(size_t index, float major);
 

--- a/src/miroil/eventdispatch.cpp
+++ b/src/miroil/eventdispatch.cpp
@@ -19,11 +19,30 @@
 #include <mir/scene/surface.h>
 #include <mir/events/event_builders.h>
 #include <mir/events/input_event.h>
+#include <mir/events/event_helpers.h>
+
+namespace mev = mir::events;
+namespace geom = mir::geometry;
 
 void miroil::dispatch_input_event(const miral::Window& window, const MirInputEvent* event)
 {
     if (auto surface = std::shared_ptr<mir::scene::Surface>(window))
     {
-        surface->consume(mir::events::clone_event(*event));
+        std::shared_ptr<MirEvent> const clone = mev::clone_event(*event);
+        mev::map_positions(*clone, [&](auto global, auto local)
+            {
+                if (!local)
+                {
+                    // If local position is not set, local position is confunsingly being stored in global positon. This
+                    // is a remnant of before Mir stored local and global positon in separate variables within the
+                    // event.
+                    local = global;
+                    std::shared_ptr<mir::scene::Surface> const surface{window};
+                    auto surface_displacement = geom::DisplacementF{as_displacement(surface->input_bounds().top_left)};
+                    global = local.value() + surface_displacement;
+                }
+                return std::make_pair(global, local);
+            });
+        surface->consume(clone);
     }
 }

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -313,9 +313,13 @@ void mf::WlPointer::axes(std::shared_ptr<MirPointerEvent const> const& event)
 
 void mf::WlPointer::enter_or_motion(std::shared_ptr<MirPointerEvent const> const& event, WlSurface& root_surface)
 {
-    auto const root_position = std::make_pair(
-        mir_pointer_event_axis_value(event.get(), mir_pointer_axis_x),
-        mir_pointer_event_axis_value(event.get(), mir_pointer_axis_y));
+    if (!event->local_position())
+    {
+        log_error("pointer event cannot be sent to wl_surface as it lacks a local poisition");
+        return;
+    }
+
+    auto const root_position = event->local_position().value();
 
     WlSurface* target_surface;
     if (current_buttons != 0 && surface_under_cursor)
@@ -326,14 +330,11 @@ void mf::WlPointer::enter_or_motion(std::shared_ptr<MirPointerEvent const> const
     else
     {
         // Else choose whatever subsurface we are over top of
-        geom::Point root_point{root_position.first, root_position.second};
+        geom::Point root_point{root_position};
         target_surface = root_surface.subsurface_at(root_point).value_or(&root_surface);
     }
 
-    auto const offset = target_surface->total_offset();
-    auto const position_on_target = std::make_pair(
-        root_position.first - offset.dx.as_int(),
-        root_position.second - offset.dy.as_int());
+    auto const position_on_target = root_position - geom::DisplacementF{target_surface->total_offset()};
 
     if (!surface_under_cursor || &surface_under_cursor.value() != target_surface)
     {
@@ -344,8 +345,8 @@ void mf::WlPointer::enter_or_motion(std::shared_ptr<MirPointerEvent const> const
         send_enter_event(
             enter_serial.value(),
             target_surface->raw_resource(),
-            position_on_target.first,
-            position_on_target.second);
+            position_on_target.x.as_value(),
+            position_on_target.y.as_value());
         current_position = position_on_target;
         needs_frame = true;
         destroy_listener_id = target_surface->add_destroy_listener([this]()
@@ -366,8 +367,8 @@ void mf::WlPointer::enter_or_motion(std::shared_ptr<MirPointerEvent const> const
         default:
             send_motion_event(
                 timestamp_of(event),
-                position_on_target.first,
-                position_on_target.second);
+                position_on_target.x.as_value(),
+                position_on_target.y.as_value());
             current_position = position_on_target;
             needs_frame = true;
         }

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -110,7 +110,7 @@ private:
     wayland::DestroyListenerId destroy_listener_id; ///< ID of this pointer's destroy listener on surface_under_cursor
     bool needs_frame{false};
     MirPointerButtons current_buttons{0};
-    std::optional<std::pair<float, float>> current_position;
+    std::optional<geometry::PointF> current_position;
     std::unique_ptr<Cursor> cursor;
     wayland::Weak<wayland::RelativePointerV1> relative_pointer;
     geometry::Displacement cursor_hotspot;

--- a/src/server/frontend_wayland/wl_touch.cpp
+++ b/src/server/frontend_wayland/wl_touch.cpp
@@ -54,9 +54,12 @@ void mf::WlTouch::event(std::shared_ptr<MirTouchEvent const> const& event, WlSur
 
     for (auto i = 0u; i < mir_touch_event_point_count(event.get()); ++i)
     {
-        auto const position = std::make_pair(
-            mir_touch_event_axis_value(event.get(), i, mir_touch_axis_x),
-            mir_touch_event_axis_value(event.get(), i, mir_touch_axis_y));
+        if (!event->local_position(i))
+        {
+            log_error("touch event cannot be sent to wl_surface as it lacks a local poisition");
+            continue;
+        }
+        auto const position = event->local_position(i).value();
         int const touch_id = mir_touch_event_id(event.get(), i);
         MirTouchAction const action = mir_touch_event_action(event.get(), i);
 
@@ -90,14 +93,12 @@ void mf::WlTouch::down(
     std::chrono::milliseconds const& ms,
     int32_t touch_id,
     WlSurface& root_surface,
-    std::pair<float, float> const& root_position)
+    geometry::PointF root_position)
 {
-    geom::Point root_point{root_position.first, root_position.second};
+    geom::Point root_point{root_position};
     auto const target_surface = root_surface.subsurface_at(root_point).value_or(&root_surface);
     auto const offset = target_surface->total_offset();
-    auto const position_on_target = std::make_pair(
-        root_position.first - offset.dx.as_int(),
-        root_position.second - offset.dy.as_int());
+    auto const position_on_target = root_position - geom::DisplacementF{offset};
 
     auto const listener_id = target_surface->add_destroy_listener(
         [this, touch_id]()
@@ -115,15 +116,15 @@ void mf::WlTouch::down(
         ms.count(),
         target_surface->raw_resource(),
         touch_id,
-        position_on_target.first,
-        position_on_target.second);
+        position_on_target.x.as_value(),
+        position_on_target.y.as_value());
     needs_frame = true;
 }
 
 void mf::WlTouch::motion(
     std::chrono::milliseconds const& ms,
     int32_t touch_id,
-    std::pair<float, float> const& root_position)
+    geometry::PointF root_position)
 {
     auto const touch = touch_id_to_surface.find(touch_id);
 
@@ -139,15 +140,13 @@ void mf::WlTouch::motion(
     }
 
     auto const offset = touch->second.surface.value().total_offset();
-    auto const position_on_target = std::make_pair(
-        root_position.first - offset.dx.as_int(),
-        root_position.second - offset.dy.as_int());
+    auto const position_on_target = root_position - geom::DisplacementF{offset};
 
     send_motion_event(
         ms.count(),
         touch_id,
-        position_on_target.first,
-        position_on_target.second);
+        position_on_target.x.as_value(),
+        position_on_target.y.as_value());
     needs_frame = true;
 }
 

--- a/src/server/frontend_wayland/wl_touch.h
+++ b/src/server/frontend_wayland/wl_touch.h
@@ -72,11 +72,11 @@ private:
         std::chrono::milliseconds const& ms,
         int32_t touch_id,
         WlSurface& root_surface,
-        std::pair<float, float> const& root_position);
+        geometry::PointF root_position);
     void motion(
         std::chrono::milliseconds const& ms,
         int32_t touch_id,
-        std::pair<float, float> const& root_position);
+        geometry::PointF root_position);
     void up(uint32_t serial, std::chrono::milliseconds const& ms, int32_t touch_id);
     void maybe_frame();
 };

--- a/src/server/frontend_xwayland/xwayland_surface_observer.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface_observer.cpp
@@ -23,7 +23,7 @@
 #include "wayland_input_dispatcher.h"
 
 #include <mir/executor.h>
-#include <mir/events/event_builders.h>
+#include <mir/events/event_helpers.h>
 #include <mir/events/input_event.h>
 
 #include <mir/log.h>
@@ -145,8 +145,17 @@ void mf::XWaylandSurfaceObserver::input_consumed(ms::Surface const*, std::shared
     {
         // Must clone the event so we can scale the positions to XWayland scale
         auto const owned_event = std::dynamic_pointer_cast<MirInputEvent>(
-            std::shared_ptr<MirEvent>(mev::clone_event(*event)));
-        mev::scale_positions(*owned_event, scale);
+            std::shared_ptr<MirEvent>{mev::clone_event(*event)});
+
+        mev::map_positions(*owned_event, [&](auto global, auto local)
+            {
+                if (local)
+                {
+                    // Scale positions based on the XWayland scale
+                    local = as_point(as_displacement(local.value()) * scale);
+                }
+                return std::make_pair(global, local);
+            });
 
         if (is_move_resize_event(mir_event_get_input_event(owned_event.get())))
         {

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -21,7 +21,7 @@
 #include "mir/scene/null_observer.h"
 #include "mir/scene/surface.h"
 #include "mir/scene/null_surface_observer.h"
-#include "mir/events/event_builders.h"
+#include "mir/events/event_helpers.h"
 #include "mir/events/pointer_event.h"
 #include "mir_toolkit/mir_cookie.h"
 
@@ -91,6 +91,17 @@ struct InputDispatcherSceneObserver :
     std::function<void()> const on_surface_resized;
 };
 
+void set_local_positions_based_on_surface_input_bounds(
+    MirEvent& event,
+    mir::geometry::Rectangle const& input_bounds)
+{
+    mev::map_positions(event, [&](auto global, auto local)
+        {
+            local = global - geom::DisplacementF{as_displacement(input_bounds.top_left)};
+            return std::make_pair(global, local);
+        });
+}
+
 void deliver_without_relative_motion(
     std::shared_ptr<mi::Surface> const& surface,
     MirEvent const* ev,
@@ -122,7 +133,7 @@ void deliver_without_relative_motion(
         0.0f,
         0.0f);
 
-    mev::transform_positions(*to_deliver, geom::Displacement{bounds.top_left.x.as_int(), bounds.top_left.y.as_int()});
+    set_local_positions_based_on_surface_input_bounds(*to_deliver, bounds);
     if (!drag_and_drop_handle.empty())
         mev::set_drag_and_drop_handle(*to_deliver, drag_and_drop_handle);
     surface->consume(std::move(to_deliver));
@@ -139,7 +150,7 @@ void deliver(
         mev::set_drag_and_drop_handle(*to_deliver, drag_and_drop_handle);
 
     auto const& bounds = surface->input_bounds();
-    mev::transform_positions(*to_deliver, geom::Displacement{bounds.top_left.x.as_int(), bounds.top_left.y.as_int()});
+    set_local_positions_based_on_surface_input_bounds(*to_deliver, bounds);
     surface->consume(std::move(to_deliver));
 }
 
@@ -423,14 +434,13 @@ void mi::SurfaceInputDispatcher::send_enter_exit_event(std::shared_ptr<mi::Surfa
                                                        MirPointerEvent const* pev,
                                                        MirPointerAction action)
 {
-    geom::DisplacementF const surface_displacement{as_displacement(surface->input_bounds().top_left)};
     auto const* input_ev = mir_pointer_event_input_event(pev);
     auto event = mev::clone_event(*mir_input_event_get_event(input_ev));
     auto const pointer_ev = static_cast<MirPointerEvent*>(event.get());
     pointer_ev->set_action(action);
     if (pointer_ev->position())
     {
-        pointer_ev->set_position(pointer_ev->position().value() - surface_displacement);
+        set_local_positions_based_on_surface_input_bounds(*event, surface->input_bounds());
     }
     if (!drag_and_drop_handle.empty())
     {

--- a/src/server/shell/decoration/input.cpp
+++ b/src/server/shell/decoration/input.cpp
@@ -21,6 +21,8 @@
 
 #include "mir/scene/surface.h"
 #include "mir/scene/null_surface_observer.h"
+#include "mir/events/pointer_event.h"
+#include "mir/events/touch_event.h"
 #include "mir_toolkit/cursors.h"
 
 namespace ms = mir::scene;
@@ -61,11 +63,11 @@ struct msd::InputManager::Observer
             case mir_pointer_action_motion:
             case mir_pointer_action_enter:
             {
-                geom::Point const location{
-                    mir_pointer_event_axis_value(pointer_ev, mir_pointer_axis_x),
-                    mir_pointer_event_axis_value(pointer_ev, mir_pointer_axis_y)};
-                bool pressed = mir_pointer_event_button_state(pointer_ev, mir_pointer_button_primary);
-                manager->pointer_event(timestamp, location, pressed);
+                if (auto const position = pointer_ev->local_position())
+                {
+                    bool pressed = mir_pointer_event_button_state(pointer_ev, mir_pointer_button_primary);
+                    manager->pointer_event(timestamp, geom::Point{position.value()}, pressed);
+                }
             }   break;
 
             case mir_pointer_action_leave:
@@ -89,10 +91,10 @@ struct msd::InputManager::Observer
                 case mir_touch_action_down:
                 case mir_touch_action_change:
                 {
-                    geom::Point const location{
-                        mir_touch_event_axis_value(touch_ev, i, mir_touch_axis_x),
-                        mir_touch_event_axis_value(touch_ev, i, mir_touch_axis_y)};
-                    manager->touch_event(id, timestamp, location);
+                    if (auto const position = touch_ev->local_position(i))
+                    {
+                        manager->touch_event(id, timestamp, geom::Point{position.value()});
+                    }
                 }   break;
                 case mir_touch_action_up:
                 {

--- a/tests/unit-tests/input/test_surface_input_dispatcher.cpp
+++ b/tests/unit-tests/input/test_surface_input_dispatcher.cpp
@@ -481,8 +481,8 @@ TEST_F(SurfaceInputDispatcher, touch_delivered_to_surface)
     auto surface = scene.add_surface({{1, 1}, {1, 1}});
 
     InSequence seq;
-    EXPECT_CALL(*surface, consume(mt::TouchEvent(0,0))).Times(1);
-    EXPECT_CALL(*surface, consume(mt::TouchUpEvent(0,0))).Times(1);
+    EXPECT_CALL(*surface, consume(mt::TouchEvent(1,1))).Times(1);
+    EXPECT_CALL(*surface, consume(mt::TouchUpEvent(1,1))).Times(1);
 
     dispatcher.start();
 
@@ -497,16 +497,16 @@ TEST_F(SurfaceInputDispatcher, touch_delivered_only_to_top_surface)
     auto surface = scene.add_surface({{1, 1}, {3, 3}});
 
     InSequence seq;
-    EXPECT_CALL(*surface, consume(mt::TouchEvent(0,0))).Times(1);
+    EXPECT_CALL(*surface, consume(mt::TouchEvent(1,1))).Times(1);
     EXPECT_CALL(*surface, consume(mt::TouchUpEvent(1,1))).Times(1);
-    EXPECT_CALL(*bottom_surface, consume(mt::TouchEvent(0,0))).Times(0);
-    EXPECT_CALL(*bottom_surface, consume(mt::TouchUpEvent(0,0))).Times(0);
+    EXPECT_CALL(*bottom_surface, consume(mt::TouchEvent(1,1))).Times(0);
+    EXPECT_CALL(*bottom_surface, consume(mt::TouchUpEvent(1,1))).Times(0);
 
     dispatcher.start();
 
     FakeToucher toucher;
     EXPECT_TRUE(dispatcher.dispatch(toucher.touch_at({1,1})));
-    EXPECT_TRUE(dispatcher.dispatch(toucher.release_at({2,2})));
+    EXPECT_TRUE(dispatcher.dispatch(toucher.release_at({1,1})));
 }
 
 TEST_F(SurfaceInputDispatcher, gestures_persist_over_touch_down)


### PR DESCRIPTION
Reverts #2945, which reverted #2785. SSDs now use local positions which fixes #2943.