### PR TITLE
[spike] drag-n-drop

### DIFF
--- a/src/include/server/mir/default_server_configuration.h
+++ b/src/include/server/mir/default_server_configuration.h
@@ -61,6 +61,7 @@ class DisplayChanger;
 class DragIconController;
 class EventSink;
 class InputConfigurationChanger;
+class PointerInputDispatcher;
 class SessionAuthorizer;
 class SurfaceStack;
 }
@@ -254,6 +255,7 @@ public:
     virtual std::shared_ptr<frontend::SessionAuthorizer>      the_session_authorizer();
     virtual std::shared_ptr<frontend::DisplayChanger>         the_frontend_display_changer();
     virtual std::shared_ptr<frontend::DragIconController>     the_drag_icon_controller();
+    virtual std::shared_ptr<frontend::PointerInputDispatcher> the_pointer_input_dispatcher();
     /** @name frontend configuration - internal dependencies
      * internal dependencies of frontend
      *  @{ */

--- a/src/include/server/mir/frontend/pointer_input_dispatcher.h
+++ b/src/include/server/mir/frontend/pointer_input_dispatcher.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_FRONTEND_POINTER_INPUT_DISPATCHER_H_
+#define MIR_FRONTEND_POINTER_INPUT_DISPATCHER_H_
+
+#include <memory>
+
+namespace mir
+{
+namespace scene { class Surface; }
+
+namespace frontend
+{
+
+/// An interface to modify the routing of pointer events
+class PointerInputDispatcher
+{
+public:
+    virtual ~PointerInputDispatcher() = default;
+
+    // Sometimes (e.g. drag-n-drop) the frontend wants routing to ignore the surface on which gestures start
+    virtual void start_ignore_gesture_owner() = 0;
+    virtual void end_ignore_gesture_owner() = 0;
+
+protected:
+    PointerInputDispatcher() = default;
+    PointerInputDispatcher(PointerInputDispatcher const&) = delete;
+    PointerInputDispatcher& operator=(PointerInputDispatcher const&) = delete;
+};
+
+}
+}
+
+#endif // MIR_FRONTEND_POINTER_INPUT_DISPATCHER_H_

--- a/src/include/server/mir/scene/clipboard.h
+++ b/src/include/server/mir/scene/clipboard.h
@@ -39,6 +39,8 @@ public:
     /// does not remain locked when notifying observers, so clipboard->paste_source() may return a different value than
     /// source.
     virtual void paste_source_set(std::shared_ptr<DataExchangeSource> const& source) = 0;
+    virtual void drag_n_drop_source_set(std::shared_ptr<DataExchangeSource> const& source) { (void)source; }
+    virtual void drag_n_drop_source_cleared(std::shared_ptr<DataExchangeSource> const& source) { (void)source; }
 
 private:
     ClipboardObserver(ClipboardObserver const&) = delete;
@@ -60,6 +62,11 @@ public:
 
     /// Clears the current copy-paste source ONLY if it is the same as the given source, otherwise does nothing.
     virtual void clear_paste_source(DataExchangeSource const& source) = 0;
+
+    /// Sets the given source to be the current drag & drop source for all clients.
+    virtual void set_drag_n_drop_source(std::shared_ptr<DataExchangeSource> const& source) = 0;
+    /// Clears the current drag-n-drop source ONLY if it is the same as the given source, otherwise does nothing.
+    virtual void clear_drag_n_drop_source(std::shared_ptr<DataExchangeSource> const& source) = 0;
 };
 }
 }

--- a/src/include/server/mir/scene/data_exchange.h
+++ b/src/include/server/mir/scene/data_exchange.h
@@ -53,6 +53,10 @@ public:
     /// target accepted a mime type
     virtual void offer_accepted(std::optional<std::string> const& mime_type) {(void)mime_type; }
 
+    /// target indicated an action
+    virtual uint32_t offer_set_actions(uint32_t dnd_actions, uint32_t preferred_action)
+        { (void)dnd_actions; (void)preferred_action; return 0; }
+
 private:
     DataExchangeSource(DataExchangeSource const&) = delete;
     DataExchangeSource& operator=(DataExchangeSource const&) = delete;

--- a/src/include/server/mir/scene/data_exchange.h
+++ b/src/include/server/mir/scene/data_exchange.h
@@ -19,8 +19,9 @@
 
 #include "mir/fd.h"
 
-#include <vector>
+#include <optional>
 #include <string>
