### PR TITLE
platform/DisplaySink: Remove pixel_size() accessor

### DIFF
--- a/include/platform/mir/graphics/display_sink.h
+++ b/include/platform/mir/graphics/display_sink.h
@@ -59,9 +59,6 @@ public:
     /** The area the DisplaySink occupies in the virtual screen space. */
     virtual geometry::Rectangle view_area() const = 0;
 
-    /** The size in pixels of the underlying display */
-    virtual auto pixel_size() const -> geometry::Size = 0;
-
     /** This will render renderlist to the screen and post the result to the
      *  screen if there is a hardware optimization that can be done.
      *  \param [in] renderlist

--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -307,6 +307,8 @@ public:
     public:
         MappableFB() = default;
         virtual ~MappableFB() override = default;
+
+        using renderer::software::WriteMappableBuffer::size;
     };
 
     virtual auto supported_formats() const

--- a/include/platform/mir/graphics/platform.h
+++ b/include/platform/mir/graphics/platform.h
@@ -165,7 +165,6 @@ public:
 
     virtual auto surface_for_sink(
         DisplaySink& sink,
-        geometry::Size size,
         GLConfig const& config) -> std::unique_ptr<gl::OutputSurface> = 0;
 };
 
@@ -313,8 +312,10 @@ public:
     virtual auto supported_formats() const
         -> std::vector<DRMFormat> = 0;
 
-    virtual auto alloc_fb(geometry::Size pixel_size, DRMFormat format)
+    virtual auto alloc_fb(DRMFormat format)
         -> std::unique_ptr<MappableFB> = 0;
+
+    virtual auto output_size() const -> geometry::Size = 0;
 };
 
 class GBMDisplayProvider : public DisplayProvider
@@ -382,7 +383,7 @@ public:
         virtual auto claim_framebuffer() -> std::unique_ptr<Framebuffer> = 0;
     };
 
-    virtual auto make_surface(geometry::Size size, DRMFormat format, std::span<uint64_t> modifiers) -> std::unique_ptr<GBMSurface> = 0;
+    virtual auto make_surface(DRMFormat format, std::span<uint64_t> modifiers) -> std::unique_ptr<GBMSurface> = 0;
 };
 
 class DmaBufBuffer;
@@ -420,6 +421,7 @@ public:
     };
 
     virtual auto claim_stream() -> EGLStreamKHR = 0;
+    virtual auto output_size() const -> geometry::Size = 0;
 };
 
 class GenericEGLDisplayProvider : public DisplayProvider

--- a/src/platforms/common/server/cpu_copy_output_surface.cpp
+++ b/src/platforms/common/server/cpu_copy_output_surface.cpp
@@ -283,7 +283,7 @@ auto mgc::CPUCopyOutputSurface::Impl::commit() -> std::unique_ptr<mg::Framebuffe
          */
         glReadPixels(
             0, 0,
-            size().width.as_int(), size().height.as_int(),
+            fb->size().width.as_uint32_t(), fb->size().height.as_uint32_t(),
             pixel_layout, GL_UNSIGNED_BYTE, mapping->data());
     }
     return fb;

--- a/src/platforms/common/server/cpu_copy_output_surface.h
+++ b/src/platforms/common/server/cpu_copy_output_surface.h
@@ -35,8 +35,7 @@ public:
     CPUCopyOutputSurface(
         EGLDisplay dpy,
         EGLContext share_ctx,
-        CPUAddressableDisplayAllocator& allocator,
-        geometry::Size size);
+        CPUAddressableDisplayAllocator& allocator);
 
     ~CPUCopyOutputSurface() override;
 

--- a/src/platforms/common/server/kms_cpu_addressable_display_provider.h
+++ b/src/platforms/common/server/kms_cpu_addressable_display_provider.h
@@ -31,19 +31,22 @@ class CPUAddressableDisplayAllocator : public graphics::CPUAddressableDisplayAll
 public:
     /// Create an CPUAddressableDisplayAllocator if and only if supported by the device
     /// \return the provider, or an empty pointer
