### PR TITLE
Fix gtest pkg-config detection

### DIFF
--- a/cmake/FindGtestGmock.cmake
+++ b/cmake/FindGtestGmock.cmake
@@ -1,7 +1,7 @@
 include(FindPackageHandleStandardArgs)
 
-pkg_check_modules(GTEST QUIET "gtest >= 1.8.0")
-pkg_check_modules(GTEST_MAIN QUIET "gtest_main >= 1.8.0")
+pkg_check_modules(GTEST QUIET gtest>=1.8.0)
+pkg_check_modules(GTEST_MAIN QUIET gtest_main>=1.8.0)
 if (GTEST_FOUND AND GTEST_MAIN_FOUND)
     # If we can find package configuration for gtest use it!
     set(GTEST_LIBRARY ${GTEST_LIBRARIES})


### PR DESCRIPTION
For some reason now there's some issue when passing the version string to pkg_check_modules with spaces inbetween which breaks setting a bunch of used variables.

  pkg_check_modules(GTEST "gtest >= 1.8.0")

  -- Checking for module 'gtest >= 1.8.0'
  --   Found gtest , version

vs.

  pkg_check_modules(GTEST "gtest>=1.8.0")

  -- Checking for module 'gtest>=1.8.0'
  --   Found gtest, version 1.14.0

---

Saw this issue on Alpine Linux when building v1.8.2, but patch applies the same to main so I don't see why it shouldn't be correct for main also.