+#include <vector>
 
 namespace mir
 {
@@ -48,6 +49,9 @@ public:
 
     /// The DnD actions supported
     virtual auto actions() -> uint32_t { return 0; }
+
+    /// target accepted a mime type
+    virtual void offer_accepted(std::optional<std::string> const& mime_type) {(void)mime_type; }
 
 private:
     DataExchangeSource(DataExchangeSource const&) = delete;

--- a/src/include/server/mir/scene/data_exchange.h
+++ b/src/include/server/mir/scene/data_exchange.h
@@ -40,6 +40,15 @@ public:
     /// Instructs the source to start sending it's data in the given mime type to the given fd.
     virtual void initiate_send(std::string const& mime_type, Fd const& target_fd) = 0;
 
+    /// The destination has cancelled the (DnD) transfer
+    virtual void cancelled() {}
+
+    /// The user has dropped the (DnD) transfer
+    virtual void dnd_drop_performed() {}
+
+    /// The DnD actions supported
+    virtual auto actions() -> uint32_t { return 0; }
+
 private:
     DataExchangeSource(DataExchangeSource const&) = delete;
     DataExchangeSource& operator=(DataExchangeSource const&) = delete;

--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -54,6 +54,7 @@ set(
   ${CMAKE_CURRENT_BINARY_DIR}/wayland_frontend.tp.h
   std_layout_uptr.h
   shm.cpp                       shm.h
+  ${PROJECT_SOURCE_DIR}/src/include/server/mir/frontend/pointer_input_dispatcher.h
 )
 
 add_custom_command(

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -222,6 +222,7 @@ mf::WaylandConnector::WaylandConnector(
     std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> const& keyboard_observer_registrar,
     std::shared_ptr<mi::InputDeviceRegistry> const& input_device_registry,
     std::shared_ptr<mi::CompositeEventFilter> const& composite_event_filter,
+    std::shared_ptr<DragIconController> drag_icon_controller,
     std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
     std::shared_ptr<mf::SessionAuthorizer> const& session_authorizer,
     std::shared_ptr<SurfaceStack> const& surface_stack,
@@ -292,7 +293,11 @@ mf::WaylandConnector::WaylandConnector(
         executor,
         display_config_registrar);
 
-    data_device_manager_global = std::make_unique<WlDataDeviceManager>(display.get(), executor, main_clipboard);
+    data_device_manager_global = std::make_unique<WlDataDeviceManager>(
+        display.get(),
+        executor,
+        main_clipboard,
+        std::move(drag_icon_controller));
 
     extensions->init(WaylandExtensions::Context{
         display.get(),

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -223,6 +223,7 @@ mf::WaylandConnector::WaylandConnector(
     std::shared_ptr<mi::InputDeviceRegistry> const& input_device_registry,
     std::shared_ptr<mi::CompositeEventFilter> const& composite_event_filter,
     std::shared_ptr<DragIconController> drag_icon_controller,
+    std::shared_ptr<PointerInputDispatcher> pointer_input_dispatcher,
     std::shared_ptr<mg::GraphicBufferAllocator> const& allocator,
     std::shared_ptr<mf::SessionAuthorizer> const& session_authorizer,
     std::shared_ptr<SurfaceStack> const& surface_stack,
@@ -297,7 +298,8 @@ mf::WaylandConnector::WaylandConnector(
         display.get(),
         executor,
         main_clipboard,
-        std::move(drag_icon_controller));
+        std::move(drag_icon_controller),
+        std::move(pointer_input_dispatcher));
 
     extensions->init(WaylandExtensions::Context{
         display.get(),

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -18,8 +18,10 @@
 #define MIR_FRONTEND_WAYLAND_CONNECTOR_H_
 
 #include "wayland_wrapper.h"
-#include "mir/frontend/connector.h"
+
 #include "mir/fd.h"
+#include "mir/frontend/connector.h"
+#include "mir/frontend/drag_icon_controller.h"
 #include "mir/optional_value.h"
 
 #include <wayland-server-core.h>
@@ -27,13 +29,18 @@
 #include <unordered_set>
 #include <thread>
 #include <vector>
-#include <mir/server_configuration.h>
 
 namespace mir
 {
 class Executor;
+class MainLoop;
 template<typename>
 class ObserverRegistrar;
+
+namespace compositor
+{
+class ScreenShooter;
+}
 
 namespace input
 {
@@ -54,7 +61,10 @@ class Shell;
 }
 namespace scene
 {
+class Clipboard;
+class IdleHub;
 class Surface;
+class TextInputHub;
 }
 namespace time
 {
@@ -129,6 +139,7 @@ public:
         std::shared_ptr<ObserverRegistrar<input::KeyboardObserver>> const& keyboard_observer_registrar,
         std::shared_ptr<input::InputDeviceRegistry> const& input_device_registry,
         std::shared_ptr<input::CompositeEventFilter> const& composite_event_filter,
+        std::shared_ptr<frontend::DragIconController> drag_icon_controller,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
         std::shared_ptr<SessionAuthorizer> const& session_authorizer,
         std::shared_ptr<SurfaceStack> const& surface_stack,

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -72,16 +72,17 @@ class Clock;
 }
 namespace frontend
 {
-class WlCompositor;
-class WlSubcompositor;
-class WlApplication;
-class WlSeat;
 class OutputManager;
+class PointerInputDispatcher;
 class SessionAuthorizer;
-class WlDataDeviceManager;
-class WlSurface;
 class SurfaceStack;
+class WlApplication;
+class WlCompositor;
+class WlDataDeviceManager;
+class WlSeat;
 class WlShm;
+class WlSubcompositor;
+class WlSurface;
 
 class WaylandExtensions
 {
@@ -140,6 +141,7 @@ public:
         std::shared_ptr<input::InputDeviceRegistry> const& input_device_registry,
         std::shared_ptr<input::CompositeEventFilter> const& composite_event_filter,
         std::shared_ptr<frontend::DragIconController> drag_icon_controller,
+        std::shared_ptr<PointerInputDispatcher> pointer_input_dispatcher,
         std::shared_ptr<graphics::GraphicBufferAllocator> const& allocator,
         std::shared_ptr<SessionAuthorizer> const& session_authorizer,
         std::shared_ptr<SurfaceStack> const& surface_stack,

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -319,6 +319,7 @@ std::shared_ptr<mf::Connector>
                 the_input_device_registry(),
                 the_composite_event_filter(),
                 the_drag_icon_controller(),
+                the_pointer_input_dispatcher(),
                 the_buffer_allocator(),
                 the_session_authorizer(),
                 the_frontend_surface_stack(),

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -318,6 +318,7 @@ std::shared_ptr<mf::Connector>
                 the_keyboard_observer_registrar(),
                 the_input_device_registry(),
                 the_composite_event_filter(),
+                the_drag_icon_controller(),
                 the_buffer_allocator(),
                 the_session_authorizer(),
                 the_frontend_surface_stack(),

--- a/src/server/frontend_wayland/wayland_input_dispatcher.cpp
+++ b/src/server/frontend_wayland/wayland_input_dispatcher.cpp
@@ -52,7 +52,7 @@ void mf::WaylandInputDispatcher::handle_event(std::shared_ptr<MirInputEvent cons
     case mir_input_event_type_pointer:
     {
         auto const pointer_event = dynamic_pointer_cast<MirPointerEvent const>(event);
-        seat->for_each_listener(wl_surface.value().client, [&](WlPointer* pointer)
+        seat->for_each_listener(wl_surface.value().client, [&](PointerEventDispatcher* pointer)
             {
                 pointer->event(pointer_event, wl_surface.value());
             });

--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -90,7 +90,7 @@ public:
 
     void set_actions(uint32_t dnd_actions, uint32_t preferred_action) override
     {
-        (void)dnd_actions, (void)preferred_action;
+        send_action_event_if_supported(source->offer_set_actions(dnd_actions, preferred_action));
     }
 
 private:
@@ -110,9 +110,9 @@ mf::WlDataDevice::Offer::Offer(WlDataDevice* device, std::shared_ptr<ms::DataExc
     {
         send_offer_event(type);
     }
-    
-    send_action_event(0);
-    send_source_actions_event_if_supported(mf::WlDataDevice::Offer::source->actions());
+
+    send_action_event_if_supported(mw::DataDeviceManager::DndAction::none);
+    send_source_actions_event_if_supported(source->actions());
 }
 
 void mf::WlDataDevice::Offer::receive(std::string const& mime_type, mir::Fd fd)

--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -212,21 +212,7 @@ void mf::WlDataDevice::start_drag(
             mw::ProtocolError(resource, Error::role, "Origin surface does not exist."));
     }
 
-    // TODO {arg} does this check really belong in DataDevice?
-    auto const drag_event = client->event_for(serial);
-
-    if (!drag_event || !drag_event.value() || mir_event_get_type(drag_event.value().get()) != mir_event_type_input)
-    {
-        BOOST_THROW_EXCEPTION(
-            mw::ProtocolError(resource, Error::role, "Serial does not correspond to an input event"));
-    }
-
-    auto const input_ev = mir_event_get_input_event(drag_event.value().get());
-    if (mir_input_event_get_type(input_ev) != mir_input_event_type_pointer)
-    {
-        BOOST_THROW_EXCEPTION(
-            mw::ProtocolError(resource, Error::role, "Serial does not correspond to a pointer event"));
-    }
+    validate_pointer_event(client->event_for(serial));
 
     if (auto const wl_source = WlDataSource::from(source.value()))
     {
@@ -238,6 +224,22 @@ void mf::WlDataDevice::start_drag(
 
             drag_surface.emplace(icon_surface, drag_icon_controller);
         }
+    }
+}
+
+void mf::WlDataDevice::validate_pointer_event(std::optional<std::shared_ptr<MirEvent const>> drag_event) const
+{
+    if (!drag_event || !drag_event.value() || mir_event_get_type(drag_event.value().get()) != mir_event_type_input)
+    {
+        BOOST_THROW_EXCEPTION(
+            mw::ProtocolError(this->resource, Error::role, "Serial does not correspond to an input event"));
+    }
+
+    auto const input_ev = mir_event_get_input_event(drag_event.value().get());
+    if (mir_input_event_get_type(input_ev) != mir_input_event_type_pointer)
+    {
+        BOOST_THROW_EXCEPTION(
+            mw::ProtocolError(this->resource, Error::role, "Serial does not correspond to a pointer event"));
     }
 }
 

--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -75,6 +75,7 @@ public:
     {
         (void)serial;
         accepted_mime_type = mime_type;
+        source->offer_accepted(mime_type);
     }
 
     void receive(std::string const& mime_type, mir::Fd fd) override;

--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -93,11 +93,13 @@ mf::WlDataDevice::WlDataDevice(
     wl_resource* new_resource,
     Executor& wayland_executor,
     scene::Clipboard& clipboard,
-    mf::WlSeat& seat)
+    mf::WlSeat& seat,
+    std::shared_ptr<DragIconController> drag_icon_controller)
     : mw::DataDevice(new_resource, Version<3>()),
       clipboard{clipboard},
       seat{seat},
-      clipboard_observer{std::make_shared<ClipboardObserver>(this)}
+      clipboard_observer{std::make_shared<ClipboardObserver>(this)},
+      drag_icon_controller{std::move(drag_icon_controller)}
 {
     clipboard.register_interest(clipboard_observer, wayland_executor);
     // this will call focus_on() with the initial state

--- a/src/server/frontend_wayland/wl_data_device.cpp
+++ b/src/server/frontend_wayland/wl_data_device.cpp
@@ -192,24 +192,30 @@ void mf::WlDataDevice::start_drag(
         BOOST_THROW_EXCEPTION(
             mw::ProtocolError(resource, Error::role, "Origin surface does not exist."));
     }
- 
+
+    auto const drag_event = client->event_for(serial);
+
+    if (!drag_event || !drag_event.value() || mir_event_get_type(drag_event.value().get()) != mir_event_type_input)
+    {
+        BOOST_THROW_EXCEPTION(
+            mw::ProtocolError(resource, Error::role, "Serial does not correspond to an input event"));
+    }
+
+    auto const input_ev = mir_event_get_input_event(drag_event.value().get());
+    if (mir_input_event_get_type(input_ev) != mir_input_event_type_pointer)
+    {
+        BOOST_THROW_EXCEPTION(
+            mw::ProtocolError(resource, Error::role, "Serial does not correspond to a pointer event"));
+    }
+
+    // TODO {arg} start the drag logic
+
     if (icon)
     {
         auto const icon_surface = WlSurface::from(icon.value());
 
-        auto const drag_event = client->event_for(serial);
-        if (drag_event && drag_event.value() && mir_event_get_type(drag_event.value().get()) == mir_event_type_input)
-        {
-            auto const input_ev = mir_event_get_input_event(drag_event.value().get());
-            auto const& ev_type = mir_input_event_get_type(input_ev);
-            if (ev_type == mir_input_event_type_pointer)
-            {
-                drag_surface.emplace(icon_surface, drag_icon_controller);
-            }
-        }
+        drag_surface.emplace(icon_surface, drag_icon_controller);
     }
-
-    // TODO {arg} start the drag logic
 }
 
 void mf::WlDataDevice::focus_on(WlSurface* surface)

--- a/src/server/frontend_wayland/wl_data_device.h
+++ b/src/server/frontend_wayland/wl_data_device.h
@@ -19,6 +19,7 @@
 
 #include "wayland_wrapper.h"
 #include "wl_seat.h"
+#include "wl_surface.h"
 
 namespace mir
 {
@@ -31,6 +32,8 @@ class DataExchangeSource;
 
 namespace frontend
 {
+class DragIconController;
+
 class WlDataDevice : public wayland::DataDevice, public WlSeat::FocusListener
 {
 public:
@@ -38,7 +41,8 @@ public:
         wl_resource* new_resource,
         Executor& wayland_executor,
         scene::Clipboard& clipboard,
-        WlSeat& seat);
+        WlSeat& seat,
+        std::shared_ptr<DragIconController> drag_icon_controller);
     ~WlDataDevice();
 
     /// Wayland requests
@@ -65,6 +69,7 @@ private:
     scene::Clipboard& clipboard;
     WlSeat& seat;
     std::shared_ptr<ClipboardObserver> const clipboard_observer;
+    std::shared_ptr<DragIconController> const drag_icon_controller;
     bool has_focus = false;
     wayland::Weak<Offer> current_offer;
 };

--- a/src/server/frontend_wayland/wl_data_device.h
+++ b/src/server/frontend_wayland/wl_data_device.h
@@ -21,6 +21,8 @@
 #include "wl_seat.h"
 #include "wl_surface.h"
 
+#include "mir/events/event.h"
+
 namespace mir
 {
 class Executor;
@@ -84,6 +86,8 @@ private:
     void paste_source_set(std::shared_ptr<scene::DataExchangeSource> const& source);
     void drag_n_drop_source_set(std::shared_ptr<scene::DataExchangeSource> const& source);
     void drag_n_drop_source_cleared(std::shared_ptr<scene::DataExchangeSource> const& source);
+
+    void validate_pointer_event(std::optional<std::shared_ptr<MirEvent const>> drag_event) const;
 
     scene::Clipboard& clipboard;
     WlSeat& seat;

--- a/src/server/frontend_wayland/wl_data_device.h
+++ b/src/server/frontend_wayland/wl_data_device.h
@@ -19,7 +19,6 @@
 
 #include "wayland_wrapper.h"
 #include "wl_seat.h"
-#include "wl_surface.h"
 
 #include "mir/events/event.h"
 
@@ -34,24 +33,6 @@ class DataExchangeSource;
 
 namespace frontend
 {
-class DragIconController;
-class PointerInputDispatcher;
-
-class DragIconSurface : public NullWlSurfaceRole
-{
-public:
-    DragIconSurface(WlSurface* icon, std::shared_ptr<DragIconController> drag_icon_controller);
-    ~DragIconSurface();
-
-    auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>> override;
-
-private:
-    wayland::Weak<WlSurface> const surface;
-    std::shared_ptr<scene::Surface> shared_scene_surface;
-    std::shared_ptr<DragIconController> const drag_icon_controller;
-
-};
-
 class WlDataDevice : public wayland::DataDevice, public WlSeat::FocusListener
 {
 public:
@@ -59,9 +40,7 @@ public:
         wl_resource* new_resource,
         Executor& wayland_executor,
         scene::Clipboard& clipboard,
-        WlSeat& seat,
-        std::shared_ptr<DragIconController> drag_icon_controller,
-        std::shared_ptr<PointerInputDispatcher> pointer_input_dispatcher);
+        WlSeat& seat);
     ~WlDataDevice();
 
     /// Wayland requests
@@ -94,13 +73,10 @@ private:
     scene::Clipboard& clipboard;
     WlSeat& seat;
     std::shared_ptr<ClipboardObserver> const clipboard_observer;
-    std::shared_ptr<DragIconController> const drag_icon_controller;
-    std::shared_ptr<PointerInputDispatcher> const pointer_input_dispatcher;
     bool has_focus = false;
     std::weak_ptr<scene::DataExchangeSource> weak_source;
     wayland::Weak<Offer> current_offer;
     wayland::Weak<WlSurface> weak_surface;
-    std::optional<DragIconSurface> drag_surface;
     bool sent_enter = false;
 };
 }

--- a/src/server/frontend_wayland/wl_data_device.h
+++ b/src/server/frontend_wayland/wl_data_device.h
@@ -35,6 +35,7 @@ class DataExchangeSource;
 namespace frontend
 {
 class DragIconController;
+class PointerInputDispatcher;
 
 class DragIconSurface : public NullWlSurfaceRole
 {
@@ -59,7 +60,8 @@ public:
         Executor& wayland_executor,
         scene::Clipboard& clipboard,
         WlSeat& seat,
-        std::shared_ptr<DragIconController> drag_icon_controller);
+        std::shared_ptr<DragIconController> drag_icon_controller,
+        std::shared_ptr<PointerInputDispatcher> pointer_input_dispatcher);
     ~WlDataDevice();
 
     /// Wayland requests
@@ -93,7 +95,9 @@ private:
     WlSeat& seat;
     std::shared_ptr<ClipboardObserver> const clipboard_observer;
     std::shared_ptr<DragIconController> const drag_icon_controller;
+    std::shared_ptr<PointerInputDispatcher> const pointer_input_dispatcher;
     bool has_focus = false;
+    std::weak_ptr<scene::DataExchangeSource> weak_source;
     wayland::Weak<Offer> current_offer;
     wayland::Weak<WlSurface> weak_surface;
     std::optional<DragIconSurface> drag_surface;

--- a/src/server/frontend_wayland/wl_data_device.h
+++ b/src/server/frontend_wayland/wl_data_device.h
@@ -34,6 +34,21 @@ namespace frontend
 {
 class DragIconController;
 
+class DragWlSurface : public NullWlSurfaceRole
+{
+public:
+    DragWlSurface(WlSurface* icon, std::shared_ptr<DragIconController> drag_icon_controller);
+    ~DragWlSurface();
+
+    auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>> override;
+
+private:
+    wayland::Weak<WlSurface> const surface;
+    std::shared_ptr<scene::Surface> shared_scene_surface;
+    std::shared_ptr<DragIconController> const drag_icon_controller;
+
+};
+
 class WlDataDevice : public wayland::DataDevice, public WlSeat::FocusListener
 {
 public:
@@ -48,11 +63,11 @@ public:
     /// Wayland requests
     /// @{
     void start_drag(
-        std::optional<wl_resource*> const& source, wl_resource* origin,
-        std::optional<wl_resource*> const& icon, uint32_t serial) override
-    {
-        (void)source, (void)origin, (void)icon, (void)serial;
-    }
+        std::optional<wl_resource*> const& source,
+        wl_resource* origin,
+        std::optional<wl_resource*> const& icon,
+        uint32_t serial) override;
+
     void set_selection(std::optional<wl_resource*> const& source, uint32_t serial) override;
     /// @}
 
@@ -72,6 +87,7 @@ private:
     std::shared_ptr<DragIconController> const drag_icon_controller;
     bool has_focus = false;
     wayland::Weak<Offer> current_offer;
+    std::optional<DragWlSurface> drag_surface;
 };
 }
 }

--- a/src/server/frontend_wayland/wl_data_device.h
+++ b/src/server/frontend_wayland/wl_data_device.h
@@ -34,11 +34,11 @@ namespace frontend
 {
 class DragIconController;
 
-class DragWlSurface : public NullWlSurfaceRole
+class DragIconSurface : public NullWlSurfaceRole
 {
 public:
-    DragWlSurface(WlSurface* icon, std::shared_ptr<DragIconController> drag_icon_controller);
-    ~DragWlSurface();
+    DragIconSurface(WlSurface* icon, std::shared_ptr<DragIconController> drag_icon_controller);
+    ~DragIconSurface();
 
     auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>> override;
 
@@ -71,6 +71,8 @@ public:
     void set_selection(std::optional<wl_resource*> const& source, uint32_t serial) override;
     /// @}
 
+    void event(std::shared_ptr<MirPointerEvent const> const& event, WlSurface& root_surface);
+
 private:
     class ClipboardObserver;
     class Offer;
@@ -80,6 +82,8 @@ private:
 
     /// Called by the clipboard observer
     void paste_source_set(std::shared_ptr<scene::DataExchangeSource> const& source);
+    void drag_n_drop_source_set(std::shared_ptr<scene::DataExchangeSource> const& source);
+    void drag_n_drop_source_cleared(std::shared_ptr<scene::DataExchangeSource> const& source);
 
     scene::Clipboard& clipboard;
     WlSeat& seat;
@@ -87,7 +91,8 @@ private:
     std::shared_ptr<DragIconController> const drag_icon_controller;
     bool has_focus = false;
     wayland::Weak<Offer> current_offer;
-    std::optional<DragWlSurface> drag_surface;
+    wayland::Weak<WlSurface> weak_surface;
+    std::optional<DragIconSurface> drag_surface;
 };
 }
 }

--- a/src/server/frontend_wayland/wl_data_device.h
+++ b/src/server/frontend_wayland/wl_data_device.h
@@ -93,6 +93,7 @@ private:
     wayland::Weak<Offer> current_offer;
     wayland::Weak<WlSurface> weak_surface;
     std::optional<DragIconSurface> drag_surface;
+    bool sent_enter = false;
 };
 }
 }

--- a/src/server/frontend_wayland/wl_data_device_manager.cpp
+++ b/src/server/frontend_wayland/wl_data_device_manager.cpp
@@ -26,10 +26,12 @@ namespace mw = mir::wayland;
 mf::WlDataDeviceManager::WlDataDeviceManager(
     struct wl_display* display,
     std::shared_ptr<mir::Executor> const& wayland_executor,
-    std::shared_ptr<ms::Clipboard> const& clipboard) :
+    std::shared_ptr<ms::Clipboard> const& clipboard,
+    std::shared_ptr<DragIconController> drag_icon_controller) :
     Global(display, Version<3>()),
     wayland_executor{wayland_executor},
-    clipboard{clipboard}
+    clipboard{clipboard},
+    drag_icon_controller{std::move(drag_icon_controller)}
 {
 }
 
@@ -51,7 +53,12 @@ void mf::WlDataDeviceManager::Instance::create_data_source(wl_resource* new_data
 void mf::WlDataDeviceManager::Instance::get_data_device(wl_resource* new_data_device, wl_resource* seat)
 {
     auto const realseat = mf::WlSeat::from(seat);
-    new WlDataDevice{new_data_device, *manager->wayland_executor, *manager->clipboard, *realseat};
+    new WlDataDevice{
+        new_data_device,
+        *manager->wayland_executor,
+        *manager->clipboard,
+        *realseat,
+        manager->drag_icon_controller};
 }
 
 void mf::WlDataDeviceManager::bind(wl_resource* new_resource)

--- a/src/server/frontend_wayland/wl_data_device_manager.cpp
+++ b/src/server/frontend_wayland/wl_data_device_manager.cpp
@@ -18,6 +18,7 @@
 #include "wl_data_device.h"
 #include "wl_data_source.h"
 #include "wl_seat.h"
+#include "mir/frontend/pointer_input_dispatcher.h"
 
 namespace mf = mir::frontend;
 namespace ms = mir::scene;
@@ -27,11 +28,13 @@ mf::WlDataDeviceManager::WlDataDeviceManager(
     struct wl_display* display,
     std::shared_ptr<mir::Executor> const& wayland_executor,
     std::shared_ptr<ms::Clipboard> const& clipboard,
-    std::shared_ptr<DragIconController> drag_icon_controller) :
+    std::shared_ptr<DragIconController> drag_icon_controller,
+    std::shared_ptr<PointerInputDispatcher> pointer_input_dispatcher) :
     Global(display, Version<3>()),
     wayland_executor{wayland_executor},
     clipboard{clipboard},
-    drag_icon_controller{std::move(drag_icon_controller)}
+    drag_icon_controller{std::move(drag_icon_controller)},
+    pointer_input_dispatcher{std::move(pointer_input_dispatcher)}
 {
 }
 
@@ -58,7 +61,8 @@ void mf::WlDataDeviceManager::Instance::get_data_device(wl_resource* new_data_de
         *manager->wayland_executor,
         *manager->clipboard,
         *realseat,
-        manager->drag_icon_controller};
+        manager->drag_icon_controller,
+        manager->pointer_input_dispatcher};
 }
 
 void mf::WlDataDeviceManager::bind(wl_resource* new_resource)

