### PR TITLE
debian: prefer glmark-es2-x11

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -196,7 +196,7 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends},
          ${shlibs:Depends},
          xwayland,
-         glmark2-es2,
+         glmark2-es2-x11 | glmark2-es2,
          glmark2-es2-wayland,
          mesa-utils-extra,
          dmz-cursor-theme,


### PR DESCRIPTION
It's a new package, prefer it

https://packages.ubuntu.com/search?keywords=glmark2-es2-x11 https://packages.debian.org/search?keywords=glmark2-es2-x11