### PR TITLE
Clean out legacy of mirclient drag-and-drop support

### DIFF
--- a/include/common/mir/events/event_builders.h
+++ b/include/common/mir/events/event_builders.h
@@ -200,8 +200,8 @@ EventUPtr make_touch_event(
 EventUPtr clone_event(MirEvent const& event);
 void set_window_id(MirEvent& event, int window_id);
 
+[[deprecated("Not meaningful: legacy of mirclient API")]]
 EventUPtr make_start_drag_and_drop_event(frontend::SurfaceId const& surface_id, std::vector<uint8_t> const& handle);
-void set_drag_and_drop_handle(MirEvent& event, std::vector<uint8_t> const& handle);
 
 [[deprecated("Internally functions from event_helpers.h should be used, externally this should not be needed")]]
 void transform_positions(MirEvent& event, mir::geometry::Displacement const& movement);

--- a/include/common/mir/events/event_builders.h
+++ b/include/common/mir/events/event_builders.h
@@ -202,7 +202,8 @@ void set_window_id(MirEvent& event, int window_id);
 
 [[deprecated("Not meaningful: legacy of mirclient API")]]
 EventUPtr make_start_drag_and_drop_event(frontend::SurfaceId const& surface_id, std::vector<uint8_t> const& handle);
-
+[[deprecated("Not meaningful: legacy of mirclient API")]]
+void set_drag_and_drop_handle(MirEvent& event, std::vector<uint8_t> const& handle);
 [[deprecated("Internally functions from event_helpers.h should be used, externally this should not be needed")]]
 void transform_positions(MirEvent& event, mir::geometry::Displacement const& movement);
 [[deprecated("Internally functions from event_helpers.h should be used, externally this should not be needed")]]

--- a/include/miral/miral/window_management_policy.h
+++ b/include/miral/miral/window_management_policy.h
@@ -235,6 +235,7 @@ public:
      *
      * @param window_info   the window
      */
+    [[deprecated("Not meaningful: legacy of mirclient API")]]
     virtual void handle_request_drag_and_drop(WindowInfo& window_info) = 0;
 
     /** request from client to initiate move

--- a/src/common/events/event_builders.cpp
+++ b/src/common/events/event_builders.cpp
@@ -87,7 +87,7 @@ mir::EventUPtr mev::make_window_configure_event(mf::SurfaceId const& surface_id,
     return make_uptr_event(e);
 }
 
-auto mev::make_start_drag_and_drop_event(frontend::SurfaceId const& surface_id, std::vector<uint8_t> const& handle)
+auto mev::make_start_drag_and_drop_event(frontend::SurfaceId const& surface_id, std::vector<uint8_t> const& /*handle*/)
     -> EventUPtr
 {
     auto e = new_event<MirWindowEvent>();
@@ -95,7 +95,6 @@ auto mev::make_start_drag_and_drop_event(frontend::SurfaceId const& surface_id, 
     e->set_id(surface_id.as_value());
     e->set_attrib(mir_window_attribs);
     e->set_value(0);
-    e->set_dnd_handle(handle);
 
     return make_uptr_event(e);
 
@@ -491,14 +490,3 @@ void mev::set_window_id(MirEvent& event, int window_id)
         BOOST_THROW_EXCEPTION(std::invalid_argument("Event has no window id."));
     }
 }
-
-void mev::set_drag_and_drop_handle(MirEvent& event, std::vector<uint8_t> const& handle)
-{
-    if (event.type() == mir_event_type_input)
-    {
-        auto const input_event = event.to_input();
-        if (mir_input_event_get_type(input_event) == mir_input_event_type_pointer)
-            const_cast<MirPointerEvent*>(mir_input_event_get_pointer_event(input_event))->set_dnd_handle(handle);
-    }
-}
-

--- a/src/common/events/event_builders.cpp
+++ b/src/common/events/event_builders.cpp
@@ -490,3 +490,7 @@ void mev::set_window_id(MirEvent& event, int window_id)
         BOOST_THROW_EXCEPTION(std::invalid_argument("Event has no window id."));
     }
 }
