### PR TITLE
Reduce scope for confusion between Tips and Gloss

### DIFF
--- a/src/server/frontend_wayland/wl_shell.cpp
+++ b/src/server/frontend_wayland/wl_shell.cpp
@@ -65,7 +65,7 @@ protected:
         mir::shell::SurfaceSpecification mods;
 
         if (flags & mw::ShellSurface::Transient::inactive)
-            mods.type = mir_window_type_gloss;
+            mods.type = mir_window_type_tip;
         if (auto parent = parent_surface.scene_surface())
             mods.parent = parent.value();
         mods.aux_rect = geom::Rectangle{{x, y}, {}};
@@ -118,7 +118,7 @@ protected:
         mir::shell::SurfaceSpecification mods;
 
         if (flags & mw::ShellSurface::Transient::inactive)
-            mods.type = mir_window_type_gloss;
+            mods.type = mir_window_type_tip;
         if (auto parent = parent_surface.scene_surface())
             mods.parent = parent.value();
         mods.aux_rect = geom::Rectangle{{x, y}, {}};

--- a/src/server/frontend_wayland/xdg_shell_stable.cpp
+++ b/src/server/frontend_wayland/xdg_shell_stable.cpp
@@ -320,7 +320,7 @@ mf::XdgPopupStable::XdgPopupStable(
       xdg_surface{xdg_surface}
 {
     positioner.ensure_complete();
-    positioner.type = mir_window_type_gloss;
+    positioner.type = mir_window_type_tip;
     if (parent_role)
     {
         if (auto scene_surface = parent_role.value()->scene_surface())

--- a/src/server/frontend_wayland/xdg_shell_v6.cpp
+++ b/src/server/frontend_wayland/xdg_shell_v6.cpp
@@ -318,7 +318,7 @@ mf::XdgPopupV6::XdgPopupV6(
     auto const& parent_role = parent_surface->window_role();
     auto parent_scene_surface = parent_role ? parent_role.value().scene_surface() : std::nullopt;
 
-    specification->type = mir_window_type_gloss;
+    specification->type = mir_window_type_tip;
     if (parent_scene_surface)
         specification->parent = parent_scene_surface.value();
     else

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -216,7 +216,7 @@ auto wm_window_type_to_mir_window_type(
                  wm_type == connection->_NET_WM_WINDOW_TYPE_DND ||
                  wm_type == connection->_NET_WM_WINDOW_TYPE_DIALOG)
         {
-            return mir_window_type_gloss;
+            return mir_window_type_tip;
         }
         else if (mir::verbose_xwayland_logging_enabled())
         {
@@ -231,7 +231,7 @@ auto wm_window_type_to_mir_window_type(
     // be taken as _NET_WM_WINDOW_TYPE_NORMAL."
     if (is_transient_for && !override_redirect)
     {
-        return mir_window_type_gloss;
+        return mir_window_type_tip;
     }
     else
     {


### PR DESCRIPTION
We've failed to distinguished "Gloss" and "Tip" in our window management implementation, and that's led us to labelling "Tips" `mir_window_type_gloss`.

Label "Tips" `mir_window_type_tip` correctly. (Issue about the incorrect "Gloss" implementation: #3045.)