### PR TITLE
Sharing CpuAdressableDisplayProvider between eglstreams and gbm platforms

### DIFF
--- a/src/platforms/common/server/CMakeLists.txt
+++ b/src/platforms/common/server/CMakeLists.txt
@@ -14,6 +14,11 @@ add_library(server_platform_common STATIC
   one_shot_device_observer.cpp
   cpu_copy_output_surface.cpp
   cpu_copy_output_surface.h
+  basic_cpu_addressable_display_provider.cpp
+  basic_cpu_addressable_display_provider.h
+  cpu_addressable_fb.cpp
+  cpu_addressable_fb.h
+  kms_framebuffer.h
 )
 
 target_include_directories(

--- a/src/platforms/common/server/CMakeLists.txt
+++ b/src/platforms/common/server/CMakeLists.txt
@@ -14,8 +14,8 @@ add_library(server_platform_common STATIC
   one_shot_device_observer.cpp
   cpu_copy_output_surface.cpp
   cpu_copy_output_surface.h
-  basic_cpu_addressable_display_provider.cpp
-  basic_cpu_addressable_display_provider.h
+  kms_cpu_addressable_display_provider.cpp
+  kms_cpu_addressable_display_provider.h
   cpu_addressable_fb.cpp
   cpu_addressable_fb.h
   kms_framebuffer.h

--- a/src/platforms/common/server/basic_cpu_addressable_display_provider.cpp
+++ b/src/platforms/common/server/basic_cpu_addressable_display_provider.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "basic_cpu_addressable_display_provider.h"
+#include "cpu_addressable_fb.h"
+#include <drm_fourcc.h>
+#include <xf86drm.h>
+
+namespace
+{
+auto drm_get_cap_checked(mir::Fd const& drm_fd, uint64_t cap) -> uint64_t
+{
+    uint64_t value;
+    if (drmGetCap(drm_fd, cap, &value))
+    {
+        BOOST_THROW_EXCEPTION((
+            std::system_error{
+                errno,
+                std::system_category(),
+                "Failed to query DRM capabilities"}));
+    }
+    return value;
+}
+}
+
+namespace mg = mir::graphics;
+namespace geom = mir::geometry;
+
+mg::BasicCPUAddressableDisplayProvider::BasicCPUAddressableDisplayProvider(mir::Fd drm_fd)
+    : drm_fd{std::move(drm_fd)},
+      supports_modifiers{drm_get_cap_checked(this->drm_fd, DRM_CAP_ADDFB2_MODIFIERS) == 1}
+{
+}
+
+auto mg::BasicCPUAddressableDisplayProvider::supported_formats() const
+-> std::vector<mg::DRMFormat>
+{
+    // TODO: Pull out of DRM info
+    return {mg::DRMFormat{DRM_FORMAT_XRGB8888}, mg::DRMFormat{DRM_FORMAT_ARGB8888}};
+}
+
+auto mg::BasicCPUAddressableDisplayProvider::alloc_fb(
+    geom::Size size, DRMFormat format) -> std::unique_ptr<MappableFB>
+{
+    return std::make_unique<mg::CPUAddressableFB>(drm_fd, supports_modifiers, format, size);
+}

--- a/src/platforms/common/server/basic_cpu_addressable_display_provider.h
+++ b/src/platforms/common/server/basic_cpu_addressable_display_provider.h
@@ -14,33 +14,32 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_GRAPHICS_EGLSTREAM_INTERFACE_PROVIDER_H_
-#define MIR_GRAPHICS_EGLSTREAM_INTERFACE_PROVIDER_H_
+#ifndef MIR_GRAPHICS_BASIC_CPU_ADDRESSABLE_DISPLAY_PROVIDER_H
+#define MIR_GRAPHICS_BASIC_CPU_ADDRESSABLE_DISPLAY_PROVIDER_H
 
 #include "mir/graphics/platform.h"
-#include "mir/fd.h"
+#include <mir/fd.h>
 
-#include <optional>
-
-namespace mir::graphics::eglstream
+namespace mir
 {
-class InterfaceProvider : public DisplayInterfaceProvider
+namespace graphics
+{
+class BasicCPUAddressableDisplayProvider : public CPUAddressableDisplayProvider
 {
 public:
-    InterfaceProvider(EGLDisplay dpy, mir::Fd drm_fd);
-    InterfaceProvider(InterfaceProvider const& from, EGLStreamKHR with_stream);
+    explicit BasicCPUAddressableDisplayProvider(mir::Fd drm_fd);
 
-protected:
-    auto maybe_create_interface(DisplayProvider::Tag const& tag)
-        -> std::shared_ptr<DisplayProvider> override;
+    auto supported_formats() const
+        -> std::vector<DRMFormat> override;
+
+    auto alloc_fb(geometry::Size pixel_size, DRMFormat format)
+        -> std::unique_ptr<MappableFB> override;
 
 private:
-    EGLDisplay dpy;
-    std::optional<EGLStreamKHR> stream;
-    mir::Fd drm_fd;
+    mir::Fd const drm_fd;
+    bool const supports_modifiers;
 };
-
-;
+}
 }
 
-#endif // MIR_GRAPHICS_EGLSTREAM_INTERFACE_PROVIDER_H_
+#endif //MIR_GRAPHICS_BASIC_CPU_ADDRESSABLE_DISPLAY_PROVIDER_H

--- a/src/platforms/common/server/cpu_addressable_fb.cpp
+++ b/src/platforms/common/server/cpu_addressable_fb.cpp
@@ -16,7 +16,6 @@
 
 #include "cpu_addressable_fb.h"
 
-#include "mir/geometry/forward.h"
 #include "mir/log.h"
 #include "mir_toolkit/common.h"
 
@@ -26,9 +25,8 @@
 #include <drm_fourcc.h>
 
 namespace mg = mir::graphics;
-namespace mgg = mg::gbm;
 
-class mgg::CPUAddressableFB::Buffer : public mir::renderer::software::RWMappableBuffer
+class mg::CPUAddressableFB::Buffer : public mir::renderer::software::RWMappableBuffer
 {
     template<typename T>
     class Mapping : public mir::renderer::software::Mapping<T>
@@ -53,7 +51,7 @@ class mgg::CPUAddressableFB::Buffer : public mir::renderer::software::RWMappable
             if (::munmap(const_cast<typename std::remove_const<T>::type *>(data_), len_) == -1)
             {
                 // It's unclear how this could happen, but tell *someone* about it if it does!
-                mir::log_error("Failed to unmap CPU buffer: %s (%i)", strerror(errno), errno);
+                mir::log(mir::logging::Severity::error, "Failed to unmap CPU buffer: %s (%i)", strerror(errno), errno);
             }
         }
 
@@ -102,7 +100,7 @@ public:
 
         if (auto const err = drmIoctl(drm_fd, DRM_IOCTL_MODE_DESTROY_DUMB, &params))
         {
-            mir::log_error("Failed destroy CPU-accessible buffer: %s (%i)", strerror(-err), -err);
+            mir::log(mir::logging::Severity::error, "Failed destroy CPU-accessible buffer: %s (%i)", strerror(-err), -err);
         }
     }
 
@@ -248,7 +246,7 @@ private:
     size_t const size_;
 };
 