+
+void mev::set_drag_and_drop_handle(MirEvent& /*event*/, std::vector<uint8_t> const& /*handle*/)
+{
+}

--- a/src/common/events/pointer_event.cpp
+++ b/src/common/events/pointer_event.cpp
@@ -124,11 +124,6 @@ void MirPointerEvent::set_action(MirPointerAction action)
     action_ = action;
 }
 
-void MirPointerEvent::set_dnd_handle(std::vector<uint8_t> const& handle)
-{
-    dnd_handle_ = handle;
-}
-
 namespace
 {
 struct MyMirBlob : MirBlob
@@ -139,23 +134,6 @@ struct MyMirBlob : MirBlob
 
     std::vector<uint8_t> data_;
 };
-}
-
-MirBlob* MirPointerEvent::dnd_handle() const
-{
-    if (!dnd_handle_)
-        return nullptr;
-
-    auto const dnd_handle = *dnd_handle_;
-
-    auto blob = std::make_unique<MyMirBlob>();
-    blob->data_.reserve(dnd_handle.size());
-
-    // Can't use std::copy() as the CapnP iterators don't provide an iterator category
-    for (auto p = dnd_handle.begin(); p != dnd_handle.end(); ++p)
-        blob->data_.push_back(*p);
-
-    return blob.release();
 }
 
 auto MirPointerEvent::axis_source() const -> MirPointerAxisSource

--- a/src/common/events/window_event.cpp
+++ b/src/common/events/window_event.cpp
@@ -56,11 +56,6 @@ void MirWindowEvent::set_value(int value)
     value_ = value;
 }
 
-void MirWindowEvent::set_dnd_handle(std::vector<uint8_t> const& handle)
-{
-    dnd_handle_ = handle;
-}
-
 namespace
 {
 struct MyMirBlob : MirBlob
@@ -71,23 +66,5 @@ struct MyMirBlob : MirBlob
 
     std::vector<uint8_t> data_;
 };
-}
-
-MirBlob* MirWindowEvent::dnd_handle() const
-{
-    if (!dnd_handle_)
-        return nullptr;
-
-    auto blob = std::make_unique<MyMirBlob>();
-
-    auto reader = *dnd_handle_;
-
-    blob->data_.reserve(reader.size());
-
-    // Can't use std::copy() as the CapnP iterators don't provide an iterator category
-    for (auto p = reader.begin(); p != reader.end(); ++p)
-        blob->data_.push_back(*p);
-
-    return blob.release();
 }
 

--- a/src/include/common/mir/events/pointer_event.h
+++ b/src/include/common/mir/events/pointer_event.h
@@ -65,9 +65,6 @@ struct MirPointerEvent : MirInputEvent
     MirPointerButtons buttons() const;
     void set_buttons(MirPointerButtons buttons);
 
-    void set_dnd_handle(std::vector<uint8_t> const& handle);
-    MirBlob* dnd_handle() const;
-
 private:
     std::optional<mir::geometry::PointF> local_position_;
     std::optional<mir::geometry::PointF> position_;

--- a/src/include/common/mir/events/window_event.h
+++ b/src/include/common/mir/events/window_event.h
@@ -38,14 +38,10 @@ struct MirWindowEvent : MirEvent
     int value() const;
     void set_value(int value);
 
-    void set_dnd_handle(std::vector<uint8_t> const& handle);
-    MirBlob* dnd_handle() const;
-
 private:
     int id_ = 0;
     MirWindowAttrib attrib_ = {};
     int value_ = 0;
-    std::optional<std::vector<uint8_t>> dnd_handle_;
 };
 
 #endif /* MIR_COMMON_WINDOW_EVENT_H_ */

--- a/src/include/server/mir/shell/abstract_shell.h
+++ b/src/include/server/mir/shell/abstract_shell.h
@@ -95,11 +95,6 @@ public:
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp) override;
 
