### PR TITLE
tests: updated the desktop file manager so that we can more easily write tests for it

### DIFF
--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -38,6 +38,7 @@ set(
   resource_lifetime_tracker.cpp resource_lifetime_tracker.h
   wl_region.cpp                 wl_region.h
   foreign_toplevel_manager_v1.cpp foreign_toplevel_manager_v1.h
+  desktop_file_manager.cpp      desktop_file_manager.h
   frame_executor.cpp            frame_executor.h
   virtual_keyboard_v1.cpp       virtual_keyboard_v1.h
   virtual_pointer_v1.cpp        virtual_pointer_v1.h

--- a/src/server/frontend_wayland/desktop_file_manager.cpp
+++ b/src/server/frontend_wayland/desktop_file_manager.cpp
@@ -25,9 +25,9 @@
 namespace mf = mir::frontend;
 
 mf::DesktopFile::DesktopFile(const char* id, const char* wm_class, const char* exec)
-    : id{id},
-      wm_class{wm_class},
-      exec{exec}
+    : id{id ? id : ""},
+      wm_class{wm_class ? wm_class : ""},
+      exec{exec ? exec : ""}
 {}
 
 mf::DesktopFileManager::DesktopFileManager(std::shared_ptr<DesktopFileCache> cache)
@@ -61,7 +61,7 @@ std::string mf::DesktopFileManager::resolve_app_id(const scene::Surface* surface
     for(char &ch : lowercase_desktop_file)
         ch = std::tolower(ch);
 
-    found = lookup_basename(desktop_file);
+    found = lookup_basename(lowercase_desktop_file);
     if (found)
         return found->id;
 

--- a/src/server/frontend_wayland/desktop_file_manager.cpp
+++ b/src/server/frontend_wayland/desktop_file_manager.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "desktop_file_manager.h"
+
+#include "mir/main_loop.h"
+#include "mir/scene/surface.h"
+#include "mir/scene/session.h"
+#include <fstream>
+#include <filesystem>
+
+namespace mf = mir::frontend;
+
+mf::DesktopFile::DesktopFile(const char* id, const char* wm_class, const char* exec)
+    : id{id},
+      wm_class{wm_class},
+      exec{exec}
+{}
+
+mf::DesktopFileManager::DesktopFileManager(std::shared_ptr<DesktopFileCache> cache)
+    : cache{cache}
+{
+}
+
+std::string mf::DesktopFileManager::resolve_app_id(const scene::Surface* surface)
+{
+    // In this method, we're attempting to resolve a Surface back to it's GAppInfo so that
+    // we can report a best-effort app_id to the user.
+    // Unfortunately, the connection between a window and a desktop is ill-defined.
+    // Hence, we jump through a series of hoops in the hope that we'll find what we're looking for.
+    // For more info on the checks happening here, see:
+    // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/src/shell-window-tracker.c?ref_type=heads#L387
+    auto app_id = surface->application_id();
+
+    // First, let's see if this is just a WM_CLASS
+    auto app = cache->lookup_by_wm_class(app_id);
+    if (app)
+        return app->id;
+
+    // Second, let's see if we can map it straight to a desktop file
+    auto desktop_file = app_id + ".desktop";
+    auto found = lookup_basename(desktop_file);
+    if (found)
+        return found->id;
+
+    // Third, lowercase it and try again
+    auto lowercase_desktop_file = desktop_file;
+    for(char &ch : lowercase_desktop_file)
+        ch = std::tolower(ch);
+
+    found = lookup_basename(desktop_file);
+    if (found)
+        return found->id;
+
+    // Fourth, get the exec command from our pid and see if we can match it to a GAppInfo's Exec
+    auto session = surface->session().lock();
+    auto pid = session->process_id();
+    found = resolve_if_executable_matches(pid);
+    if (found)
+        return found->id;
+
+    // Fifth, check if the window belongs to snap
+    found = resolve_if_snap(pid);
+    if (found)
+        return found->id;
+
+    // Sixth, check if the window belongs to flatpak
+    found = resolve_if_flatpak(pid);
+    if (found)
+        return found->id;
+
+    // NOTE: Here is the list of things that we aren't doing, as we don't have a good way of doing it:
+    // 1. Resolving from the list of internally running apps using the PID
+    // 2. Resolving via a startup notification
+    // 3. Resolving from a GApplicationID, which GTK sends over DBUS
+    return app_id;
+}
+
+std::shared_ptr<mf::DesktopFile> mf::DesktopFileManager::lookup_basename(std::string& name)
+{
+    // Check if it's in the list of names
+    auto app = cache->lookup_by_app_id(name);
+    if (app)
+        return app;
+
+    // Otherwise, check if any of the special prefixes can find the app.
+    std::vector<const char*> vendor_prefixes{
+        "gnome-",
+        "fedora-",
+        "mozilla-",
+        "debian-" };
+    for (auto prefix : vendor_prefixes)
+    {
+        auto prefixed = prefix + name;
+        app = cache->lookup_by_app_id(prefixed);
+        if (app)
+            return app;
+    }
+
+    return nullptr;
+}
+
+std::shared_ptr<mf::DesktopFile> mf::DesktopFileManager::resolve_if_snap(int pid)
+{
+    // We are reading the security profile here, which comes to us in the form:
+    //      snap.name-space.binary-name (current).
+    std::string attr_file = "/proc/" + std::to_string(pid) + "/attr/current";
+    if (!std::filesystem::exists(attr_file))
+        return nullptr;
+
+    std::string contents;
+    std::getline(std::ifstream(attr_file), contents, '\0');
+
+    const char* SNAP_SECURITY_LABEL_PREFIX = "snap.";
+    if (!contents.starts_with(SNAP_SECURITY_LABEL_PREFIX))
+        return nullptr;
+
+    // Get the contents after snap. and before the security annotation (denoted by a space)
+    auto const contents_start_index = strlen (SNAP_SECURITY_LABEL_PREFIX);
+    auto contents_end_index = contents.find_first_of(' ', contents_start_index);
+    if (contents_end_index == std::string::npos)
+        contents_end_index = contents.size();
+    std::string sandboxed_app_id = contents.substr(contents_start_index, contents_end_index - contents_start_index);
+    for (auto& c : sandboxed_app_id)
+        if (c == '.')
+            c = '_';
+
+    // Now we will have something like firefox_firefox, for example.
+    // This should match something in the app ID map.
+    return cache->lookup_by_app_id(sandboxed_app_id + ".desktop");
+}
+
+std::shared_ptr<mf::DesktopFile> mf::DesktopFileManager::resolve_if_flatpak(int pid)
+{
+    g_autoptr(GKeyFile) key_file = g_key_file_new ();
+    g_autofree char * info_filename = g_strdup_printf ("/proc/%u/root/.flatpak-info", pid);
+
+    if (!g_key_file_load_from_file (key_file, info_filename, G_KEY_FILE_NONE, NULL))
+        return nullptr;
+
+    char* sandboxed_app_id = g_key_file_get_string (key_file, "Application", "name", NULL);
+    if (!sandboxed_app_id)
+        return nullptr;
+
+    return cache->lookup_by_app_id(std::string(sandboxed_app_id) + ".desktop");
+}
+
+std::shared_ptr<mf::DesktopFile> mf::DesktopFileManager::resolve_if_executable_matches(int pid)
+{
+    std::string proc_file = "/proc/" + std::to_string(pid) + "/cmdline";
+    std::string cmdline_call;
+    std::getline(std::ifstream(proc_file), cmdline_call, '\0');
+    for (auto file : cache->get_desktop_files())
+    {
+        if (file->exec.starts_with(cmdline_call))
+        {
+            return file;
+        }
+    }
+
+    return nullptr;
+}

--- a/src/server/frontend_wayland/desktop_file_manager.cpp
+++ b/src/server/frontend_wayland/desktop_file_manager.cpp
@@ -2,15 +2,15 @@
  * Copyright © Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * under the terms of the GNU General Public License version 3,
  * as published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/server/frontend_wayland/desktop_file_manager.cpp
+++ b/src/server/frontend_wayland/desktop_file_manager.cpp
@@ -124,12 +124,12 @@ std::shared_ptr<mf::DesktopFile> mf::DesktopFileManager::resolve_if_snap(int pid
     std::string contents;
     std::getline(std::ifstream(attr_file), contents, '\0');
 
-    const char* SNAP_SECURITY_LABEL_PREFIX = "snap.";
-    if (!contents.starts_with(SNAP_SECURITY_LABEL_PREFIX))
+    char const* const snap_security_label_prefix = "snap.";
+    if (!contents.starts_with(snap_security_label_prefix))
         return nullptr;
 
     // Get the contents after snap. and before the security annotation (denoted by a space)
-    auto const contents_start_index = strlen (SNAP_SECURITY_LABEL_PREFIX);
+    auto const contents_start_index = strlen (snap_security_label_prefix);
     auto contents_end_index = contents.find_first_of(' ', contents_start_index);
     if (contents_end_index == std::string::npos)
         contents_end_index = contents.size();

--- a/src/server/frontend_wayland/desktop_file_manager.h
+++ b/src/server/frontend_wayland/desktop_file_manager.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_DESKTOP_FILE_MANAGER_H
+#define MIR_DESKTOP_FILE_MANAGER_H
+
+#include "mir/fd.h"
+#include <vector>
+#include <string>
+#include <memory>
+#include <map>
+#include <gio/gdesktopappinfo.h>
+
+namespace mir
+{
+class MainLoop;
+
+namespace scene { class Surface; }
+
+namespace frontend
+{
+
+struct DesktopFile
+{
+    DesktopFile(const char* id, const char* wm_class, const char* exec);
+    std::string id;
+    std::string wm_class;
+    std::string exec;
+};
+
+/// Provides the DesktopFileManager with the list of files.
+class DesktopFileCache
+{
+public:
+    DesktopFileCache() = default;
+    virtual ~DesktopFileCache() = default;
+    virtual std::shared_ptr<DesktopFile> lookup_by_app_id(std::string const&) = 0;
+    virtual std::shared_ptr<DesktopFile> lookup_by_wm_class(std::string const&) = 0;
+    virtual std::vector<std::shared_ptr<DesktopFile>> const& get_desktop_files() = 0;
+};
+
+class DesktopFileManager
+{
+public:
+    DesktopFileManager(std::shared_ptr<DesktopFileCache> cache);
+    ~DesktopFileManager() = default;
+
+    std::string resolve_app_id(const scene::Surface*);
+private:
+    std::shared_ptr<DesktopFileCache> cache;
+    std::shared_ptr<DesktopFile> resolve_from_wayland_app_id(std::string& app_id);
+    std::shared_ptr<DesktopFile> lookup_basename(std::string& name);
+    std::shared_ptr<DesktopFile> resolve_if_snap(int pid);
+    std::shared_ptr<DesktopFile> resolve_if_flatpak(int pid);
+    std::shared_ptr<DesktopFile> resolve_if_executable_matches(int pid);
+};
+}
+}
+
+#endif //MIR_DESKTOP_FILE_MANAGER_H

--- a/src/server/frontend_wayland/desktop_file_manager.h
+++ b/src/server/frontend_wayland/desktop_file_manager.h
@@ -14,8 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_DESKTOP_FILE_MANAGER_H
-#define MIR_DESKTOP_FILE_MANAGER_H
+#ifndef MIR_FRONTEND_DESKTOP_FILE_MANAGER_H
+#define MIR_FRONTEND_DESKTOP_FILE_MANAGER_H
 
 #include "mir/fd.h"
 #include <vector>

--- a/src/server/frontend_wayland/desktop_file_manager.h
+++ b/src/server/frontend_wayland/desktop_file_manager.h
@@ -2,15 +2,15 @@
  * Copyright © Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * under the terms of the GNU General Public License version 3,
  * as published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/server/frontend_wayland/desktop_file_manager.h
+++ b/src/server/frontend_wayland/desktop_file_manager.h
@@ -47,9 +47,9 @@ class DesktopFileCache
 public:
     DesktopFileCache() = default;
     virtual ~DesktopFileCache() = default;
-    virtual std::shared_ptr<DesktopFile> lookup_by_app_id(std::string const&) = 0;
-    virtual std::shared_ptr<DesktopFile> lookup_by_wm_class(std::string const&) = 0;
-    virtual std::vector<std::shared_ptr<DesktopFile>> const& get_desktop_files() = 0;
+    virtual std::shared_ptr<DesktopFile> lookup_by_app_id(std::string const&) const = 0;
+    virtual std::shared_ptr<DesktopFile> lookup_by_wm_class(std::string const&) const = 0;
+    virtual std::vector<std::shared_ptr<DesktopFile>> const& get_desktop_files() const = 0;
 };
 
 class DesktopFileManager

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -581,6 +581,10 @@ void mf::GDesktopFileCache::refresh_app_cache()
     for (info = app_infos; info != NULL; info = info->next)
     {
         GAppInfo *app_info = static_cast<GAppInfo*>(info->data);
+        const bool no_display = g_desktop_app_info_get_nodisplay(G_DESKTOP_APP_INFO(app_info));
+        if (no_display)
+            continue;
+
         const char* id = g_app_info_get_id(app_info);
         const char* wm_class = g_desktop_app_info_get_startup_wm_class(G_DESKTOP_APP_INFO(app_info));
         const char* exec = g_app_info_get_executable(app_info);

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -58,9 +58,9 @@ class GDesktopFileCache : public DesktopFileCache
 public:
     GDesktopFileCache(std::shared_ptr<MainLoop> const& main_loop);
     ~GDesktopFileCache() override = default;
-    std::shared_ptr<DesktopFile> lookup_by_app_id(std::string const&) override;
-    std::shared_ptr<DesktopFile> lookup_by_wm_class(std::string const&) override;
-    std::vector<std::shared_ptr<DesktopFile>> const& get_desktop_files() override;
+    std::shared_ptr<DesktopFile> lookup_by_app_id(std::string const&) const override;
+    std::shared_ptr<DesktopFile> lookup_by_wm_class(std::string const&) const override;
+    std::vector<std::shared_ptr<DesktopFile>> const& get_desktop_files() const override;
     void refresh_app_cache();
 
 private:
@@ -615,7 +615,7 @@ void mf::GDesktopFileCache::refresh_app_cache()
     g_list_free_full(app_infos, g_object_unref);
 }
 
-std::shared_ptr<mf::DesktopFile> mf::GDesktopFileCache::lookup_by_app_id(std::string const& name)
+std::shared_ptr<mf::DesktopFile> mf::GDesktopFileCache::lookup_by_app_id(std::string const& name) const
 {
     auto app_pos = id_to_app.find(name);
     if (app_pos != id_to_app.end())
@@ -626,7 +626,7 @@ std::shared_ptr<mf::DesktopFile> mf::GDesktopFileCache::lookup_by_app_id(std::st
     return nullptr;
 }
 
-std::shared_ptr<mf::DesktopFile> mf::GDesktopFileCache::lookup_by_wm_class(std::string const& name)
+std::shared_ptr<mf::DesktopFile> mf::GDesktopFileCache::lookup_by_wm_class(std::string const& name) const
 {
     auto wm_class_pos = wm_class_to_app_info_id.find(name);
     if (wm_class_pos != wm_class_to_app_info_id.end())
@@ -638,7 +638,7 @@ std::shared_ptr<mf::DesktopFile> mf::GDesktopFileCache::lookup_by_wm_class(std::
     return nullptr;
 }
 
-const std::vector<std::shared_ptr<mf::DesktopFile>> &mf::GDesktopFileCache::get_desktop_files()
+const std::vector<std::shared_ptr<mf::DesktopFile>> &mf::GDesktopFileCache::get_desktop_files() const
 {
     return files;
 }

--- a/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
+++ b/src/server/frontend_wayland/foreign_toplevel_manager_v1.cpp
@@ -601,11 +601,7 @@ void mf::GDesktopFileCache::refresh_app_cache()
             continue;
         }
 
-        std::shared_ptr<DesktopFile> file = std::make_shared<DesktopFile>(
-            id ? id : "",
-            wm_class ? wm_class : "",
-            exec ? exec : ""
-        );
+        std::shared_ptr<DesktopFile> file = std::make_shared<DesktopFile>(id, wm_class, exec);
         files.push_back(file);
         const char* app_id = g_app_info_get_id(app_info);
         id_to_app[app_id] = file;

--- a/tests/include/mir/test/doubles/mock_surface.h
+++ b/tests/include/mir/test/doubles/mock_surface.h
@@ -85,6 +85,8 @@ struct MockSurface : public scene::BasicSurface
     MOCK_METHOD(void, set_streams, (std::list<scene::StreamInfo> const&));
 
     MOCK_METHOD(void, set_focus_state, (MirWindowFocusState));
+    MOCK_METHOD(std::string, application_id, (), (const));
+    MOCK_METHOD(std::weak_ptr<scene::Session>, session, (), (const));
 
     std::shared_ptr<MockBufferStream> const stream;
 };

--- a/tests/unit-tests/frontend_wayland/CMakeLists.txt
+++ b/tests/unit-tests/frontend_wayland/CMakeLists.txt
@@ -2,6 +2,7 @@ list(
   APPEND UNIT_TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/test_wayland_timespec.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_screencopy_v1_damage_tracker.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_desktop_file_manager.cpp
 )
 
 set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} PARENT_SCOPE)