-mgg::CPUAddressableFB::CPUAddressableFB(
+mg::CPUAddressableFB::CPUAddressableFB(
     mir::Fd const& drm_fd,
     bool supports_modifiers,
     DRMFormat format,
@@ -257,12 +255,12 @@ mgg::CPUAddressableFB::CPUAddressableFB(
 {
 }
 
-mgg::CPUAddressableFB::~CPUAddressableFB()
+mg::CPUAddressableFB::~CPUAddressableFB()
 {
     drmModeRmFB(drm_fd, fb_id);
 }
 
-mgg::CPUAddressableFB::CPUAddressableFB(
+mg::CPUAddressableFB::CPUAddressableFB(
     mir::Fd drm_fd,
     bool supports_modifiers,
     DRMFormat format,
@@ -273,32 +271,32 @@ mgg::CPUAddressableFB::CPUAddressableFB(
 {
 }
 
-auto mgg::CPUAddressableFB::map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<unsigned char>>
+auto mg::CPUAddressableFB::map_writeable() -> std::unique_ptr<mir::renderer::software::Mapping<unsigned char>>
 {
     return buffer->map_writeable();
 }
 
-auto mgg::CPUAddressableFB::format() const -> MirPixelFormat
+auto mg::CPUAddressableFB::format() const -> MirPixelFormat
 {
     return buffer->format();
 }
 
-auto mgg::CPUAddressableFB::stride() const -> geometry::Stride
+auto mg::CPUAddressableFB::stride() const -> geometry::Stride
 {
     return buffer->stride();
 }
 
-auto mgg::CPUAddressableFB::size() const -> geometry::Size
+auto mg::CPUAddressableFB::size() const -> geometry::Size
 {
     return buffer->size();
 }
 
-mgg::CPUAddressableFB::operator uint32_t() const
+mg::CPUAddressableFB::operator uint32_t() const
 {
     return fb_id;
 }
 
-auto mgg::CPUAddressableFB::fb_id_for_buffer(
+auto mg::CPUAddressableFB::fb_id_for_buffer(
     mir::Fd const &drm_fd,
     bool supports_modifiers,
     DRMFormat format,

--- a/src/platforms/common/server/cpu_addressable_fb.cpp
+++ b/src/platforms/common/server/cpu_addressable_fb.cpp
@@ -51,7 +51,7 @@ class mg::CPUAddressableFB::Buffer : public mir::renderer::software::RWMappableB
             if (::munmap(const_cast<typename std::remove_const<T>::type *>(data_), len_) == -1)
             {
                 // It's unclear how this could happen, but tell *someone* about it if it does!
-                mir::log(mir::logging::Severity::error, "Failed to unmap CPU buffer: %s (%i)", strerror(errno), errno);
+                log_error("Failed to unmap CPU buffer: %s (%i)", strerror(errno), errno);
             }
         }
 
@@ -100,7 +100,7 @@ public:
 
         if (auto const err = drmIoctl(drm_fd, DRM_IOCTL_MODE_DESTROY_DUMB, &params))
         {
-            mir::log(mir::logging::Severity::error, "Failed destroy CPU-accessible buffer: %s (%i)", strerror(-err), -err);
+            log_error("Failed destroy CPU-accessible buffer: %s (%i)", strerror(-err), -err);
         }
     }
 

--- a/src/platforms/common/server/cpu_addressable_fb.h
+++ b/src/platforms/common/server/cpu_addressable_fb.h
@@ -14,15 +14,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_GRAPHICS_GBM_FB_H_
-#define MIR_GRAPHICS_GBM_FB_H_
+#ifndef MIR_GRAPHICS_CPU_ADDRESSABLE_FB_H_
+#define MIR_GRAPHICS_CPU_ADDRESSABLE_FB_H_
 
 #include "mir/fd.h"
 #include "mir/graphics/platform.h"
 
 #include "kms_framebuffer.h"
 
-namespace mir::graphics::gbm
+namespace mir::graphics
 {
 class CPUAddressableFB : public FBHandle, public CPUAddressableDisplayProvider::MappableFB
 {
@@ -65,4 +65,4 @@ private:
 
 }
 
-#endif //MIR_GRAPHICS_GBM_FB_H_
+#endif //MIR_GRAPHICS_CPU_ADDRESSABLE_FB_H_

--- a/src/platforms/common/server/kms_cpu_addressable_display_provider.cpp
+++ b/src/platforms/common/server/kms_cpu_addressable_display_provider.cpp
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "basic_cpu_addressable_display_provider.h"
+#include "kms_cpu_addressable_display_provider.h"
 #include "cpu_addressable_fb.h"
 #include <drm_fourcc.h>
 #include <xf86drm.h>
@@ -39,20 +39,20 @@ auto drm_get_cap_checked(mir::Fd const& drm_fd, uint64_t cap) -> uint64_t
 namespace mg = mir::graphics;
 namespace geom = mir::geometry;
 
-mg::BasicCPUAddressableDisplayProvider::BasicCPUAddressableDisplayProvider(mir::Fd drm_fd)
+mg::kms::CPUAddressableDisplayProvider::CPUAddressableDisplayProvider(mir::Fd drm_fd)
     : drm_fd{std::move(drm_fd)},
       supports_modifiers{drm_get_cap_checked(this->drm_fd, DRM_CAP_ADDFB2_MODIFIERS) == 1}
 {
 }
 
-auto mg::BasicCPUAddressableDisplayProvider::supported_formats() const
+auto mg::kms::CPUAddressableDisplayProvider::supported_formats() const
 -> std::vector<mg::DRMFormat>
 {
     // TODO: Pull out of DRM info
     return {mg::DRMFormat{DRM_FORMAT_XRGB8888}, mg::DRMFormat{DRM_FORMAT_ARGB8888}};
 }
 
-auto mg::BasicCPUAddressableDisplayProvider::alloc_fb(
+auto mg::kms::CPUAddressableDisplayProvider::alloc_fb(
     geom::Size size, DRMFormat format) -> std::unique_ptr<MappableFB>
 {
     return std::make_unique<mg::CPUAddressableFB>(drm_fd, supports_modifiers, format, size);

--- a/src/platforms/common/server/kms_cpu_addressable_display_provider.cpp
+++ b/src/platforms/common/server/kms_cpu_addressable_display_provider.cpp
@@ -43,6 +43,10 @@ mg::kms::CPUAddressableDisplayProvider::CPUAddressableDisplayProvider(mir::Fd dr
     : drm_fd{std::move(drm_fd)},
       supports_modifiers{drm_get_cap_checked(this->drm_fd, DRM_CAP_ADDFB2_MODIFIERS) == 1}
 {
+    if (!drm_get_cap_checked(this->drm_fd, DRM_CAP_DUMB_BUFFER))
+    {
+        BOOST_THROW_EXCEPTION((std::runtime_error{"DRM device doesn't support CPU buffers"}));
+    }
 }
 
 auto mg::kms::CPUAddressableDisplayProvider::supported_formats() const

--- a/src/platforms/common/server/kms_cpu_addressable_display_provider.cpp
+++ b/src/platforms/common/server/kms_cpu_addressable_display_provider.cpp
@@ -43,10 +43,6 @@ mg::kms::CPUAddressableDisplayProvider::CPUAddressableDisplayProvider(mir::Fd dr
     : drm_fd{std::move(drm_fd)},
       supports_modifiers{drm_get_cap_checked(this->drm_fd, DRM_CAP_ADDFB2_MODIFIERS) == 1}
 {
-    if (!drm_get_cap_checked(this->drm_fd, DRM_CAP_DUMB_BUFFER))
-    {
-        BOOST_THROW_EXCEPTION((std::runtime_error{"DRM device doesn't support CPU buffers"}));
-    }
 }
 
 auto mg::kms::CPUAddressableDisplayProvider::supported_formats() const
@@ -60,4 +56,17 @@ auto mg::kms::CPUAddressableDisplayProvider::alloc_fb(
     geom::Size size, DRMFormat format) -> std::unique_ptr<MappableFB>
 {
     return std::make_unique<mg::CPUAddressableFB>(drm_fd, supports_modifiers, format, size);
+}
+
+auto mir::graphics::kms::CPUAddressableDisplayProvider::create_if_supported(mir::Fd const& drm_fd)
+-> std::shared_ptr<CPUAddressableDisplayProvider>
+{
+    if  (drm_get_cap_checked(drm_fd, DRM_CAP_DUMB_BUFFER))
+    {
+        return std::shared_ptr<CPUAddressableDisplayProvider>(new CPUAddressableDisplayProvider{drm_fd});
+    }
+    else
+    {
+        return {};
+    }
 }

--- a/src/platforms/common/server/kms_cpu_addressable_display_provider.h
+++ b/src/platforms/common/server/kms_cpu_addressable_display_provider.h
@@ -24,10 +24,12 @@ namespace mir
 {
 namespace graphics
 {
-class BasicCPUAddressableDisplayProvider : public CPUAddressableDisplayProvider
+namespace kms
+{
+class CPUAddressableDisplayProvider : public graphics::CPUAddressableDisplayProvider
 {
 public:
-    explicit BasicCPUAddressableDisplayProvider(mir::Fd drm_fd);
+    explicit CPUAddressableDisplayProvider(mir::Fd drm_fd);
 
     auto supported_formats() const
         -> std::vector<DRMFormat> override;
@@ -39,6 +41,7 @@ private:
     mir::Fd const drm_fd;
     bool const supports_modifiers;
 };
+}
 }
 }
 

--- a/src/platforms/common/server/kms_cpu_addressable_display_provider.h
+++ b/src/platforms/common/server/kms_cpu_addressable_display_provider.h
@@ -29,7 +29,9 @@ namespace kms
 class CPUAddressableDisplayProvider : public graphics::CPUAddressableDisplayProvider
 {
 public:
-    explicit CPUAddressableDisplayProvider(mir::Fd drm_fd);
+    /// Create an CPUAddressableDisplayProvider if and only if supported by the device
+    /// \return the provider, or an empty pointer
+    static auto create_if_supported(mir::Fd const& drm_fd) -> std::shared_ptr<CPUAddressableDisplayProvider>;
 
     auto supported_formats() const
         -> std::vector<DRMFormat> override;
@@ -38,6 +40,8 @@ public:
         -> std::unique_ptr<MappableFB> override;
 
 private:
+    explicit CPUAddressableDisplayProvider(mir::Fd drm_fd);
+
     mir::Fd const drm_fd;
     bool const supports_modifiers;
 };

--- a/src/platforms/common/server/kms_framebuffer.h
+++ b/src/platforms/common/server/kms_framebuffer.h
@@ -23,8 +23,6 @@ namespace mir
 {
 namespace graphics
 {
-namespace gbm
-{
 class FBHandle : public Framebuffer
 {
 public:
@@ -33,7 +31,6 @@ public:
     virtual operator uint32_t() const = 0;
 };
 
-}
 }
 }
 

--- a/src/platforms/eglstream-kms/server/display.cpp
+++ b/src/platforms/eglstream-kms/server/display.cpp
@@ -231,7 +231,11 @@ public:
 
             scheduled_fb = std::move(next_swap);
             next_swap = nullptr;
-            output->queue_atomic_flip(*scheduled_fb, event_handler->drm_event_data());
+            if (!output->queue_atomic_flip(*scheduled_fb, event_handler->drm_event_data()))
+            {
+                // If we failed to submit the flip then we're not going to get the event!
+                event_handler->cancel_flip_events(output->crtc_id());
+            }
             return;
         }
 

--- a/src/platforms/eglstream-kms/server/drm_event_handler.h
+++ b/src/platforms/eglstream-kms/server/drm_event_handler.h
@@ -40,6 +40,16 @@ public:
     virtual std::future<void> expect_flip_event(
         KMSCrtcId id,
         std::function<void(unsigned int frame_number, std::chrono::milliseconds frame_time)> on_flip) = 0;
+
+    /**
+     * Cancel any pending flip events on this CRTC
+     *
+     * This is useful when we know that we're not going to get the flip event we requested,
+     * such as when a VT switch has occurred.
+     *
+     * This marks all pending flip futures as completed.
+     */
+    virtual void cancel_flip_events(KMSCrtcId id) = 0;
 };
 }
 }

--- a/src/platforms/eglstream-kms/server/egl_output.cpp
+++ b/src/platforms/eglstream-kms/server/egl_output.cpp
@@ -16,6 +16,7 @@
 
 #include "mir/log.h"
 
+#include <drm_mode.h>
 #include <epoxy/egl.h>
 
 #include "egl_output.h"
@@ -26,6 +27,7 @@
 #include <drm.h>
 #include <sys/ioctl.h>
 #include <boost/throw_exception.hpp>
+#include <system_error>
 #include <tuple>
 #include <sys/mman.h>
 
@@ -191,6 +193,8 @@ void mgek::EGLOutput::reset()
             drmModeFreeProperty(prop);
         }
     }
+
+    current_crtc = nullptr;
 }
 
 geom::Size mgek::EGLOutput::size() const
@@ -208,21 +212,15 @@ int mgek::EGLOutput::max_refresh_rate() const
 void mgek::EGLOutput::configure(size_t kms_mode_index)
 {
     mode_index = kms_mode_index;
-    auto const width = connector->modes[kms_mode_index].hdisplay;
-    auto const height = connector->modes[kms_mode_index].vdisplay;
-
-    std::unique_ptr<drmModeAtomicReq, void(*)(drmModeAtomicReqPtr)>
-        request{drmModeAtomicAlloc(), &drmModeAtomicFree};
+    refresh_connector(drm_fd, connector);
 
     mgk::DRMModeCrtcUPtr crtc;
     mgk::DRMModePlaneUPtr plane;
-
-    refresh_connector(drm_fd, connector);
-
     std::tie(crtc, plane) = mgk::find_crtc_with_primary_plane(drm_fd, connector);
-    auto const crtc_id = crtc->crtc_id;
+    _crtc_id = crtc->crtc_id;
+    plane_id = plane->plane_id;
+    plane_props = std::make_unique<mgk::ObjectProperties>(drm_fd, plane_id, DRM_MODE_OBJECT_PLANE);
 
-    uint32_t mode_id{0};
     auto ret = drmModeCreatePropertyBlob(
         drm_fd,
         &connector->modes[kms_mode_index],
@@ -235,50 +233,13 @@ void mgek::EGLOutput::configure(size_t kms_mode_index)
             std::system_error(-ret, std::system_category(), "Failed to create DRM Mode property blob"));
     }
 
+    auto const width = connector->modes[mode_index].hdisplay;
+    auto const height = connector->modes[mode_index].vdisplay;
     CPUAddressableFb dummy{drm_fd, width, height};
-
-    mgk::ObjectProperties crtc_props{drm_fd, crtc_id, DRM_MODE_OBJECT_CRTC};
-
-    /* Activate the CRTC and set the mode */
-    drmModeAtomicAddProperty(request.get(), crtc_id, crtc_props.id_for("MODE_ID"), mode_id);
-    drmModeAtomicAddProperty(request.get(), crtc_id, crtc_props.id_for("ACTIVE"), 1);
-
-    /* Set CRTC for the output */
-    auto const connector_id = connector->connector_id;
-    mgk::ObjectProperties connector_props{drm_fd, connector_id, DRM_MODE_OBJECT_CONNECTOR};
-    drmModeAtomicAddProperty(request.get(), connector_id, connector_props.id_for("CRTC_ID"), crtc_id);
-
-    /* Set up the output plane... */
-    auto const plane_id = plane->plane_id;
-    mgk::ObjectProperties plane_props{drm_fd, plane_id, DRM_MODE_OBJECT_PLANE};
-
-    /* Source viewport. Coordinates are 16.16 fixed point format */
-    drmModeAtomicAddProperty(request.get(), plane_id, plane_props.id_for("SRC_X"), 0);
-    drmModeAtomicAddProperty(request.get(), plane_id, plane_props.id_for("SRC_Y"), 0);
-    drmModeAtomicAddProperty(request.get(), plane_id, plane_props.id_for("SRC_W"), width << 16);
-    drmModeAtomicAddProperty(request.get(), plane_id, plane_props.id_for("SRC_H"), height << 16);
-
-    /* Destination viewport. Coordinates are *not* 16.16 */
-    drmModeAtomicAddProperty(request.get(), plane_id, plane_props.id_for("CRTC_X"), 0);
-    drmModeAtomicAddProperty(request.get(), plane_id, plane_props.id_for("CRTC_Y"), 0);
-    drmModeAtomicAddProperty(request.get(), plane_id, plane_props.id_for("CRTC_W"), width);
-    drmModeAtomicAddProperty(request.get(), plane_id, plane_props.id_for("CRTC_H"), height);
-
-    /* Set a surface for the plane, and connect to the CRTC */
-    drmModeAtomicAddProperty(request.get(), plane_id, plane_props.id_for("FB_ID"), dummy.id());
-    drmModeAtomicAddProperty(request.get(), plane_id, plane_props.id_for("CRTC_ID"), crtc_id);
-
-    /* We don't monitor the DRM events (yet), so have no userdata */
-    ret = drmModeAtomicCommit(drm_fd, request.get(), DRM_MODE_ATOMIC_ALLOW_MODESET, nullptr);
-
-    if (ret != 0)
-    {
-        BOOST_THROW_EXCEPTION(
-            std::system_error(-ret, std::system_category(), "Failed to commit atomic KMS configuration change"));
-    }
+    atomic_commit(dummy.id(), nullptr, DRM_MODE_ATOMIC_ALLOW_MODESET);
 
     EGLAttrib const crtc_filter[] = {
-        EGL_DRM_CRTC_EXT, static_cast<EGLAttrib>(crtc_id),
+        EGL_DRM_CRTC_EXT, static_cast<EGLAttrib>(_crtc_id),
         EGL_NONE};
     int found_layers{0};
     if (eglGetOutputLayersEXT(display, crtc_filter, &layer, 1, &found_layers) != EGL_TRUE)
@@ -286,16 +247,14 @@ void mgek::EGLOutput::configure(size_t kms_mode_index)
         BOOST_THROW_EXCEPTION((
             mg::egl_error(
                 std::string{"Failed to find EGLOutputEXT corresponding to DRM CRTC "} +
-                std::to_string(crtc_id))));
+                std::to_string(_crtc_id))));
     }
     if (found_layers != 1)
     {
         BOOST_THROW_EXCEPTION(std::runtime_error{
             std::string{"Failed to find EGLOutputEXT corresponding to DRM CRTC "} +
-            std::to_string(crtc_id)});
+            std::to_string(_crtc_id)});
     }
