### PR TITLE
Fix MultiplexingDisplay names

### DIFF
--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -184,10 +184,19 @@ private:
 
         static auto name_for_output(
             mg::DisplayConfigurationOutput const& output,
-            std::map<mg::DisplayConfigurationOutputType, unsigned>& output_counts) -> std::string
+            std::map<mg::DisplayConfigurationCardId, std::map<mg::DisplayConfigurationOutputType, unsigned>>& output_counts,
+            bool multiple_cards) -> std::string
         {
-            output_counts[output.type]++;    // The map will default-initialise any as-yet-unseen types to 0
-            return std::string{mir::output_type_name(static_cast<unsigned>(output.type))} + "-" + std::to_string(output_counts[output.type]);
+            output_counts[output.card_id][output.type]++;    // The map will default-initialise any as-yet-unseen cards to the empty map
+                                                             // and any as-yet-unseen output types to 0.
+            std::stringstream name;
+            name << mir::output_type_name(static_cast<unsigned>(output.type));
+            if (multiple_cards)
+            {
+                name << "-" << output.card_id.as_value() + 1;
+            }
+            name << "-" << output_counts[output.card_id][output.type];
+            return name.str();
         }
 
         static auto construct_output_map(
@@ -195,8 +204,9 @@ private:
             std::vector<mg::DisplayConfigurationOutput>& backing_store) -> std::vector<OutputInfo>
         {
             std::vector<OutputInfo> outputs;
-            std::map <mg::DisplayConfigurationOutputType, unsigned> output_type_counts;
+            std::map<mg::DisplayConfigurationCardId, std::map<mg::DisplayConfigurationOutputType, unsigned>> output_type_counts;
             int next_id = 1;
+            int card_index = 0;   // Really, I want std::views::enumerate here, but that's C++23
             for (auto const& conf : confs)
             {
                 conf->for_each_output(
@@ -204,13 +214,15 @@ private:
                     {
                         backing_store.push_back(output);
                         backing_store.back().id = mg::DisplayConfigurationOutputId{next_id};
-                        backing_store.back().name = name_for_output(backing_store.back(), output_type_counts);
+                        backing_store.back().card_id = mg::DisplayConfigurationCardId{card_index};
+                        backing_store.back().name = name_for_output(backing_store.back(), output_type_counts, confs.size() > 1);
                         next_id++;
                         outputs.emplace_back(
                             component,
                             output.id,
                             backing_store.size() - 1);
                     });
+                ++card_index;
             }
             return outputs;
         }

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -18,8 +18,10 @@
 #include "mir/graphics/display_configuration.h"
 #include "mir/renderer/gl/context.h"
 #include "mir/output_type_names.h"
+
 #include <boost/throw_exception.hpp>
 #include <stdexcept>
