### PR TITLE
Wlr foreign toplevel manager will return the desktop id as the app_id if it can

### DIFF
--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(../frontend_xwayland ${CMAKE_CURRENT_BINARY_DIR})
 # One day, maybe, we can add include dependences to an OBJECT library. Until then...
 get_property(mirwayland_includes TARGET mirwayland PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 include_directories(${mirwayland_includes})
+pkg_check_modules(GIOUnix REQUIRED IMPORTED_TARGET gio-unix-2.0)
 
 set(
   WAYLAND_SOURCES
@@ -105,4 +106,7 @@ target_link_libraries(mirfrontend-wayland
     mirplatform
     mircommon
     mircore
+  PRIVATE
+    PkgConfig::GIOUnix
 )
+

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -535,6 +535,11 @@ mf::DesktopFileManager::DesktopFileManager(std::shared_ptr<MainLoop> const& main
     else
     {
         data_directories = {"/usr/local/share", "/usr/share"};
+        if (auto home = getenv("HOME"))
+            data_directories.push_back(std::string(home) + "/.local/share");
+
+        if (const char* xdg_data_home_dir = std::getenv("XDG_DATA_HOME"))
+            data_directories.push_back(xdg_data_home_dir);
     }
 
     for (auto directory : data_directories)

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.h
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.h
@@ -24,6 +24,7 @@
 namespace mir
 {
 class Executor;
+class MainLoop;
 namespace shell
 {
 class Shell;
@@ -36,7 +37,8 @@ auto create_foreign_toplevel_manager_v1(
     wl_display* display,
     std::shared_ptr<shell::Shell> const& shell,
     std::shared_ptr<Executor> const& wayland_executor,
-    std::shared_ptr<SurfaceStack> const& surface_stack)
+    std::shared_ptr<SurfaceStack> const& surface_stack,
+    std::shared_ptr<MainLoop> const& main_loop)
 -> std::shared_ptr<wayland::ForeignToplevelManagerV1::Global>;
 }
 }

--- a/src/server/frontend_wayland/wayland_connector.cpp
+++ b/src/server/frontend_wayland/wayland_connector.cpp
@@ -316,7 +316,8 @@ mf::WaylandConnector::WaylandConnector(
         input_device_registry,
         composite_event_filter,
         allocator,
-        screen_shooter});
+        screen_shooter,
+        main_loop});
 
     shm_global = std::make_unique<WlShm>(display.get(), executor);
 

--- a/src/server/frontend_wayland/wayland_connector.h
+++ b/src/server/frontend_wayland/wayland_connector.h
@@ -105,6 +105,7 @@ public:
         std::shared_ptr<input::CompositeEventFilter> composite_event_filter;
         std::shared_ptr<graphics::GraphicBufferAllocator> graphic_buffer_allocator;
         std::shared_ptr<compositor::ScreenShooter> screen_shooter;
+        std::shared_ptr<MainLoop> main_loop;
     };
 
     WaylandExtensions() = default;

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -117,7 +117,8 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
                 ctx.display,
                 ctx.shell,
                 ctx.wayland_executor,
-                ctx.surface_stack);
+                ctx.surface_stack,
+                ctx.main_loop);
         }),
     make_extension_builder<mw::RelativePointerManagerV1>([](auto const& ctx)
         {


### PR DESCRIPTION
## What's new?
- I am proposing a new protocol called to `mir-foreign-toplevel-management-unstable-v1.xml` that will provide everything that the WLR version provides in addition to a mapping from the surface to a `.desktop` file
- The solution is convoluted to say the least
- **Why?**: some shell elements (specifically launchers) need to know which app is open so that they can make an informed decision about what to do when a desktop file is interacted with (e.g. clicking the icon of an already-opened app in the launcher should focus it instead of opening a new instance).

This is super convoluted, as there is no standardized way of doing this AFAIK. There is `WM_CLASS`, but that is hardly used and maybe deprecated. 

## Questions for the reviewer
- :heavy_check_mark:  Should this be a new protocol, e.g. `mir-foreign-toplevel-management-unstable-v1.xml`?
- :heavy_check_mark: How often do we refresh the app cache? Should that even be cached?