-
-    using_saved_crtc = false;
 }
 
 EGLOutputLayerEXT mgek::EGLOutput::output_layer() const
@@ -314,6 +273,67 @@ uint32_t mgek::EGLOutput::crtc_id() const
         BOOST_THROW_EXCEPTION((std::runtime_error{"EGLOutputLayer is associated with invalid CRTC?!"}));
     }
     return static_cast<uint32_t>(crtc_id);
+}
+
+int mgek::EGLOutput::atomic_commit(uint64_t fb, const void *drm_event_userdata, uint32_t flags)
+{
+    auto const width = connector->modes[mode_index].hdisplay;
+    auto const height = connector->modes[mode_index].vdisplay;
+
+    std::unique_ptr<drmModeAtomicReq, void(*)(drmModeAtomicReqPtr)>
+        request{drmModeAtomicAlloc(), &drmModeAtomicFree};
+
+    if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
+    {
+        mgk::ObjectProperties crtc_props{drm_fd, _crtc_id, DRM_MODE_OBJECT_CRTC};
+
+        /* Activate the CRTC and set the mode */
+        drmModeAtomicAddProperty(request.get(), _crtc_id, crtc_props.id_for("MODE_ID"), mode_id);
+        drmModeAtomicAddProperty(request.get(), _crtc_id, crtc_props.id_for("ACTIVE"), 1);
+
+        /* Set CRTC for the output */
+        auto const connector_id = connector->connector_id;
+        mgk::ObjectProperties connector_props{drm_fd, connector_id, DRM_MODE_OBJECT_CONNECTOR};
+        drmModeAtomicAddProperty(request.get(), connector_id, connector_props.id_for("CRTC_ID"), _crtc_id);
+    }
+
+    /* Source viewport. Coordinates are 16.16 fixed point format */
+    drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("SRC_X"), 0);
+    drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("SRC_Y"), 0);
+    drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("SRC_W"), width << 16);
+    drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("SRC_H"), height << 16);
+
+    /* Destination viewport. Coordinates are *not* 16.16 */
+    drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("CRTC_X"), 0);
+    drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("CRTC_Y"), 0);
+    drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("CRTC_W"), width);
+    drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("CRTC_H"), height);
+
+    /* Set a surface for the plane */
+    drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("CRTC_ID"), _crtc_id);
+    drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("FB_ID"), fb);
+
+    auto ret = drmModeAtomicCommit(drm_fd, request.get(), flags, const_cast<void*>(drm_event_userdata));
+    if (ret != 0)
+    {
+        return ret;
+    }
+
+    using_saved_crtc = false;
+    return 0;
+}
+
+bool mgek::EGLOutput::queue_atomic_flip(FBHandle const& fb, void const* drm_event_userdata)
+{
+    uint32_t flags = flags_for_next_flip | DRM_MODE_ATOMIC_NONBLOCK | DRM_MODE_PAGE_FLIP_EVENT;
+    flags_for_next_flip = 0;
+    int ret = atomic_commit(fb, drm_event_userdata, flags);
+    if (ret != 0)
+    {
+        BOOST_THROW_EXCEPTION((std::system_error{-ret, std::system_category(), "Failed to commit Atomic KMS state"}));
+    }
+
+    return true;
 }
 
 void mgek::EGLOutput::clear_crtc()
@@ -346,6 +366,8 @@ void mgek::EGLOutput::clear_crtc()
                 std::system_category(),
                 "Couldn't clear output "s + mgk::connector_name(connector)}));
     }
+
+    current_crtc = nullptr;
 }
 
 void mgek::EGLOutput::restore_saved_crtc()
@@ -381,4 +403,9 @@ void mgek::EGLOutput::set_power_mode(MirPowerMode mode)
     {
         BOOST_THROW_EXCEPTION((std::system_error{-ret, std::system_category(), "Failed to set output power mode"}));
     }
+}
+
+void mgek::EGLOutput::set_flags_for_next_flip(uint32_t flags)
+{
+    flags_for_next_flip = flags;
 }

--- a/src/platforms/eglstream-kms/server/egl_output.cpp
+++ b/src/platforms/eglstream-kms/server/egl_output.cpp
@@ -313,6 +313,11 @@ int mgek::EGLOutput::atomic_commit(uint64_t fb, const void *drm_event_userdata, 
     drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("CRTC_ID"), _crtc_id);
     drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("FB_ID"), fb);
 
+    // TEST: Make modeset commits synchronous, to avoid EBUSY?
+    if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
+    {
+        flags &= ~DRM_MODE_ATOMIC_NONBLOCK;
+    }
     auto ret = drmModeAtomicCommit(drm_fd, request.get(), flags, const_cast<void*>(drm_event_userdata));
     if (ret != 0)
     {
@@ -339,10 +344,11 @@ bool mgek::EGLOutput::queue_atomic_flip(FBHandle const& fb, void const* drm_even
              *
              * Whatever we're switching to can handle the CRTCs; this should not be fatal.
              */
-            mir::log_info("Couldn't clear output %s (drmModeSetCrtc: %s (%i))",
+            mir::log_info("Failed to submit page flip on %s (drmModeSetCrtc: %s (%i))",
                 mgk::connector_name(connector).c_str(),
                 strerror(-ret),
                 -ret);
+            return false;
         }
         else
         {

--- a/src/platforms/eglstream-kms/server/egl_output.cpp
+++ b/src/platforms/eglstream-kms/server/egl_output.cpp
@@ -313,11 +313,6 @@ int mgek::EGLOutput::atomic_commit(uint64_t fb, const void *drm_event_userdata, 
     drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("CRTC_ID"), _crtc_id);
     drmModeAtomicAddProperty(request.get(), plane_id, plane_props->id_for("FB_ID"), fb);
 
-    // TEST: Make modeset commits synchronous, to avoid EBUSY?
-    if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
-    {
-        flags &= ~DRM_MODE_ATOMIC_NONBLOCK;
-    }
     auto ret = drmModeAtomicCommit(drm_fd, request.get(), flags, const_cast<void*>(drm_event_userdata));
     if (ret != 0)
     {

--- a/src/platforms/eglstream-kms/server/egl_output.h
+++ b/src/platforms/eglstream-kms/server/egl_output.h
@@ -49,7 +49,7 @@ public:
 
     EGLOutputLayerEXT output_layer() const;
     uint32_t crtc_id() const;
-    bool queue_atomic_flip(FBHandle const& fb, void const* drm_event_userdata);
+    auto queue_atomic_flip(FBHandle const& fb, void const* drm_event_userdata) -> std::optional<std::error_code>;
     void clear_crtc();
 
     void set_power_mode(MirPowerMode mode);

--- a/src/platforms/eglstream-kms/server/egl_output.h
+++ b/src/platforms/eglstream-kms/server/egl_output.h
@@ -79,7 +79,7 @@ private:
     uint32_t mode_id;
 
     int dpms_enum_id;
-    uint32_t flags_for_next_flip;
+    uint32_t flags_for_next_flip = 0;
 };
 
 }

--- a/src/platforms/eglstream-kms/server/egl_output.h
+++ b/src/platforms/eglstream-kms/server/egl_output.h
@@ -74,7 +74,7 @@ private:
 
     uint32_t plane_id;
     std::unique_ptr<graphics::kms::ObjectProperties> plane_props;
-    uint32_t _crtc_id;
+    uint32_t crtc_id_;
 
     uint32_t mode_id;
 

--- a/src/platforms/eglstream-kms/server/egl_output.h
+++ b/src/platforms/eglstream-kms/server/egl_output.h
@@ -18,6 +18,7 @@
 #define MIR_GRAPHICS_EGLSTREAM_KMS_OUTPUT_H_
 
 #include "kms-utils/drm_mode_resources.h"
+#include "kms_framebuffer.h"
 #include "mir/geometry/size.h"
 #include "mir/geometry/point.h"
 #include "mir/geometry/displacement.h"
@@ -48,12 +49,15 @@ public:
 
     EGLOutputLayerEXT output_layer() const;
     uint32_t crtc_id() const;
+    bool queue_atomic_flip(FBHandle const& fb, void const* drm_event_userdata);
     void clear_crtc();
 
     void set_power_mode(MirPowerMode mode);
+    void set_flags_for_next_flip(uint32_t flags);
 
 private:
     void restore_saved_crtc();
+    int atomic_commit(uint64_t fb, void const* drm_event_userdata, uint32_t flags);
 
     int const drm_fd;
 
@@ -63,11 +67,19 @@ private:
 
     graphics::kms::DRMModeConnectorUPtr connector;
 
+    mir::graphics::kms::DRMModeCrtcUPtr current_crtc;
     size_t mode_index;
     drmModeCrtc saved_crtc;
     bool using_saved_crtc;
 
+    uint32_t plane_id;
+    std::unique_ptr<graphics::kms::ObjectProperties> plane_props;
+    uint32_t _crtc_id;
+
+    uint32_t mode_id;
+
     int dpms_enum_id;
+    uint32_t flags_for_next_flip;
 };
 
 }

--- a/src/platforms/eglstream-kms/server/eglstream_interface_provider.cpp
+++ b/src/platforms/eglstream-kms/server/eglstream_interface_provider.cpp
@@ -83,7 +83,7 @@ auto mg::eglstream::InterfaceProvider::maybe_create_interface(DisplayProvider::T
     }
     if (dynamic_cast<mg::CPUAddressableDisplayProvider::Tag const*>(&tag))
     {
-        return std::make_shared<mg::kms::CPUAddressableDisplayProvider>(drm_fd);
+        return mg::kms::CPUAddressableDisplayProvider::create_if_supported(drm_fd);
     }
     return nullptr;
 }

--- a/src/platforms/eglstream-kms/server/eglstream_interface_provider.cpp
+++ b/src/platforms/eglstream-kms/server/eglstream_interface_provider.cpp
@@ -16,7 +16,7 @@
 
 #include "eglstream_interface_provider.h"
 #include "mir/graphics/platform.h"
-#include "basic_cpu_addressable_display_provider.h"
+#include "kms_cpu_addressable_display_provider.h"
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
@@ -83,7 +83,7 @@ auto mg::eglstream::InterfaceProvider::maybe_create_interface(DisplayProvider::T
     }
     if (dynamic_cast<mg::CPUAddressableDisplayProvider::Tag const*>(&tag))
     {
-        return std::make_shared<mg::BasicCPUAddressableDisplayProvider>(drm_fd);
+        return std::make_shared<mg::kms::CPUAddressableDisplayProvider>(drm_fd);
     }
     return nullptr;
 }

