### PR TITLE
Pass event instead of timestamp to move/resize requests

### DIFF
--- a/src/include/server/mir/shell/abstract_shell.h
+++ b/src/include/server/mir/shell/abstract_shell.h
@@ -103,12 +103,12 @@ public:
     void request_move(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp) override;
+        MirInputEvent const* event) override;
 
     void request_resize(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp,
+        MirInputEvent const* event,
         MirResizeEdge edge) override;
 
     std::shared_ptr<scene::PromptSession> start_prompt_session_for(

--- a/src/include/server/mir/shell/shell.h
+++ b/src/include/server/mir/shell/shell.h
@@ -122,12 +122,12 @@ public:
     virtual void request_move(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp) = 0;
+        MirInputEvent const* event) = 0;
 
     virtual void request_resize(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp,
+        MirInputEvent const* event,
         MirResizeEdge edge) = 0;
 
 /** @} */

--- a/src/include/server/mir/shell/shell_wrapper.h
+++ b/src/include/server/mir/shell/shell_wrapper.h
@@ -104,12 +104,12 @@ public:
     void request_move(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp) override;
+        MirInputEvent const* event) override;
 
     void request_resize(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp,
+        MirInputEvent const* event,
         MirResizeEdge edge) override;
 
     void add_display(geometry::Rectangle const& area) override;

--- a/src/include/server/mir/shell/system_compositor_window_manager.h
+++ b/src/include/server/mir/shell/system_compositor_window_manager.h
@@ -105,12 +105,12 @@ private:
     void handle_request_move(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp) override;
+        MirInputEvent const* event) override;
 
     void handle_request_resize(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp,
+        MirInputEvent const* event,
         MirResizeEdge edge) override;
 
     int set_surface_attribute(

--- a/src/include/server/mir/shell/window_manager.h
+++ b/src/include/server/mir/shell/window_manager.h
@@ -86,12 +86,12 @@ public:
     virtual void handle_request_move(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp) = 0;
+        MirInputEvent const* event) = 0;
 
     virtual void handle_request_resize(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp,
+        MirInputEvent const* event,
         MirResizeEdge edge) = 0;
 
     virtual ~WindowManager() = default;

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -116,12 +116,12 @@ public:
     void handle_request_move(
         std::shared_ptr<mir::scene::Session> const& session,
         std::shared_ptr<mir::scene::Surface> const& surface,
-        uint64_t timestamp) override;
+        MirInputEvent const* event) override;
 
     void handle_request_resize(
         std::shared_ptr<mir::scene::Session> const& session,
         std::shared_ptr<mir::scene::Surface> const& surface,
-        uint64_t timestamp,
+        MirInputEvent const* event,
         ::MirResizeEdge edge) override;
 
     int set_surface_attribute(
@@ -254,7 +254,6 @@ private:
     mir::geometry::Rectangles outputs;
     mir::geometry::Point cursor;
     uint64_t last_input_event_timestamp{0};
-    MirEvent const* last_input_event{nullptr};
     miral::MRUWindowList mru_active_windows;
     bool allow_active_window = true;
     std::set<Window> fullscreen_surfaces;

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -168,8 +168,7 @@ void mf::WindowWlSurfaceRole::initiate_interactive_move(uint32_t serial)
     {
         if (auto const ev = input_event_for(serial))
         {
-            auto const timestamp = mir_input_event_get_event_time(mir_event_get_input_event(ev.get()));
-            shell->request_move(session, scene_surface, timestamp);
+            shell->request_move(session, scene_surface, mir_event_get_input_event(ev.get()));
         }
     }
 }
@@ -180,8 +179,7 @@ void mf::WindowWlSurfaceRole::initiate_interactive_resize(MirResizeEdge edge, ui
     {
         if (auto const ev = input_event_for(serial))
         {
-            auto const timestamp = mir_input_event_get_event_time(mir_event_get_input_event(ev.get()));
-            shell->request_resize(session, scene_surface, timestamp, edge);
+            shell->request_resize(session, scene_surface, mir_event_get_input_event(ev.get()), edge);
         }
     }
 }

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -772,11 +772,11 @@ void mf::XWaylandSurface::move_resize(uint32_t detail)
     auto const action = static_cast<NetWmMoveresize>(detail);
     if (action == NetWmMoveresize::MOVE)
     {
-        shell->request_move(scene_surface->session().lock(), scene_surface, event->event_time().count());
+        shell->request_move(scene_surface->session().lock(), scene_surface, event.get());
     }
     else if (auto const edge = wm_resize_edge_to_mir_resize_edge(action))
     {
-        shell->request_resize(scene_surface->session().lock(), scene_surface, event->event_time().count(), edge.value());
+        shell->request_resize(scene_surface->session().lock(), scene_surface, event.get(), edge.value());
     }
     else
     {

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -373,18 +373,18 @@ void msh::AbstractShell::request_drag_and_drop(
 void msh::AbstractShell::request_move(
     std::shared_ptr<scene::Session> const& session,
     std::shared_ptr<scene::Surface> const& surface,
-    uint64_t timestamp)
+    MirInputEvent const* event)
 {
-    window_manager->handle_request_move(session, surface, timestamp);
+    window_manager->handle_request_move(session, surface, event);
 }
 
 void msh::AbstractShell::request_resize(
     std::shared_ptr<scene::Session> const& session,
     std::shared_ptr<scene::Surface> const& surface,
-    uint64_t timestamp,
+    MirInputEvent const* event,
     MirResizeEdge edge)
 {
-    window_manager->handle_request_resize(session, surface, timestamp, edge);
+    window_manager->handle_request_resize(session, surface, event, edge);
 }
 
 void msh::AbstractShell::focus_next_session()

--- a/src/server/shell/decoration/basic_decoration.cpp
+++ b/src/server/shell/decoration/basic_decoration.cpp
@@ -226,14 +226,14 @@ void msd::BasicDecoration::input_state_updated()
     update(window_state.get(), previous_input_state.get());
 }
 