--- a/src/server/frontend_wayland/wl_data_device_manager.cpp
+++ b/src/server/frontend_wayland/wl_data_device_manager.cpp
@@ -50,7 +50,12 @@ mf::WlDataDeviceManager::Instance::Instance(wl_resource* new_resource, WlDataDev
 
 void mf::WlDataDeviceManager::Instance::create_data_source(wl_resource* new_data_source)
 {
-    new WlDataSource{new_data_source, manager->wayland_executor, *manager->clipboard};
+    new WlDataSource{
+        new_data_source,
+        manager->wayland_executor,
+        *manager->clipboard,
+        manager->drag_icon_controller,
+        manager->pointer_input_dispatcher};
 }
 
 void mf::WlDataDeviceManager::Instance::get_data_device(wl_resource* new_data_device, wl_resource* seat)
@@ -60,9 +65,7 @@ void mf::WlDataDeviceManager::Instance::get_data_device(wl_resource* new_data_de
         new_data_device,
         *manager->wayland_executor,
         *manager->clipboard,
-        *realseat,
-        manager->drag_icon_controller,
-        manager->pointer_input_dispatcher};
+        *realseat};
 }
 
 void mf::WlDataDeviceManager::bind(wl_resource* new_resource)

--- a/src/server/frontend_wayland/wl_data_device_manager.h
+++ b/src/server/frontend_wayland/wl_data_device_manager.h
@@ -29,18 +29,22 @@ class Clipboard;
 
 namespace frontend
 {
+class DragIconController;
+
 class WlDataDeviceManager : public wayland::DataDeviceManager::Global
 {
 public:
     WlDataDeviceManager(
         struct wl_display* display,
         std::shared_ptr<Executor> const& wayland_executor,
-        std::shared_ptr<scene::Clipboard> const& clipboard);
+        std::shared_ptr<scene::Clipboard> const& clipboard,
+        std::shared_ptr<DragIconController> drag_icon_controller);
     ~WlDataDeviceManager();
 
 private:
     std::shared_ptr<Executor> const wayland_executor;
     std::shared_ptr<scene::Clipboard> const clipboard;
+    std::shared_ptr<DragIconController> const drag_icon_controller;
 
     void bind(wl_resource* new_resource) override;
 

--- a/src/server/frontend_wayland/wl_data_device_manager.h
+++ b/src/server/frontend_wayland/wl_data_device_manager.h
@@ -30,6 +30,7 @@ class Clipboard;
 namespace frontend
 {
 class DragIconController;
+class PointerInputDispatcher;
 
 class WlDataDeviceManager : public wayland::DataDeviceManager::Global
 {
@@ -38,13 +39,15 @@ public:
         struct wl_display* display,
         std::shared_ptr<Executor> const& wayland_executor,
         std::shared_ptr<scene::Clipboard> const& clipboard,
-        std::shared_ptr<DragIconController> drag_icon_controller);
+        std::shared_ptr<DragIconController> drag_icon_controller,
+        std::shared_ptr<PointerInputDispatcher> pointer_input_dispatcher);
     ~WlDataDeviceManager();
 
 private:
     std::shared_ptr<Executor> const wayland_executor;
     std::shared_ptr<scene::Clipboard> const clipboard;
     std::shared_ptr<DragIconController> const drag_icon_controller;
+    std::shared_ptr<PointerInputDispatcher> pointer_input_dispatcher;
 
     void bind(wl_resource* new_resource) override;
 

--- a/src/server/frontend_wayland/wl_data_source.cpp
+++ b/src/server/frontend_wayland/wl_data_source.cpp
@@ -174,6 +174,18 @@ public:
         }
     }
 
