### PR TITLE
CI/snaps: Bump timeout for building mir-libs.

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -12,7 +12,7 @@ jobs:
   mir-libs:
     runs-on: ubuntu-latest
 
-    timeout-minutes: 240
+    timeout-minutes: 360
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
armhf has consistently been *slightly* too slow to hit the 4hr(!) timeout we currently have.

Since this doesn't gate merging, bump it up to 6hrs to ensure people can test PR builds. Eventually.