### PR TITLE
spread: drop Alpine 3.17, Fedora 36

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -38,8 +38,7 @@ jobs:
                  "lxd:ubuntu-22.04:spread/build/ubuntu:ubsan_clang"'
         fi
 
-        TASKS+='"lxd:alpine-3.17:spread/build/alpine:amd64"
-                "lxd:alpine-3.18:spread/build/alpine:amd64"
+        TASKS+='"lxd:alpine-3.18:spread/build/alpine:amd64"
                 "lxd:alpine-edge:spread/build/alpine:amd64"
                 "lxd:ubuntu-22.04:spread/build/sbuild:debian_sid"
                 "lxd:ubuntu-22.04:spread/build/sbuild:ubuntu"
@@ -48,7 +47,6 @@ jobs:
                 "lxd:ubuntu-22.04:spread/build/sbuild:ubuntu_arm64"
                 "lxd:ubuntu-22.04:spread/build/sbuild:ubuntu_armhf"
                 "lxd:ubuntu-22.04:spread/build/ubuntu:clang"
-                "lxd:fedora-36:spread/build/fedora:amd64"
                 "lxd:fedora-37:spread/build/fedora:amd64"
                 "lxd:fedora-38:spread/build/fedora:amd64"
                 "lxd:fedora-rawhide:spread/build/fedora:amd64"

--- a/spread.yaml
+++ b/spread.yaml
@@ -5,11 +5,9 @@ kill-timeout: 45m
 backends:
     lxd:
         systems:
-            - alpine-3.17
             - alpine-3.18
             - alpine-edge
             - ubuntu-22.04
-            - fedora-36
             - fedora-37
             - fedora-38
             - fedora-rawhide:


### PR DESCRIPTION
We've Alpine 3.18 now, and F36 is EOL:

https://docs.fedoraproject.org/en-US/releases/eol/