### PR TITLE
Remove TODO from 2015 to detect host refresh rate/max fps for Mir-on-X client.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ pkg_check_modules(WAYLAND_SERVER REQUIRED IMPORTED_TARGET wayland-server)
 pkg_check_modules(X11_XCURSOR REQUIRED IMPORTED_TARGET xcursor)
 pkg_check_modules(XCB REQUIRED IMPORTED_TARGET xcb)
 pkg_check_modules(XCB_COMPOSITE REQUIRED IMPORTED_TARGET xcb-composite)
+pkg_check_modules(XCB_RANDR REQUIRED IMPORTED_TARGET xcb-randr)
 pkg_check_modules(XCB_RENDER REQUIRED IMPORTED_TARGET xcb-render)
 pkg_check_modules(XCB_XFIXES REQUIRED IMPORTED_TARGET xcb-xfixes)
 

--- a/debian/control
+++ b/debian/control
@@ -45,7 +45,6 @@ Build-Depends: cmake,
                python3-venv:native,
                libxcb-composite0-dev,
                libxcb-xfixes0-dev,
-# iirc debian/changelog also needs to be updated for the package to get rebuilt/upgraded with xcb-randr support
                libxcb-randr0-dev,
                libxcb-render0-dev,
                libxcb-composite0-dev,

--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,7 @@ Build-Depends: cmake,
                libxcb-composite0-dev,
                libxcb-xfixes0-dev,
 # iirc debian/changelog also needs to be updated for the package to get rebuilt/upgraded with xcb-randr support
-#               libxcb-randr0-dev,
+               libxcb-randr0-dev,
                libxcb-render0-dev,
                libxcb-composite0-dev,
                libx11-xcb-dev,

--- a/debian/control
+++ b/debian/control
@@ -45,6 +45,8 @@ Build-Depends: cmake,
                python3-venv:native,
                libxcb-composite0-dev,
                libxcb-xfixes0-dev,
+# iirc debian/changelog also needs to be updated for the package to get rebuilt/upgraded with xcb-randr support
+#               libxcb-randr0-dev,
                libxcb-render0-dev,
                libxcb-composite0-dev,
                libx11-xcb-dev,

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,6 +42,7 @@ parts:
     - libumockdev-dev
     - libwayland-dev
     - libxcb-composite0-dev
+    - libxcb-randr0-dev
     - libx11-xcb-dev
     - libxcursor-dev
     - libxkbcommon-dev
@@ -84,6 +85,7 @@ parts:
     - libx11-6
     - libxau6
     - libxcb-composite0
+    - libxcb-randr0
     - libxcb-render0
     - libxcb-xfixes0
     - libxcb1

