### PR TITLE
Fix for satellite windows being moved when the parent moves

### DIFF
--- a/src/miral/minimal_window_manager.cpp
+++ b/src/miral/minimal_window_manager.cpp
@@ -272,6 +272,11 @@ bool miral::MinimalWindowManager::begin_pointer_resize(
 auto miral::MinimalWindowManager::confirm_inherited_move(WindowInfo const& window_info, Displacement movement)
 -> Rectangle
 {
+    // Satellite windows don't need to move with their parent
+    if (window_info.type() == mir_window_type_satellite)
+    {
+        return {window_info.window().top_left(), window_info.window().size()};
+    }
     return {window_info.window().top_left()+movement, window_info.window().size()};
 }
 


### PR DESCRIPTION
## What's new?
This is a suggestion, but I think it is correct. Satellite windows should not move with their parent, right?

## To test
- Fire up gimp with satellite windows
- Move the main window and note that the satellites don't  move as well