+    void offer_accepted(const std::optional<std::string> &mime_type) override
+    {
+        if (wl_data_source)
+        {
+            wl_data_source.value().send_target_event(mime_type);
+        }
+        else
+        {
+            return DataExchangeSource::offer_accepted(mime_type);
+        }
+    }
+
 private:
     std::shared_ptr<Executor> const wayland_executor;
     wayland::Weak<WlDataSource> const wl_data_source;

--- a/src/server/frontend_wayland/wl_data_source.cpp
+++ b/src/server/frontend_wayland/wl_data_source.cpp
@@ -86,6 +86,34 @@ public:
             });
     }
 
+    void cancelled() override
+    {
+        if (wl_data_source)
+        {
+            wl_data_source.value().send_cancelled_event();
+        }
+    }
+
+    void dnd_drop_performed() override
+    {
+        if (wl_data_source)
+        {
+            return wl_data_source.value().send_dnd_drop_performed_event_if_supported();
+        }
+    }
+
+    auto actions() -> uint32_t override
+    {
+        if (wl_data_source)
+        {
+            return wl_data_source.value().dnd_actions;
+        }
+        else
+        {
+            return DataExchangeSource::actions();
+        }
+    }
+
 private:
     std::shared_ptr<Executor> const wayland_executor;
     wayland::Weak<WlDataSource> const wl_data_source;
