### PR TITLE
ci: don't fail-fast on snaps

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -38,6 +38,7 @@ jobs:
     timeout-minutes: 30
 
     strategy:
+      fail-fast: false
       matrix:
         include:
         - snap: MirServer/mir-test-tools


### PR DESCRIPTION
Ref.:

https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures