### PR TITLE
platform/DisplayBuffer: Add pixel_size() accessor.

### DIFF
--- a/include/platform/mir/graphics/display_buffer.h
+++ b/include/platform/mir/graphics/display_buffer.h
@@ -58,6 +58,9 @@ public:
     /** The area the DisplayBuffer occupies in the virtual screen space. */
     virtual geometry::Rectangle view_area() const = 0;
 
+    /** The size in pixels of the underlying display */
+    virtual auto pixel_size() const -> geometry::Size = 0;
+
     /** This will render renderlist to the screen and post the result to the 
      *  screen if there is a hardware optimization that can be done.
      *  \param [in] renderlist 

--- a/src/platforms/eglstream-kms/server/display.cpp
+++ b/src/platforms/eglstream-kms/server/display.cpp
@@ -200,6 +200,11 @@ public:
         return output->extents();
     }
 
+    auto pixel_size() const -> mir::geometry::Size override
+    {
+        return output->size();
+    }
+
     glm::mat2 transformation() const override
     {
         return output->transformation();

--- a/src/platforms/gbm-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.cpp
@@ -101,6 +101,12 @@ geom::Rectangle mgg::DisplayBuffer::view_area() const
     return area;
 }
 
+auto mgg::DisplayBuffer::pixel_size() const -> geom::Size
+{
+    // All the outputs (are meant to) have the same size; KMSOutput::size() gives the size in pixels
+    return outputs.front()->size();
+}
+
 glm::mat2 mgg::DisplayBuffer::transformation() const
 {
     return transform;

--- a/src/platforms/gbm-kms/server/kms/display_buffer.h
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.h
@@ -59,6 +59,8 @@ public:
 
     geometry::Rectangle view_area() const override;
 
+    auto pixel_size() const -> geometry::Size override;
+
     void set_next_image(std::unique_ptr<Framebuffer> content) override;
 
     bool overlay(std::vector<DisplayElement> const& renderlist) override;

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "displayclient.h"
+#include "mir/fatal.h"
 #include "wl_egl_display_provider.h"
 #include "mir/graphics/platform.h"
 #include <mir/graphics/pixel_format_utils.h>
@@ -97,6 +98,7 @@ public:
 
     // DisplayBuffer implementation
     auto view_area() const -> geometry::Rectangle override;
+    auto pixel_size() const -> geometry::Size override;
     bool overlay(std::vector<DisplayElement> const& renderlist) override;
     auto transformation() const -> glm::mat2 override;
     auto display_provider() const -> std::shared_ptr<DisplayInterfaceProvider> override;
@@ -396,6 +398,19 @@ auto mgw::DisplayClient::Output::recommended_sleep() const -> std::chrono::milli
 auto mgw::DisplayClient::Output::view_area() const -> geometry::Rectangle
 {
     return dcout.extents();
+}
+
+auto mgw::DisplayClient::Output::pixel_size() const -> geometry::Size
+{
+    if (!has_initialized)
+    {
+        mir::fatal_error("Attempt to get Wayland output size before initialisation is complete");
+    }
+    /* output_size is the size we pass to WlDisplayProvider,
+     * which becomes the size of the wl_egl_window,
+     * which is the pixel size.
+     */
+    return output_size;
 }
 
 bool mgw::DisplayClient::Output::overlay(std::vector<DisplayElement> const&)

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -136,7 +136,8 @@ mgx::Display::Display(
         auto display_buffer = std::make_unique<mgx::DisplayBuffer>(
             this->parent,
             *window,
-            configuration->extents());
+            configuration->extents(),
+            actual_size);
         top_left.x += as_delta(configuration->extents().size.width);
         outputs.push_back(std::make_unique<OutputInfo>(
             this,

--- a/src/platforms/x11/graphics/display_buffer.cpp
+++ b/src/platforms/x11/graphics/display_buffer.cpp
@@ -28,9 +28,11 @@ namespace geom=mir::geometry;
 
 mgx::DisplayBuffer::DisplayBuffer(std::shared_ptr<Platform> parent,
                                   xcb_window_t win,
-                                  geometry::Rectangle const& view_area)
+                                  geometry::Rectangle const& view_area,
+                                  geometry::Size pixel_size)
                                   : parent{std::move(parent)},
                                     area{view_area},
+                                    in_pixels{pixel_size},
                                     transform(1),
                                     x_win{win}
 {
@@ -39,6 +41,11 @@ mgx::DisplayBuffer::DisplayBuffer(std::shared_ptr<Platform> parent,
 geom::Rectangle mgx::DisplayBuffer::view_area() const
 {
     return area;
+}
+
+auto mgx::DisplayBuffer::pixel_size() const -> geom::Size
+{
+    return in_pixels;
 }
 
 auto mgx::DisplayBuffer::overlay(std::vector<DisplayElement> const& /*renderlist*/) -> bool

--- a/src/platforms/x11/graphics/display_buffer.h
+++ b/src/platforms/x11/graphics/display_buffer.h
@@ -46,9 +46,11 @@ public:
     DisplayBuffer(
             std::shared_ptr<Platform> parent,
             xcb_window_t win,
-            geometry::Rectangle const& view_area);
+            geometry::Rectangle const& view_area,
+            geometry::Size pixel_size);
 
     auto view_area() const -> geometry::Rectangle override;
+    auto pixel_size() const -> geometry::Size override;
 
     auto overlay(std::vector<DisplayElement> const& renderlist) -> bool override;
     void set_next_image(std::unique_ptr<Framebuffer> content) override;
@@ -70,6 +72,7 @@ private:
     std::shared_ptr<Platform> const parent;
     std::shared_ptr<helpers::Framebuffer> next_frame;
     geometry::Rectangle area;
+    geometry::Size in_pixels;
     glm::mat2 transform;
     xcb_window_t const x_win;
 };

--- a/src/server/compositor/default_display_buffer_compositor_factory.cpp
+++ b/src/server/compositor/default_display_buffer_compositor_factory.cpp
@@ -83,7 +83,7 @@ mc::DefaultDisplayBufferCompositorFactory::create_compositor_for(
     auto const chosen_allocator = best_provider.second;
     
     auto output_surface = chosen_allocator->surface_for_output(
-        display_provider, display_buffer.view_area().size, *gl_config);
+        display_provider, display_buffer.pixel_size(), *gl_config);
     auto renderer = renderer_factory->create_renderer_for(std::move(output_surface), chosen_allocator);
     renderer->set_viewport(display_buffer.view_area());
     return std::make_unique<DefaultDisplayBufferCompositor>(

--- a/tests/include/mir/test/doubles/mock_display_buffer.h
+++ b/tests/include/mir/test/doubles/mock_display_buffer.h
@@ -39,6 +39,7 @@ public:
             .WillByDefault(Return(geometry::Rectangle{{0,0},{0,0}}));
     }
     MOCK_METHOD(geometry::Rectangle, view_area, (), (const override));
+    MOCK_METHOD(geometry::Size, pixel_size, (), (const override));
     MOCK_METHOD(bool, overlay, (std::vector<graphics::DisplayElement> const&), (override));
     MOCK_METHOD(void, set_next_image, (std::unique_ptr<graphics::Framebuffer>), (override));
     MOCK_METHOD(glm::mat2, transformation, (), (const override));

--- a/tests/include/mir/test/doubles/null_display_buffer.h
+++ b/tests/include/mir/test/doubles/null_display_buffer.h
@@ -30,6 +30,7 @@ class NullDisplayBuffer : public graphics::DisplayBuffer
 {
 public:
     geometry::Rectangle view_area() const override { return geometry::Rectangle(); }
+    auto pixel_size() const -> geometry::Size override { return geometry::Size(); }
     bool overlay(std::vector<mir::graphics::DisplayElement> const&) override { return false; }
     void set_next_image(std::unique_ptr<mir::graphics::Framebuffer>) override { }
     glm::mat2 transformation() const override { return glm::mat2(1); }

--- a/tests/mir_test_framework/headless_display_buffer_compositor_factory.cpp
+++ b/tests/mir_test_framework/headless_display_buffer_compositor_factory.cpp
@@ -121,6 +121,6 @@ mtf::HeadlessDisplayBufferCompositorFactory::create_compositor_for(mg::DisplayBu
         std::shared_ptr<PassthroughTracker> const tracker;
     };
     auto output_surface =
-        render_platform->surface_for_output(db.display_provider(), db.view_area().size, *gl_config);
+        render_platform->surface_for_output(db.display_provider(), db.pixel_size(), *gl_config);
     return std::make_unique<HeadlessDBC>(db, std::move(output_surface), render_platform, tracker);
 }

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
@@ -380,7 +380,7 @@ TEST_F(MesaDisplayMultiMonitorTest, flip_flips_all_connected_crtcs)
             group.for_each_display_buffer(
                 [provider](mg::DisplayBuffer& db)
                 {
-                    auto fb = provider->alloc_fb(db.view_area().size, mg::DRMFormat{DRM_FORMAT_ABGR8888});
+                    auto fb = provider->alloc_fb(db.pixel_size(), mg::DRMFormat{DRM_FORMAT_ABGR8888});
                     db.set_next_image(std::move(fb));
                 });
            group.post();
@@ -394,7 +394,7 @@ TEST_F(MesaDisplayMultiMonitorTest, flip_flips_all_connected_crtcs)
             group.for_each_display_buffer(
                 [provider](mg::DisplayBuffer& db)
                 {
-                    auto fb = provider->alloc_fb(db.view_area().size, mg::DRMFormat{DRM_FORMAT_ARGB8888});
+                    auto fb = provider->alloc_fb(db.pixel_size(), mg::DRMFormat{DRM_FORMAT_ARGB8888});
                     db.set_next_image(std::move(fb));
                 });
            group.post();


### PR DESCRIPTION
We need this when allocating `Framebuffer`s.

Fixes: #3103