--- a/tests/unit-tests/frontend_wayland/test_desktop_file_manager.cpp
+++ b/tests/unit-tests/frontend_wayland/test_desktop_file_manager.cpp
@@ -16,10 +16,13 @@
 
 #include "src/server/frontend_wayland/desktop_file_manager.h"
 #include "mir/scene/observer.h"
+#include "mir/test/doubles/mock_surface.h"
+#include "mir/test/doubles/mock_scene_session.h"
 #include "mir/scene/surface_observer.h"
 #include "mir/test/doubles/mock_frontend_surface_stack.h"
 #include "mir/test/doubles/explicit_executor.h"
 #include "mir/test/fake_shared.h"
+#include <gmock/gmock.h>
 
 namespace mf = mir::frontend;
 namespace ms = mir::scene;
@@ -65,11 +68,67 @@ struct DesktopFileManager : Test
 {
     std::shared_ptr<InMemoryDesktopFileCache> cache;
     std::shared_ptr<mf::DesktopFileManager> file_manager;
+    mtd::MockSurface surface;
+    std::shared_ptr<mtd::MockSceneSession> session;
+
+    const char* APPLICATION_ID = "test_app_id";
+    const char* DESKTOP_FILE_APP_ID = "test_app_id.desktop";
+    const int PID = -12345; // Negative so it never accidentally works
 
     void SetUp() override
     {
+        session = std::make_shared<mtd::MockSceneSession>();
+        ON_CALL(*session, process_id)
+            .WillByDefault(testing::Invoke([this]() {
+                return PID;
+            }));
+
+        ON_CALL(surface, application_id())
+            .WillByDefault(testing::Invoke([this]() { return APPLICATION_ID; }));
+
+        ON_CALL(surface, session())
+            .WillByDefault(testing::Invoke([this]() {
+                return session;
+            }));
+
         cache = std::make_shared<InMemoryDesktopFileCache>();
         file_manager = std::make_shared<mf::DesktopFileManager>(cache);
     }
 };
 
+TEST_F(DesktopFileManager, can_find_app_when_app_id_matches)
+{
+    auto new_file = std::make_shared<mf::DesktopFile>(DESKTOP_FILE_APP_ID, nullptr, nullptr);
+    cache->files.push_back(new_file);
+    auto app_id = file_manager->resolve_app_id(&surface);
+    EXPECT_THAT(app_id, Eq(new_file->id));
+}
+
+TEST_F(DesktopFileManager, can_find_app_when_wm_class_matches)
+{
+    auto new_file = std::make_shared<mf::DesktopFile>(nullptr, APPLICATION_ID, nullptr);
+    cache->files.push_back(new_file);
+    auto app_id = file_manager->resolve_app_id(&surface);
+    EXPECT_THAT(app_id, Eq(new_file->id));
+}
+
+TEST_F(DesktopFileManager, can_find_app_when_app_id_matches_despite_being_uppercase)
+{
+    auto uppercase_app_id = std::string(APPLICATION_ID);
+    for(char &ch : uppercase_app_id)
+        ch = std::toupper(ch);
+
+    ON_CALL(surface, application_id())
+        .WillByDefault(testing::Invoke([uppercase_app_id]() { return uppercase_app_id; }));
+
+    auto new_file = std::make_shared<mf::DesktopFile>(DESKTOP_FILE_APP_ID, nullptr, nullptr);
+    cache->files.push_back(new_file);
+    auto app_id = file_manager->resolve_app_id(&surface);
+    EXPECT_THAT(app_id, Eq(new_file->id));
+}
+
+TEST_F(DesktopFileManager, when_all_fail_application_id_is_returned)
+{
+    auto app_id = file_manager->resolve_app_id(&surface);
+    EXPECT_THAT(app_id, Eq(APPLICATION_ID));
+}