--- a/src/platforms/eglstream-kms/server/eglstream_interface_provider.cpp
+++ b/src/platforms/eglstream-kms/server/eglstream_interface_provider.cpp
@@ -16,6 +16,7 @@
 
 #include "eglstream_interface_provider.h"
 #include "mir/graphics/platform.h"
+#include "basic_cpu_addressable_display_provider.h"
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
@@ -60,14 +61,16 @@ auto DisplayProviderImpl::claim_stream() -> EGLStreamKHR
 }
 }
 
-mg::eglstream::InterfaceProvider::InterfaceProvider(EGLDisplay dpy)
-    : dpy{dpy}
+mg::eglstream::InterfaceProvider::InterfaceProvider(EGLDisplay dpy, mir::Fd drm_fd)
+    : dpy{dpy},
+      drm_fd{drm_fd}
 {
 }
 
 mg::eglstream::InterfaceProvider::InterfaceProvider(InterfaceProvider const& from, EGLStreamKHR with_stream)
     : dpy{from.dpy},
-      stream{with_stream}
+      stream{with_stream},
+      drm_fd{from.drm_fd}
 {
 }
 
@@ -77,6 +80,10 @@ auto mg::eglstream::InterfaceProvider::maybe_create_interface(DisplayProvider::T
     if (dynamic_cast<EGLStreamDisplayProvider::Tag const*>(&tag))
     {
         return std::make_shared<DisplayProviderImpl>(dpy, stream);
+    }
+    if (dynamic_cast<mg::CPUAddressableDisplayProvider::Tag const*>(&tag))
+    {
+        return std::make_shared<mg::BasicCPUAddressableDisplayProvider>(drm_fd);
     }
     return nullptr;
 }

--- a/src/platforms/eglstream-kms/server/kms_display_configuration.cpp
+++ b/src/platforms/eglstream-kms/server/kms_display_configuration.cpp
@@ -267,11 +267,11 @@ void mge::KMSDisplayConfiguration::update()
 }
 
 void mge::KMSDisplayConfiguration::for_each_output(
-    std::function<void(kms::EGLOutput const&)> const& f) const
+    std::function<void(std::shared_ptr<kms::EGLOutput> const&)> const& f) const
 {
     for (auto const& output : outputs)
     {
-        f(*output);
+        f(output);
     }
 }
 

--- a/src/platforms/eglstream-kms/server/kms_display_configuration.h
+++ b/src/platforms/eglstream-kms/server/kms_display_configuration.h
@@ -45,7 +45,7 @@ public:
     size_t get_kms_mode_index(DisplayConfigurationOutputId id, size_t conf_mode_index) const;
     void update();
 
-    void for_each_output(std::function<void(kms::EGLOutput const&)> const& f) const;
+    void for_each_output(std::function<void(std::shared_ptr<kms::EGLOutput> const&)> const& f) const;
 
 private:
     void update_output(

--- a/src/platforms/eglstream-kms/server/platform.cpp
+++ b/src/platforms/eglstream-kms/server/platform.cpp
@@ -22,6 +22,7 @@
 #include "mir/graphics/platform.h"
 #include "utils.h"
 #include "eglstream_interface_provider.h"
+#include "basic_cpu_addressable_display_provider.h"
 
 #include "one_shot_device_observer.h"
 
@@ -245,7 +246,7 @@ mge::DisplayPlatform::DisplayPlatform(
             std::to_string(std::get<0>(egl_version)) + "." + std::to_string(std::get<1>(egl_version))}));
     }
 
-    provider = std::make_shared<InterfaceProvider>(display);
+    provider = std::make_shared<InterfaceProvider>(display, drm_node);
 }
 
 mge::DisplayPlatform::~DisplayPlatform()

--- a/src/platforms/eglstream-kms/server/platform.cpp
+++ b/src/platforms/eglstream-kms/server/platform.cpp
@@ -22,7 +22,6 @@
 #include "mir/graphics/platform.h"
 #include "utils.h"
 #include "eglstream_interface_provider.h"
-#include "basic_cpu_addressable_display_provider.h"
 
 #include "one_shot_device_observer.h"
 

--- a/src/platforms/eglstream-kms/server/threaded_drm_event_handler.cpp
+++ b/src/platforms/eglstream-kms/server/threaded_drm_event_handler.cpp
@@ -15,23 +15,80 @@
  */
 
 #include "threaded_drm_event_handler.h"
+#include "mir/log.h"
+#include "mir/logging/logger.h"
 
 #include <boost/throw_exception.hpp>
 #include <boost/exception/enable_error_info.hpp>
 #include <boost/exception/info.hpp>
 
+#include <system_error>
 #include <xf86drm.h>
 #include <poll.h>
 #include <cstring>
+#include <fcntl.h>
 #include <algorithm>
 
 namespace mge = mir::graphics::eglstream;
 
+
+
+class mge::ThreadedDRMEventHandler::Pipe
+{
+public:
+    Pipe()
+        : Pipe(checked_pipe(O_CLOEXEC))
+    {
+    }
+
+    auto read_fd() const -> int
+    {
+        return read;
+    }
+
+    auto read_from() -> uint32_t
+    {
+        uint32_t buffer;
+        if (::read(read, &buffer, sizeof(buffer)) != sizeof(buffer))
+        {
+            BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to read from pipe"}));
+        }
+        return buffer;
+    }
+
+    void write_to(uint32_t data)
+    {
+        if (::write(write, &data, sizeof(data)) != sizeof(data))
+        {
+            BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to write to pipe"}));
+        }
+    }
+private:
+    static auto checked_pipe(int flags) -> std::array<int, 2>
+    {
+        std::array<int, 2> pipefds;
+        if (pipe2(pipefds.data(), flags))
+        {
+            BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to create pipe()"}));
+        }
+        return pipefds;
+    }
+
+    Pipe(std::array<int, 2> pipefds)
+        : read{mir::Fd{pipefds[0]}},
+          write{mir::Fd{pipefds[1]}}
+    {
+    }
+
+    mir::Fd const read;
+    mir::Fd const write;
+};
+
 mge::ThreadedDRMEventHandler::ThreadedDRMEventHandler(mir::Fd drm_fd)
     : drm_fd{std::move(drm_fd)},
+      cancel_pipe{std::make_unique<Pipe>()},
       dispatch_thread{[this]() { event_loop(); }}
 {
-
 }
 
 mge::ThreadedDRMEventHandler::~ThreadedDRMEventHandler()
@@ -97,6 +154,15 @@ std::future<void> mge::ThreadedDRMEventHandler::expect_flip_event(
     return pending_expectations.back()->completion.get_future();
 }
 