-    static auto create_if_supported(mir::Fd const& drm_fd) -> std::shared_ptr<CPUAddressableDisplayAllocator>;
+    static auto create_if_supported(mir::Fd const& drm_fd, geometry::Size size)
+        -> std::shared_ptr<CPUAddressableDisplayAllocator>;
 
     auto supported_formats() const
         -> std::vector<DRMFormat> override;
 
-    auto alloc_fb(geometry::Size pixel_size, DRMFormat format)
+    auto alloc_fb(DRMFormat format)
         -> std::unique_ptr<MappableFB> override;
 
+    auto output_size() const -> geometry::Size override;
 private:
-    explicit CPUAddressableDisplayAllocator(mir::Fd drm_fd);
+    explicit CPUAddressableDisplayAllocator(mir::Fd drm_fd, geometry::Size size);
 
     mir::Fd const drm_fd;
     bool const supports_modifiers;
+    geometry::Size const size;
 };
 }
 }

--- a/src/platforms/eglstream-kms/server/buffer_allocator.cpp
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.cpp
@@ -731,7 +731,6 @@ auto mir::graphics::eglstream::GLRenderingProvider::as_texture(std::shared_ptr<B
 
 auto mge::GLRenderingProvider::surface_for_sink(
     DisplaySink& sink,
-    geom::Size size,
     mg::GLConfig const& gl_config) -> std::unique_ptr<gl::OutputSurface>
 {
     if (auto stream_platform = sink.acquire_compatible_allocator<EGLStreamDisplayAllocator>())
@@ -743,7 +742,7 @@ auto mge::GLRenderingProvider::surface_for_sink(
                 pick_stream_surface_config(dpy, gl_config),
                 static_cast<EGLContext>(*ctx),
                 stream_platform->claim_stream(),
-                size);
+                stream_platform->output_size());
         }
         catch (std::exception const& err)
         {
@@ -759,8 +758,7 @@ auto mge::GLRenderingProvider::surface_for_sink(
         return std::make_unique<mgc::CPUCopyOutputSurface>(
             dpy,
             static_cast<EGLContext>(*ctx),
-            *cpu_provider,
-            size);
+            *cpu_provider);
     }
     BOOST_THROW_EXCEPTION((std::runtime_error{"DisplayInterfaceProvider does not support any viable output interface"}));
 }

--- a/src/platforms/eglstream-kms/server/buffer_allocator.h
+++ b/src/platforms/eglstream-kms/server/buffer_allocator.h
@@ -108,7 +108,6 @@ public:
 
     auto surface_for_sink(
         DisplaySink& sink,
-        geometry::Size size,
         GLConfig const& gl_config) -> std::unique_ptr<gl::OutputSurface> override;
 private:
     EGLDisplay dpy;

--- a/src/platforms/eglstream-kms/server/display.cpp
+++ b/src/platforms/eglstream-kms/server/display.cpp
@@ -205,6 +205,11 @@ public:
         return output->size();
     }
 
+    auto output_size() const -> geom::Size override
+    {
+        return output->size();
+    }
+
     glm::mat2 transformation() const override
     {
         return output->transformation();
@@ -365,7 +370,7 @@ public:
         }
         if (dynamic_cast<mg::CPUAddressableDisplayAllocator::Tag const*>(&type_tag))
         {
-            kms_allocator = mg::kms::CPUAddressableDisplayAllocator::create_if_supported(drm_node);
+            kms_allocator = mg::kms::CPUAddressableDisplayAllocator::create_if_supported(drm_node, output->size());
             return kms_allocator.get();
         }
         return nullptr;

--- a/src/platforms/eglstream-kms/server/display.cpp
+++ b/src/platforms/eglstream-kms/server/display.cpp
@@ -200,11 +200,6 @@ public:
         return output->extents();
     }
 