@@ -178,8 +206,12 @@ void mf::WlDataSource::drag_n_drop_source_cleared(std::shared_ptr<scene::DataExc
 {
     if (source && dnd_source.lock() == source)
     {
-        send_dnd_drop_performed_event_if_supported();
         dnd_source.reset();
         dnd_source_source_is_ours = false;
     }
+}
+
+void mir::frontend::WlDataSource::set_actions(uint32_t dnd_actions)
+{
+    this->dnd_actions = dnd_actions;
 }

--- a/src/server/frontend_wayland/wl_data_source.h
+++ b/src/server/frontend_wayland/wl_data_source.h
@@ -47,10 +47,7 @@ public:
     /// Wayland requests
     /// @{
     void offer(std::string const& mime_type) override;
-    void set_actions(uint32_t dnd_actions) override
-    {
-        (void)dnd_actions;
-    }
+    void set_actions(uint32_t dnd_actions) override;
     /// @}
 
 private:
@@ -70,6 +67,7 @@ private:
 
     std::weak_ptr<scene::DataExchangeSource> dnd_source;
     bool dnd_source_source_is_ours{false};
+    uint32_t dnd_actions;
 };
 }
 }

--- a/src/server/frontend_wayland/wl_data_source.h
+++ b/src/server/frontend_wayland/wl_data_source.h
@@ -42,6 +42,7 @@ public:
     static auto from(struct wl_resource* resource) -> WlDataSource*;
 
     void set_clipboard_paste_source();