-    void request_drag_and_drop(
-        std::shared_ptr<scene::Session> const& session,
-        std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp) override;
-
     void request_move(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
@@ -151,9 +146,6 @@ public:
     void remove_display(geometry::Rectangle const& area) override;
 
     bool handle(MirEvent const& event) override;
-
-    void set_drag_and_drop_handle(std::vector<uint8_t> const& handle) override;
-    void clear_drag_and_drop_handle() override;
 
 protected:
     std::shared_ptr<InputTargeter> const input_targeter;

--- a/src/include/server/mir/shell/focus_controller.h
+++ b/src/include/server/mir/shell/focus_controller.h
@@ -53,9 +53,6 @@ public:
 
     virtual void raise(SurfaceSet const& surfaces) = 0;
 
-    virtual void set_drag_and_drop_handle(std::vector<uint8_t> const& handle) = 0;
-    virtual void clear_drag_and_drop_handle() = 0;
-
 protected:
     FocusController() = default;
     FocusController(FocusController const&) = delete;

--- a/src/include/server/mir/shell/input_targeter.h
+++ b/src/include/server/mir/shell/input_targeter.h
@@ -40,9 +40,6 @@ public:
     virtual void set_focus(std::shared_ptr<input::Surface> const& focus_surface) = 0;
     virtual void clear_focus() = 0;
 
-    virtual void set_drag_and_drop_handle(std::vector<uint8_t> const& handle) = 0;
-    virtual void clear_drag_and_drop_handle() = 0;
-
 protected:
     InputTargeter() = default;
     InputTargeter(InputTargeter const&) = delete;

--- a/src/include/server/mir/shell/shell.h
+++ b/src/include/server/mir/shell/shell.h
@@ -114,11 +114,6 @@ public:
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp) = 0;
 
-    virtual void request_drag_and_drop(
-        std::shared_ptr<scene::Session> const& session,
-        std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp) = 0;
-
     virtual void request_move(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,

--- a/src/include/server/mir/shell/shell_wrapper.h
+++ b/src/include/server/mir/shell/shell_wrapper.h
@@ -96,11 +96,6 @@ public:
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp) override;
 
-    void request_drag_and_drop(
-        std::shared_ptr<scene::Session> const& session,
-        std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp) override;
-
     void request_move(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,
@@ -116,9 +111,6 @@ public:
     void remove_display(geometry::Rectangle const& area) override;
 
     bool handle(MirEvent const& event) override;
-
-    void set_drag_and_drop_handle(std::vector<uint8_t> const& handle) override;
-    void clear_drag_and_drop_handle() override;
 
 protected:
     std::shared_ptr<Shell> const wrapped;

--- a/src/include/server/mir/shell/system_compositor_window_manager.h
+++ b/src/include/server/mir/shell/system_compositor_window_manager.h
@@ -97,11 +97,6 @@ private:
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp) override;
 
-    void handle_request_drag_and_drop(
-        std::shared_ptr<scene::Session> const& session,
-        std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp) override;
-
     void handle_request_move(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,

--- a/src/include/server/mir/shell/window_manager.h
+++ b/src/include/server/mir/shell/window_manager.h
@@ -78,11 +78,6 @@ public:
         std::shared_ptr<scene::Surface> const& surface,
         uint64_t timestamp) = 0;
 