+void mge::ThreadedDRMEventHandler::cancel_flip_events(KMSCrtcId id)
+{
+    mir::log(
+        mir::logging::Severity::debug,
+        "ThreadedDRMEventHandler",
+        "Scheduling cancel of flip events for CRTC %i", id);
+    cancel_pipe->write_to(id);
+}
+
 void mge::ThreadedDRMEventHandler::event_loop() noexcept
 {
     drmEventContext ctx;
@@ -137,11 +203,16 @@ void mge::ThreadedDRMEventHandler::event_loop() noexcept
          */
         lock.unlock();
 
-        pollfd events;
-        events.fd = drm_fd;
-        events.events = POLLIN;
+        pollfd events[2];
+        // DRM events
+        events[0].fd = drm_fd;
+        events[0].events = POLLIN;
+        // Cancel events
+        events[1].fd = cancel_pipe->read_fd();
+        events[1].events = POLLIN;
+
         // TODO: Maybe have a non-infinite timeout here?
-        auto result = ::poll(&events, 1, -1);
+        auto result = ::poll(events, 2, -1);
 
         // We've got some events; reclaim the lock and process them.
         lock.lock();
@@ -166,9 +237,32 @@ void mge::ThreadedDRMEventHandler::event_loop() noexcept
                 }
             }
         }
-        else if (events.revents & POLLIN)
-        {
-            drmHandleEvent(drm_fd, &ctx);
+        else
+        {   // DRM event
+            if (events[0].revents & POLLIN)
+            {
+                drmHandleEvent(drm_fd, &ctx);
+            }  // Cancel event
+            if (events[1].revents & POLLIN)
+            {
+                auto crtc_id = cancel_pipe->read_from();
+                        mir::log(
+                            mir::logging::Severity::debug,
+                            "ThreadedDRMEventHandler",
+                            "Cancelling any page flip notification for CRTC %i", crtc_id);
+                for (auto& slot :pending_expectations)
+                {
+                    if (slot && slot->id == crtc_id)
+                    {
+                        mir::log(
+                            mir::logging::Severity::debug,
+                            "ThreadedDRMEventHandler",
+                            "Cancelling page flip notification for CRTC %i", crtc_id);
+                        slot->completion.set_value();
+                        slot = {};
+                    }
+                }
+            }
         }
     }
 }

