### PR TITLE
Fix MirRunner::stop()

### DIFF
--- a/src/miral/runner.cpp
+++ b/src/miral/runner.cpp
@@ -258,7 +258,7 @@ void miral::MirRunner::stop()
 
     if (auto const server = self->weak_server.lock())
     {
-        server->stop();
+        server->the_main_loop()->enqueue(this, [server] { server->stop(); });
     }
 }
 


### PR DESCRIPTION
We were trying to shut down the server on whatever thread was calling MirRunner::stop(). That worked fine for the input thread (for example), but if it were the Wayland thread the server became unresponsive and internal clients couldn't close.

Fixes: #3070