-    virtual void handle_request_drag_and_drop(
-        std::shared_ptr<scene::Session> const& session,
-        std::shared_ptr<scene::Surface> const& surface,
-        uint64_t timestamp) = 0;
-
     virtual void handle_request_move(
         std::shared_ptr<scene::Session> const& session,
         std::shared_ptr<scene::Surface> const& surface,

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -388,20 +388,6 @@ void miral::BasicWindowManager::handle_raise_surface(
         policy->handle_raise_window(info_for(surface));
 }
 
-void miral::BasicWindowManager::handle_request_drag_and_drop(
-    std::shared_ptr<mir::scene::Session> const& /*session*/,
-    std::shared_ptr<mir::scene::Surface> const& surface,
-    uint64_t timestamp)
-{
-    Locker lock{this};
-
-    if (!surface_known(surface, "drag-and-drop"))
-        return;
-
-    if (timestamp >= last_input_event_timestamp)
-        policy->handle_request_drag_and_drop(info_for(surface));
-}
-
 void miral::BasicWindowManager::handle_request_move(
     std::shared_ptr<mir::scene::Session> const& /*session*/,
     std::shared_ptr<mir::scene::Surface> const& surface,

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -108,11 +108,6 @@ public:
         std::shared_ptr<mir::scene::Surface> const& surface,
         uint64_t timestamp) override;
 
-    void handle_request_drag_and_drop(
-        std::shared_ptr<mir::scene::Session> const& session,
-        std::shared_ptr<mir::scene::Surface> const& surface,
-        uint64_t timestamp) override;
-
     void handle_request_move(
         std::shared_ptr<mir::scene::Session> const& session,
         std::shared_ptr<mir::scene::Surface> const& surface,

--- a/src/miral/window_management_trace.cpp
+++ b/src/miral/window_management_trace.cpp
@@ -817,12 +817,15 @@ try {
 }
 MIRAL_TRACE_EXCEPTION
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 void miral::WindowManagementTrace::handle_request_drag_and_drop(miral::WindowInfo& window_info)
 try {
     mir::log_info("%s window_info=%s", __func__, dump_of(window_info).c_str());
     policy->handle_request_drag_and_drop(window_info);
 }
 MIRAL_TRACE_EXCEPTION
+#pragma GCC diagnostic pop
 
 void miral::WindowManagementTrace::handle_request_move(miral::WindowInfo& window_info, MirInputEvent const* input_event)
 try {

--- a/src/server/input/null_input_targeter.h
+++ b/src/server/input/null_input_targeter.h
@@ -36,9 +36,6 @@ struct NullInputTargeter : public shell::InputTargeter
     void clear_focus() override
     {
     }
-
-    void set_drag_and_drop_handle(std::vector<uint8_t> const&) override {}
-    void clear_drag_and_drop_handle() override {}
 };
 
 }

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -348,7 +348,7 @@ void mi::SurfaceInputDispatcher::surface_moved(ms::Surface const* moved_surface)
         send_motion_event_to_moved_surface(
             ctx,
             moved_surface,
-            [this](auto surf, auto ev) { deliver_without_relative_motion(surf, ev); });
+            [](auto surf, auto ev) { deliver_without_relative_motion(surf, ev); });
     }
 }
 

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -463,15 +463,10 @@ bool mi::SurfaceInputDispatcher::dispatch_pointer(MirInputDeviceId id, std::shar
     {
         deliver(pointer_state.gesture_owner, ev);
 
-        auto const gesture_terminated = is_gesture_terminator(pev);
-
-        if (gesture_terminated)
+        if (is_gesture_terminator(pev))
         {
             pointer_state.gesture_owner.reset();
-        }
 
-        if (gesture_terminated)
-        {
             auto target = scene->input_surface_at(event_x_y);
 
             if (pointer_state.current_target != target)
@@ -482,9 +477,6 @@ bool mi::SurfaceInputDispatcher::dispatch_pointer(MirInputDeviceId id, std::shar
                 pointer_state.current_target = target;
                 if (target)
                     send_enter_exit_event(target, pev, mir_pointer_action_enter);
-
-                if (!gesture_terminated)
-                    pointer_state.gesture_owner = target;
             }
         }
 

--- a/src/server/input/surface_input_dispatcher.cpp
+++ b/src/server/input/surface_input_dispatcher.cpp
@@ -102,10 +102,7 @@ void set_local_positions_based_on_surface_input_bounds(
         });
 }
 
-void deliver_without_relative_motion(
-    std::shared_ptr<mi::Surface> const& surface,
-    MirEvent const* ev,
-    std::vector<uint8_t> const& drag_and_drop_handle)
+void deliver_without_relative_motion(std::shared_ptr<mi::Surface> const& surface, MirEvent const* ev)
 {
     auto const* input_ev = mir_event_get_input_event(ev);
     auto const* pev = mir_input_event_get_pointer_event(input_ev);
@@ -134,20 +131,12 @@ void deliver_without_relative_motion(
         0.0f);
 
     set_local_positions_based_on_surface_input_bounds(*to_deliver, bounds);
-    if (!drag_and_drop_handle.empty())
-        mev::set_drag_and_drop_handle(*to_deliver, drag_and_drop_handle);
     surface->consume(std::move(to_deliver));
 }
 
