### PR TITLE
tests/wlcs: Drop frame_timestamp_increases from expected failures

### DIFF
--- a/tests/acceptance-tests/wayland/CMakeLists.txt
+++ b/tests/acceptance-tests/wayland/CMakeLists.txt
@@ -35,7 +35,6 @@ pkg_get_variable(WLCS_BINARY wlcs test_runner)
 
 set(EXPECTED_FAILURES
 
-  ClientSurfaceEventsTest.frame_timestamp_increases
   ClientSurfaceEventsTest.surface_gets_enter_event
   ClientSurfaceEventsTest.surface_gets_leave_event
   SubsurfaceTest.place_above_simple


### PR DESCRIPTION
Mir has actually been sending correct (or, at least, not wildly incorrect) timestamps on frame events for quite some time, but the test itself was broken.

Now that the test is not broken (and was then fixed *again*), remove it from the XFAIL list so CI will pass again.