### PR TITLE
Support for not compositing until at least one renderable has been sent to the compositor

### DIFF
--- a/src/include/server/mir/compositor/display_buffer_compositor.h
+++ b/src/include/server/mir/compositor/display_buffer_compositor.h
@@ -29,7 +29,8 @@ class DisplayBufferCompositor
 public:
     virtual ~DisplayBufferCompositor() = default;
 
-    virtual void composite(SceneElementSequence&& scene_sequence) = 0;
+    /// Returns true if any compositing happened, otherwise false.
+    virtual bool composite(SceneElementSequence&& scene_sequence) = 0;
 
 protected:
     DisplayBufferCompositor() = default;

--- a/src/server/compositor/default_display_buffer_compositor.cpp
+++ b/src/server/compositor/default_display_buffer_compositor.cpp
@@ -44,6 +44,10 @@ mc::DefaultDisplayBufferCompositor::DefaultDisplayBufferCompositor(
 
 void mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& scene_elements)
 {
+    if (scene_elements.size() == 0 && !has_rendered)
+        return;
+
+    has_rendered = true;
     report->began_frame(this);
 
     auto const& view_area = display_buffer.view_area();

--- a/src/server/compositor/default_display_buffer_compositor.cpp
+++ b/src/server/compositor/default_display_buffer_compositor.cpp
@@ -42,12 +42,12 @@ mc::DefaultDisplayBufferCompositor::DefaultDisplayBufferCompositor(
 {
 }
 
-void mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& scene_elements)
+bool mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& scene_elements)
 {
-    if (scene_elements.size() == 0 && !has_rendered)
-        return;
+    if (scene_elements.size() == 0 && !completed_first_render)
+        return false;
 
-    has_rendered = true;
+    completed_first_render = true;
     report->began_frame(this);
 
     auto const& view_area = display_buffer.view_area();
@@ -138,4 +138,5 @@ void mc::DefaultDisplayBufferCompositor::composite(mc::SceneElementSequence&& sc
     }
 
     report->finished_frame(this);
+    return true;
 }

--- a/src/server/compositor/default_display_buffer_compositor.h
+++ b/src/server/compositor/default_display_buffer_compositor.h
@@ -56,6 +56,7 @@ private:
     std::shared_ptr<renderer::Renderer> const renderer;
     std::unique_ptr<graphics::RenderingProvider::FramebufferProvider> const fb_adaptor;
     std::shared_ptr<compositor::CompositorReport> const report;
+    bool has_rendered = false;
 };
 
 }

--- a/src/server/compositor/default_display_buffer_compositor.h
+++ b/src/server/compositor/default_display_buffer_compositor.h
@@ -49,14 +49,14 @@ public:
         std::shared_ptr<renderer::Renderer> const& renderer,
         std::shared_ptr<compositor::CompositorReport> const& report);
 
-    void composite(SceneElementSequence&& scene_sequence) override;
+    bool composite(SceneElementSequence&& scene_sequence) override;
 
 private:
     graphics::DisplayBuffer& display_buffer;
     std::shared_ptr<renderer::Renderer> const renderer;
     std::unique_ptr<graphics::RenderingProvider::FramebufferProvider> const fb_adaptor;
     std::shared_ptr<compositor::CompositorReport> const report;
-    bool has_rendered = false;
+    bool completed_first_render = false;
 };
 
 }

--- a/src/server/compositor/multi_threaded_compositor.cpp
+++ b/src/server/compositor/multi_threaded_compositor.cpp
@@ -341,7 +341,6 @@ void mc::MultiThreadedCompositor::start()
     scene->add_observer(observer);
 
     /* Optional first render */
-    compose_on_start = false;
     if (compose_on_start)
         schedule_compositing(1);
 

--- a/src/server/compositor/multi_threaded_compositor.cpp
+++ b/src/server/compositor/multi_threaded_compositor.cpp
@@ -266,7 +266,6 @@ private:
     std::promise<void> stopped;
     std::future<void> stopped_future;
     bool not_posted_yet = true;
-    bool has_done_first_render = false;
 };
 
 }

