### PR TITLE
Add a feature flag to hide hybrid capability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "${build_types}" FORCE)
 # Enable cmake-gui to display a drop down list for CMAKE_BUILD_TYPE
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${build_types}")
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -144,7 +144,7 @@ void hybrid_check(std::vector<std::pair<mg::SupportedDevice, std::shared_ptr<mir
         std::stable_sort(std::begin(platform_modules), std::end(platform_modules),
              [](auto const& l, auto const& r) { return l.first.support_level > r.first.support_level; });
 
-        platform_modules.resize(std::min(1ul, platform_modules.size()));
+        platform_modules.resize(std::min(1uz, platform_modules.size()));
     }
 }
 }


### PR DESCRIPTION
The intent is to allows us to merge without exposing functionality we are still polishing.

This uses an environment variable (`MIR_EXPERIMENTAL_HYBRID_GRAPHICS`), not a configuration option, as that is easy to drop seamlessly later.