+    void set_drag_n_drop_source();
 
     /// Wayland requests
     /// @{
@@ -57,6 +58,8 @@ private:
     class Source;
 
     void paste_source_set(std::shared_ptr<scene::DataExchangeSource> const& source);
+    void drag_n_drop_source_set(std::shared_ptr<scene::DataExchangeSource> const& source);
+    void drag_n_drop_source_cleared(std::shared_ptr<scene::DataExchangeSource> const& source);
 
     std::shared_ptr<Executor> const wayland_executor;
     scene::Clipboard& clipboard;
@@ -64,6 +67,9 @@ private:
     std::vector<std::string> mime_types;
     std::weak_ptr<scene::DataExchangeSource> paste_source;
     bool clipboards_paste_source_is_ours{false};
+
+    std::weak_ptr<scene::DataExchangeSource> dnd_source;
+    bool dnd_source_source_is_ours{false};
 };
 }
 }

--- a/src/server/frontend_wayland/wl_data_source.h
+++ b/src/server/frontend_wayland/wl_data_source.h
@@ -18,6 +18,7 @@
 #define MIR_FRONTEND_WL_DATA_SOURCE_H_
 
 #include "wayland_wrapper.h"
+#include "wl_surface.h"
 
 namespace mir
 {
@@ -30,19 +31,24 @@ class DataExchangeSource;
 
 namespace frontend
 {
+class DragIconController;
+class PointerInputDispatcher;
+
 class WlDataSource : public wayland::DataSource
 {
 public:
     WlDataSource(
         wl_resource* new_resource,
         std::shared_ptr<Executor> const& wayland_executor,
-        scene::Clipboard& clipboard);
+        scene::Clipboard& clipboard,
+        std::shared_ptr<DragIconController> drag_icon_controller,
+        std::shared_ptr<PointerInputDispatcher> pointer_input_dispatcher);
     ~WlDataSource();
 
     static auto from(struct wl_resource* resource) -> WlDataSource*;
 
     void set_clipboard_paste_source();
-    void set_drag_n_drop_source();
+    void start_drag_n_drop_gesture(std::optional<wl_resource*> const& icon);
 
     /// Wayland requests
     /// @{
@@ -51,16 +57,32 @@ public:
     /// @}
 
 private:
+    class DragIconSurface : public NullWlSurfaceRole
+    {
+    public:
+        DragIconSurface(WlSurface* icon, std::shared_ptr<DragIconController> drag_icon_controller);
+        ~DragIconSurface();
+
+        auto scene_surface() const -> std::optional<std::shared_ptr<scene::Surface>> override;
+
+    private:
+        wayland::Weak<WlSurface> const surface;
+        std::shared_ptr<scene::Surface> shared_scene_surface;
+        std::shared_ptr<DragIconController> const drag_icon_controller;
+    };
     class ClipboardObserver;
     class Source;
 
     void paste_source_set(std::shared_ptr<scene::DataExchangeSource> const& source);
     void drag_n_drop_source_set(std::shared_ptr<scene::DataExchangeSource> const& source);
     void drag_n_drop_source_cleared(std::shared_ptr<scene::DataExchangeSource> const& source);
+    void end_drag_n_drop_gesture();
 
     std::shared_ptr<Executor> const wayland_executor;
     scene::Clipboard& clipboard;
     std::shared_ptr<ClipboardObserver> const clipboard_observer;
+    std::shared_ptr<DragIconController> const drag_icon_controller;
+    std::shared_ptr<PointerInputDispatcher> const pointer_input_dispatcher;
     std::vector<std::string> mime_types;
     std::weak_ptr<scene::DataExchangeSource> paste_source;
     bool clipboards_paste_source_is_ours{false};
@@ -68,6 +90,7 @@ private:
     std::weak_ptr<scene::DataExchangeSource> dnd_source;
     bool dnd_source_source_is_ours{false};
     uint32_t dnd_actions;
+    std::optional<DragIconSurface> drag_surface;
 };
 }
 }

