### PR TITLE
Avoid undefined behavior

### DIFF
--- a/src/common/input/xkb_mapper.cpp
+++ b/src/common/input/xkb_mapper.cpp
@@ -153,7 +153,7 @@ void mircv::XKBMapper::update_modifier()
             xkb_modifiers_.depressed |= device_xkb_modifiers.depressed;
             xkb_modifiers_.latched |= device_xkb_modifiers.latched;
             xkb_modifiers_.locked |= device_xkb_modifiers.locked;
-            if (mapping_state.first == last_device_id)
+            if (last_device_id && mapping_state.first == last_device_id.value())
             {
                 xkb_modifiers_.effective_layout = device_xkb_modifiers.effective_layout;
             }

--- a/src/include/common/mir/input/xkb_mapper.h
+++ b/src/include/common/mir/input/xkb_mapper.h
@@ -25,6 +25,7 @@
 #include <xkbcommon/xkbcommon.h>
 #include <xkbcommon/xkbcommon-compose.h>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -111,7 +112,7 @@ private:
     std::shared_ptr<xkb_keymap> default_compiled_keymap;
     XKBComposeTablePtr compose_table;
     MirXkbModifiers xkb_modifiers_;
-    MirInputDeviceId last_device_id;
+    std::optional<MirInputDeviceId> last_device_id;
 
     mir::optional_value<MirInputEventModifiers> modifier_state;
     std::unordered_map<MirInputDeviceId, std::unique_ptr<XkbMappingState>> device_mapping;


### PR DESCRIPTION
We don't guarantee that `XKBMapper::map_event()` sets `last_device_id` before we use it in `XKBMapper::update_modifier()` and valgrind complains.