--- a/src/platforms/x11/CMakeLists.txt
+++ b/src/platforms/x11/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(
   PkgConfig::XCB
   PkgConfig::XCB_COMPOSITE
   PkgConfig::XCB_XFIXES
+  PkgConfig::XCB_RANDR
   PkgConfig::XCB_RENDER
   xkbcommon
   xcb-xkb

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -124,7 +124,7 @@ mgx::Display::Display(
             title,
             actual_size);
         auto pf = x11_resources->conn->default_pixel_format();
-        auto refresh = x11_resources->conn->get_output_refresh_rates();
+        auto refresh = x11_resources->conn->get_output_refresh_rate();
         auto configuration = DisplayConfiguration::build_output(
             pf,
             actual_size,

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -124,9 +124,11 @@ mgx::Display::Display(
             title,
             actual_size);
         auto pf = x11_resources->conn->default_pixel_format();
+        auto refresh = x11_resources->conn->get_output_refresh_rates();
         auto configuration = DisplayConfiguration::build_output(
             pf,
             actual_size,
+            static_cast<double>(refresh),
             top_left,
             geom::Size{
                 actual_size.width * pixel_size_mm.width.as_value(),

--- a/src/platforms/x11/graphics/display.cpp
+++ b/src/platforms/x11/graphics/display.cpp
@@ -128,7 +128,7 @@ mgx::Display::Display(
         auto configuration = DisplayConfiguration::build_output(
             pf,
             actual_size,
-            static_cast<double>(refresh),
+            refresh,
             top_left,
             geom::Size{
                 actual_size.width * pixel_size_mm.width.as_value(),

--- a/src/platforms/x11/graphics/display_configuration.cpp
+++ b/src/platforms/x11/graphics/display_configuration.cpp
@@ -40,7 +40,6 @@ std::shared_ptr<mg::DisplayConfigurationOutput> mgx::DisplayConfiguration::build
             mg::DisplayConfigurationLogicalGroupId{0},
             mg::DisplayConfigurationOutputType::unknown,
             {pf},
-            //TODO: query fps
             {mg::DisplayConfigurationMode{pixels, refresh}},
             0,
             physical_size_mm,

--- a/src/platforms/x11/graphics/display_configuration.cpp
+++ b/src/platforms/x11/graphics/display_configuration.cpp
@@ -26,6 +26,7 @@ int mgx::DisplayConfiguration::last_output_id{0};
 std::shared_ptr<mg::DisplayConfigurationOutput> mgx::DisplayConfiguration::build_output(
     MirPixelFormat pf,
     geom::Size const pixels,
+    double const refresh,
     geom::Point const top_left,
     geom::Size const physical_size_mm,
     const float scale,
@@ -40,7 +41,7 @@ std::shared_ptr<mg::DisplayConfigurationOutput> mgx::DisplayConfiguration::build
             mg::DisplayConfigurationOutputType::unknown,
             {pf},
             //TODO: query fps
-            {mg::DisplayConfigurationMode{pixels, 60.0}},
+            {mg::DisplayConfigurationMode{pixels, refresh}},
             0,
             physical_size_mm,
             true,

--- a/src/platforms/x11/graphics/display_configuration.h
+++ b/src/platforms/x11/graphics/display_configuration.h
@@ -33,6 +33,7 @@ public:
     static std::shared_ptr<DisplayConfigurationOutput> build_output(
         MirPixelFormat pf,
         geometry::Size const pixels,
+        double const refresh,
         geometry::Point const top_left,
         geometry::Size const physical_size_mm,
         float const scale,

--- a/src/platforms/x11/x11_resources.cpp
+++ b/src/platforms/x11/x11_resources.cpp
@@ -24,10 +24,6 @@
 #include <xcb/randr.h>
 #include <boost/throw_exception.hpp>
 
-#include <stdexcept>
-#include <memory>
-#include <string>
-
 namespace mg=mir::graphics;
 namespace mx = mir::X;
 

--- a/src/platforms/x11/x11_resources.cpp
+++ b/src/platforms/x11/x11_resources.cpp
@@ -103,7 +103,7 @@ public:
         return atom;
     }
 
-    auto get_output_refresh_rates() -> uint16_t override
+    auto get_output_refresh_rate() const -> uint16_t override
     {
         // I'm assuming we handle xcb errors somewhere with events.
         auto ver_cookie = xcb_randr_query_version_unchecked(conn, 1, 2);

--- a/src/platforms/x11/x11_resources.cpp
+++ b/src/platforms/x11/x11_resources.cpp
@@ -110,7 +110,17 @@ public:
         xcb_randr_query_version_reply(conn, ver_cookie,nullptr);
         auto screen_cookie = xcb_randr_get_screen_info_unchecked(conn,screen_->root);
         auto screen_reply = xcb_randr_get_screen_info_reply(conn, screen_cookie, nullptr);
-        mir::logging::log(mir::logging::Severity::debug, std::format("Detected {}Hz host output refresh rate.",screen_reply->rate) , "mir:x11");
+        #ifdef __cpp_lib_format
+        auto log_msg = std::format("Detected {}Hz host output refresh rate.",screen_reply->rate);
+        #else
+        auto log_msg = [&]()
+        {
+          std::ostringstream x;
+          x << "Detected " << screen_reply->rate << "Hz host output refresh rate.";
+          return x.str();
+        }();
+        #endif
+        mir::logging::log(mir::logging::Severity::debug, log_msg, "mir:x11");
         return screen_reply->rate;
     }
 

--- a/src/platforms/x11/x11_resources.h
+++ b/src/platforms/x11/x11_resources.h
@@ -55,7 +55,7 @@ public:
     virtual auto screen() const -> xcb_screen_t* = 0;
     /// Synchronous for now, since that makes everything simpler
     virtual auto intern_atom(std::string const& name) const -> xcb_atom_t = 0;
-    virtual auto get_output_refresh_rates() -> uint16_t = 0;
+    virtual auto get_output_refresh_rate() const -> uint16_t = 0;
     virtual auto get_extension_data(xcb_extension_t *ext) const -> xcb_query_extension_reply_t const* = 0;
     virtual auto generate_id() const -> uint32_t = 0;
     virtual auto default_pixel_format() const -> MirPixelFormat = 0;

--- a/src/platforms/x11/x11_resources.h
+++ b/src/platforms/x11/x11_resources.h
@@ -28,8 +28,11 @@
 #include <unordered_map>
 #include <functional>
 #include <mutex>
+#if __has_include(<format>)
 #include <format>
-
+#else
+#include <sstream>
+#endif
 typedef struct _XDisplay Display;
 
 namespace mir

--- a/src/platforms/x11/x11_resources.h
+++ b/src/platforms/x11/x11_resources.h
@@ -20,7 +20,6 @@
 #include "mir/geometry/forward.h"
 #include "mir_toolkit/common.h"
 
-
 #include <xcb/xcb.h>
 #include <optional>
 #include <unordered_map>

--- a/src/platforms/x11/x11_resources.h
+++ b/src/platforms/x11/x11_resources.h
@@ -20,19 +20,13 @@
 #include "mir/geometry/forward.h"
 #include "mir_toolkit/common.h"
 
-#include <stdexcept>
-#include <memory>
-#include <string>
+
 #include <xcb/xcb.h>
 #include <optional>
 #include <unordered_map>
 #include <functional>
 #include <mutex>
-#if __has_include(<format>)
-#include <format>
-#else
-#include <sstream>
-#endif
+
 typedef struct _XDisplay Display;
 
 namespace mir
@@ -58,7 +52,7 @@ public:
     virtual auto screen() const -> xcb_screen_t* = 0;
     /// Synchronous for now, since that makes everything simpler
     virtual auto intern_atom(std::string const& name) const -> xcb_atom_t = 0;
-    virtual auto get_output_refresh_rate() const -> uint16_t = 0;
+    virtual auto get_output_refresh_rate() const -> double = 0;
     virtual auto get_extension_data(xcb_extension_t *ext) const -> xcb_query_extension_reply_t const* = 0;
     virtual auto generate_id() const -> uint32_t = 0;
     virtual auto default_pixel_format() const -> MirPixelFormat = 0;

--- a/src/platforms/x11/x11_resources.h
+++ b/src/platforms/x11/x11_resources.h
@@ -20,11 +20,15 @@
 #include "mir/geometry/forward.h"
 #include "mir_toolkit/common.h"
 
+#include <stdexcept>
+#include <memory>
+#include <string>
 #include <xcb/xcb.h>
 #include <optional>
 #include <unordered_map>
 #include <functional>
 #include <mutex>
+#include <format>
 
 typedef struct _XDisplay Display;
 
@@ -51,6 +55,7 @@ public:
     virtual auto screen() const -> xcb_screen_t* = 0;
     /// Synchronous for now, since that makes everything simpler
     virtual auto intern_atom(std::string const& name) const -> xcb_atom_t = 0;
+    virtual auto get_output_refresh_rates() -> uint16_t = 0;
     virtual auto get_extension_data(xcb_extension_t *ext) const -> xcb_query_extension_reply_t const* = 0;
     virtual auto generate_id() const -> uint32_t = 0;
     virtual auto default_pixel_format() const -> MirPixelFormat = 0;

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -138,6 +138,7 @@ target_link_libraries(mirserver
     PkgConfig::XCB
     PkgConfig::XCB_COMPOSITE
     PkgConfig::XCB_XFIXES
+    PkgConfig::XCB_RANDR
     PkgConfig::XCB_RENDER
     PkgConfig::X11_XCURSOR
     PkgConfig::LTTNG_UST

--- a/tests/include/mir/test/doubles/mock_x11_resources.h
+++ b/tests/include/mir/test/doubles/mock_x11_resources.h
@@ -42,7 +42,7 @@ public:
     MOCK_CONST_METHOD0(poll_for_event, xcb_generic_event_t*());
     MOCK_CONST_METHOD0(screen, xcb_screen_t*());
     MOCK_CONST_METHOD1(intern_atom, xcb_atom_t(std::string const& name));
-    MOCK_CONST_METHOD0(get_output_refresh_rate,uint16_t());
+    MOCK_CONST_METHOD0(get_output_refresh_rate,double());
     MOCK_CONST_METHOD1(get_extension_data, xcb_query_extension_reply_t const*(xcb_extension_t *ext));
     MOCK_CONST_METHOD0(generate_id, uint32_t());
     MOCK_CONST_METHOD0(default_pixel_format, MirPixelFormat());

--- a/tests/include/mir/test/doubles/mock_x11_resources.h
+++ b/tests/include/mir/test/doubles/mock_x11_resources.h
@@ -42,6 +42,7 @@ public:
     MOCK_CONST_METHOD0(poll_for_event, xcb_generic_event_t*());
     MOCK_CONST_METHOD0(screen, xcb_screen_t*());
     MOCK_CONST_METHOD1(intern_atom, xcb_atom_t(std::string const& name));
+    MOCK_CONST_METHOD0(get_output_refresh_rate,uint16_t());
     MOCK_CONST_METHOD1(get_extension_data, xcb_query_extension_reply_t const*(xcb_extension_t *ext));
     MOCK_CONST_METHOD0(generate_id, uint32_t());
     MOCK_CONST_METHOD0(default_pixel_format, MirPixelFormat());


### PR DESCRIPTION
There's a few sticky things here:
- First of all, I'm adding a new dependency. However, xcb-randr should already exist anywhere xcb is installed, as far as I know. On my distribution this is not even a separate package. I've added the relevant stanza for debian/ubuntu in the control file (commented out for now), but, if I remember debian packaging correctly, this won't apply until the version is bumped in the changelog. 
- I'm following the general trend of ignoring xcb errors. They're usually non-fatal.
- If the randr extension version of the host X11 is <1.2, this will probably either not work or return nonsense. OTOH, if someone is doing development or testing of Mir-on-X on an Xorg that doesn't support 1.2+, they're probably doing it deliberately.
- More importantly, should I also follow [this guide](https://github.com/MirServer/mir/blob/c1d267021c9c13798d161d7ca73aad9bd4b93bbe/doc/sphinx/dso_versioning_guide.md?plain=1#L106) to make a versioned `mgx::DisplayConfiguration::build_output` ? Would I also have to add it to the relevant symbols.map, first ?