-void msd::BasicDecoration::request_move(std::chrono::nanoseconds const& timestamp)
+void msd::BasicDecoration::request_move(MirInputEvent const* event)
 {
-    shell->request_move(session, window_surface, timestamp.count());
+    shell->request_move(session, window_surface, event);
 }
 
-void msd::BasicDecoration::request_resize(std::chrono::nanoseconds const& timestamp, MirResizeEdge edge)
+void msd::BasicDecoration::request_resize(MirInputEvent const* event, MirResizeEdge edge)
 {
-    shell->request_resize(session, window_surface, timestamp.count(), edge);
+    shell->request_resize(session, window_surface, event, edge);
 }
 
 void msd::BasicDecoration::request_toggle_maximize()

--- a/src/server/shell/decoration/basic_decoration.h
+++ b/src/server/shell/decoration/basic_decoration.h
@@ -27,6 +27,8 @@
 #include <chrono>
 #include <optional>
 
+struct MirInputEvent;
+
 namespace mir
 {
 class Executor;
@@ -76,8 +78,8 @@ public:
     void window_state_updated();
     void input_state_updated();
 
-    void request_move(std::chrono::nanoseconds const& timestamp);
-    void request_resize(std::chrono::nanoseconds const& timestamp, MirResizeEdge edge);
+    void request_move(MirInputEvent const* event);
+    void request_resize(MirInputEvent const* event, MirResizeEdge edge);
     void request_toggle_maximize();
     void request_minimize();
     void request_close();

--- a/src/server/shell/decoration/input.h
+++ b/src/server/shell/decoration/input.h
@@ -27,6 +27,8 @@
 #include <map>
 #include <optional>
 
+struct MirEvent;
+
 namespace mir
 {
 namespace scene
@@ -122,10 +124,10 @@ private:
         WindowState const& window_state,
         StaticGeometry const& static_geometry,
         MirResizeEdge resize_edge) -> geometry::Rectangle;
-    void pointer_event(std::chrono::nanoseconds timestamp, geometry::Point location, bool pressed);
-    void pointer_leave(std::chrono::nanoseconds timestamp);
-    void touch_event(int32_t id, std::chrono::nanoseconds timestamp, geometry::Point location);
-    void touch_up(int32_t id, std::chrono::nanoseconds timestamp);
+    void pointer_event(std::shared_ptr<MirEvent const> const& event, geometry::Point location, bool pressed);
+    void pointer_leave(std::shared_ptr<MirEvent const> const& event);
+    void touch_event(std::shared_ptr<MirEvent const> const& event, int32_t id, geometry::Point location);
+    void touch_up(std::shared_ptr<MirEvent const> const& event, int32_t id);
 
     class Observer;
 
@@ -135,8 +137,8 @@ private:
     std::shared_ptr<Observer> const observer;
     std::shared_ptr<ThreadsafeAccess<BasicDecoration>> decoration;
     std::vector<geometry::Rectangle> input_shape;
-    /// Timestamp of the most recent event, or the event currently being processed
-    std::chrono::nanoseconds event_timestamp{0};
+    /// The most recent event, or the event currently being processed
+    std::shared_ptr<MirEvent const> latest_event;
     /// Timestamp of the previous up event (not the one currently being processed)
     std::chrono::nanoseconds previous_up_timestamp{0};
     std::string current_cursor_name{""};

--- a/src/server/shell/shell_wrapper.cpp
+++ b/src/server/shell/shell_wrapper.cpp
@@ -152,18 +152,18 @@ void msh::ShellWrapper::request_drag_and_drop(
 void msh::ShellWrapper::request_move(
     std::shared_ptr<ms::Session> const& session,
     std::shared_ptr<ms::Surface> const& surface,
-    uint64_t timestamp)
+    MirInputEvent const* event)
 {
-    wrapped->request_move(session, surface, timestamp);
+    wrapped->request_move(session, surface, event);
 }
 
 void msh::ShellWrapper::request_resize(
     std::shared_ptr<scene::Session> const& session,
     std::shared_ptr<scene::Surface> const& surface,
-    uint64_t timestamp,
+    MirInputEvent const* event,
     MirResizeEdge edge)
 {
-    wrapped->request_resize(session, surface, timestamp, edge);
+    wrapped->request_resize(session, surface, event, edge);
 }
 
 void msh::ShellWrapper::add_display(geometry::Rectangle const& area)

--- a/src/server/shell/system_compositor_window_manager.cpp
+++ b/src/server/shell/system_compositor_window_manager.cpp
@@ -229,14 +229,14 @@ void msh::SystemCompositorWindowManager::handle_request_drag_and_drop(
 void msh::SystemCompositorWindowManager::handle_request_move(
     std::shared_ptr<ms::Session> const& /*session*/,
     std::shared_ptr<ms::Surface> const& /*surface*/,
-    uint64_t /*timestamp*/)
+    MirInputEvent const* /*event*/)
 {
 }
 
 void msh::SystemCompositorWindowManager::handle_request_resize(
     std::shared_ptr<scene::Session> const& /*session*/,
     std::shared_ptr<scene::Surface> const& /*surface*/,
-    uint64_t /*timestamp*/,
+    MirInputEvent const* /*event*/,
     MirResizeEdge /*edge*/)
 {
 }

--- a/tests/include/mir/test/doubles/mock_window_manager.h
+++ b/tests/include/mir/test/doubles/mock_window_manager.h
@@ -59,8 +59,8 @@ struct MockWindowManager : shell::WindowManager
 
     MOCK_METHOD3(handle_raise_surface, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, uint64_t));
     MOCK_METHOD3(handle_request_drag_and_drop, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, uint64_t));