--- a/tests/include/mir/test/doubles/null_display_buffer_compositor_factory.h
+++ b/tests/include/mir/test/doubles/null_display_buffer_compositor_factory.h
@@ -37,11 +37,12 @@ public:
     {
         struct NullDisplayBufferCompositor : compositor::DisplayBufferCompositor
         {
-            void composite(compositor::SceneElementSequence&&)
+            bool composite(compositor::SceneElementSequence&&) override
             {
                 // yield() is needed to ensure reasonable runtime under
                 // valgrind for some tests
                 std::this_thread::yield();
+                return true;
             }
         };
 

--- a/tests/integration-tests/test_surface_stack_with_compositor.cpp
+++ b/tests/integration-tests/test_surface_stack_with_compositor.cpp
@@ -164,7 +164,17 @@ struct SurfaceStackCompositor : public Test
             streams,
             std::shared_ptr<mg::CursorImage>(),
             null_scene_report)},
-        stub_buffer(std::make_shared<mtd::StubBuffer>())
+        stub_buffer(std::make_shared<mtd::StubBuffer>()),
+        other_stub_surface{std::make_shared<ms::BasicSurface>(
+            nullptr /* session */,
+            mw::Weak<mf::WlSurface>{},
+            std::string("stub"),
+            geom::Rectangle{{0,0},{1,1}},
+            mir_pointer_unconfined,
+            streams,
+            std::shared_ptr<mg::CursorImage>(),
+            null_scene_report)},
+        other_stub_buffer(std::make_shared<mtd::StubBuffer>())
     {
         ON_CALL(*mock_buffer_stream, lock_compositor_buffer(_))
             .WillByDefault(Return(mt::fake_shared(*stub_buffer)));
@@ -179,6 +189,8 @@ struct SurfaceStackCompositor : public Test
     std::list<ms::StreamInfo> const streams;
     std::shared_ptr<ms::BasicSurface> stub_surface;
     std::shared_ptr<mg::Buffer> stub_buffer;
+    std::shared_ptr<ms::BasicSurface> other_stub_surface;
+    std::shared_ptr<mg::Buffer> other_stub_buffer;
     CountingDisplaySyncGroup stub_primary_db;
     CountingDisplaySyncGroup stub_secondary_db;
     StubDisplay stub_display{stub_primary_db, stub_secondary_db};
@@ -196,8 +208,11 @@ std::chrono::milliseconds const default_delay{-1};
 
 }
 
