### PR TITLE
(#2509) Handling integer overflows for dimensions for XWaylandSurface

### DIFF
--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -1223,10 +1223,10 @@ void mf::XWaylandSurface::prep_surface_spec(ProofOfMutexLock const&, msh::Surfac
 
 #define SCALE_SIZE(type, prop) \
     if (mods.prop) \
-    {                          \
+    { \
         auto scaled_value = mods.prop.value() * inv_scale; \
-        if (scaled_value.as_int() >= 0)            \
-        {                      \
+        if (scaled_value.as_int() >= 0) \
+        { \
             mods.prop = scaled_value; \
         } \
     }

--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -1223,8 +1223,12 @@ void mf::XWaylandSurface::prep_surface_spec(ProofOfMutexLock const&, msh::Surfac
 
 #define SCALE_SIZE(type, prop) \
     if (mods.prop) \
-    { \
-        mods.prop = std::max(geom::type{1}, mods.prop.value() * inv_scale); \
+    {                          \
+        auto scaled_value = mods.prop.value() * inv_scale; \
+        if (scaled_value.as_int() >= 0)            \
+        {                      \
+            mods.prop = scaled_value; \
+        } \
     }
 
     SCALE_SIZE(Width, width);


### PR DESCRIPTION
# https://github.com/MirServer/mir/issues/2509

You can find some more info on the solution to this one in the ticket itself :point_up: 

## How to test
- Run `miral-app` or something
- Open up mattermost
- Click the fullscreen button _or_  resize it using the edges
- Note that this now works!

## Solution

- I am going to assume that the width and height are never naturally negative. Hence, if we overflow during the multiplication, we can expect the int to go negative.
- This might just be an unsafe multiplication all-around, especially if we have a negative scale (e.g. a scale of 0.25 would result in an `inv_scale` of 8)

## Screen recording
[Screencast from 09-21-2023 05:02:28 PM.webm](https://github.com/MirServer/mir/assets/25062299/c29bab31-daf9-4755-88e8-1bd94b4fbf63)