--- a/tests/unit-tests/frontend_wayland/test_desktop_file_manager.cpp
+++ b/tests/unit-tests/frontend_wayland/test_desktop_file_manager.cpp
@@ -1,25 +1,23 @@
 /*
  * Copyright © Canonical Ltd.
  *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License version 2 or 3,
- * as published by the Free Software Foundation.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "src/server/frontend_wayland/desktop_file_manager.h"
-#include "mir/scene/observer.h"
 #include "mir/test/doubles/mock_surface.h"
 #include "mir/test/doubles/mock_scene_session.h"
 #include "mir/scene/surface_observer.h"
-#include "mir/test/doubles/mock_frontend_surface_stack.h"
 #include "mir/test/doubles/explicit_executor.h"
 #include "mir/test/fake_shared.h"
 #include <gmock/gmock.h>

--- a/tests/unit-tests/frontend_wayland/test_desktop_file_manager.cpp
+++ b/tests/unit-tests/frontend_wayland/test_desktop_file_manager.cpp
@@ -18,25 +18,58 @@
 #include "mir/scene/observer.h"
 #include "mir/scene/surface_observer.h"
 #include "mir/test/doubles/mock_frontend_surface_stack.h"
-#include "mir/test/doubles/mock_surface.h"
 #include "mir/test/doubles/explicit_executor.h"
 #include "mir/test/fake_shared.h"
 
 namespace mf = mir::frontend;
 namespace ms = mir::scene;
-namespace mw = mir::wayland;
 namespace geom = mir::geometry;
 namespace mt = mir::test;
 namespace mtd = mir::test::doubles;
 
 using namespace testing;
 
+namespace
+{
+
+class InMemoryDesktopFileCache : public mf::DesktopFileCache
+{
+public:
+    std::shared_ptr<mf::DesktopFile> lookup_by_app_id(std::string const& name) const override
+    {
+        for (auto file : files)
+            if (file->id == name)
+                return file;
+        return nullptr;
+    }
+
+    std::shared_ptr<mf::DesktopFile> lookup_by_wm_class(std::string const& name) const override
+    {
+        for (auto file : files)
+            if (file->wm_class == name)
+                return file;
+        return nullptr;
+    }
+
+    std::vector<std::shared_ptr<mf::DesktopFile>> const& get_desktop_files() const override
+    {
+        return files;
+    }
+
+    std::vector<std::shared_ptr<mf::DesktopFile>> files;
+};
+
+}
+
 struct DesktopFileManager : Test
 {
+    std::shared_ptr<InMemoryDesktopFileCache> cache;
     std::shared_ptr<mf::DesktopFileManager> file_manager;
 
     void SetUp() override
     {
-
+        cache = std::make_shared<InMemoryDesktopFileCache>();
+        file_manager = std::make_shared<mf::DesktopFileManager>(cache);
     }
 };
+

--- a/tests/unit-tests/frontend_wayland/test_desktop_file_manager.cpp
+++ b/tests/unit-tests/frontend_wayland/test_desktop_file_manager.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "src/server/frontend_wayland/desktop_file_manager.h"
+#include "mir/scene/observer.h"
+#include "mir/scene/surface_observer.h"
+#include "mir/test/doubles/mock_frontend_surface_stack.h"
+#include "mir/test/doubles/mock_surface.h"
+#include "mir/test/doubles/explicit_executor.h"
+#include "mir/test/fake_shared.h"
+
+namespace mf = mir::frontend;
+namespace ms = mir::scene;
+namespace mw = mir::wayland;
+namespace geom = mir::geometry;
+namespace mt = mir::test;
+namespace mtd = mir::test::doubles;
+
+using namespace testing;
+
+struct DesktopFileManager : Test
+{
+    std::shared_ptr<mf::DesktopFileManager> file_manager;
+
+    void SetUp() override
+    {
+
+    }
+};


### PR DESCRIPTION
## What's new?
- Fixed a bug where `gnome-disks` wasn't showing up (we needed a `NoDisplay` check)
- Wrote tests for everything except fileystem-specific stuff