-    MOCK_METHOD3(handle_request_move, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, uint64_t));
-    MOCK_METHOD4(handle_request_resize, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, uint64_t, MirResizeEdge));
+    MOCK_METHOD3(handle_request_move, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, MirInputEvent const*));
+    MOCK_METHOD4(handle_request_resize, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, MirInputEvent const*, MirResizeEdge));
 
     MOCK_METHOD4(set_surface_attribute,
         int(std::shared_ptr<scene::Session> const& session,

--- a/tests/include/mir/test/doubles/stub_shell.h
+++ b/tests/include/mir/test/doubles/stub_shell.h
@@ -189,14 +189,14 @@ struct StubShell : public shell::Shell
     void request_move(
         std::shared_ptr<scene::Session> const& /*session*/,
         std::shared_ptr<scene::Surface> const& /*surface*/,
-        uint64_t /*timestamp*/) override
+        MirInputEvent const* /*event*/) override
     {
     }
 
     void request_resize(
         std::shared_ptr<scene::Session> const& /*session*/,
         std::shared_ptr<scene::Surface> const& /*surface*/,
-        uint64_t /*timestamp*/,
+        MirInputEvent const* /*event*/,
         MirResizeEdge /*edge*/) override
     {
     }

--- a/tests/miral/ignored_requests.cpp
+++ b/tests/miral/ignored_requests.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "test_window_manager_tools.h"
+#include "mir/events/event_builders.h"
 
 using namespace miral;
 using namespace testing;
@@ -48,6 +49,9 @@ struct IgnoredRequests : mt::TestWindowManagerTools, WithParamInterface<IgnoredR
 {
     Size const window_size{200, 200};
     mir::shell::SurfaceSpecification simple_modification;
+    mir::EventUPtr event{
+        mir::events::make_pointer_event({}, std::chrono::nanoseconds{100}, {}, {}, {}, {}, {}, {}, {}, {}, {})};
+    MirInputEvent const* input_ev = mir_event_get_input_event(event.get());
 
     void SetUp() override
     {
@@ -135,14 +139,14 @@ TEST_P(IgnoredRequests, drag_and_drop_unknown_surface_noops)
 TEST_P(IgnoredRequests, move_unknown_surface_noops)
 {
     auto const window = GetParam().window(*this);
-    basic_window_manager.handle_request_move(session, window, 100);
+    basic_window_manager.handle_request_move(session, window, input_ev);
 }
 
 TEST_P(IgnoredRequests, resize_unknown_surface_noops)
 {
     auto const window = GetParam().window(*this);
 
-    basic_window_manager.handle_request_resize(session, window, 100, mir_resize_edge_southeast);
+    basic_window_manager.handle_request_resize(session, window, input_ev, mir_resize_edge_southeast);
 }
 
 TEST_F(IgnoredRequests, remove_session_twice_noops)

--- a/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
+++ b/tests/unit-tests/shell/test_decoration_basic_decoration.cpp
@@ -139,12 +139,12 @@ struct MockShell
     MOCK_METHOD3(request_move, void(
         std::shared_ptr<ms::Session> const&,
         std::shared_ptr<ms::Surface> const&,
-        uint64_t));
+        MirInputEvent const*));
 
     MOCK_METHOD4(request_resize, void(
         std::shared_ptr<ms::Session> const&,
         std::shared_ptr<ms::Surface> const&,
-        uint64_t,
+        MirInputEvent const*,
         MirResizeEdge));
 
     MOCK_METHOD5(create_surface, std::shared_ptr<ms::Surface>(


### PR DESCRIPTION
Fixes #1792 the way I've planned to for some time