+#include <sstream>
 #include <functional>
 
 namespace mg = mir::graphics;

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -184,9 +184,10 @@ private:
 
         static auto name_for_output(
             mg::DisplayConfigurationOutput const& output,
-            [[maybe_unused]] std::map<mg::DisplayConfigurationOutputType, unsigned>& output_counts) -> std::string
+            std::map<mg::DisplayConfigurationOutputType, unsigned>& output_counts) -> std::string
         {
-            return std::string{mir::output_type_name(static_cast<unsigned>(output.type))} + "-" + std::to_string(output.id.as_value());
+            output_counts[output.type]++;    // The map will default-initialise any as-yet-unseen types to 0
+            return std::string{mir::output_type_name(static_cast<unsigned>(output.type))} + "-" + std::to_string(output_counts[output.type]);
         }
 
         static auto construct_output_map(

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -186,16 +186,16 @@ private:
 
         static auto name_for_output(
             mg::DisplayConfigurationOutput const& output,
-            std::map<mg::DisplayConfigurationCardId, std::map<mg::DisplayConfigurationOutputType, unsigned>>& output_counts,
-            bool multiple_cards) -> std::string
+            std::map<mg::DisplayConfigurationCardId, std::map<mg::DisplayConfigurationOutputType, unsigned>>& output_counts)
+            -> std::string
         {
             output_counts[output.card_id][output.type]++;    // The map will default-initialise any as-yet-unseen cards to the empty map
                                                              // and any as-yet-unseen output types to 0.
             std::stringstream name;
             name << mir::output_type_name(static_cast<unsigned>(output.type));
-            if (multiple_cards)
+            if (output.card_id.as_value())
             {
-                name << "-" << output.card_id.as_value() + 1;
+                name << "-" << output.card_id.as_value();
             }
             name << "-" << output_counts[output.card_id][output.type];
             return name.str();
@@ -217,7 +217,7 @@ private:
                         backing_store.push_back(output);
                         backing_store.back().id = mg::DisplayConfigurationOutputId{next_id};
                         backing_store.back().card_id = mg::DisplayConfigurationCardId{card_index};
-                        backing_store.back().name = name_for_output(backing_store.back(), output_type_counts, confs.size() > 1);
+                        backing_store.back().name = name_for_output(backing_store.back(), output_type_counts);
                         next_id++;
                         outputs.emplace_back(
                             component,

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -181,11 +181,19 @@ private:
         };
         std::vector<OutputInfo> const output_map;
 
+        static auto name_for_output(
+            mg::DisplayConfigurationOutput const& output,
+            [[maybe_unused]] std::map<mg::DisplayConfigurationOutputType, unsigned>& output_counts) -> std::string
+        {
+            return std::string{"OUT-"} + std::to_string(output.id.as_value());
+        }
+
         static auto construct_output_map(
             std::vector<std::unique_ptr<mg::DisplayConfiguration>> const& confs,
             std::vector<mg::DisplayConfigurationOutput>& backing_store) -> std::vector<OutputInfo>
         {
             std::vector<OutputInfo> outputs;
+            std::map <mg::DisplayConfigurationOutputType, unsigned> output_type_counts;
             int next_id = 1;
             for (auto const& conf : confs)
             {
@@ -194,6 +202,7 @@ private:
                     {
                         backing_store.push_back(output);
                         backing_store.back().id = mg::DisplayConfigurationOutputId{next_id};
+                        backing_store.back().name = name_for_output(backing_store.back(), output_type_counts);
                         next_id++;
                         outputs.emplace_back(
                             component,

--- a/src/server/graphics/multiplexing_display.cpp
+++ b/src/server/graphics/multiplexing_display.cpp
@@ -17,6 +17,7 @@
 #include "multiplexing_display.h"
 #include "mir/graphics/display_configuration.h"
 #include "mir/renderer/gl/context.h"
+#include "mir/output_type_names.h"
 #include <boost/throw_exception.hpp>
 #include <stdexcept>
 #include <functional>
@@ -185,7 +186,7 @@ private:
             mg::DisplayConfigurationOutput const& output,
             [[maybe_unused]] std::map<mg::DisplayConfigurationOutputType, unsigned>& output_counts) -> std::string
         {
-            return std::string{"OUT-"} + std::to_string(output.id.as_value());
+            return std::string{mir::output_type_name(static_cast<unsigned>(output.type))} + "-" + std::to_string(output.id.as_value());
         }
 
         static auto construct_output_map(

--- a/tests/unit-tests/graphics/test_multiplexing_display.cpp
+++ b/tests/unit-tests/graphics/test_multiplexing_display.cpp
@@ -912,7 +912,7 @@ TEST(MultiplexingDisplay, output_name_does_not_contain_card_id_when_only_one_car
         });
 }
 
-TEST(MultiplexingDisplay, when_multiple_cards_exist_outputs_are_numbered_by_card)
+TEST(MultiplexingDisplay, when_additional_cards_exist_their_outputs_are_numbered_by_card)
 {
     std::vector<std::vector<mg::DisplayConfigurationOutput>> display_confs;
     std::vector<DisplayConfigurationOutputGenerator> gens;
@@ -966,14 +966,14 @@ TEST(MultiplexingDisplay, when_multiple_cards_exist_outputs_are_numbered_by_card
     EXPECT_THAT(
         output_names,
         UnorderedElementsAreArray({
+            "DVI-I-1",
+            "DVI-I-2",
             "DVI-I-1-1",
             "DVI-I-1-2",
             "DVI-I-2-1",
             "DVI-I-2-2",
-            "DVI-I-3-1",
-            "DVI-I-3-2",
+            "HDMI-A-1",
             "HDMI-A-1-1",
-            "HDMI-A-2-1",
-            "HDMI-A-3-1"})
+            "HDMI-A-2-1"})
         );
 }


### PR DESCRIPTION
This ensures that output names in a `MultiplexingDisplay` configuration match the existing names.