-    auto pixel_size() const -> mir::geometry::Size override
-    {
-        return output->size();
-    }
-
     auto output_size() const -> geom::Size override
     {
         return output->size();

--- a/src/platforms/gbm-kms/server/buffer_allocator.h
+++ b/src/platforms/gbm-kms/server/buffer_allocator.h
@@ -106,7 +106,6 @@ public:
 
     auto surface_for_sink(
         DisplaySink& sink,
-        geometry::Size size,
         GLConfig const& config) -> std::unique_ptr<gl::OutputSurface> override;
 
 private:

--- a/src/platforms/gbm-kms/server/gbm_display_allocator.cpp
+++ b/src/platforms/gbm-kms/server/gbm_display_allocator.cpp
@@ -25,9 +25,10 @@ namespace mg = mir::graphics;
 namespace mgg = mir::graphics::gbm;
 namespace geom = mir::geometry;
 
-mgg::GBMDisplayAllocator::GBMDisplayAllocator(mir::Fd drm_fd, std::shared_ptr<struct gbm_device> gbm)
+mgg::GBMDisplayAllocator::GBMDisplayAllocator(mir::Fd drm_fd, std::shared_ptr<struct gbm_device> gbm, geom::Size size)
     : fd{std::move(drm_fd)},
-      gbm{std::move(gbm)}
+      gbm{std::move(gbm)},
+      size{size}
 {
 }
 
@@ -205,9 +206,9 @@ private:
 };
 }
 
-auto mgg::GBMDisplayAllocator::make_surface(geom::Size size, DRMFormat format, std::span<uint64_t> modifiers)
+auto mgg::GBMDisplayAllocator::make_surface(DRMFormat format, std::span<uint64_t> modifiers)
     -> std::unique_ptr<GBMSurface>
 {
-    return std::make_unique<GBMSurfaceImpl>(fd, gbm.get(), std::move(size), format, modifiers);
+    return std::make_unique<GBMSurfaceImpl>(fd, gbm.get(), size, format, modifiers);
 }
 

--- a/src/platforms/gbm-kms/server/gbm_display_allocator.h
+++ b/src/platforms/gbm-kms/server/gbm_display_allocator.h
@@ -22,15 +22,16 @@ namespace mir::graphics::gbm
 class GBMDisplayAllocator : public graphics::GBMDisplayAllocator
 {
 public:
-    GBMDisplayAllocator(mir::Fd drm_fd, std::shared_ptr<struct gbm_device> gbm);
+    GBMDisplayAllocator(mir::Fd drm_fd, std::shared_ptr<struct gbm_device> gbm, geometry::Size size);
 
     auto supported_formats() const -> std::vector<DRMFormat> override;
 
     auto modifiers_for_format(DRMFormat format) const -> std::vector<uint64_t> override;
 
-    auto make_surface(geometry::Size size, DRMFormat format, std::span<uint64_t> modifier) -> std::unique_ptr<GBMSurface> override;
+    auto make_surface(DRMFormat format, std::span<uint64_t> modifier) -> std::unique_ptr<GBMSurface> override;
 private:
     mir::Fd const fd;
     std::shared_ptr<struct gbm_device> const gbm;
+    geometry::Size const size;
 };
 }

