### PR TITLE
Packaging: Add new -dev dependencies to the relevant packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -128,6 +128,7 @@ Depends: libmirplatform27 (= ${binary:Version}),
          libmircommon-dev (= ${binary:Version}),
          libboost-program-options-dev,
          ${misc:Depends},
+         libgbm-dev,
 Breaks: libmirplatform (<< 0.6)
 Replaces: libmirplatform (<< 0.6)
 Description: Display server for Ubuntu - development headers
@@ -596,7 +597,8 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: libmirwayland4 (= ${binary:Version}),
          libmircore-dev (= ${binary:Version}),
          ${misc:Depends},
-         libmirwayland-bin (= ${binary:Version})
+         libmirwayland-bin (= ${binary:Version}),
+         libwayland-dev,
 Description: Display server for Ubuntu - generated wrappers for Wayland
  protocol extensions.
  .

--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -25,7 +25,6 @@
 #include "mir/graphics/drm_formats.h"
 #include "mir/module_properties.h"
 #include "mir/module_deleter.h"
-#include "mir/udev/wrapper.h"
 #include "mir/renderer/sw/pixel_source.h"
 
 #include <EGL/egl.h>
@@ -47,6 +46,12 @@ class ProgramOption;
 namespace renderer::software
 {
 class WriteMappableBuffer;
+}
+
+namespace udev
+{
+class Context;
+class Device;
 }
 
 /// Graphics subsystem. Mediates interaction between core system and

--- a/src/platforms/renderer-generic-egl/platform_symbols.cpp
+++ b/src/platforms/renderer-generic-egl/platform_symbols.cpp
@@ -22,6 +22,7 @@
 #include "mir/module_deleter.h"
 #include "mir/assert_module_entry_point.h"
 #include "mir/libname.h"
+#include "mir/udev/wrapper.h"
 #include "mir/graphics/platform.h"
 #include "mir/graphics/egl_error.h"
 #include "mir/graphics/gl_config.h"

--- a/src/platforms/virtual/graphics.cpp
+++ b/src/platforms/virtual/graphics.cpp
@@ -22,6 +22,7 @@
 #include <mir/assert_module_entry_point.h>
 #include <mir/libname.h>
 #include <mir/options/program_option.h>
+#include <mir/udev/wrapper.h>
 
 namespace mg = mir::graphics;
 namespace mo = mir::options;

--- a/src/platforms/wayland/platform_symbols.cpp
+++ b/src/platforms/wayland/platform_symbols.cpp
@@ -23,6 +23,7 @@
 #include <mir/assert_module_entry_point.h>
 #include <mir/libname.h>
 #include <mir/options/program_option.h>
+#include <mir/udev/wrapper.h>
 
 namespace mg = mir::graphics;
 namespace mo = mir::options;

--- a/src/platforms/x11/graphics/graphics.cpp
+++ b/src/platforms/x11/graphics/graphics.cpp
@@ -23,6 +23,7 @@
 #include "mir/module_deleter.h"
 #include "mir/assert_module_entry_point.h"
 #include "mir/libname.h"
+#include "mir/udev/wrapper.h"
 #include "mir/graphics/egl_error.h"
 #include "mir/graphics/egl_logger.h"
 

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -37,6 +37,7 @@
 #include "mir/log.h"
 #include "mir/report_exception.h"
 #include "mir/main_loop.h"
+#include "mir/udev/wrapper.h"
 
 #include <boost/throw_exception.hpp>
 

--- a/src/server/graphics/platform_probe.cpp
+++ b/src/server/graphics/platform_probe.cpp
@@ -17,6 +17,7 @@
 #include "mir/log.h"
 #include "mir/graphics/platform.h"
 #include "mir/shared_library.h"
+#include "mir/udev/wrapper.h"
 #include "platform_probe.h"
 
 #include <boost/throw_exception.hpp>

--- a/tests/mir_test_framework/platform_graphics_dummy.cpp
+++ b/tests/mir_test_framework/platform_graphics_dummy.cpp
@@ -17,6 +17,7 @@
 #include "mir/libname.h"
 #include "mir/graphics/platform.h"
 #include "mir/assert_module_entry_point.h"
+#include "mir/udev/wrapper.h"
 
 namespace mg = mir::graphics;
 

--- a/tests/mir_test_framework/platform_graphics_throw.cpp
+++ b/tests/mir_test_framework/platform_graphics_throw.cpp
@@ -20,6 +20,7 @@
 #include "mir/assert_module_entry_point.h"
 #include "mir/libname.h"
 #include "mir/options/program_option.h"
+#include "mir/udev/wrapper.h"
 
 #include <boost/throw_exception.hpp>
 #include <stdlib.h>

--- a/tests/platform_test_harness/graphics_platform_test_harness.cpp
+++ b/tests/platform_test_harness/graphics_platform_test_harness.cpp
@@ -27,6 +27,7 @@
 #include "mir/renderer/renderer.h"
 #include "mir/main_loop.h"
 #include "mir/renderer/gl/gl_surface.h"
+#include "mir/udev/wrapper.h"
 
 #include "../../src/include/platform/mir/graphics/pixel_format_utils.h"
 #include "mir/default_server_configuration.h"

--- a/tests/unit-tests/graphics/test_platform_prober.cpp
+++ b/tests/unit-tests/graphics/test_platform_prober.cpp
@@ -21,6 +21,7 @@
 #include "mir/graphics/platform.h"
 #include "src/server/graphics/platform_probe.h"
 #include "mir/options/program_option.h"
+#include "mir/udev/wrapper.h"
 
 #include "mir/raii.h"
 

--- a/tests/unit-tests/platforms/x11/test_platform.cpp
+++ b/tests/unit-tests/platforms/x11/test_platform.cpp
@@ -22,6 +22,7 @@
 #include "src/platforms/x11/graphics/platform.h"
 #include "src/platforms/x11/x11_resources.h"
 #include "src/server/report/null/display_report.h"
+#include "mir/udev/wrapper.h"
 
 #include "mir/test/doubles/mock_x11_resources.h"
 #include "mir/test/doubles/mock_x11.h"


### PR DESCRIPTION
We use these packages in the headers, so include them in the `-dev` dependencies.