-TEST_F(SurfaceStackCompositor, composes_on_start_if_told_to_in_constructor)
+TEST_F(SurfaceStackCompositor, composes_on_start_if_told_to_in_constructor_when_stack_has_at_least_one_surface)
 {
+    streams.front().stream->submit_buffer(stub_buffer);
+    stack.add_surface(stub_surface, mi::InputReceptionMode::normal);
+
     mc::MultiThreadedCompositor mt_compositor(
         mt::fake_shared(stub_display),
         mt::fake_shared(stack),
@@ -208,6 +223,20 @@ TEST_F(SurfaceStackCompositor, composes_on_start_if_told_to_in_constructor)
 
     EXPECT_TRUE(stub_primary_db.has_posted_at_least(1, timeout));
     EXPECT_TRUE(stub_secondary_db.has_posted_at_least(1, timeout));
+}
+
+TEST_F(SurfaceStackCompositor, does_not_compose_on_start_if_told_to_in_constructor_but_has_no_surfaces)
+{
+    mc::MultiThreadedCompositor mt_compositor(
+        mt::fake_shared(stub_display),
+        mt::fake_shared(stack),
+        mt::fake_shared(dbc_factory),
+        mt::fake_shared(stub_display_listener),
+        null_comp_report, default_delay, true);
+    mt_compositor.start();
+
+    EXPECT_TRUE(stub_primary_db.has_posted_at_least(0, timeout));
+    EXPECT_TRUE(stub_secondary_db.has_posted_at_least(0, timeout));
 }
 
 TEST_F(SurfaceStackCompositor, does_not_composes_on_start_if_told_not_to_in_constructor)
@@ -343,6 +372,9 @@ TEST_F(SurfaceStackCompositor, removing_a_surface_triggers_composition)
 {
     streams.front().stream->submit_buffer(stub_buffer);
     stack.add_surface(stub_surface, mi::InputReceptionMode::normal);
+
+    streams.front().stream->submit_buffer(other_stub_buffer);
+    stack.add_surface(other_stub_surface, mi::InputReceptionMode::normal);
 
     mc::MultiThreadedCompositor mt_compositor(
         mt::fake_shared(stub_display),

--- a/tests/integration-tests/test_surface_stack_with_compositor.cpp
+++ b/tests/integration-tests/test_surface_stack_with_compositor.cpp
@@ -165,13 +165,15 @@ struct SurfaceStackCompositor : public Test
             std::shared_ptr<mg::CursorImage>(),
             null_scene_report)},
         stub_buffer(std::make_shared<mtd::StubBuffer>()),
+        other_stream(std::make_shared<mc::Stream>(geom::Size{ 1, 1 }, mir_pixel_format_abgr_8888 )),
+        other_streams({ { other_stream, {0,0}, {} } }),
         other_stub_surface{std::make_shared<ms::BasicSurface>(
             nullptr /* session */,
             mw::Weak<mf::WlSurface>{},
-            std::string("stub"),
-            geom::Rectangle{{0,0},{1,1}},
+            std::string("other_stub"),
+            geom::Rectangle{{10,0},{1,1}},
             mir_pointer_unconfined,
-            streams,
+            other_streams,
             std::shared_ptr<mg::CursorImage>(),
             null_scene_report)},
         other_stub_buffer(std::make_shared<mtd::StubBuffer>())
@@ -189,6 +191,8 @@ struct SurfaceStackCompositor : public Test
     std::list<ms::StreamInfo> const streams;
     std::shared_ptr<ms::BasicSurface> stub_surface;
     std::shared_ptr<mg::Buffer> stub_buffer;
+    std::shared_ptr<mc::Stream> other_stream;
+    std::list<ms::StreamInfo> const other_streams;
     std::shared_ptr<ms::BasicSurface> other_stub_surface;
     std::shared_ptr<mg::Buffer> other_stub_buffer;
     CountingDisplaySyncGroup stub_primary_db;
@@ -373,7 +377,7 @@ TEST_F(SurfaceStackCompositor, removing_a_surface_triggers_composition)
     streams.front().stream->submit_buffer(stub_buffer);
     stack.add_surface(stub_surface, mi::InputReceptionMode::normal);
 
-    streams.front().stream->submit_buffer(other_stub_buffer);
+    other_streams.front().stream->submit_buffer(other_stub_buffer);
     stack.add_surface(other_stub_surface, mi::InputReceptionMode::normal);
 
     mc::MultiThreadedCompositor mt_compositor(

--- a/tests/mir_test_framework/headless_display_buffer_compositor_factory.cpp
+++ b/tests/mir_test_framework/headless_display_buffer_compositor_factory.cpp
@@ -93,7 +93,7 @@ mtf::HeadlessDisplayBufferCompositorFactory::create_compositor_for(mg::DisplayBu
             return renderables;
         }
 
-        void composite(mir::compositor::SceneElementSequence&& seq) override
+        bool composite(mir::compositor::SceneElementSequence&& seq) override
         {
             auto renderlist = filter(seq, db.view_area());
 
@@ -113,6 +113,7 @@ mtf::HeadlessDisplayBufferCompositorFactory::create_compositor_for(mg::DisplayBu
             }
 
             output->commit();
+            return true;
         }
         mg::DisplayBuffer& db;
         std::unique_ptr<mg::gl::OutputSurface> const output;

--- a/tests/unit-tests/compositor/test_multi_threaded_compositor.cpp
+++ b/tests/unit-tests/compositor/test_multi_threaded_compositor.cpp
@@ -159,11 +159,12 @@ public:
     {
     }
 
-    void composite(mc::SceneElementSequence&&)
+    bool composite(mc::SceneElementSequence&&)
     {
         mark_render_buffer();
         /* Reduce run-time under valgrind */
         std::this_thread::yield();
+        return true;
     }
 
 private:
@@ -275,11 +276,12 @@ public:
     {
     }
 
-    void composite(mc::SceneElementSequence&&) override
+    bool composite(mc::SceneElementSequence&&) override
     {
         fake_surface_update();
         /* Reduce run-time under valgrind */
         std::this_thread::yield();
+        return true;
     }
 
 private:


### PR DESCRIPTION
## To test
1. Checkout https://github.com/MirServer/mir/pull/3086 and run `sudo make install`
2. Checkout https://github.com/MirServer/ubuntu-frame/pull/157 and build it
3. From a VT, run plymouth
```sh
sudo plymouthd
sudo plymouth show-splash
sudo plymouth deactivate
```
The splash should still be on the screen
4. Run frame:
```
./frame --wallpaper=false
```
5. Wait however long you like and note that you still see the splash
6. Run some other app (e.g. gedit) and note that the splash disappears

## What's new?
- `DefaultDisplayBufferCompositor::composite` now returns a boolean telling the caller if any compositing happened or not
- If the `MultithreadedCompositor` needs compositing, a `post` will happen, otherwise nothing will happen