--- a/src/platforms/gbm-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.cpp
@@ -342,7 +342,7 @@ auto mgg::DisplaySink::maybe_create_allocator(DisplayAllocator::Tag const& type_
     {
         if (!kms_allocator)
         {
-            kms_allocator = kms::CPUAddressableDisplayAllocator::create_if_supported(drm_fd());
+            kms_allocator = kms::CPUAddressableDisplayAllocator::create_if_supported(drm_fd(), outputs.front()->size());
         }
         return kms_allocator.get();
     }
@@ -350,7 +350,7 @@ auto mgg::DisplaySink::maybe_create_allocator(DisplayAllocator::Tag const& type_
     {
         if (!gbm_allocator)
         {
-            gbm_allocator = std::make_unique<GBMDisplayAllocator>(drm_fd(), gbm);
+            gbm_allocator = std::make_unique<GBMDisplayAllocator>(drm_fd(), gbm, outputs.front()->size());
         }
         return gbm_allocator.get();
     }

--- a/src/platforms/gbm-kms/server/kms/display_buffer.cpp
+++ b/src/platforms/gbm-kms/server/kms/display_buffer.cpp
@@ -105,12 +105,6 @@ geom::Rectangle mgg::DisplaySink::view_area() const
     return area;
 }
 
-auto mgg::DisplaySink::pixel_size() const -> geom::Size
-{
-    // All the outputs (are meant to) have the same size; KMSOutput::size() gives the size in pixels
-    return outputs.front()->size();
-}
-
 glm::mat2 mgg::DisplaySink::transformation() const
 {
     return transform;

--- a/src/platforms/gbm-kms/server/kms/display_sink.h
+++ b/src/platforms/gbm-kms/server/kms/display_sink.h
@@ -59,8 +59,6 @@ public:
 
     geometry::Rectangle view_area() const override;
 
-    auto pixel_size() const -> geometry::Size override;
-
     void set_next_image(std::unique_ptr<Framebuffer> content) override;
 
     bool overlay(std::vector<DisplayElement> const& renderlist) override;

--- a/src/platforms/renderer-generic-egl/buffer_allocator.cpp
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.cpp
@@ -427,7 +427,6 @@ auto mge::GLRenderingProvider::suitability_for_display(
 
 auto mge::GLRenderingProvider::surface_for_sink(
     DisplaySink& sink,
-    geometry::Size size,
     GLConfig const& config)
     -> std::unique_ptr<gl::OutputSurface>
 {
@@ -440,8 +439,7 @@ auto mge::GLRenderingProvider::surface_for_sink(
     return std::make_unique<mgc::CPUCopyOutputSurface>(
         dpy,
         ctx,
-        *cpu_provider,
-        size);
+        *cpu_provider);
 }
 
 auto mge::GLRenderingProvider::make_framebuffer_provider(DisplaySink& /*sink*/)

--- a/src/platforms/renderer-generic-egl/buffer_allocator.h
+++ b/src/platforms/renderer-generic-egl/buffer_allocator.h
@@ -101,7 +101,6 @@ public:
 
     auto surface_for_sink(
         DisplaySink& sink,
-        geometry::Size size,
         GLConfig const& config) -> std::unique_ptr<gl::OutputSurface> override;
 
 private:

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -137,8 +137,7 @@ mgx::Display::Display(
             x11_resources->conn->connection(),
             *window,
             this->egl,
-            configuration->extents(),
-            actual_size);
+            configuration->extents());
         top_left.x += as_delta(configuration->extents().size.width);
         outputs.push_back(std::make_unique<OutputInfo>(
             this,

--- a/src/platforms/x11/graphics/display_sink.cpp
+++ b/src/platforms/x11/graphics/display_sink.cpp
@@ -52,10 +52,8 @@ mgx::DisplaySink::DisplaySink(
     xcb_connection_t* connection,
     xcb_window_t win,
     std::shared_ptr<helpers::EGLHelper> egl,
-    geometry::Rectangle const& view_area,
-    geometry::Size pixel_size)
+    geometry::Rectangle const& view_area)
     : area{view_area},
-      in_pixels{pixel_size},
       transform(1),
       egl{std::move(egl)},
       x11_connection{connection},
@@ -68,11 +66,6 @@ mgx::DisplaySink::~DisplaySink() = default;
 geom::Rectangle mgx::DisplaySink::view_area() const
 {
     return area;
-}
-
-auto mgx::DisplaySink::pixel_size() const -> geom::Size
-{
-    return in_pixels;
 }
 
 auto mgx::DisplaySink::overlay(std::vector<DisplayElement> const& /*renderlist*/) -> bool

--- a/src/platforms/x11/graphics/display_sink.h
+++ b/src/platforms/x11/graphics/display_sink.h
@@ -47,13 +47,11 @@ public:
             xcb_connection_t* connection,
             xcb_window_t win,
             std::shared_ptr<helpers::EGLHelper> egl,
-            geometry::Rectangle const& view_area,
-            geometry::Size pixel_size);
+            geometry::Rectangle const& view_area);
 
     ~DisplaySink();
 
     auto view_area() const -> geometry::Rectangle override;
-    auto pixel_size() const -> geometry::Size override;
 
     auto overlay(std::vector<DisplayElement> const& renderlist) -> bool override;
     void set_next_image(std::unique_ptr<Framebuffer> content) override;

--- a/src/server/compositor/basic_screen_shooter.h
+++ b/src/server/compositor/basic_screen_shooter.h
@@ -81,8 +81,9 @@ private:
          * is likely to be taking screenshots of consistent size
          */
         std::unique_ptr<renderer::Renderer> current_renderer;
-        std::unique_ptr<graphics::DisplaySink> offscreen_sink;
+        geometry::Size last_rendered_size;
 
+        std::unique_ptr<graphics::DisplaySink> offscreen_sink;
         std::shared_ptr<OneShotBufferDisplayProvider> const output;
     };
     std::shared_ptr<Self> const self;

