### PR TITLE
Add --mir-version command line option. solves MirServer/mir#3058

### DIFF
--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -295,7 +295,7 @@ void mo::DefaultConfiguration::parse_arguments(
     {
         desc.add_options()
             ("help,h", "this help text");
-		desc.add_options()
+        desc.add_options()
             ("version,V", "display Mir version and exit");
 
         options.parse_arguments(desc, argc, argv);
@@ -306,11 +306,11 @@ void mo::DefaultConfiguration::parse_arguments(
             tokens.push_back(token.c_str());
         if (!tokens.empty()) unparsed_arguments_handler(tokens.size(), tokens.data());
         if (options.is_set("version"))
-		{
-			std::ostringstream mir_version;
-			mir_version << MIR_VERSION_MAJOR << "." << MIR_VERSION_MINOR << "." << MIR_VERSION_MICRO << std::endl;
-			BOOST_THROW_EXCEPTION(mir::ExitWithOutput(the_version_of_mir.str()));
-		}
+        {
+            std::ostringstream mir_version;
+            mir_version << MIR_VERSION_MAJOR << "." << MIR_VERSION_MINOR << "." << MIR_VERSION_MICRO << std::endl;
+            BOOST_THROW_EXCEPTION(mir::ExitWithOutput(mir_version.str()));
+        }
         if (options.is_set("help"))
         {
             std::ostringstream help_text;

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -296,7 +296,7 @@ void mo::DefaultConfiguration::parse_arguments(
         desc.add_options()
             ("help,h", "this help text");
 		desc.add_options()
-            ("mir-version", "display MIR platform version");
+            ("version,V", "display Mir version and exit");
 
         options.parse_arguments(desc, argc, argv);
 
@@ -305,10 +305,10 @@ void mo::DefaultConfiguration::parse_arguments(
         for (auto const& token : unparsed_arguments)
             tokens.push_back(token.c_str());
         if (!tokens.empty()) unparsed_arguments_handler(tokens.size(), tokens.data());
-        if (options.is_set("mir-version"))
+        if (options.is_set("version"))
 		{
-			std::ostringstream the_version_of_mir;
-			the_version_of_mir << "MIR Platform version " << MIR_VERSION_MAJOR << "." << MIR_VERSION_MINOR << "." << MIR_VERSION_MICRO << "." << std::endl;
+			std::ostringstream mir_version;
+			mir_version << MIR_VERSION_MAJOR << "." << MIR_VERSION_MINOR << "." << MIR_VERSION_MICRO << std::endl;
 			BOOST_THROW_EXCEPTION(mir::ExitWithOutput(the_version_of_mir.str()));
 		}
         if (options.is_set("help"))

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -295,6 +295,8 @@ void mo::DefaultConfiguration::parse_arguments(
     {
         desc.add_options()
             ("help,h", "this help text");
+		desc.add_options()
+            ("mir-version", "display MIR platform version");
 
         options.parse_arguments(desc, argc, argv);
 
@@ -303,7 +305,12 @@ void mo::DefaultConfiguration::parse_arguments(
         for (auto const& token : unparsed_arguments)
             tokens.push_back(token.c_str());
         if (!tokens.empty()) unparsed_arguments_handler(tokens.size(), tokens.data());
-
+        if (options.is_set("mir-version"))
+		{
+			std::ostringstream the_version_of_mir;
+			the_version_of_mir << "MIR Platform version " << MIR_VERSION_MAJOR << "." << MIR_VERSION_MINOR << "." << MIR_VERSION_MICRO << "." << std::endl;
+			BOOST_THROW_EXCEPTION(mir::ExitWithOutput(the_version_of_mir.str()));
+		}
         if (options.is_set("help"))
         {
             std::ostringstream help_text;

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -295,7 +295,7 @@ void mo::DefaultConfiguration::parse_arguments(
     {
         desc.add_options()
             ("help,h", "this help text");
-        desc.add_options()
+		desc.add_options()
             ("version,V", "display Mir version and exit");
 
         options.parse_arguments(desc, argc, argv);
@@ -305,19 +305,17 @@ void mo::DefaultConfiguration::parse_arguments(
         for (auto const& token : unparsed_arguments)
             tokens.push_back(token.c_str());
         if (!tokens.empty()) unparsed_arguments_handler(tokens.size(), tokens.data());
-        
-        // Handle one-off options such as `help` or `version`
-        std::map<const char *,std::function<std::ostringstream & (std::ostringstream &)>> oneoff_options {
-            {"version",[&](std::ostringstream & oneoff_output) -> std::ostringstream & {oneoff_output <<MIR_VERSION_MAJOR << "." << MIR_VERSION_MINOR << "." << MIR_VERSION_MICRO << std::endl; return oneoff_output;}},
-            {"help",[&](std::ostringstream & oneoff_output) -> std::ostringstream & {oneoff_output << desc; return oneoff_output;}}
-        };
-        for(auto oopt : oneoff_options) {
-            if(options.is_set(oopt.first))
-            {
-                std::ostringstream oneoff_output;
-                // Intentionally throw exception for non-error condition as per ExitWithOutput documentation.
-                BOOST_THROW_EXCEPTION(mir::ExitWithOutput(oopt.second(oneoff_output).str()));
-            }
+        if (options.is_set("version"))
+		{
+			std::ostringstream mir_version;
+			mir_version << MIR_VERSION_MAJOR << "." << MIR_VERSION_MINOR << "." << MIR_VERSION_MICRO << std::endl;
+			BOOST_THROW_EXCEPTION(mir::ExitWithOutput(the_version_of_mir.str()));
+		}
+        if (options.is_set("help"))
+        {
+            std::ostringstream help_text;
+            help_text << desc;
+            BOOST_THROW_EXCEPTION(mir::ExitWithOutput(help_text.str()));
         }
     }
     catch (po::error const& error)

--- a/src/platform/options/default_configuration.cpp
+++ b/src/platform/options/default_configuration.cpp
@@ -305,17 +305,20 @@ void mo::DefaultConfiguration::parse_arguments(
         for (auto const& token : unparsed_arguments)
             tokens.push_back(token.c_str());
         if (!tokens.empty()) unparsed_arguments_handler(tokens.size(), tokens.data());
-        if (options.is_set("version"))
-        {
-            std::ostringstream mir_version;
-            mir_version << MIR_VERSION_MAJOR << "." << MIR_VERSION_MINOR << "." << MIR_VERSION_MICRO << std::endl;
-            BOOST_THROW_EXCEPTION(mir::ExitWithOutput(mir_version.str()));
-        }
+
+        // See the ExitWithOutput documentation for information about its usage.
         if (options.is_set("help"))
         {
             std::ostringstream help_text;
             help_text << desc;
             BOOST_THROW_EXCEPTION(mir::ExitWithOutput(help_text.str()));
+        }
+
+        if (options.is_set("version"))
+        {
+            std::ostringstream mir_version;
+            mir_version << MIR_VERSION_MAJOR << "." << MIR_VERSION_MINOR << "." << MIR_VERSION_MICRO << std::endl;
+            BOOST_THROW_EXCEPTION(mir::ExitWithOutput(mir_version.str()));
         }
     }
     catch (po::error const& error)


### PR DESCRIPTION
Tested with miral-shell built from within this repo and with my own compositor linking against this version.
I also looked in unit tests to see if I could add it there, but the existing test for options uses test data rather than real responses from built artifacts. Please let me know if there's another one that I've missed that would be suitable for this.