--- a/src/server/frontend_wayland/wl_data_source.h
+++ b/src/server/frontend_wayland/wl_data_source.h
@@ -77,6 +77,7 @@ private:
     void drag_n_drop_source_set(std::shared_ptr<scene::DataExchangeSource> const& source);
     void drag_n_drop_source_cleared(std::shared_ptr<scene::DataExchangeSource> const& source);
     void end_drag_n_drop_gesture();
+    uint32_t drag_n_drop_set_actions(uint32_t dnd_actions, uint32_t preferred_action);
 
     std::shared_ptr<Executor> const wayland_executor;
     scene::Clipboard& clipboard;

--- a/src/server/frontend_wayland/wl_pointer.cpp
+++ b/src/server/frontend_wayland/wl_pointer.cpp
@@ -342,6 +342,7 @@ void mf::WlPointer::enter_or_motion(std::shared_ptr<MirPointerEvent const> const
         leave(event); // If we're currently on a surface, leave it
         enter_serial = client->next_serial(event);
         cursor->apply_to(target_surface);
+        buttons(event);
         send_enter_event(
             enter_serial.value(),
             target_surface->raw_resource(),

--- a/src/server/frontend_wayland/wl_pointer.h
+++ b/src/server/frontend_wayland/wl_pointer.h
@@ -74,11 +74,11 @@ public:
     /// Convert the Mir event into Wayland events and send them to the client. root_surface is the one that received
     /// the Mir event, but the final Wayland event may be sent to a subsurface.
     void event(std::shared_ptr<MirPointerEvent const> const& event, WlSurface& root_surface);
+    void leave(std::optional<std::shared_ptr<MirPointerEvent const>> const& event);
 
     struct Cursor;
 
 private:
-    void leave(std::optional<std::shared_ptr<MirPointerEvent const>> const& event);
     void buttons(std::shared_ptr<MirPointerEvent const> const& event);
     /// Returns true if any axis events were sent
     template<typename Tag>

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -23,6 +23,7 @@
 #include "wl_keyboard.h"
 #include "wl_pointer.h"
 #include "wl_touch.h"
+#include "wl_data_device.h"
 
 #include "mir/executor.h"
 #include "mir/wayland/client.h"
@@ -370,8 +371,27 @@ mf::PointerEventDispatcher::PointerEventDispatcher(WlPointer* wl_pointer) :
 
 void mf::PointerEventDispatcher::event(std::shared_ptr<MirPointerEvent const> const& event, WlSurface& root_surface)
 {
-    if (wl_pointer)
+    if (wl_data_device)
+    {
+        wl_data_device.value().event(event, root_surface);
+    }
+    else if (wl_pointer)
     {
         wl_pointer.value().event(event, root_surface);
     }
+}
+
+void mf::PointerEventDispatcher::start_dispatch_to_data_device(WlDataDevice* wl_data_device)
+{
+    this->wl_data_device = wayland::Weak<WlDataDevice>{wl_data_device};
+
+    if (wl_pointer)
+    {
+        wl_pointer.value().leave(std::nullopt);
+    }
+}
+
+void mf::PointerEventDispatcher::stop_dispatch_to_data_device()
+{
+    wl_data_device = wayland::Weak<WlDataDevice>{};
 }

--- a/src/server/frontend_wayland/wl_seat.cpp
+++ b/src/server/frontend_wayland/wl_seat.cpp
@@ -35,6 +35,7 @@
 #include "mir/input/mir_keyboard_config.h"
 #include "mir/input/keyboard_observer.h"
 #include "mir/scene/surface.h"
+#include "mir_toolkit/events/input/pointer_event.h"
 
 #include <mutex>
 #include <algorithm>

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -58,8 +58,12 @@ public:
     explicit PointerEventDispatcher(WlPointer* wl_pointer);
 
     void event(std::shared_ptr<MirPointerEvent const> const& event, WlSurface& root_surface);
+
+    void start_dispatch_to_data_device(WlDataDevice* wl_data_device);
+    void stop_dispatch_to_data_device();
 private:
     wayland::Weak<WlPointer> wl_pointer;
+    wayland::Weak<WlDataDevice> wl_data_device;
 };
 
 class WlSeat : public wayland::Seat::Global

--- a/src/server/frontend_wayland/wl_seat.h
+++ b/src/server/frontend_wayland/wl_seat.h
@@ -24,6 +24,8 @@
 #include <vector>
 #include <functional>
 
+struct MirPointerEvent;
+
 namespace mir
 {
 class Executor;
@@ -46,8 +48,19 @@ class WlPointer;
 class WlKeyboard;
 class WlTouch;
 class WlSurface;
+class WlDataDevice;
 class KeyboardCallbacks;
 class KeyboardHelper;
+
+class PointerEventDispatcher
+{
+public:
+    explicit PointerEventDispatcher(WlPointer* wl_pointer);
+
+    void event(std::shared_ptr<MirPointerEvent const> const& event, WlSurface& root_surface);
+private:
+    wayland::Weak<WlPointer> wl_pointer;
+};
 
 class WlSeat : public wayland::Seat::Global
 {
@@ -65,7 +78,7 @@ public:
 
     static auto from(struct wl_resource* resource) -> WlSeat*;
 
-    void for_each_listener(wayland::Client* client, std::function<void(WlPointer*)> func);
+    void for_each_listener(wayland::Client* client, std::function<void(PointerEventDispatcher*)> func);
     void for_each_listener(wayland::Client* client, std::function<void(WlKeyboard*)> func);
     void for_each_listener(wayland::Client* client, std::function<void(WlTouch*)> func);
 
@@ -109,7 +122,7 @@ private:
 
     // listener list are shared pointers so devices can keep them around long enough to remove themselves
     std::shared_ptr<ListenerList<FocusListener>> const focus_listeners;
-    std::shared_ptr<ListenerList<WlPointer>> const pointer_listeners;
+    std::shared_ptr<ListenerList<PointerEventDispatcher>> const pointer_listeners;
     std::shared_ptr<ListenerList<WlKeyboard>> const keyboard_listeners;
     std::shared_ptr<ListenerList<WlTouch>> const touch_listeners;
 

--- a/src/server/input/default_configuration.cpp
+++ b/src/server/input/default_configuration.cpp
@@ -131,6 +131,12 @@ mir::DefaultServerConfiguration::the_surface_input_dispatcher()
         });
 }
 