--- a/src/server/compositor/default_display_buffer_compositor_factory.cpp
+++ b/src/server/compositor/default_display_buffer_compositor_factory.cpp
@@ -81,7 +81,7 @@ mc::DefaultDisplayBufferCompositorFactory::create_compositor_for(
     auto const chosen_allocator = best_provider.second;
     
     auto output_surface = chosen_allocator->surface_for_sink(
-        display_sink, display_sink.pixel_size(), *gl_config);
+        display_sink, *gl_config);
     auto renderer = renderer_factory->create_renderer_for(std::move(output_surface), chosen_allocator);
     renderer->set_viewport(display_sink.view_area());
     return std::make_unique<DefaultDisplayBufferCompositor>(

--- a/tests/include/mir/test/doubles/mock_gl_rendering_provider.h
+++ b/tests/include/mir/test/doubles/mock_gl_rendering_provider.h
@@ -31,7 +31,7 @@ public:
     MOCK_METHOD(
         std::unique_ptr<graphics::gl::OutputSurface>,
         surface_for_sink,
-        (graphics::DisplaySink&, geometry::Size, graphics::GLConfig const&),
+        (graphics::DisplaySink&, graphics::GLConfig const&),
         (override));
     MOCK_METHOD(
         graphics::probe::Result,

--- a/tests/include/mir/test/doubles/null_display_sink.h
+++ b/tests/include/mir/test/doubles/null_display_sink.h
@@ -30,7 +30,6 @@ class NullDisplaySink : public graphics::DisplaySink
 {
 public:
     geometry::Rectangle view_area() const override { return geometry::Rectangle(); }
-    auto pixel_size() const -> geometry::Size override { return geometry::Size(); }
     bool overlay(std::vector<mir::graphics::DisplayElement> const&) override { return false; }
     void set_next_image(std::unique_ptr<mir::graphics::Framebuffer>) override { }
     glm::mat2 transformation() const override { return glm::mat2(1); }

--- a/tests/include/mir/test/doubles/stub_gl_rendering_provider.h
+++ b/tests/include/mir/test/doubles/stub_gl_rendering_provider.h
@@ -52,7 +52,6 @@ public:
 
     auto surface_for_sink(
         graphics::DisplaySink&,
-        geometry::Size,
         graphics::GLConfig const&) -> std::unique_ptr<graphics::gl::OutputSurface> override
     {
         return std::make_unique<testing::NiceMock<MockOutputSurface>>();

--- a/tests/mir_test_framework/headless_display_buffer_compositor_factory.cpp
+++ b/tests/mir_test_framework/headless_display_buffer_compositor_factory.cpp
@@ -121,6 +121,6 @@ mtf::HeadlessDisplayBufferCompositorFactory::create_compositor_for(mg::DisplaySi
         std::shared_ptr<PassthroughTracker> const tracker;
     };
     auto output_surface =
-        render_platform->surface_for_sink(display_sink, display_sink.pixel_size(), *gl_config);
+        render_platform->surface_for_sink(display_sink, *gl_config);
     return std::make_unique<HeadlessDBC>(display_sink, std::move(output_surface), render_platform, tracker);
 }

--- a/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
+++ b/tests/unit-tests/compositor/test_basic_screen_shooter.cpp
@@ -78,9 +78,9 @@ struct BasicScreenShooter : Test
                 {
                     return default_gl_behaviour_provider.as_texture(std::move(buffer));
                 });
-        ON_CALL(*gl_provider, surface_for_sink(_, _, _))
+        ON_CALL(*gl_provider, surface_for_sink(_, _))
             .WillByDefault(
-                [](mg::DisplaySink& sink, auto size, auto const&)
+                [](mg::DisplaySink& sink, auto const&)
                     -> std::unique_ptr<mg::gl::OutputSurface>
                 {
                     if (auto cpu_provider = sink.acquire_compatible_allocator<mg::CPUAddressableDisplayAllocator>())
@@ -89,9 +89,9 @@ struct BasicScreenShooter : Test
                         auto format = cpu_provider->supported_formats().front();
                         ON_CALL(*surface, commit())
                             .WillByDefault(
-                                [cpu_provider, size, format]()
+                                [cpu_provider, format]()
                                 {
-                                    return cpu_provider->alloc_fb(size, format);
+                                    return cpu_provider->alloc_fb(format);
                                 });
                         return surface;
                     }
@@ -210,7 +210,7 @@ TEST_F(BasicScreenShooter, throw_in_scene_elements_for_causes_graceful_failure)
 TEST_F(BasicScreenShooter, throw_in_surface_for_output_handled_gracefully)
 {
     ON_CALL(*gl_provider, surface_for_sink).WillByDefault(
-        [](auto&, auto, auto&) -> std::unique_ptr<mg::gl::OutputSurface>
+        [](auto&, auto&) -> std::unique_ptr<mg::gl::OutputSurface>
         {
             BOOST_THROW_EXCEPTION((std::runtime_error{"Throw in surface_for_sink"}));
         });

--- a/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
+++ b/tests/unit-tests/platforms/gbm-kms/kms/test_display_multi_monitor.cpp
@@ -380,7 +380,7 @@ TEST_F(MesaDisplayMultiMonitorTest, flip_flips_all_connected_crtcs)
                 [](mg::DisplaySink& sink)
                 {
                     auto provider = sink.acquire_compatible_allocator<mg::CPUAddressableDisplayAllocator>();
-                    auto fb = provider->alloc_fb(sink.pixel_size(), mg::DRMFormat{DRM_FORMAT_ABGR8888});
+                    auto fb = provider->alloc_fb(mg::DRMFormat{DRM_FORMAT_ABGR8888});
                     sink.set_next_image(std::move(fb));
                 });
            group.post();
@@ -395,7 +395,7 @@ TEST_F(MesaDisplayMultiMonitorTest, flip_flips_all_connected_crtcs)
                 [](mg::DisplaySink& sink)
                 {
                     auto provider = sink.acquire_compatible_allocator<mg::CPUAddressableDisplayAllocator>();
-                    auto fb = provider->alloc_fb(sink.pixel_size(), mg::DRMFormat{DRM_FORMAT_ARGB8888});
+                    auto fb = provider->alloc_fb(mg::DRMFormat{DRM_FORMAT_ARGB8888});
                     sink.set_next_image(std::move(fb));
                 });
            group.post();


### PR DESCRIPTION
Because each `DisplaySink` knows how big the buffers it needs, and each `DisplayAllocator` is easily associated with a single `DisplaySink`, we can let the `DisplayAllocator` allocate buffers of the correct size.