### PR TITLE
Make sure to call connection_is_allowed on xwayland sessions

### DIFF
--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -298,6 +298,7 @@ mf::WaylandConnector::WaylandConnector(
         display.get(),
         executor,
         shell,
+        session_authorizer,
         main_clipboard,
         primary_selection_clipboard,
         text_input_hub,

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -82,6 +82,7 @@ public:
         wl_display* display;
         std::shared_ptr<Executor> wayland_executor;
         std::shared_ptr<shell::Shell> shell;
+        std::shared_ptr<SessionAuthorizer> session_authorizer;
         std::shared_ptr<scene::Clipboard> main_clipboard;
         std::shared_ptr<scene::Clipboard> primary_selection_clipboard;
         std::shared_ptr<scene::TextInputHub> text_input_hub;

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -181,6 +181,7 @@ ExtensionBuilder const xwayland_builder {
             return std::make_shared<mf::XWaylandWMShell>(
                 ctx.wayland_executor,
                 ctx.shell,
+                ctx.session_authorizer,
                 ctx.main_clipboard,
                 *ctx.seat,
                 ctx.surface_stack);

--- a/src/server/frontend_xwayland/xwayland_client_manager.cpp
+++ b/src/server/frontend_xwayland/xwayland_client_manager.cpp
@@ -20,6 +20,10 @@
 #include "mir/shell/shell.h"
 #include "mir/scene/session.h"
 #include "mir/log.h"
+#include "mir/frontend/session_authorizer.h"
+#include "mir/frontend/session_credentials.h"
+
+#include <sys/stat.h>
 
 namespace mf = mir::frontend;
 namespace msh = mir::shell;
@@ -43,8 +47,10 @@ auto mf::XWaylandClientManager::Session::session() const -> std::shared_ptr<scen
     return _session;
 }
 
-mf::XWaylandClientManager::XWaylandClientManager(std::shared_ptr<shell::Shell> const& shell)
-    : shell{shell}
+mf::XWaylandClientManager::XWaylandClientManager(std::shared_ptr<shell::Shell> const& shell,
+                                                 std::shared_ptr<SessionAuthorizer> const& session_authorizer)
+    : shell{shell},
+      session_authorizer{session_authorizer}
 {
 }
 
@@ -80,6 +86,24 @@ auto mf::XWaylandClientManager::session_for_client(pid_t client_pid) -> std::sha
     }
     else
     {
+        struct stat proc_stat;
+        std::string proc = "/proc/";
+        proc += std::to_string(client_pid);
+
+        // Fallback to get(uid,gid) if we can't stat
+        auto uid = getuid();
+        auto gid = getgid();
+        if (stat(proc.c_str(), &proc_stat) != -1)
+        {
+            uid = proc_stat.st_uid;
+            gid = proc_stat.st_gid;
+        }
+
+        if (!session_authorizer->connection_is_allowed({client_pid, uid, gid}))
+        {
+            log_error("X11 session not authorized for PID %d, rejecting!", client_pid);
+            return nullptr;
+        }
         session = std::make_shared<Session>(this, client_pid);
         sessions_by_pid[client_pid] = session;
         if (verbose_xwayland_logging_enabled())

--- a/src/server/frontend_xwayland/xwayland_client_manager.h
+++ b/src/server/frontend_xwayland/xwayland_client_manager.h
@@ -35,6 +35,8 @@ class Session;
 }
 namespace frontend
 {
+class SessionAuthorizer;
+
 /// Keeps track of which session is associated with which XWayland client PID
 class XWaylandClientManager
 {
@@ -55,7 +57,8 @@ public:
         std::shared_ptr<scene::Session> const _session;
     };
 
-    XWaylandClientManager(std::shared_ptr<shell::Shell> const& shell);
+    XWaylandClientManager(std::shared_ptr<shell::Shell> const& shell,
+                          std::shared_ptr<SessionAuthorizer> const& session_authorizer);
     ~XWaylandClientManager();
 
     auto session_for_client(pid_t client_pid) -> std::shared_ptr<Session>;
@@ -64,6 +67,7 @@ private:
     void drop_expired(pid_t client_pid);
 
     std::shared_ptr<shell::Shell> const shell;
+    std::shared_ptr<SessionAuthorizer> const session_authorizer;
     std::mutex mutex;
     std::unordered_map<pid_t, std::weak_ptr<Session>> sessions_by_pid;
 };

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -717,8 +717,9 @@ void mf::XWaylandSurface::attach_wl_surface(WlSurface* wl_surface)
 
     if (rejected)
     {
-        scene_surface_close_requested();
+        xcb_kill_client(*connection, window);
         close();
+        connection->flush();
         return;
     }
 

