### PR TITLE
Sorting the egl-generic rendering platform to the end of the list

### DIFF
--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -41,7 +41,6 @@
 #include <boost/throw_exception.hpp>
 
 #include <sstream>
-#include <algorithm>
 
 namespace mg = mir::graphics;
 


### PR DESCRIPTION
Fixes https://github.com/MirServer/mir/issues/3112

## How to test
- Get access to an nvidia hybrid platform
- Run `sudo XDG_RUNTIME_DIR=/run ./bin/mir_performance_tests --gtest_filter=GLMark2Wayland.*` and it should all work