### PR TITLE
 Send modifiers after keyboard enter

### DIFF
--- a/src/server/frontend_wayland/wl_keyboard.cpp
+++ b/src/server/frontend_wayland/wl_keyboard.cpp
@@ -110,14 +110,11 @@ void mf::WlKeyboard::send_key(std::shared_ptr<MirKeyboardEvent const> const& eve
 
 void mf::WlKeyboard::send_modifiers(MirXkbModifiers const& modifiers)
 {
-    if (focused_surface)
-    {
-        auto const serial = client->next_serial(nullptr);
-        send_modifiers_event(
-            serial,
-            modifiers.depressed,
-            modifiers.latched,
-            modifiers.locked,
-            modifiers.effective_layout);
-    }
+    auto const serial = client->next_serial(nullptr);
+    send_modifiers_event(
+        serial,
+        modifiers.depressed,
+        modifiers.latched,
+        modifiers.locked,
+        modifiers.effective_layout);
 }


### PR DESCRIPTION
We need to re-sync modifier state after `wl_keyboard.enter()`, so we need `WlKeyboard::send_modifiers()` to send the modifiers unconditionally.

Fixes: #2985

Note that this condition originates in #2537 which "fixed" #2535 and #2025.

Alternative to #2988