### PR TITLE
(#2365) Updated Doxyfile.in to ignore namespaces that we do not want exported

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -985,7 +985,13 @@ EXCLUDE_PATTERNS       = *.capnp.c++ \
 EXCLUDE_SYMBOLS        = google \
                          mfd \
                          mgg \
-                         mp
+                         mp \
+                         mir::frontend \
+                         mir::graphics \
+                         mir::scene \
+                         mir::shell \
+                         mir::compositor \
+                         mir::input
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/include/core/mir/anonymous_shm_file.h
+++ b/include/core/mir/anonymous_shm_file.h
@@ -23,10 +23,6 @@
 namespace mir
 {
 
-namespace detail
-{
-}
-
 class AnonymousShmFile : public ShmFile
 {
 public:


### PR DESCRIPTION
# https://github.com/MirServer/mir/issues/2365

## What's new?
- Removed an empty namespace reference
- Added a bunch of `mir::` namespaces to our ignored list of namespaces. AFAIK, this is the best solution (see [here](https://sourceforge.net/p/doxygen/mailman/message/32202449/) for more details)
- I did not remove the `namespace wallpaper` document, as that is rightly being exported because we export docs for all of `example-server-lib`. My suggestion would be for all of the example code to be in an `namespace example` so as not to confused doc-readers with the rest of the documentation. I think that is outside of the scope of this PR though