### PR TITLE
various: Drop nonexistent symbols from symbols.map

### DIFF
--- a/src/common/symbols.map
+++ b/src/common/symbols.map
@@ -346,7 +346,6 @@ MIR_COMMON_2.8 {
     mir::SharedLibraryProberReport::operator*;
     mir::SignalBlocker::?SignalBlocker*;
     mir::SignalBlocker::SignalBlocker*;
-    mir::default_server_socket;
     mir::detail::RefCountedLibrary::?RefCountedLibrary*;
     mir::detail::RefCountedLibrary::RefCountedLibrary*;
     mir::detail::RefCountedLibrary::operator*;

--- a/src/platform/symbols.map
+++ b/src/platform/symbols.map
@@ -147,7 +147,6 @@ MIR_PLATFORM_2.16 {
     mir::options::vt_console;
     mir::options::vt_option_name*;
     mir::options::wayland_extensions_opt;
-    mir::options::wayland_extensions_value;
     mir::options::x11_display_opt;
     mir::options::x11_scale_opt;
     mir::renderer::software::alloc_buffer_with_content*;

--- a/src/platforms/eglstream-kms/server/symbols.map.in
+++ b/src/platforms/eglstream-kms/server/symbols.map.in
@@ -1,8 +1,6 @@
 @MIR_SERVER_GRAPHICS_PLATFORM_VERSION@ {
   global:
     add_graphics_platform_options;
-    create_host_platform;
-    create_guest_platform;
     probe_display_platform;
     probe_rendering_platform;
     describe_graphics_module;

--- a/src/platforms/virtual/symbols.map.in
+++ b/src/platforms/virtual/symbols.map.in
@@ -8,10 +8,3 @@
     *;
 };
 
-@MIR_SERVER_INPUT_PLATFORM_VERSION@ {
-  global:
-   add_input_platform_options;
-   create_input_platform;
-   probe_input_platform;
-   describe_input_module;
-};

--- a/src/platforms/x11/symbols.map.in
+++ b/src/platforms/x11/symbols.map.in
@@ -2,8 +2,6 @@
   global: 
    add_graphics_platform_options;
    probe_display_platform;
-   create_host_platform;
-   create_guest_platform;
    describe_graphics_module;
    create_display_platform;
   local: *;

--- a/tests/mir_test_framework/symbols-server.map.in
+++ b/tests/mir_test_framework/symbols-server.map.in
@@ -15,8 +15,6 @@ WORK_AROUND_MUSL_RTLD_NEXT_BUG {
 @MIR_SERVER_GRAPHICS_PLATFORM_VERSION@ {
   global:
     add_graphics_platform_options;
-    create_host_platform;
-    create_guest_platform;
     create_display_platform;
     create_rendering_platform;
     probe_display_platform;


### PR DESCRIPTION
`mold` likes to complain about these; newer `lld`s make this a hard error