--- a/src/server/frontend_xwayland/xwayland_wm.cpp
+++ b/src/server/frontend_xwayland/xwayland_wm.cpp
@@ -148,7 +148,7 @@ mf::XWaylandWM::XWaylandWM(
       clipboard_provider{std::make_unique<XWaylandClipboardProvider>(connection, dispatcher, wm_shell->clipboard)},
       wm_window{create_wm_window(*connection)},
       scene_observer{std::make_shared<XWaylandSceneObserver>(this)},
-      client_manager{std::make_shared<XWaylandClientManager>(wm_shell->shell)},
+      client_manager{std::make_shared<XWaylandClientManager>(wm_shell->shell, wm_shell->session_authorizer)},
       assumed_surface_scale{assumed_surface_scale}
 {
     uint32_t const attrib_values[]{

--- a/src/server/frontend_xwayland/xwayland_wm_shell.h
+++ b/src/server/frontend_xwayland/xwayland_wm_shell.h
@@ -39,6 +39,7 @@ class SurfaceStack;
 class WlSeat;
 class WlSurface;
 class XWaylandSurface;
+class SessionAuthorizer;
 
 class XWaylandWMShell
 {
@@ -46,11 +47,13 @@ public:
     XWaylandWMShell(
         std::shared_ptr<Executor> const& wayland_executor,
         std::shared_ptr<shell::Shell> const& shell,
+        std::shared_ptr<SessionAuthorizer> const& session_authorizer,
         std::shared_ptr<scene::Clipboard> const& clipboard,
         WlSeat& seat,
         std::shared_ptr<SurfaceStack> const& surface_stack)
         : wayland_executor{wayland_executor},
           shell{shell},
+          session_authorizer{session_authorizer},
           clipboard{clipboard},
           seat{seat},
           surface_stack{surface_stack}
@@ -59,6 +62,7 @@ public:
 
     std::shared_ptr<Executor> const wayland_executor;
     std::shared_ptr<shell::Shell> const shell;
+    std::shared_ptr<SessionAuthorizer> const session_authorizer;
     std::shared_ptr<scene::Clipboard> const clipboard;
     WlSeat& seat;
     std::shared_ptr<SurfaceStack> const surface_stack;

--- a/tests/unit-tests/frontend_xwayland/test_xwayland_client_manager.cpp
+++ b/tests/unit-tests/frontend_xwayland/test_xwayland_client_manager.cpp
@@ -17,8 +17,8 @@
 #include "src/server/frontend_xwayland/xwayland_client_manager.h"
 #include "mir/test/doubles/stub_shell.h"
 #include "mir/test/doubles/stub_session.h"
+#include "mir/test/doubles/stub_session_authorizer.h"
 #include "mir/test/fake_shared.h"
-
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -42,6 +42,7 @@ struct MockShell : mtd::StubShell
 struct XWaylandClientManagerTest : Test
 {
     NiceMock<MockShell> shell;
+    NiceMock<mtd::MockSessionAuthorizer> auth;
     mtd::StubSession session_1;
     mtd::StubSession session_2;
     mtd::StubSession session_3;
@@ -57,12 +58,12 @@ struct XWaylandClientManagerTest : Test
 
 TEST_F(XWaylandClientManagerTest, can_be_created)
 {
-    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+    mf::XWaylandClientManager manager{mt::fake_shared(shell), mt::fake_shared(auth)};
 }
 
 TEST_F(XWaylandClientManagerTest, get_session_initially_creates_session)
 {
-    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+    mf::XWaylandClientManager manager{mt::fake_shared(shell), mt::fake_shared(auth)};
 
     EXPECT_CALL(shell, open_session(1, _, _, _))
         .Times(1)
@@ -74,7 +75,7 @@ TEST_F(XWaylandClientManagerTest, get_session_initially_creates_session)
 
 TEST_F(XWaylandClientManagerTest, repeated_get_session_with_same_pid_returns_same_session)
 {
-    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+    mf::XWaylandClientManager manager{mt::fake_shared(shell), mt::fake_shared(auth)};
 
     EXPECT_CALL(shell, open_session(1, _, _, _))
         .Times(1)
@@ -89,7 +90,7 @@ TEST_F(XWaylandClientManagerTest, repeated_get_session_with_same_pid_returns_sam
 
 TEST_F(XWaylandClientManagerTest, repeated_get_session_with_different_pids_creates_new_sessions)
 {
-    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+    mf::XWaylandClientManager manager{mt::fake_shared(shell), mt::fake_shared(auth)};
 
     EXPECT_CALL(shell, open_session(_, _, _, _))
         .Times(3)
@@ -108,7 +109,7 @@ TEST_F(XWaylandClientManagerTest, repeated_get_session_with_different_pids_creat
 
 TEST_F(XWaylandClientManagerTest, resetting_client_session_closes_session)
 {
-    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+    mf::XWaylandClientManager manager{mt::fake_shared(shell), mt::fake_shared(auth)};
 
     EXPECT_CALL(shell, open_session(_, _, _, _))
         .Times(1)
@@ -126,7 +127,7 @@ TEST_F(XWaylandClientManagerTest, resetting_client_session_closes_session)
 
 TEST_F(XWaylandClientManagerTest, reset_does_not_close_session_if_multiple_owners)
 {
-    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+    mf::XWaylandClientManager manager{mt::fake_shared(shell), mt::fake_shared(auth)};
 
     EXPECT_CALL(shell, open_session(_, _, _, _))
         .Times(1)
@@ -143,7 +144,7 @@ TEST_F(XWaylandClientManagerTest, reset_does_not_close_session_if_multiple_owner
 
 TEST_F(XWaylandClientManagerTest, session_closed_when_all_client_sessions_reset)
 {
-    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+    mf::XWaylandClientManager manager{mt::fake_shared(shell), mt::fake_shared(auth)};
 
     EXPECT_CALL(shell, open_session(_, _, _, _))
         .Times(1)
@@ -162,7 +163,7 @@ TEST_F(XWaylandClientManagerTest, session_closed_when_all_client_sessions_reset)
 
 TEST_F(XWaylandClientManagerTest, new_session_created_after_old_session_for_same_pid_closed)
 {
-    mf::XWaylandClientManager manager{mt::fake_shared(shell)};
+    mf::XWaylandClientManager manager{mt::fake_shared(shell), mt::fake_shared(auth)};
     auto client_session_1 = manager.session_for_client(1);
     client_session_1.reset();
 


### PR DESCRIPTION
As xwayland/x11 has no way of telling us gid and uid so we try to get this from running stat on /proc/(pid)

Same as https://github.com/MirServer/mir/pull/2835 but fixed issues pointed out by @AlanGriffiths 

Part of fix for: https://github.com/MirServer/mir/issues/2830