### PR TITLE
Refactored wayland_client.c to support the virtual platform

### DIFF
--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -129,25 +129,6 @@ auto select_platforms_from_list(std::string const& selection, std::vector<std::s
 
     return selected_modules;
 }
-
-void hybrid_check(std::vector<std::pair<mg::SupportedDevice, std::shared_ptr<mir::SharedLibrary>>>& platform_modules)
-{
-    static bool const experimental_hybrid_graphics = getenv("MIR_EXPERIMENTAL_HYBRID_GRAPHICS");
-
-    if (!experimental_hybrid_graphics)
-    {
-        std::stable_sort(std::begin(platform_modules), std::end(platform_modules),
-             [](auto const& l, auto const& r) { return l.first.support_level > r.first.support_level; });
-
-        if (!platform_modules.empty())
-        {
-            auto const erase_begin = std::remove_if(platform_modules.begin(), platform_modules.end(),
-                [platform=platform_modules.front().second](auto const& pm) { return pm.second != platform; });
-
-            platform_modules.erase(erase_begin, platform_modules.end());
-        }
-    }
-}
 }
 
 auto mir::DefaultServerConfiguration::the_display_platforms() -> std::vector<std::shared_ptr<graphics::DisplayPlatform>> const&
@@ -213,8 +194,6 @@ auto mir::DefaultServerConfiguration::the_display_platforms() -> std::vector<std
             else
             {
                 platform_modules = mir::graphics::display_modules_for_device(platforms, dynamic_cast<mir::options::ProgramOption&>(*the_options()), the_console_services());
-
-                hybrid_check(platform_modules);
             }
 
             for (auto const& [device, platform]: platform_modules)
@@ -343,8 +322,6 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
             else
             {
                 platform_modules = mir::graphics::rendering_modules_for_device(platforms, display_interfaces, dynamic_cast<mir::options::ProgramOption&>(*the_options()), the_console_services());
-
-                hybrid_check(platform_modules);
             }
 
             for (auto const& [device, platform]: platform_modules)

--- a/tests/performance-tests/CMakeLists.txt
+++ b/tests/performance-tests/CMakeLists.txt
@@ -19,27 +19,26 @@ install(PROGRAMS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir-smoke-test-runner
 )
 
 find_program(EGLINFO_EXECUTABLE eglinfo)
-find_program(XVFB_RUN_EXECUTABLE xvfb-run)
 find_program(GLMARK2_EXECUTABLE glmark2-es2-wayland)
 
 CMAKE_DEPENDENT_OPTION(
   MIR_RUN_SMOKE_TESTS "Run mir-smoke-test-runner as part of testsuite" ON
-  "EGLINFO_EXECUTABLE;XVFB_RUN_EXECUTABLE" OFF
+  "EGLINFO_EXECUTABLE" OFF
 )
 
 CMAKE_DEPENDENT_OPTION(
   MIR_RUN_PERFORMANCE_TESTS "Run mir_performance_tests as part of testsuite" OFF
-  "XVFB_RUN_EXECUTABLE;GLMARK2_EXECUTABLE" OFF
+  "GLMARK2_EXECUTABLE" OFF
 )
 
 if(MIR_RUN_SMOKE_TESTS)
   mir_add_test(NAME mir-smoke-test-runner
-      COMMAND "xvfb-run" "--auto-servernum" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir-smoke-test-runner"
+    COMMAND "env" "MIR_SERVER_PLATFORM_DISPLAY_LIBS=mir:virtual" "MIR_SERVER_VIRTUAL_OUTPUT=1280x1024" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir-smoke-test-runner"
   )
 endif()
 
 if(MIR_RUN_PERFORMANCE_TESTS)
   mir_add_test(NAME mir_performance_tests
-    COMMAND "xvfb-run" "--auto-servernum" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir_performance_tests"
+    COMMAND "env" "MIR_SERVER_PLATFORM_DISPLAY_LIBS=mir:virtual" "MIR_SERVER_VIRTUAL_OUTPUT=1280x1024" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mir_performance_tests" "--gtest_filter=-CompositorPerformance.regression_test_1563287"
   )
 endif()


### PR DESCRIPTION
## What's new?
- Fixes https://github.com/MirServer/mir/issues/3102
- Rendering in the same manner as ubuntu-frame does it so that everything works with the virtual platform

## To test:
Run this and see that we don't block any longer:
```sh
WAYLAND_DISPLAY=wayland-99 MIR_SERVER_PLATFORM_DISPLAY_LIBS=mir:virtual MIR_SERVER_VIRTUAL_OUTPUT=1280x1024 ./bin/mir_demo_server --test-timeout=3 --test-client ./bin/mir_demo_client_wayland
```