### PR TITLE
Ensure that the SetWindowManagementPolicy lives long enough

### DIFF
--- a/include/test/mir_test_framework/async_server_runner.h
+++ b/include/test/mir_test_framework/async_server_runner.h
@@ -56,10 +56,6 @@ private:
     std::list<TemporaryEnvironmentValue> env;
     mir::test::AutoJoinThread server_thread;
 
-    // Once we migrate away from "legacy" window management stubs this can become
-    // SetWindowManagementPolicy set_window_management_policy;
-    std::function<void(mir::Server&)> set_window_management_policy;
-
     std::mutex mutex;
     std::condition_variable started;
     bool server_running{false};

--- a/tests/performance-tests/test_glmark2-es2.cpp
+++ b/tests/performance-tests/test_glmark2-es2.cpp
@@ -41,7 +41,7 @@ namespace
 {
 struct AbstractGLMark2Test : testing::Test, mtf::AsyncServerRunner {
     void SetUp() override {
-        miral::set_window_management_policy<miral::MinimalWindowManager>()(server);
+        set_window_management_policy(server);
         start_server();
     }
 
@@ -119,6 +119,10 @@ struct AbstractGLMark2Test : testing::Test, mtf::AsyncServerRunner {
             }
         }
     }
+
+private:
+    miral::SetWindowManagementPolicy const set_window_management_policy =
+        miral::set_window_management_policy<miral::MinimalWindowManager>();
 };
 
 struct GLMark2Xwayland : AbstractGLMark2Test


### PR DESCRIPTION
Having SetWindowManagementPolicy as a temporary didn't guarantee it lived long enough to be used by the server startup. Making it a member variable does (as it lasts much longer - until server shutdown).

Fixes: #2900