-void deliver(
-    std::shared_ptr<mi::Surface> const& surface,
-    MirEvent const* ev,
-    std::vector<uint8_t> const& drag_and_drop_handle)
+void deliver(std::shared_ptr<mi::Surface> const& surface, MirEvent const* ev)
 {
     auto to_deliver = mev::clone_event(*ev);
-
-    if (!drag_and_drop_handle.empty())
-        mev::set_drag_and_drop_handle(*to_deliver, drag_and_drop_handle);
 
     auto const& bounds = surface->input_bounds();
     set_local_positions_based_on_surface_input_bounds(*to_deliver, bounds);
@@ -359,7 +348,7 @@ void mi::SurfaceInputDispatcher::surface_moved(ms::Surface const* moved_surface)
         send_motion_event_to_moved_surface(
             ctx,
             moved_surface,
-            [this](auto surf, auto ev) { deliver_without_relative_motion(surf, ev, drag_and_drop_handle); });
+            [this](auto surf, auto ev) { deliver_without_relative_motion(surf, ev); });
     }
 }
 
@@ -442,10 +431,7 @@ void mi::SurfaceInputDispatcher::send_enter_exit_event(std::shared_ptr<mi::Surfa
     {
         set_local_positions_based_on_surface_input_bounds(*event, surface->input_bounds());
     }
-    if (!drag_and_drop_handle.empty())
-    {
-        mev::set_drag_and_drop_handle(*event, drag_and_drop_handle);
-    }
+
     surface->consume(std::move(event));
 }
 
