### PR TITLE
Fix for mir_performance_tests failure due to not cleaning up our displays

### DIFF
--- a/src/platforms/eglstream-kms/server/display.cpp
+++ b/src/platforms/eglstream-kms/server/display.cpp
@@ -181,6 +181,21 @@ public:
         pending_flip = satisfied_promise.get_future();
     }
 
+    ~DisplayBuffer()
+    {
+        if (output_stream != EGL_NO_STREAM_KHR)
+        {
+            eglDestroyStreamKHR(dpy, output_stream);
+            output_stream = nullptr;
+        }
+
+        if (ctx != EGL_NO_CONTEXT)
+        {
+            eglDestroyContext(dpy, ctx);
+            ctx = nullptr;
+        }
+    }
+
     mir::geometry::Rectangle view_area() const override
     {
         return view_area_;

--- a/src/platforms/eglstream-kms/server/platform.cpp
+++ b/src/platforms/eglstream-kms/server/platform.cpp
@@ -248,6 +248,14 @@ mge::DisplayPlatform::DisplayPlatform(
     provider = std::make_shared<InterfaceProvider>(display);
 }
 
+mge::DisplayPlatform::~DisplayPlatform()
+{
+    if (display != EGL_NO_DISPLAY)
+    {
+        eglTerminate(display);
+    }
+}
+
 auto mge::DisplayPlatform::create_display(
     std::shared_ptr<DisplayConfigurationPolicy> const& configuration_policy,
     std::shared_ptr<GLConfig> const& gl_config)

--- a/src/platforms/eglstream-kms/server/platform.h
+++ b/src/platforms/eglstream-kms/server/platform.h
@@ -65,6 +65,8 @@ public:
         EGLDeviceEXT device,
         std::shared_ptr<DisplayReport> display_report);
 
+    ~DisplayPlatform();
+
     auto create_display(
         std::shared_ptr<DisplayConfigurationPolicy> const& initial_conf_policy,
         std::shared_ptr<GLConfig> const& gl_config)


### PR DESCRIPTION
## How to test
- On an nvidia + intel platform, run:
```sh
sudo MIR_EXPERIMENTAL_HYBRID_GRAPHICS=1 MIR_SERVER_PLATFORM_RENDERING_LIBS=mir:eglstream-kms XDG_RUNTIME_DIR=/run/ ./bin/mir_performance_tests --gtest_filter=GLMark2Wayland.*
```

## Expected output
```
LD_LIBRARY_PATH=./bin/../lib/
MIR_SERVER_PLATFORM_PATH=./bin/../lib/server-modules/
exec=./bin/mir_performance_tests.bin
Running main() from main.cpp
Note: Google Test filter = GLMark2Wayland.*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from GLMark2Wayland
[ RUN      ] GLMark2Wayland.fullscreen
Saving server logs to: /tmp/GLMark2Wayland_fullscreen_server.log
libEGL warning: egl: failed to create dri2 screen
libEGL warning: egl: failed to create dri2 screen
libEGL warning: egl: failed to create dri2 screen
libEGL warning: egl: failed to create dri2 screen
Saving GLMark2 detailed results to: /tmp/GLMark2Wayland_fullscreen.log
[       OK ] GLMark2Wayland.fullscreen (11871 ms)
[ RUN      ] GLMark2Wayland.windowed
Saving server logs to: /tmp/GLMark2Wayland_windowed_server.log
libEGL warning: egl: failed to create dri2 screen
libEGL warning: egl: failed to create dri2 screen
libEGL warning: egl: failed to create dri2 screen
libEGL warning: egl: failed to create dri2 screen
Saving GLMark2 detailed results to: /tmp/GLMark2Wayland_windowed.log
[       OK ] GLMark2Wayland.windowed (11712 ms)
[----------] 2 tests from GLMark2Wayland (23584 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (23584 ms total)
[  PASSED  ] 2 tests.
```