+std::shared_ptr<mir::frontend::PointerInputDispatcher>
+mir::DefaultServerConfiguration::the_pointer_input_dispatcher()
+{
+    return the_surface_input_dispatcher();
+}
+
 std::shared_ptr<mi::InputDispatcher>
 mir::DefaultServerConfiguration::the_input_dispatcher()
 {

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -464,7 +464,6 @@ bool mi::SurfaceInputDispatcher::dispatch_pointer(MirInputDeviceId /*id*/, std::
 
             if (is_gesture_terminator(pev))
             {
-                deliver(gesture_owner, ev);
                 gesture_owner.reset();
             }
 

--- a/src/server/input/surface_input_dispatcher.h
+++ b/src/server/input/surface_input_dispatcher.h
@@ -17,13 +17,14 @@
 #ifndef MIR_INPUT_DEFAULT_INPUT_DISPATCHER_H_
 #define MIR_INPUT_DEFAULT_INPUT_DISPATCHER_H_
 
+#include "mir/executor.h"
+#include "mir/frontend/pointer_input_dispatcher.h"
+#include "mir/geometry/point.h"
 #include "mir/input/input_dispatcher.h"
 #include "mir/input/keyboard_observer.h"
-#include "mir/shell/input_targeter.h"
-#include "mir/geometry/point.h"
-#include "mir/observer_registrar.h"
 #include "mir/observer_multiplexer.h"
-#include "mir/executor.h"
+#include "mir/observer_registrar.h"
+#include "mir/shell/input_targeter.h"
 
 #include <memory>
 #include <mutex>
@@ -45,6 +46,7 @@ class Scene;
 class SurfaceInputDispatcher :
     public input::InputDispatcher,
     public shell::InputTargeter,
+    public frontend::PointerInputDispatcher,
     public ObserverRegistrar<KeyboardObserver>
 {
 public:
@@ -66,6 +68,10 @@ public:
         std::weak_ptr<KeyboardObserver> const& observer,
         Executor& executor) override;
     void unregister_interest(KeyboardObserver const& observer) override;
+
+    void start_ignore_gesture_owner() override;
+
+    void end_ignore_gesture_owner() override;
 
 private:
     bool dispatch_key(std::shared_ptr<MirEvent const> const& ev);
@@ -119,6 +125,13 @@ private:
     std::shared_ptr<MirEvent const> last_pointer_event;
     std::weak_ptr<input::Surface> focus_surface;
     bool screen_is_locked;
+    bool ignore_gesture_owner = false;
+
+    bool send_to_surface(
+        std::shared_ptr<input::Surface> const& target,
+        MirPointerEvent const* pev,
+        MirPointerAction const& action,
+        MirEvent const* ev);
 };
 
 }

--- a/src/server/scene/basic_clipboard.cpp
+++ b/src/server/scene/basic_clipboard.cpp
@@ -86,7 +86,7 @@ void mir::scene::BasicClipboard::set_drag_n_drop_source(std::shared_ptr<DataExch
 {
     if (!source)
     {
-        fatal_error("BasicClipboard::set_drag_n_drop_source(nullptr)");
+        fatal_error("BasicClipboard::start_drag_n_drop_gesture(nullptr)");
     }
     bool notify{false};
     {

--- a/src/server/scene/basic_clipboard.cpp
+++ b/src/server/scene/basic_clipboard.cpp
@@ -80,3 +80,46 @@ void ms::BasicClipboard::clear_paste_source(DataExchangeSource const& source)
         multiplexer.paste_source_set(nullptr);
     }
 }
+
+
+void mir::scene::BasicClipboard::set_drag_n_drop_source(std::shared_ptr<DataExchangeSource> const& source)
+{
+    if (!source)
+    {
+        fatal_error("BasicClipboard::set_drag_n_drop_source(nullptr)");
+    }
+    bool notify{false};
+    {
+        std::lock_guard lock{paste_mutex};
+        if (dnd_source_ != source)
+        {
+            notify = true;
+            dnd_source_ = source;
+        }
+    }
+    if (notify)
+    {
+        multiplexer.drag_n_drop_source_set(source);
+    }
+}
+
+void mir::scene::BasicClipboard::clear_drag_n_drop_source(std::shared_ptr<DataExchangeSource> const& source)
+{
+    if (!source)
+    {
+        fatal_error("BasicClipboard::clear_drag_n_drop_source(nullptr)");
+    }
+    bool notify{false};
+    {
+        std::lock_guard lock{paste_mutex};
+        if (dnd_source_ == source)
+        {
+            notify = true;
+            dnd_source_.reset();
+        }
+    }
+    if (notify)
+    {
+        multiplexer.drag_n_drop_source_cleared(source);
+    }
+}

--- a/src/server/scene/basic_clipboard.h
+++ b/src/server/scene/basic_clipboard.h
@@ -38,6 +38,16 @@ public:
     {
         for_each_observer(&ClipboardObserver::paste_source_set, source);
     }
+
+    void drag_n_drop_source_set(std::shared_ptr<DataExchangeSource> const& source) override
+    {
+        for_each_observer(&ClipboardObserver::drag_n_drop_source_set, source);
+    }
+
+    void drag_n_drop_source_cleared(std::shared_ptr<DataExchangeSource> const& source) override
+    {
+        for_each_observer(&ClipboardObserver::drag_n_drop_source_cleared, source);
+    }
 };
 
 /// Interface for the global object that manages data transfers between clients (such as copy-paste)
@@ -48,6 +58,9 @@ public:
     void set_paste_source(std::shared_ptr<DataExchangeSource> const& source) override;
     void clear_paste_source() override;
     void clear_paste_source(DataExchangeSource const& source) override;
+    void set_drag_n_drop_source(std::shared_ptr<DataExchangeSource> const& source) override;
+
+    void clear_drag_n_drop_source(std::shared_ptr<DataExchangeSource> const& source) override;
 
     /// Implement ObserverRegistrar<ClipboardObserver>
     /// @{
@@ -70,6 +83,7 @@ private:
 
     std::mutex mutable paste_mutex;
     std::shared_ptr<DataExchangeSource> paste_source_; ///< Can be null
+    std::shared_ptr<DataExchangeSource> dnd_source_; ///< Can be null
 };
 }
 }

--- a/src/server/symbols.map
+++ b/src/server/symbols.map
@@ -933,5 +933,6 @@ MIR_SERVER_2.14 {
   global:
     extern "C++" {
       "mir::DefaultServerConfiguration::the_drag_icon_controller()";
+      "mir::DefaultServerConfiguration::the_pointer_input_dispatcher()";
     };
 } MIR_SERVER_2.11;


### PR DESCRIPTION
This isn't intended to land: but I'll be using it as the basis for a production implementation. 

It provides enough drag-n-drop to, for example, reorder tabs in Firefox.

There are no tests (yet) and I'm sure there are bugs. CI will tell us if what I've done is portable across our various build chains 