@@ -475,7 +461,7 @@ bool mi::SurfaceInputDispatcher::dispatch_pointer(MirInputDeviceId id, std::shar
 
     if (pointer_state.gesture_owner)
     {
-        deliver(pointer_state.gesture_owner, ev, drag_and_drop_handle);
+        deliver(pointer_state.gesture_owner, ev);
 
         auto const gesture_terminated = is_gesture_terminator(pev);
 
@@ -484,7 +470,7 @@ bool mi::SurfaceInputDispatcher::dispatch_pointer(MirInputDeviceId id, std::shar
             pointer_state.gesture_owner.reset();
         }
 
-        if (gesture_terminated || !drag_and_drop_handle.empty())
+        if (gesture_terminated)
         {
             auto target = scene->input_surface_at(event_x_y);
 
@@ -536,11 +522,11 @@ bool mi::SurfaceInputDispatcher::dispatch_pointer(MirInputDeviceId id, std::shar
         if (sent_ev)
         {
             if (action != mir_pointer_action_motion)
-                deliver_without_relative_motion(target, ev, drag_and_drop_handle);
+                deliver_without_relative_motion(target, ev);
         }
         else
         {
-            deliver(target, ev, drag_and_drop_handle);
+            deliver(target, ev);
         }
         return true;
     }
@@ -596,7 +582,7 @@ bool mi::SurfaceInputDispatcher::dispatch_touch(MirInputDeviceId id, MirEvent co
 
     if (gesture_owner)
     {
-        deliver(gesture_owner, ev, drag_and_drop_handle);
+        deliver(gesture_owner, ev);
 
         if (is_gesture_end(tev))
             gesture_owner.reset();
@@ -664,18 +650,6 @@ void mi::SurfaceInputDispatcher::clear_focus()
 {
     std::lock_guard lg(dispatcher_mutex);
     set_focus_locked(lg, nullptr);
-}
-
-void mir::input::SurfaceInputDispatcher::set_drag_and_drop_handle(std::vector<uint8_t> const& handle)
-{
-    std::lock_guard lg(dispatcher_mutex);
-    drag_and_drop_handle = handle;
-}
-
-void mir::input::SurfaceInputDispatcher::clear_drag_and_drop_handle()
-{
-    std::lock_guard lg(dispatcher_mutex);
-    drag_and_drop_handle.clear();
 }
 
 void mir::input::SurfaceInputDispatcher::register_interest(std::weak_ptr<KeyboardObserver> const& observer)

--- a/src/server/input/surface_input_dispatcher.h
+++ b/src/server/input/surface_input_dispatcher.h
@@ -60,9 +60,6 @@ public:
     void set_focus(std::shared_ptr<input::Surface> const& target) override;
     void clear_focus() override;
 
-    void set_drag_and_drop_handle(std::vector<uint8_t> const& handle) override;
-    void clear_drag_and_drop_handle() override;
-
     // ObserverRegistrar
     void register_interest(std::weak_ptr<KeyboardObserver> const& observer) override;
     void register_interest(
@@ -127,7 +124,6 @@ private:
     std::mutex dispatcher_mutex;
     std::shared_ptr<MirEvent const> last_pointer_event;
     std::weak_ptr<input::Surface> focus_surface;
-    std::vector<uint8_t> drag_and_drop_handle;
     bool started;
 };
 

--- a/src/server/shell/abstract_shell.cpp
+++ b/src/server/shell/abstract_shell.cpp
@@ -362,14 +362,6 @@ void msh::AbstractShell::raise_surface(
     window_manager->handle_raise_surface(session, surface, timestamp);
 }
 
-void msh::AbstractShell::request_drag_and_drop(
-    std::shared_ptr<scene::Session> const& session,
-    std::shared_ptr<scene::Surface> const& surface,
-    uint64_t timestamp)
-{
-    window_manager->handle_request_drag_and_drop(session, surface, timestamp);
-}
-
 void msh::AbstractShell::request_move(
     std::shared_ptr<scene::Session> const& session,
     std::shared_ptr<scene::Surface> const& surface,
@@ -687,12 +679,3 @@ void msh::AbstractShell::raise(SurfaceSet const& surfaces)
     report->surfaces_raised(surfaces);
 }
 
-void msh::AbstractShell::set_drag_and_drop_handle(std::vector<uint8_t> const& handle)
-{
-    input_targeter->set_drag_and_drop_handle(handle);
-}
-
-void msh::AbstractShell::clear_drag_and_drop_handle()
-{
-    input_targeter->clear_drag_and_drop_handle();
-}

--- a/src/server/shell/shell_wrapper.cpp
+++ b/src/server/shell/shell_wrapper.cpp
@@ -141,14 +141,6 @@ void msh::ShellWrapper::raise_surface(
     wrapped->raise_surface(session, surface, timestamp);
 }
 
-void msh::ShellWrapper::request_drag_and_drop(
-    std::shared_ptr<ms::Session> const& session,
-    std::shared_ptr<ms::Surface> const& surface,
-    uint64_t timestamp)
-{
-    wrapped->request_drag_and_drop(session, surface, timestamp);
-}
-
 void msh::ShellWrapper::request_move(
     std::shared_ptr<ms::Session> const& session,
     std::shared_ptr<ms::Surface> const& surface,
@@ -194,14 +186,4 @@ auto msh::ShellWrapper::surface_at(geometry::Point cursor) const -> std::shared_
 void msh::ShellWrapper::raise(SurfaceSet const& surfaces)
 {
     return wrapped->raise(surfaces);
-}
-
-void msh::ShellWrapper::set_drag_and_drop_handle(std::vector<uint8_t> const& handle)
-{
-    wrapped->set_drag_and_drop_handle(handle);
-}
-
-void msh::ShellWrapper::clear_drag_and_drop_handle()
-{
-    wrapped->clear_drag_and_drop_handle();
 }

--- a/src/server/shell/system_compositor_window_manager.cpp
+++ b/src/server/shell/system_compositor_window_manager.cpp
@@ -219,13 +219,6 @@ void msh::SystemCompositorWindowManager::handle_raise_surface(
 {
 }
 
-void msh::SystemCompositorWindowManager::handle_request_drag_and_drop(
-    std::shared_ptr<ms::Session> const& /*session*/,
-    std::shared_ptr<ms::Surface> const& /*surface*/,
-    uint64_t /*timestamp*/)
-{
-}
-
 void msh::SystemCompositorWindowManager::handle_request_move(
     std::shared_ptr<ms::Session> const& /*session*/,
     std::shared_ptr<ms::Surface> const& /*surface*/,

--- a/tests/include/mir/test/doubles/mock_window_manager.h
+++ b/tests/include/mir/test/doubles/mock_window_manager.h
@@ -58,7 +58,6 @@ struct MockWindowManager : shell::WindowManager
     MOCK_METHOD1(handle_pointer_event, bool(MirPointerEvent const*));
 
     MOCK_METHOD3(handle_raise_surface, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, uint64_t));
-    MOCK_METHOD3(handle_request_drag_and_drop, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, uint64_t));
     MOCK_METHOD3(handle_request_move, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, MirInputEvent const*));
     MOCK_METHOD4(handle_request_resize, void(std::shared_ptr<scene::Session> const&, std::shared_ptr<scene::Surface> const&, MirInputEvent const*, MirResizeEdge));
 

--- a/tests/include/mir/test/doubles/stub_input_targeter.h
+++ b/tests/include/mir/test/doubles/stub_input_targeter.h
@@ -34,9 +34,6 @@ struct StubInputTargeter : public shell::InputTargeter
     void clear_focus() override
     {
     }
-
-    void set_drag_and_drop_handle(std::vector<uint8_t> const&) override {}
-    void clear_drag_and_drop_handle() override {}
 };
 
 }

--- a/tests/include/mir/test/doubles/stub_shell.h
+++ b/tests/include/mir/test/doubles/stub_shell.h
@@ -87,14 +87,6 @@ struct StubShell : public shell::Shell
     void raise(shell::SurfaceSet const& /*surfaces*/) override
     {
     }
-
-    void set_drag_and_drop_handle(std::vector<uint8_t> const& /*handle*/) override
-    {
-    }
-
-    void clear_drag_and_drop_handle() override
-    {
-    }
     /// @}
 
     /// Overrides from shell::Shell
@@ -173,13 +165,6 @@ struct StubShell : public shell::Shell
     }
 
     void raise_surface(
-        std::shared_ptr<scene::Session> const& /*session*/,
-        std::shared_ptr<scene::Surface> const& /*surface*/,
-        uint64_t /*timestamp*/) override
-    {
-    }
-
-    void request_drag_and_drop(
         std::shared_ptr<scene::Session> const& /*session*/,
         std::shared_ptr<scene::Surface> const& /*surface*/,
         uint64_t /*timestamp*/) override

--- a/tests/miral/ignored_requests.cpp
+++ b/tests/miral/ignored_requests.cpp
@@ -130,12 +130,6 @@ TEST_P(IgnoredRequests, raise_unknown_surface_noops)
     basic_window_manager.handle_raise_surface(session, window, 100);
 }
 
-TEST_P(IgnoredRequests, drag_and_drop_unknown_surface_noops)
-{
-    auto const window = GetParam().window(*this);
-    basic_window_manager.handle_request_drag_and_drop(session, window, 100);
-}
-
 TEST_P(IgnoredRequests, move_unknown_surface_noops)
 {
     auto const window = GetParam().window(*this);

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -58,10 +58,6 @@ struct StubFocusController : mir::shell::FocusController
 
     virtual auto surface_at(mir::geometry::Point /*cursor*/) const -> std::shared_ptr<mir::scene::Surface> override
         { return {}; }
-
-    void set_drag_and_drop_handle(std::vector<uint8_t> const& /*handle*/) override {}
-
-    void clear_drag_and_drop_handle() override {}
 };
 
 struct StubDisplayLayout : mir::shell::DisplayLayout


### PR DESCRIPTION
It is now clear we don't need this at all for implementing drag and drop in Wayland.

So delete the implementation and explicitly deprecate the APIs