--- a/src/platforms/eglstream-kms/server/threaded_drm_event_handler.cpp
+++ b/src/platforms/eglstream-kms/server/threaded_drm_event_handler.cpp
@@ -156,10 +156,6 @@ std::future<void> mge::ThreadedDRMEventHandler::expect_flip_event(
 
 void mge::ThreadedDRMEventHandler::cancel_flip_events(KMSCrtcId id)
 {
-    mir::log(
-        mir::logging::Severity::debug,
-        "ThreadedDRMEventHandler",
-        "Scheduling cancel of flip events for CRTC %i", id);
     cancel_pipe->write_to(id);
 }
 
@@ -246,18 +242,10 @@ void mge::ThreadedDRMEventHandler::event_loop() noexcept
             if (events[1].revents & POLLIN)
             {
                 auto crtc_id = cancel_pipe->read_from();
-                        mir::log(
-                            mir::logging::Severity::debug,
-                            "ThreadedDRMEventHandler",
-                            "Cancelling any page flip notification for CRTC %i", crtc_id);
                 for (auto& slot :pending_expectations)
                 {
                     if (slot && slot->id == crtc_id)
                     {
-                        mir::log(
-                            mir::logging::Severity::debug,
-                            "ThreadedDRMEventHandler",
-                            "Cancelling page flip notification for CRTC %i", crtc_id);
                         slot->completion.set_value();
                         slot = {};
                     }

--- a/src/platforms/eglstream-kms/server/threaded_drm_event_handler.h
+++ b/src/platforms/eglstream-kms/server/threaded_drm_event_handler.h
@@ -45,6 +45,7 @@ public:
         KMSCrtcId id,
         std::function<void(unsigned int, std::chrono::milliseconds)> on_flip) override;
 
+    void cancel_flip_events(KMSCrtcId id) override;
 private:
     void event_loop() noexcept;
 
@@ -57,6 +58,8 @@ private:
         void* data) noexcept;
 
     mir::Fd const drm_fd;
+    class Pipe;
+    std::unique_ptr<Pipe> const cancel_pipe;
 
     struct FlipEventData
     {

--- a/src/platforms/gbm-kms/server/kms/CMakeLists.txt
+++ b/src/platforms/gbm-kms/server/kms/CMakeLists.txt
@@ -37,9 +37,6 @@ add_library(
   egl_helper.cpp
   quirks.cpp
   quirks.h
-  kms_framebuffer.h
-  cpu_addressable_fb.cpp
-  cpu_addressable_fb.h
 )
 
 target_link_libraries(

--- a/src/platforms/gbm-kms/server/kms/display.h
+++ b/src/platforms/gbm-kms/server/kms/display.h
@@ -104,22 +104,6 @@ private:
     std::weak_ptr<Cursor> cursor;
 };
 
-class CPUAddressableDisplayProvider : public graphics::CPUAddressableDisplayProvider
-{
-public:
-    explicit CPUAddressableDisplayProvider(mir::Fd drm_fd);
-
-    auto supported_formats() const
-        -> std::vector<DRMFormat> override;
-
-    auto alloc_fb(geometry::Size pixel_size, DRMFormat format)
-        -> std::unique_ptr<MappableFB> override;
-
-private:
-    mir::Fd const drm_fd;
-    bool const supports_modifiers;
-};
-
 class GBMDisplayProvider : public graphics::GBMDisplayProvider
 {
 public:

--- a/src/platforms/gbm-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.cpp
@@ -137,11 +137,6 @@ bool mgg::DisplayBuffer::overlay(std::vector<DisplayElement> const& renderable_l
         next_swap = std::move(fb);
         return true;
     }
-    if (auto fb = std::dynamic_pointer_cast<graphics::FBHandle>(renderable_list[0].buffer))
-    {
-        next_swap = std::move(fb);
-        return true;
-    }
     return false;
 }
 

--- a/src/platforms/gbm-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.cpp
@@ -76,7 +76,7 @@ mgg::DisplayBuffer::DisplayBuffer(
     {
         mir::log_info("Clearing screen due to differing encountered and target modes");
         // TODO: Pull a supported format out of KMS rather than assuming XRGB8888
-        auto initial_fb = std::make_shared<mgg::CPUAddressableFB>(
+        auto initial_fb = std::make_shared<graphics::CPUAddressableFB>(
             std::move(drm_fd),
             false,
             DRMFormat{DRM_FORMAT_XRGB8888},
@@ -132,7 +132,12 @@ bool mgg::DisplayBuffer::overlay(std::vector<DisplayElement> const& renderable_l
         return false;
     }
 
-    if (auto fb = std::dynamic_pointer_cast<mgg::FBHandle>(renderable_list[0].buffer))
+    if (auto fb = std::dynamic_pointer_cast<graphics::FBHandle>(renderable_list[0].buffer))
+    {
+        next_swap = std::move(fb);
+        return true;
+    }
+    if (auto fb = std::dynamic_pointer_cast<graphics::FBHandle>(renderable_list[0].buffer))
     {
         next_swap = std::move(fb);
         return true;

--- a/src/platforms/gbm-kms/server/kms/display_buffer.h
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.h
@@ -40,7 +40,6 @@ namespace gbm
 {
 
 class Platform;
-class FBHandle;
 class KMSOutput;
 class NativeBuffer;
 

--- a/src/platforms/gbm-kms/server/kms/kms_output.h
+++ b/src/platforms/gbm-kms/server/kms/kms_output.h
@@ -33,11 +33,10 @@ namespace mir
 namespace graphics
 {
 class DisplayConfigurationOutput;
+class FBHandle;
 
 namespace gbm
 {
-
-class FBHandle;
 
 class KMSOutput
 {

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -384,7 +384,7 @@ protected:
         }
         if (dynamic_cast<mg::CPUAddressableDisplayProvider::Tag const*>(&type_tag))
         {
-            return std::make_shared<mg::kms::CPUAddressableDisplayProvider>(drm_fd);
+            return mg::kms::CPUAddressableDisplayProvider::create_if_supported(drm_fd);
         }
         return {};  
     }

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -30,7 +30,7 @@
 #include "one_shot_device_observer.h"
 #include "mir/graphics/linux_dmabuf.h"
 #include "mir/graphics/egl_context_executor.h"
-#include "basic_cpu_addressable_display_provider.h"
+#include "kms_cpu_addressable_display_provider.h"
 #include "surfaceless_egl_context.h"
 #include <boost/throw_exception.hpp>
 #include <drm_fourcc.h>
@@ -384,7 +384,7 @@ protected:
         }
         if (dynamic_cast<mg::CPUAddressableDisplayProvider::Tag const*>(&type_tag))
         {
-            return std::make_shared<mg::BasicCPUAddressableDisplayProvider>(drm_fd);
+            return std::make_shared<mg::kms::CPUAddressableDisplayProvider>(drm_fd);
         }
         return {};  
     }

--- a/src/platforms/gbm-kms/server/kms/platform.cpp
+++ b/src/platforms/gbm-kms/server/kms/platform.cpp
@@ -30,6 +30,7 @@
 #include "one_shot_device_observer.h"
 #include "mir/graphics/linux_dmabuf.h"
 #include "mir/graphics/egl_context_executor.h"
+#include "basic_cpu_addressable_display_provider.h"
 #include "surfaceless_egl_context.h"
 #include <boost/throw_exception.hpp>
 #include <drm_fourcc.h>
@@ -383,7 +384,7 @@ protected:
         }
         if (dynamic_cast<mg::CPUAddressableDisplayProvider::Tag const*>(&type_tag))
         {
-            return std::make_shared<mgg::CPUAddressableDisplayProvider>(drm_fd);
+            return std::make_shared<mg::BasicCPUAddressableDisplayProvider>(drm_fd);
         }
         return {};  
     }

--- a/tests/unit-tests/platforms/gbm-kms/kms/mock_kms_output.h
+++ b/tests/unit-tests/platforms/gbm-kms/kms/mock_kms_output.h
@@ -34,20 +34,20 @@ struct MockKMSOutput : public graphics::gbm::KMSOutput
     MOCK_CONST_METHOD0(size, geometry::Size());
     MOCK_CONST_METHOD0(max_refresh_rate, int());
 
-    bool set_crtc(graphics::gbm::FBHandle const& fb) override
+    bool set_crtc(graphics::FBHandle const& fb) override
     {
         return set_crtc_thunk(&fb);
     }
 
     MOCK_METHOD0(has_crtc_mismatch, bool());
-    MOCK_METHOD1(set_crtc_thunk, bool(graphics::gbm::FBHandle const*));
+    MOCK_METHOD1(set_crtc_thunk, bool(graphics::FBHandle const*));
     MOCK_METHOD0(clear_crtc, void());
 
-    bool schedule_page_flip(graphics::gbm::FBHandle const& fb) override
+    bool schedule_page_flip(graphics::FBHandle const& fb) override
     {
         return schedule_page_flip_thunk(&fb);
     }
-    MOCK_METHOD1(schedule_page_flip_thunk, bool(graphics::gbm::FBHandle const*));
+    MOCK_METHOD1(schedule_page_flip_thunk, bool(graphics::FBHandle const*));
     MOCK_METHOD0(wait_for_page_flip, void());
 
     MOCK_CONST_METHOD0(last_frame, graphics::Frame());
@@ -63,8 +63,8 @@ struct MockKMSOutput : public graphics::gbm::KMSOutput
     MOCK_METHOD0(refresh_hardware_state, void());
     MOCK_CONST_METHOD1(update_from_hardware_state, void(graphics::DisplayConfigurationOutput&));
 
-    MOCK_CONST_METHOD1(fb_for, std::shared_ptr<graphics::gbm::FBHandle const>(gbm_bo*));
-    MOCK_CONST_METHOD1(fb_for, std::shared_ptr<graphics::gbm::FBHandle const>(graphics::DMABufBuffer const&));
+    MOCK_CONST_METHOD1(fb_for, std::shared_ptr<graphics::FBHandle const>(gbm_bo*));
+    MOCK_CONST_METHOD1(fb_for, std::shared_ptr<graphics::FBHandle const>(graphics::DMABufBuffer const&));
     MOCK_CONST_METHOD1(buffer_requires_migration, bool(gbm_bo*));
     MOCK_CONST_METHOD0(drm_fd, int());
 };

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
@@ -345,6 +345,9 @@ TEST_F(MesaDisplayMultiMonitorTest, flip_flips_all_connected_crtcs)
     EXPECT_CALL(mock_drm, drmModeAddFB2(mtd::IsFdOfDevice(drm_device),
                                         _, _, _, _, _, _, _, _))
         .WillRepeatedly(DoAll(SetArgPointee<7>(fb_id), Return(0)));
+    EXPECT_CALL(mock_drm, drmModeAddFB2WithModifiers(mtd::IsFdOfDevice(drm_device),
+                                                     _, _, _, _, _, _, _, _, _))
+        .WillRepeatedly(DoAll(SetArgPointee<8>(fb_id), Return(0)));
 
     /* All crtcs are flipped */
     for (int i = 0; i < num_connected_outputs; i++)

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_real_kms_output.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_real_kms_output.cpp
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "kms/kms_framebuffer.h"
+#include "kms_framebuffer.h"
 #include "src/platforms/gbm-kms/server/kms/real_kms_output.h"
 #include "src/platforms/gbm-kms/server/kms/page_flipper.h"
 #include "mir/fatal.h"
@@ -55,7 +55,7 @@ public:
     MOCK_METHOD1(wait_for_flip, mg::Frame(uint32_t));
 };
 
-class MockKMSFramebuffer : public mgg::FBHandle
+class MockKMSFramebuffer : public mg::FBHandle
 {
 public:
     MockKMSFramebuffer(uint32_t fb_id)


### PR DESCRIPTION
## What's new?
- The EglStreams platform now has a `CPUAddressableDisplayProvider` so that it works in this specific hybrid situation
- Moved some classes to be shared between GBM and EGLStreams

## How to test
```
sudo XDG_RUNTIME_DIR=/run ./bin/mir_demo_server --platform-rendering-libs mir:gbm-kms
```

It still SIGABRTs after, but it gets through the selection part.