### PR TITLE
Add .mailmap file to map old commits to Sophie's new name and email

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Sophie Winter <git@phie.me> <9331264+wmww@users.noreply.github.com>
+Sophie Winter <git@phie.me> <wilcoze@gmail.com>
+Sophie Winter <git@phie.me> <william.wold@canonical.com>
+Sophie Winter <git@phie.me> <wm@wmww.sh>


### PR DESCRIPTION
Hi!

My old name is all over Mir git history. I don't care that much so I never proposed filter-branching it out, but I recently found out with a simple .mailmap you can get a lot of the same benefits without changing history. If this is merged my new name will be displayed on my old commits and on git blame, both locally and on github.