### PR TITLE
Suggestion: Fixing a few broken links in the markdown version of the files and some light reorganization

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,6 +1,5 @@
 # Mir hacking guide
 
-
 ## Style Guide
 
 There is a *coding style guide* in the guides subdirectory. To build it into an
@@ -81,6 +80,7 @@ You can configure *Mir* to provide runtime information helpful for debugging
 by enabling component reports:
 
  - *[Component Reports](./doc/component_reports.md)*
+
 
 ## Documentation
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -24,7 +24,7 @@ There is a *coding style guide* in the guides subdirectory. To build it into an
     $ cmake ..
     $ make guides
 
-(Or if you're reading the web version [here](https://mir-server.io/doc/cppguide/index.html)).
+(Or if you're reading the web version [here](cppguide/index.html)).
 
 
 ## Code structure

--- a/HACKING.md
+++ b/HACKING.md
@@ -80,4 +80,11 @@ documented.
 There are *design notes* and an *architecture diagram* (.dia) in the design
 subdirectory.
 
+## Debugging
+You can configure *Mir* to provide runtime information helpful for debugging
+by enabling component reports:
+
+- *[Component Reports](./doc/component_reports.md)*
+
+
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -2,13 +2,10 @@
 
 ## Building & running
 
-For build instructions, please see:
+For build instructions, and a brief guide describing how to run the *Mir binaries* please see:
 - *[Getting and Using Mir](./doc/getting_and_using_mir.md)*.
-
-Once you have the project built, there are some brief guides in that doucment that
-describe how to run the *Mir binaries*. You might think it's obvious but there are some important things
-you need to know to get it working, and also to prevent your existing *X server*
-from dying at the same time
+_You might think it's obvious but there are some important things you need to know to get it working,
+and also to prevent your existing *X server* from dying at the same time!_
 
 You can configure *Mir* to provide runtime information helpful for debugging
 by enabling component reports:

--- a/HACKING.md
+++ b/HACKING.md
@@ -30,7 +30,7 @@ There is a *coding style guide* in the guides subdirectory. To build it into an
 
 ## Code structure
 
-<b><i>include/</i></b>
+_**include/**_
 
 The include subdirectory contains header files "published" by corresponding parts
 of the system. For example, *include/mir/option/option.h* provides a system-wide interface
@@ -45,14 +45,14 @@ should not expose platform or implementation technology types *etc.* (And as pub
 are normally implementations of interfaces they do not use these types.)
 
 
-<b><i>_src/_</i></b>
+_**src/**_
 
 This comprises the implementation of *Mir*. Header files for use within the component
 should be put here. The only headers from the source tree that should be included are
 ones from the current component (ones that do not require a path component).
 
 
-<b><i>_test/_</i></b>
+_**test/**_
 
 This contains unit, integration and acceptance tests written using *gtest/gmock*. Tests
 largely depend upon the public interfaces of components - but tests of units within

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,6 +1,20 @@
 # Mir hacking guide
 
-## Style Guide
+## Building & running
+
+There are some brief guides describing how to run the *Mir binaries* once you have
+them built. You might think it's obvious but there are some important things
+you need to know to get it working, and also to prevent your existing *X server*
+from dying at the same time.
+
+- *[Getting and Using Mir](./doc/getting_and_using_mir.md)*
+
+You can configure *Mir* to provide runtime information helpful for debugging
+by enabling component reports:
+
+- *[Component Reports](./doc/component_reports.md)*
+
+## Style guide
 
 There is a *coding style guide* in the guides subdirectory. To build it into an
 *html* file:
@@ -65,21 +79,6 @@ validity. Unless otherwise documented functions and constructors that
 take pointer parameters have validity of the referenced objects as a
 precondition. Exceptions to the rule must be of limited scope and 
 documented.
-
-
-## Running
-
-There are some brief guides describing how to run the *Mir binaries* once you have
-them built. You might think it's obvious but there are some important things
-you need to know to get it working, and also to prevent your existing *X server*
-from dying at the same time.
-
- - *[Getting and Using Mir](./doc/getting_and_using_mir.md)*
-
-You can configure *Mir* to provide runtime information helpful for debugging
-by enabling component reports:
-
- - *[Component Reports](./doc/component_reports.md)*
 
 
 ## Documentation

--- a/HACKING.md
+++ b/HACKING.md
@@ -7,10 +7,6 @@ For build instructions, and a brief guide describing how to run the *Mir binarie
 _You might think it's obvious but there are some important things you need to know to get it working,
 and also to prevent your existing *X server* from dying at the same time!_
 
-You can configure *Mir* to provide runtime information helpful for debugging
-by enabling component reports:
-
-- *[Component Reports](./doc/component_reports.md)*
 
 ## Style guide
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -2,12 +2,13 @@
 
 ## Building & running
 
-There are some brief guides describing how to run the *Mir binaries* once you have
-them built. You might think it's obvious but there are some important things
-you need to know to get it working, and also to prevent your existing *X server*
-from dying at the same time.
+For build instructions, please see:
+- *[Getting and Using Mir](./doc/getting_and_using_mir.md)*.
 
-- *[Getting and Using Mir](./doc/getting_and_using_mir.md)*
+Once you have the project built, there are some brief guides in that doucment that
+describe how to run the *Mir binaries*. You might think it's obvious but there are some important things
+you need to know to get it working, and also to prevent your existing *X server*
+from dying at the same time
 
 You can configure *Mir* to provide runtime information helpful for debugging
 by enabling component reports:

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,21 +1,22 @@
-Mir hacking guide
-=================
+# Mir hacking guide
 
-Coding *Mir*
-----------
 
-There's a *__coding style guide__* in the guides subdirectory. To build it into an
+## Style Guide
+
+There is a *coding style guide* in the guides subdirectory. To build it into an
 *html* file:
 
+    $ mkdir build
+    $ cd build
+    $ cmake ..
     $ make guides
 
-(Or if you're reading the web version [here](cppguide/index.html)).
+(Or if you're reading the web version [here](https://mir-server.io/doc/cppguide/index.html)).
 
 
-Code structure
---------------
+## Code structure
 
-*__Code structure: include__*
+<b><i>include/</i></b>
 
 The include subdirectory contains header files "published" by corresponding parts
 of the system. For example, *include/mir/option/option.h* provides a system-wide interface
@@ -30,22 +31,21 @@ should not expose platform or implementation technology types *etc.* (And as pub
 are normally implementations of interfaces they do not use these types.)
 
 
-*__Code structure: src__*
+<b><i>_src/_</i></b>
 
 This comprises the implementation of *Mir*. Header files for use within the component
 should be put here. The only headers from the source tree that should be included are
 ones from the current component (ones that do not require a path component).
 
 
-*__Code structure: test__*
+<b><i>_test/_</i></b>
 
 This contains unit, integration and acceptance tests written using *gtest/gmock*. Tests
 largely depend upon the public interfaces of components - but tests of units within
 a component will include headers from within the source tree.
 
 
-Error handling strategy
------------------------
+## Error handling strategy
 
 If a function cannot meet its post-conditions it throws an exception and meets
 __AT LEAST__ the basic exception safety guarantee. It is a good idea to document the
@@ -57,8 +57,7 @@ preconditions may be verified using the "*assert"* macro - which may or may
 not report problems (depending upon the __NDEBUG__ define).
 
 
-Implicit rules
---------------
+## Implicit rules
 
 There are a lot of __pointers__ (mostly smart, but a few raw ones) passed
 around in the code. We have adopted the general rule that pointers are
@@ -69,23 +68,21 @@ precondition. Exceptions to the rule must be of limited scope and
 documented.
 
 
-Running *Mir*
------------
+## Running
 
 There are some brief guides describing how to run the *Mir binaries* once you have
 them built. You might think it's obvious but there are some important things
 you need to know to get it working, and also to prevent your existing *X server*
 from dying at the same time.
 
- - *\ref getting_and_using_mir*
+ - *[Getting and Using Mir](./doc/getting_and_using_mir.md)*
 
 You can configure *Mir* to provide runtime information helpful for debugging
 by enabling component reports:
 
- - *\ref component_reports*
+ - *[Component Reports](./doc/component_reports.md)*
 
-Documentation
--------------
+## Documentation
 
 There are *design notes* and an *architecture diagram* (.dia) in the design
 subdirectory.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ## Resources
-The Mir project website is <http://www.mir-server.io/>,
+The Mir project website is <http://mir-server.io/>,
 the code is [hosted on GitHub](https://github.com/MirServer)
 
 For announcements and other discussions on Mir see:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Mir - Wayland compositor
-========================
+# Mir - Wayland compositor
 
 **Mir** is set of libraries for building Wayland based shells. Mir 
 simplifies the complexity that shell authors need to deal with: it
@@ -16,8 +15,7 @@ Window management is integrated into Mir with useful default behaviour
 and is extremely customisable by shell authors using a simple high-level
 API.
 
-License
--------
+## License
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 2 or 3 as
 published by the Free Software Foundation.
@@ -30,8 +28,18 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-Website
--------
-Mir's website is hosted on <https://mir-server.io/>.
+## Resources
+The Mir project website is <http://www.mirserver.io/>,
+the code is [hosted on GitHub](https://github.com/MirServer)
 
-\copyright Copyright © Canonical Ltd.
+For announcements and other discussions on Mir see:
+[Mir on community.ubuntu](https://community.ubuntu.com/c/mir)
+
+For other questions and discussion about the Mir project:
+the [\#mirserver](https://web.libera.chat/?channels=#mir-server) IRC channel on Libera.Chat.
+
+For developer documentation, including installation and build instructions,
+see <https://mir-server.io/doc/index.html>.
+
+# Copyright
+Copyright © Canonical Ltd.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ## Resources
-The Mir project website is <http://www.mirserver.io/>,
+The Mir project website is <http://www.mir-server.io/>,
 the code is [hosted on GitHub](https://github.com/MirServer)
 
 For announcements and other discussions on Mir see:

--- a/doc/getting_and_using_mir.md
+++ b/doc/getting_and_using_mir.md
@@ -1,18 +1,16 @@
-Getting and Using Mir  {#getting_and_using_mir}
-=====================
+# Getting and Using Mir  {#getting_and_using_mir}
 
 Mir is a library for building things, not an end-user product, but it does come
 with some demos to illustrate the possibilities.
 
-Getting Mir demos
------------------
+## Getting Mir demos
 
 The Mir libraries and demos are available on Ubuntu, Fedora and Arch. It has 
 also been built and tested on Debian but, at the time or writing, is not in the
 archive.
 
 For Linux distributions that don't currently package Mir you need to build it
-yourself. (See \ref getting_involved_in_mir).
+yourself. (See \ref building).
 
 ## Getting Mir on Ubuntu
 
@@ -53,8 +51,7 @@ It is also useful to install qterminal:
 
 On Arch Linux, you can install the [mir](https://aur.archlinux.org/packages/mir/) package from the AUR.
 
-Using Mir demos
----------------
+## Using Mir demos
 
 For convenient testing under X11 there's a "miral-app" script that wraps the
 commands used to start a server and then launches a terminal (as the current
@@ -126,3 +123,16 @@ These options can also be specified in a configuration file. For example:
     $ cat ~/.config/miral-shell.config 
     keymap=gb
     window-manager=tiling
+
+## Using Mir for server development
+
+Install the headers and libraries for using libmiral in development:
+
+    sudo apt install libmiral-dev
+
+A `miral.pc` file is provided for use with `pkg-config` or other tools. For
+example:
+
+    pkg-config --cflags miral
+
+The server API is introduced here: \ref introducing_the_miral_api

--- a/doc/getting_and_using_mir.md
+++ b/doc/getting_and_using_mir.md
@@ -123,16 +123,3 @@ These options can also be specified in a configuration file. For example:
     $ cat ~/.config/miral-shell.config 
     keymap=gb
     window-manager=tiling
-
-## Using Mir for server development
-
-Install the headers and libraries for using libmiral in development:
-
-    sudo apt install libmiral-dev
-
-A `miral.pc` file is provided for use with `pkg-config` or other tools. For
-example:
-
-    pkg-config --cflags miral
-
-The server API is introduced here: \ref introducing_the_miral_api

--- a/doc/getting_and_using_mir.md
+++ b/doc/getting_and_using_mir.md
@@ -10,7 +10,7 @@ also been built and tested on Debian but, at the time or writing, is not in the
 archive.
 
 For Linux distributions that don't currently package Mir you need to build it
-yourself. (See \ref building).
+yourself. (See [Getting Involved in Mir](./getting_involved_in_mir.md)).
 
 ## Getting Mir on Ubuntu
 

--- a/doc/getting_involved_in_mir.md
+++ b/doc/getting_involved_in_mir.md
@@ -70,6 +70,6 @@ The Mir coding guidelines are [here](https://mir-server.io/doc/cppguide/index.ht
 
 
 ## Working on code
- - Hacking guidelines can be found here: \ref md_HACKING "Mir hacking guide"
- - Information about runtime tracing can be found here: \ref component_reports
- - A guide on versioning Mir DSOs: \ref dso_versioning_guide
+ - Hacking guidelines can be found here: [Mir Hacking Guides](../HACKING.md)
+ - Information about runtime tracing can be found here: [Component Reports](./component_reports.md)
+ - A guide on versioning Mir DSOs: [DSO Versioning Guide](./dso_versioning_guide.md)

--- a/doc/getting_involved_in_mir.md
+++ b/doc/getting_involved_in_mir.md
@@ -2,7 +2,7 @@
 
 ## Getting involved
 
-The Mir project website is <http://www.mirserver.io/>, 
+The Mir project website is <http://www.mir-server.io/>, 
 the code is [hosted on GitHub](https://github.com/MirServer) 
 
 For announcements and other discussions on Mir see: 

--- a/doc/getting_involved_in_mir.md
+++ b/doc/getting_involved_in_mir.md
@@ -60,7 +60,7 @@ You can install the Mir examples, headers and libraries you've built with:
   
     sudo make install
 
-### Contributing to Mir
+## Contributing to Mir
 
 Please file bug reports at: https://github.com/MirServer/mir/issues
 
@@ -69,7 +69,7 @@ The Mir development mailing list can be found at: https://lists.ubuntu.com/mailm
 The Mir coding guidelines are [here](https://mir-server.io/doc/cppguide/index.html).
 
 
-### Working on code
+## Working on code
  - Hacking guidelines can be found here: \ref md_HACKING "Mir hacking guide"
  - Information about runtime tracing can be found here: \ref component_reports
  - A guide on versioning Mir DSOs: \ref dso_versioning_guide

--- a/doc/getting_involved_in_mir.md
+++ b/doc/getting_involved_in_mir.md
@@ -2,7 +2,7 @@
 
 ## Getting involved
 
-The Mir project website is <http://www.mir-server.io/>, 
+The Mir project website is <http://mir-server.io/>, 
 the code is [hosted on GitHub](https://github.com/MirServer) 
 
 For announcements and other discussions on Mir see: 

--- a/doc/getting_involved_in_mir.md
+++ b/doc/getting_involved_in_mir.md
@@ -71,5 +71,6 @@ The Mir coding guidelines are [here](https://mir-server.io/doc/cppguide/index.ht
 
 ## Working on code
  - Hacking guidelines can be found here: [Mir Hacking Guides](../HACKING.md)
- - Information about runtime tracing can be found here: [Component Reports](./component_reports.md)
+ - You can configure *Mir* to provide runtime information helpful for debugging
+   by enabling component reports: [Component Reports](./component_reports.md)
  - A guide on versioning Mir DSOs: [DSO Versioning Guide](./dso_versioning_guide.md)

--- a/doc/getting_involved_in_mir.md
+++ b/doc/getting_involved_in_mir.md
@@ -34,8 +34,7 @@ instructions vary across distros.
 As we build these distros in Mir's CI you can copy the instructions
 from the corresponding files under `spread/build`.
 
-Building Mir
-------------
+## Building
 
     mkdir build
     cd  build
@@ -67,13 +66,10 @@ Please file bug reports at: https://github.com/MirServer/mir/issues
 
 The Mir development mailing list can be found at: https://lists.ubuntu.com/mailman/listinfo/Mir-devel
 
-The Mir coding guidelines are [here](cppguide/index.html).
+The Mir coding guidelines are [here](https://mir-server.io/doc/cppguide/index.html).
 
-### Working on Mir code
 
- - \ref md_README  "Mir Read me"
- - \ref md_HACKING "Mir hacking guide"
- - \ref component_reports
- - \ref dso_versioning_guide
- - \ref performance_framework
- - \ref latency "Measuring visual latency"
+### Working on code
+ - Hacking guidelines can be found here: \ref md_HACKING "Mir hacking guide"
+ - Information about runtime tracing can be found here: \ref component_reports
+ - A guide on versioning Mir DSOs: \ref dso_versioning_guide

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -24,6 +24,19 @@ API.
 
 - If you want to get involved in Mir development, see: \ref getting_involved_in_mir
 
+## Using Mir for server development
+
+Install the headers and libraries for using libmiral in development:
+
+    sudo apt install libmiral-dev
+
+A `miral.pc` file is provided for use with `pkg-config` or other tools. For
+example:
+
+    pkg-config --cflags miral
+
+The server API is introduced here: \ref introducing_the_miral_api
+
 ## Community
 
 Developer blogs, develompent announcements, questions, process documentation, and design

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -19,7 +19,7 @@ API.
 - The repository can be found [here](https://github.com/MirServer/mir)
 - If you want to use the Mir snaps, see: 
   [Make a Secure Ubuntu Web Kiosk](https://mir-server.io/docs/make-a-secure-ubuntu-web-kiosk)
-
+  [Miriway: the snap](https://discourse.ubuntu.com/t/miriway-the-snap/35821)
 - If you want to try out the Mir demos on desktop, see: \ref getting_and_using_mir
 
 - If you want to get involved in Mir development, see: \ref getting_involved_in_mir

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -1,19 +1,28 @@
-Welcome to Mir {#mainpage}
-==============
+# Welcome to Mir {#mainpage}
 
-Mir is a next generation display server targeted as a replacement for the X
-window server system to unlock next-generation user experiences for devices
-ranging from Linux desktop to mobile and IoT devices powered by Ubuntu.
+**Mir** is set of libraries for building Wayland based shells. Mir
+simplifies the complexity that shell authors need to deal with: it
+provides a stable, well tested and performant platform with touch,
+mouse and tablet input, multi-display capability and secure
+client-server communications.
+
+Mir deals with the bringup and configuration of a broad array of
+graphics and input hardware, abstracts hardware differences away
+from shell authors (transparently dealing with hardware quirks) and
+integrates with system components such as greeters.
+
+Window management is integrated into Mir with useful default behaviour
+and is extremely customisable by shell authors using a simple high-level
+API.
 
  - If you want to use the Mir snaps, see: 
-   [Run a kiosk snap on Ubuntu Core](https://developer.ubuntu.com/core/examples/snaps-on-mir)
+   [Make a Secure Ubuntu Web Kiosk](https://mir-server.io/docs/make-a-secure-ubuntu-web-kiosk)
 
  - If you want to try out the Mir demos on desktop, see: \ref getting_and_using_mir
 
  - If you want to get involved in Mir development, see: \ref getting_involved_in_mir
 
-Using Mir for server development
---------------------------------
+## Using Mir for server development
 
 Install the headers and libraries for using libmiral in development:
 
@@ -26,8 +35,7 @@ example:
 
 The server API is introduced here: \ref introducing_the_miral_api
 
-Community
----------
+## Community
 
 Developer blogs, develompent announcements, questions, process documentation, and design
 discussions happen on the [Mir section of the Ubuntu Discourse](https://discourse.ubuntu.com/c/mir).

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -15,25 +15,14 @@ Window management is integrated into Mir with useful default behaviour
 and is extremely customisable by shell authors using a simple high-level
 API.
 
- - If you want to use the Mir snaps, see: 
-   [Make a Secure Ubuntu Web Kiosk](https://mir-server.io/docs/make-a-secure-ubuntu-web-kiosk)
+## Resources
+- The repository can be found [here](https://github.com/MirServer/mir)
+- If you want to use the Mir snaps, see: 
+  [Make a Secure Ubuntu Web Kiosk](https://mir-server.io/docs/make-a-secure-ubuntu-web-kiosk)
 
- - If you want to try out the Mir demos on desktop, see: \ref getting_and_using_mir
+- If you want to try out the Mir demos on desktop, see: \ref getting_and_using_mir
 
- - If you want to get involved in Mir development, see: \ref getting_involved_in_mir
-
-## Using Mir for server development
-
-Install the headers and libraries for using libmiral in development:
-
-    sudo apt install libmiral-dev
-
-A `miral.pc` file is provided for use with `pkg-config` or other tools. For
-example: 
-
-    pkg-config --cflags miral
-
-The server API is introduced here: \ref introducing_the_miral_api
+- If you want to get involved in Mir development, see: \ref getting_involved_in_mir
 
 ## Community
 

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -37,9 +37,5 @@ example:
 
 The server API is introduced here: \ref introducing_the_miral_api
 
-## Community
-
-Developer blogs, develompent announcements, questions, process documentation, and design
-discussions happen on the [Mir section of the Ubuntu Discourse](https://discourse.ubuntu.com/c/mir).
 
 Mir developers and discussion can also be found on the \#mir-server IRC channel on Freenode.


### PR DESCRIPTION
# https://github.com/MirServer/mir/issues/2993

## What's new?
- Fixed a weird issue where we were rendering html tags in our pages as plain text
- Moved around and grouped some paragraphs so that they made more sense to me (let me know if I am mistaken though)
- Using plain markdown links instead of Doxygen `\ref`s so that everything works on Github as well