### PR TITLE
platforms/wayland: Fix a lock in DisplayClient

### DIFF
--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -564,7 +564,7 @@ void mgw::DisplayClient::on_display_config_changed()
 
 void mgw::DisplayClient::delete_outputs_to_be_deleted()
 {
-    std::lock_guard{outputs_mutex};
+    std::lock_guard lock{outputs_mutex};
     outputs_to_be_deleted.clear();
 }
 


### PR DESCRIPTION
It's important to actually *name* your RAII lock object, so it doesn't immediately go out of scope and unlock the mutex!