### PR TITLE
[RFC] mir-shell

### DIFF
--- a/examples/client/CMakeLists.txt
+++ b/examples/client/CMakeLists.txt
@@ -1,18 +1,44 @@
-set(OUTPUT_PATH_HEADER "${CMAKE_CURRENT_BINARY_DIR}/xdg-shell.h")
-set(OUTPUT_PATH_SRC "${CMAKE_CURRENT_BINARY_DIR}/xdg-shell.c")
-set(PROTOCOL_PATH "${PROJECT_SOURCE_DIR}/wayland-protocols/xdg-shell.xml")
+set(XDG_SHELL_H "${CMAKE_CURRENT_BINARY_DIR}/xdg-shell.h")
+set(XDG_SHELL_C "${CMAKE_CURRENT_BINARY_DIR}/xdg-shell.c")
+set(XDG_SHELL_X "${PROJECT_SOURCE_DIR}/wayland-protocols/xdg-shell.xml")
 
 add_custom_command(
-      OUTPUT "${OUTPUT_PATH_HEADER}" "${OUTPUT_PATH_SRC}"
+      OUTPUT "${XDG_SHELL_H}" "${XDG_SHELL_C}"
       VERBATIM
-      COMMAND "sh" "-c" "wayland-scanner client-header ${PROTOCOL_PATH} ${OUTPUT_PATH_HEADER}"
-      COMMAND "sh" "-c" "wayland-scanner private-code  ${PROTOCOL_PATH} ${OUTPUT_PATH_SRC}"
+      COMMAND "sh" "-c" "wayland-scanner client-header ${XDG_SHELL_X} ${XDG_SHELL_H}"
+      COMMAND "sh" "-c" "wayland-scanner private-code  ${XDG_SHELL_X} ${XDG_SHELL_C}"
 )
 
-mir_add_wrapped_executable(mir_demo_client_wayland wayland_client.c ${OUTPUT_PATH_HEADER} ${OUTPUT_PATH_SRC})
-target_link_libraries     (mir_demo_client_wayland PkgConfig::WAYLAND_CLIENT)
+set(MIR_SHELL_H "${CMAKE_CURRENT_BINARY_DIR}/mir-shell.h")
+set(MIR_SHELL_C "${CMAKE_CURRENT_BINARY_DIR}/mir-shell.c")
+set(MIR_SHELL_X "${PROJECT_SOURCE_DIR}/wayland-protocols/mir-shell-unstable-v1.xml")
+
+add_custom_command(
+        OUTPUT "${MIR_SHELL_H}" "${MIR_SHELL_C}"
+        VERBATIM
+        COMMAND "sh" "-c" "wayland-scanner client-header ${MIR_SHELL_X} ${MIR_SHELL_H}"
+        COMMAND "sh" "-c" "wayland-scanner private-code  ${MIR_SHELL_X} ${MIR_SHELL_C}"
+)
+
+add_library(mir_demo_wayland_extensions STATIC
+        ${XDG_SHELL_C} ${XDG_SHELL_H}
+        ${MIR_SHELL_C} ${MIR_SHELL_H}
+        make_shm_pool.c make_shm_pool.h
+)
+set_target_properties     (mir_demo_wayland_extensions PROPERTIES COMPILE_FLAGS "${CMAKE_CFLAGS}  -fvisibility=hidden")
+target_include_directories(mir_demo_wayland_extensions PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries     (mir_demo_wayland_extensions PUBLIC PkgConfig::WAYLAND_CLIENT)
+
+
+mir_add_wrapped_executable(mir_demo_client_wayland wayland_client.c)
+target_link_libraries     (mir_demo_client_wayland mir_demo_wayland_extensions)
 target_include_directories(mir_demo_client_wayland PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 
 mir_add_wrapped_executable(mir_demo_client_wayland_egl_spinner spinner.cpp)
 target_link_libraries     (mir_demo_client_wayland_egl_spinner miral-spinner)
+
+
+mir_add_wrapped_executable(mir_demo_client_mir_shell mir_shell_demo.cpp wayland_runner.cpp wayland_runner.h)
+target_link_libraries     (mir_demo_client_mir_shell mir_demo_wayland_extensions)
+target_include_directories(mir_demo_client_mir_shell PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/client/make_shm_pool.c
+++ b/examples/client/make_shm_pool.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "make_shm_pool.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+struct wl_shm_pool*
+make_shm_pool(struct wl_shm* shm, int size, void **data)
+{
+    int fd = memfd_create("make_shm_pool", MFD_CLOEXEC);
+
+    if (fd < 0) {
+        return NULL;
+    }
+
+    posix_fallocate(fd, 0, size);
+
+    *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (*data == MAP_FAILED) {
+        close(fd);
+        return NULL;
+    }
+
+    struct wl_shm_pool *pool = wl_shm_create_pool(shm, fd, size);
+
+    close(fd);
+
+    return pool;
+}

--- a/examples/client/make_shm_pool.h
+++ b/examples/client/make_shm_pool.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_MAKE_SHM_POOL_H
+#define MIR_MAKE_SHM_POOL_H
+
+#include <wayland-client.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct wl_shm_pool*
+make_shm_pool(struct wl_shm* shm, int size, void** data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //MIR_MAKE_SHM_POOL_H

--- a/examples/client/mir_shell_demo.cpp
+++ b/examples/client/mir_shell_demo.cpp
@@ -1,0 +1,1078 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "make_shm_pool.h"
+#include "wayland_runner.h"
+#include "xdg-shell.h"
+#include "mir-shell.h"
+
+#include <wayland-client.h>
+#include <wayland-client-core.h>
+
+#include <X11/X.h>
+#include <getopt.h>
+#include <linux/input-event-codes.h>
+
+#include <list>
+#include <map>
+#include <memory>
+#include <string.h>
+
+using namespace std::literals;
+namespace wayland_runner = mir::client::wayland_runner;
+
+namespace
+{
+bool const tracing = getenv("MIR_SHELL_DEMO_TRACE");
+
+int32_t main_width = 400;
+int32_t main_height = 400;
+
+mir_positioner_v1_anchor satellite_anchor = MIR_POSITIONER_V1_ANCHOR_LEFT;
+int32_t satellite_offset_vertical = 50;
+int32_t satellite_offset_horizontal = 0;
+
+void parse_options(int argc, char* argv[])
+{
+    auto const option_main_width = "width";
+    auto const option_main_height = "height";
+
+    struct option const long_options[] = {
+        {option_main_width,  required_argument, 0, 0},
+        {option_main_height, required_argument, 0, 0},
+        {0, 0,                                  0, 0}
+    };
+
+    int option_index = 0;
+
+    while_has_no_init_statement:
+    if (auto c = getopt_long(argc, argv, "", long_options, &option_index); c != -1)
+    {
+
+        switch (c)
+        {
+        case 0:
+            if (option_main_width == long_options[option_index].name)
+            {
+                main_width = atoi(optarg);
+            }
+            else if (option_main_height == long_options[option_index].name)
+            {
+                main_height = atoi(optarg);
+            }
+            else
+            {
+                printf("option %s", long_options[option_index].name);
+                if (optarg)
+                    printf(" with arg %s", optarg);
+                printf("\n");
+            }
+            break;
+
+        case '?':
+            exit(EXIT_FAILURE);
+        }
+
+        goto while_has_no_init_statement;
+    }
+}
+
+[[gnu::format (printf, 1, 2)]]
+inline void trace(char const* fmt, ...)
+{
+    if (tracing)
+    {
+        va_list va;
+        va_start(va, fmt);
+        vprintf(fmt, va);
+        va_end(va);
+        putc('\n', stdout);
+        fflush(stdout);
+    }
+}
+
+int const pixel_size = 4;
+int const no_of_buffers = 2;
+
+auto const display = wl_display_connect(NULL);
+
+class window;
+class window_register
+{
+public:
+    void register_window(window* w);
+    void deregister_window(window* w);
+
+    auto window_for(wl_surface* surface) -> window*;
+    bool is_registered(window* w) const;
+
+private:
+    std::map<wl_surface*, window*> windows;
+};
+
+namespace globals
+{
+wl_compositor* compositor;
+wl_shm* shm;
+wl_seat* seat;
+wl_output* output;
+xdg_wm_base* wm_base;
+mir_shell_v1* mir_shell;
+
+window_register my_windows;
+
+void init();
+}
+
+class window
+{
+public:
+    window(int32_t width, int32_t height);
+    virtual ~window();
+
+    operator wl_surface*() const { return surface; }
+
+    auto size() const { return std::tuple(width, height); }
+
+    virtual void handle_mouse_button(wl_pointer*, uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
+    virtual void handle_keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
+    virtual void handle_keyboard_modifiers(
+        wl_keyboard* keyboard,
+        uint32_t serial,
+        uint32_t mods_depressed,
+        uint32_t mods_latched,
+        uint32_t mods_locked,
+        uint32_t group);
+
+protected:
+    struct buffer
+    {
+        wl_buffer* buffer;
+        bool available;
+        int width;
+        int height;
+        void* content_area;
+    };
+
+    void resize(int32_t width_, int32_t height_)
+    {
+        if (width == width_ && height == height_) return;
+
+        if (width_ > 0) width = width_;
+        if (height_ > 0) height = height_;
+
+        if ((width_ > 0) || (height_ > 0))
+        {
+            redraw();
+        }
+    }
+
+    void redraw();
+
+private:
+    wl_surface* const surface;
+    buffer buffers[no_of_buffers];
+    int width;
+    int height;
+    bool need_to_draw = true;
+    bool hidden = false;
+
+    void handle_frame_callback(wl_callback* callback, uint32_t);
+
+    void update_free_buffers(wl_buffer* buffer);
+    void prepare_buffer(buffer& b);
+    auto find_free_buffer() -> buffer*;
+    virtual void draw_new_content(buffer* b) = 0;
+
+    static wl_callback_listener const frame_listener;
+    static wl_buffer_listener const buffer_listener;
+
+    window(window const&) = delete;
+    window& operator=(window const&) = delete;
+};
+
+class toplevel : public window
+{
+public:
+    toplevel(int32_t width, int32_t height);
+    ~toplevel();
+
+    operator xdg_surface*() const { return xdgsurface; }
+    operator xdg_toplevel*() const { return xdgtoplevel; }
+
+private:
+    xdg_surface* const xdgsurface;
+    xdg_toplevel* const xdgtoplevel;
+
+    void handle_mouse_button(wl_pointer*, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) override;
+    void handle_xdg_toplevel_configure(xdg_toplevel*, int32_t width_, int32_t height_, wl_array*);
+
+    virtual void show_activated() = 0;
+    virtual void show_unactivated() = 0;
+
+    static xdg_toplevel_listener const shell_toplevel_listener;
+    static xdg_surface_listener const shell_surface_listener;
+};
+
+class grey_window : public toplevel
+{
+public:
+    grey_window(int32_t width, int32_t height, unsigned char intensity) :
+        toplevel(width, height), intensity(intensity) {}
+
+    grey_window(int32_t width, int32_t height, unsigned char intensity, int title_height) :
+        toplevel(width, height), intensity(intensity), title_height{title_height} {}
+
+private:
+    unsigned char const intensity;
+    unsigned char const alpha = 255;
+    int title_height = 20;
+
+    unsigned char intensity_offset = 0;
+
+    void draw_new_content(buffer* b) override;
+    virtual void show_activated() override;
+    virtual void show_unactivated() override;
+};
+
+class normal_window;
+class satellite;
+class dialog;
+class utility;
+auto make_satellite(normal_window* main_window) -> std::unique_ptr<satellite>;
+auto make_dialog(normal_window* main_window) -> std::unique_ptr<dialog>;
+auto make_utility() -> std::unique_ptr<utility>;
+
+class normal_window : public grey_window
+{
+public:
+    normal_window(int32_t width, int32_t height);
+    ~normal_window();
+
+    static std::list<std::unique_ptr<satellite>> toolboxs;
+    static std::unique_ptr<utility> my_utility;
+    static std::unique_ptr<dialog> my_dialog;
+
+protected:
+    void
+    handle_keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state) override;
+
+    void handle_keyboard_modifiers(
+        wl_keyboard* keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked,
+        uint32_t group) override;
+
+private:
+    mir_normal_surface_v1* const mir_normal_surface;
+
+    uint32_t modifiers = 0;
+};
+
+class satellite : public grey_window
+{
+public:
+    void
+    handle_keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state) override;
+
+    satellite(int32_t width, int32_t height, mir_positioner_v1* positioner, xdg_toplevel* parent);
+    ~satellite();
+
+private:
+    mir_satellite_surface_v1* const mir_surface;
+
+    void handle_repositioned(mir_satellite_surface_v1* mir_satellite_surface_v1, uint32_t token);
+
+    static mir_satellite_surface_v1_listener const satellite_listener;
+};
+
+class dialog : public grey_window
+{
+public:
+    dialog(int32_t width, int32_t height, normal_window* parent);
+    ~dialog();
+
+private:
+    normal_window* const parent;
+    mir_dialog_surface_v1* const mir_surface;
+
+    void handle_keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
+        override;
+};
+
+class utility : public grey_window
+{
+public:
+    utility(int32_t width, int32_t height);
+    ~utility();
+
+private:
+    mir_utility_surface_v1* const mir_surface;
+
+    void handle_keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
+    override;
+};
+
+class input_listener
+{
+public:
+    input_listener();
+    ~input_listener();
+
+private:
+    wl_pointer* const pointer;
+    wl_keyboard* const keyboard;
+
+    window* mouse_focus = nullptr;
+    window* keyboard_focus = nullptr;
+
+    static wl_pointer_listener const pointer_listener;
+    static wl_keyboard_listener const keyboard_listener;
+
+    void handle_mouse_button(wl_pointer*, uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
+    void handle_keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
+    void handle_keyboard_modifiers(
+        wl_keyboard* keyboard,
+        uint32_t serial,
+        uint32_t mods_depressed,
+        uint32_t mods_latched,
+        uint32_t mods_locked,
+        uint32_t group);
+    void handle_mouse_enter(wl_pointer*, uint32_t serial, wl_surface*, wl_fixed_t surface_x, wl_fixed_t surface_y);
+    void handle_mouse_leave(wl_pointer*, uint32_t serial, wl_surface*);
+    void handle_mouse_motion(wl_pointer*, uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y);
+    void handle_mouse_axis(wl_pointer*, uint32_t time, uint32_t axis, wl_fixed_t value);
+
+    void handle_keyboard_keymap(wl_keyboard* keyboard, uint32_t format, int32_t fd, uint32_t size);
+    void handle_keyboard_enter(wl_keyboard* keyboard, uint32_t serial, wl_surface* surface, wl_array* keys);
+    void handle_keyboard_leave(wl_keyboard* keyboard, uint32_t serial, wl_surface* surface);
+    void handle_keyboard_repeat_info(wl_keyboard* wl_keyboard, int32_t rate, int32_t delay);
+};
+
+void handle_registry_global(
+    wl_registry* registry,
+    uint32_t id,
+    char const* interface,
+    uint32_t version)
+{
+    if (strcmp(interface, "wl_compositor") == 0)
+    {
+        globals::compositor = static_cast<wl_compositor*>(wl_registry_bind(
+            registry, id, &wl_compositor_interface, std::min(version, 3u)));
+    }
+    else if (strcmp(interface, "wl_shm") == 0)
+    {
+        globals::shm = static_cast<wl_shm*>(wl_registry_bind(registry, id, &wl_shm_interface, std::min(version, 1u)));
+        // Normally we'd add a listener to pick up the supported formats here
+        // As luck would have it, I know that argb8888 is the only format we support :)
+    }
+    else if (strcmp(interface, "wl_seat") == 0)
+    {
+        globals::seat = static_cast<wl_seat*>(wl_registry_bind(registry, id, &wl_seat_interface, std::min(version, 4u)));
+    }
+    else if (strcmp(interface, "wl_output") == 0)
+    {
+        globals::output = static_cast<wl_output*>(wl_registry_bind(
+            registry, id, &wl_output_interface, std::min(version, 2u)));
+    }
+    else if (strcmp(interface, xdg_wm_base_interface.name) == 0)
+    {
+        globals::wm_base = static_cast<xdg_wm_base*>(wl_registry_bind(
+            registry, id, &xdg_wm_base_interface, std::min(version, 1u)));
+    }
+    else if (strcmp(interface, mir_shell_v1_interface.name) == 0)
+    {
+        globals::mir_shell = static_cast<mir_shell_v1*>(wl_registry_bind(
+            registry, id, &mir_shell_v1_interface, std::min(version, 1u)));
+    }
+}
+
+void globals::init()
+{
+    static wl_registry_listener const registry_listener =
+        {
+            .global = [](void*, auto... args) { handle_registry_global(args...); },
+            .global_remove = [](auto...) {},
+        };
+
+    static xdg_wm_base_listener const shell_listener =
+        {
+            .ping = [](void*, xdg_wm_base* shell, uint32_t serial) { xdg_wm_base_pong(shell, serial); }
+        };
+
+    auto const registry = wl_display_get_registry(display);
+
+    wl_registry_add_listener(registry, &registry_listener, NULL);
+
+    wl_display_roundtrip(display);
+
+    bool fail = false;
+    if (!compositor)
+    {
+        puts("ERROR: no wl_compositor*");
+        fail = true;
+    }
+    if (!shm)
+    {
+        puts("ERROR: no wl_shm*");
+        fail = true;
+    }
+    if (!seat)
+    {
+        puts("ERROR: no wl_seat*");
+        fail = true;
+    }
+    if (!output)
+    {
+        puts("ERROR: no wl_output*");
+        fail = true;
+    }
+    if (!wm_base)
+    {
+        puts("ERROR: no wm_base*");
+        fail = true;
+    }
+    if (!mir_shell)
+    {
+        puts("WARNING: no mir_shell*");
+    }
+
+    if (fail) abort();
+
+    xdg_wm_base_add_listener(globals::wm_base, &shell_listener, NULL);
+}
+
+// If building against newer Wayland protocol definitions we may miss trailing fields
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+wl_callback_listener const window::frame_listener =
+{
+    .done = [](void* ctx, auto... args) { static_cast<window*>(ctx)->handle_frame_callback(args...); },
+};
+
+wl_buffer_listener const window::buffer_listener =
+{
+    .release = [](void* ctx, auto... args) { static_cast<window*>(ctx)->update_free_buffers(args...); },
+};
+
+void window_register::register_window(window* w)
+{
+    windows[*w] = w;
+}
+
+void window_register::deregister_window(window* w)
+{
+    windows.erase(*w);
+}
+
+bool window_register::is_registered(window* w) const
+{
+    return w && windows.find(*w) != windows.end();
+}
+
+auto window_register::window_for(wl_surface* surface) -> window*
+{
+    return windows[surface];
+}
+
+void window::update_free_buffers(wl_buffer* buffer)
+{
+    for (int i = 0; i < no_of_buffers; ++i)
+    {
+        if (buffers[i].buffer == buffer)
+        {
+            buffers[i].available = true;
+        }
+    }
+}
+
+void window::prepare_buffer(buffer& b)
+{
+    void* pool_data = NULL;
+    wl_shm_pool* shm_pool = make_shm_pool(globals::shm, width * height * pixel_size, &pool_data);
+
+    b.buffer = wl_shm_pool_create_buffer(shm_pool, 0, width, height, width * pixel_size, WL_SHM_FORMAT_ARGB8888);
+    b.available = true;
+    b.width = width;
+    b.height = height;
+    b.content_area = pool_data;
+    wl_buffer_add_listener(b.buffer, &buffer_listener, this);
+    wl_shm_pool_destroy(shm_pool);
+}
+
+auto window::find_free_buffer() -> buffer*
+{
+    for (auto& b : buffers)
+    {
+        if (b.available)
+        {
+            if (b.width != width || b.height != height)
+            {
+                wl_buffer_destroy(b.buffer);
+                prepare_buffer(b);
+            }
+
+            b.available = false;
+            return &b;
+        }
+    }
+    return nullptr;
+}
+
+void window::handle_frame_callback(wl_callback* callback, uint32_t)
+{
+    wl_callback_destroy(callback);
+
+    if (need_to_draw)
+    {
+        redraw();
+    }
+}
+
+void window::handle_keyboard_key(wl_keyboard*, uint32_t, uint32_t, uint32_t, uint32_t)
+{
+}
+
+void window::handle_keyboard_modifiers(wl_keyboard*, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t)
+{
+}
+
+window::window(int32_t width, int32_t height) :
+    surface{wl_compositor_create_surface(globals::compositor)},
+    width{width},
+    height{height}
+{
+    for (buffer& b : buffers)
+    {
+        prepare_buffer(b);
+    }
+
+    globals::my_windows.register_window(this);
+}
+
+window::~window()
+{
+    globals::my_windows.deregister_window(this);
+    for (auto b : buffers)
+    {
+        wl_buffer_destroy(b.buffer);
+    }
+
+    wl_surface_destroy(surface);
+}
+
+void window::redraw()
+{
+    if (auto const b = find_free_buffer())
+    {
+        draw_new_content(b);
+
+        auto const new_frame_signal = wl_surface_frame(surface);
+        wl_callback_add_listener(new_frame_signal, &frame_listener, this);
+        wl_surface_attach(surface, b->buffer, 0, 0);
+        wl_surface_commit(surface);
+        need_to_draw = false;
+    }
+    else
+    {
+        need_to_draw = true;
+    }
+}
+
+void window::handle_mouse_button(wl_pointer*, uint32_t , uint32_t , uint32_t , uint32_t )
+{
+
+}
+
+toplevel::toplevel(int32_t width, int32_t height) :
+    window{width, height},
+    xdgsurface{xdg_wm_base_get_xdg_surface(globals::wm_base, *this)},
+    xdgtoplevel{xdg_surface_get_toplevel(xdgsurface)}
+{
+    xdg_surface_add_listener(xdgsurface, &shell_surface_listener, this);
+    xdg_toplevel_add_listener(xdgtoplevel, &shell_toplevel_listener, this);
+}
+
+toplevel::~toplevel()
+{
+    xdg_toplevel_destroy(xdgtoplevel);
+    xdg_surface_destroy(xdgsurface);
+}
+
+void toplevel::handle_xdg_toplevel_configure(
+    xdg_toplevel*,
+    int32_t width_,
+    int32_t height_,
+    wl_array* array)
+{
+    trace("Received toplevel_configure: width %i, height %i", width_, height_);
+
+    bool is_activated = false;
+    xdg_toplevel_state* state;
+    for (state = static_cast<decltype(state)>((array)->data); (const char*)state < ((const char*)(array)->data + (array)->size); state++)
+    {
+        if (*state == XDG_TOPLEVEL_STATE_ACTIVATED)
+            is_activated = true;
+    }
+
+    if (is_activated)
+        show_activated();
+    else
+        show_unactivated();
+
+    resize(width_, height_);
+}
+
+xdg_toplevel_listener const toplevel::shell_toplevel_listener =
+{
+    .configure = [](void* ctx, auto... args) { static_cast<toplevel*>(ctx)->handle_xdg_toplevel_configure(args...); },
+    .close = [](auto...){},
+    .configure_bounds = [](auto...){},
+    .wm_capabilities = [](auto...){},
+};
+
+xdg_surface_listener const toplevel::shell_surface_listener =
+{
+    .configure= [](auto...){},
+};
+
+void toplevel::handle_mouse_button(wl_pointer* pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state)
+{
+    window::handle_mouse_button(pointer, serial, time, button, state);
+
+    if (button == BTN_LEFT && state == WL_POINTER_BUTTON_STATE_PRESSED)
+        xdg_toplevel_move(xdgtoplevel, globals::seat, serial);
+
+    if (button == BTN_RIGHT && state == WL_POINTER_BUTTON_STATE_PRESSED)
+        xdg_toplevel_resize(xdgtoplevel, globals::seat, serial, XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT);
+}
+
+void grey_window::draw_new_content(window::buffer* b)
+{
+    auto const begin = static_cast<uint8_t*>(b->content_area);
+    auto const end_bar = begin + b->width * std::min(title_height, b->height) * pixel_size;
+    auto const end_all = begin + b->width * b->height * pixel_size;
+
+    memset(begin, std::max(intensity-intensity_offset, 0), end_bar - begin);
+    memset(end_bar, intensity, end_all - end_bar);
+    for (auto* p = begin; p != end_all; p += pixel_size)
+    {
+        p[3] = alpha;
+    }
+}
+
+void grey_window::show_activated()
+{
+    if (intensity_offset != 32)
+    {
+        intensity_offset = 32;
+        redraw();
+    }
+}
+
+void grey_window::show_unactivated()
+{
+    if (intensity_offset != 16)
+    {
+        intensity_offset = 16;
+        redraw();
+    }
+}
+
+std::list<std::unique_ptr<satellite>> normal_window::toolboxs;
+std::unique_ptr<utility> normal_window::my_utility;
+std::unique_ptr<dialog> normal_window::my_dialog;
+
+normal_window::normal_window(int32_t width, int32_t height) :
+    grey_window(width, height, 192),
+    mir_normal_surface{globals::mir_shell? mir_shell_v1_get_normal_surface(globals::mir_shell, *this) : nullptr}
+{
+    xdg_toplevel_set_title(*this, "normal");
+    redraw();
+}
+
+normal_window::~normal_window()
+{
+    if (mir_normal_surface)
+    {
+        mir_normal_surface_v1_destroy(mir_normal_surface);
+    }
+}
+
+void normal_window::handle_keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
+{
+    grey_window::handle_keyboard_key(keyboard, serial, time, key, state);
+
+    if (modifiers == ControlMask && state == WL_KEYBOARD_KEY_STATE_RELEASED)
+    {
+        switch (key)
+        {
+        case KEY_Q:wayland_runner::quit();
+            break;
+        case KEY_T:toolboxs.push_back(make_satellite(this));
+            break;
+        case KEY_D:my_dialog = make_dialog(this);
+            break;
+        case KEY_U:my_utility = make_utility();
+            break;
+        }
+    }
+    if (state == WL_KEYBOARD_KEY_STATE_RELEASED)
+    switch (key)
+    {
+    case KEY_ESC:
+        toolboxs.clear();
+        break;
+    }
+}
+
+void normal_window::handle_keyboard_modifiers(
+    wl_keyboard* keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked,
+    uint32_t group)
+{
+    grey_window::handle_keyboard_modifiers(keyboard, serial, mods_depressed, mods_latched, mods_locked, group);
+
+    modifiers = mods_depressed;
+}
+
+satellite::satellite(int32_t width, int32_t height, mir_positioner_v1* positioner, xdg_toplevel* parent) :
+    grey_window{width, height, 128, 10},
+    mir_surface{globals::mir_shell ? mir_shell_v1_get_satellite_surface(globals::mir_shell, *this, positioner) : nullptr}
+{
+    xdg_toplevel_set_parent(*this, parent);
+    xdg_toplevel_set_title(*this, "satellite");
+
+    if (mir_surface)
+    {
+        mir_satellite_surface_v1_add_listener(mir_surface, &satellite_listener, this);
+    }
+    redraw();
+}
+
+satellite::~satellite()
+{
+    if (mir_surface)
+    {
+        mir_satellite_surface_v1_destroy(mir_surface);
+    }
+}
+
+void satellite::handle_repositioned(mir_satellite_surface_v1* /*mir_satellite_surface_v1*/, uint32_t /*token*/)
+{
+    trace("Received repositioned event");
+}
+
+mir_satellite_surface_v1_listener const satellite::satellite_listener=
+{
+    .repositioned =  [](void* ctx, auto... args) { static_cast<satellite*>(ctx)->handle_repositioned(args...); },
+};
+
+void satellite::handle_keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
+{
+    grey_window::handle_keyboard_key(keyboard, serial, time, key, state);
+
+    if (state == WL_KEYBOARD_KEY_STATE_RELEASED)
+        switch (key)
+        {
+        case KEY_ESC:
+            normal_window::toolboxs.clear();
+            break;
+        }
+}
+
+auto make_satellite(normal_window* main_window) -> std::unique_ptr<satellite>
+{
+    if (globals::mir_shell)
+    {
+        auto const positioner = mir_shell_v1_create_positioner(globals::mir_shell);
+        auto const [anchor_width, anchor_height] = main_window->size();
+
+        mir_positioner_v1_set_anchor_rect(positioner, 0, 0, anchor_width, anchor_height);
+        mir_positioner_v1_set_anchor(positioner, satellite_anchor);
+        mir_positioner_v1_set_gravity(positioner, satellite_anchor);
+        mir_positioner_v1_set_offset(positioner, satellite_offset_horizontal, satellite_offset_vertical);
+
+        uint32_t constraint_adjustment = MIR_POSITIONER_V1_CONSTRAINT_ADJUSTMENT_SLIDE_X;
+        switch (satellite_anchor)
+        {
+        case MIR_POSITIONER_V1_ANCHOR_LEFT:satellite_anchor = MIR_POSITIONER_V1_ANCHOR_RIGHT;
+            break;
+        case MIR_POSITIONER_V1_ANCHOR_RIGHT:satellite_anchor = MIR_POSITIONER_V1_ANCHOR_BOTTOM;
+            constraint_adjustment = MIR_POSITIONER_V1_CONSTRAINT_ADJUSTMENT_SLIDE_Y;
+            break;
+        case MIR_POSITIONER_V1_ANCHOR_BOTTOM:satellite_anchor = MIR_POSITIONER_V1_ANCHOR_BOTTOM_LEFT;
+            constraint_adjustment = MIR_POSITIONER_V1_CONSTRAINT_ADJUSTMENT_SLIDE_Y;
+            break;
+        case MIR_POSITIONER_V1_ANCHOR_BOTTOM_LEFT:satellite_anchor = MIR_POSITIONER_V1_ANCHOR_BOTTOM_RIGHT;
+            constraint_adjustment =
+                MIR_POSITIONER_V1_CONSTRAINT_ADJUSTMENT_SLIDE_Y | MIR_POSITIONER_V1_CONSTRAINT_ADJUSTMENT_SLIDE_X;
+            break;
+        case MIR_POSITIONER_V1_ANCHOR_BOTTOM_RIGHT:constraint_adjustment =
+                                                       MIR_POSITIONER_V1_CONSTRAINT_ADJUSTMENT_SLIDE_Y |
+                                                       MIR_POSITIONER_V1_CONSTRAINT_ADJUSTMENT_SLIDE_X;
+            [[fallthrough]];
+        default:satellite_anchor = MIR_POSITIONER_V1_ANCHOR_LEFT;
+            break;
+        }
+        mir_positioner_v1_set_constraint_adjustment(positioner, constraint_adjustment);
+
+        return std::make_unique<satellite>(100, 200, positioner, *main_window);
+    }
+    else
+    {
+        return std::make_unique<satellite>(100, 200, nullptr, *main_window);
+    }
+}
+
+dialog::dialog(int32_t width, int32_t height, normal_window* parent) :
+    grey_window{width, height, 160},
+    parent{parent},
+    mir_surface{globals::mir_shell ? mir_shell_v1_get_dialog_surface(globals::mir_shell, *this) : nullptr}
+{
+    xdg_toplevel_set_parent(*this, *parent);
+    xdg_toplevel_set_title(*this, "dialog");
+    redraw();
+}
+
+dialog::~dialog()
+{
+    if (mir_surface)
+    {
+        mir_dialog_surface_v1_destroy(mir_surface);
+    }
+}
+
+void dialog::handle_keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
+{
+    grey_window::handle_keyboard_key(keyboard, serial, time, key, state);
+
+    if (state == WL_KEYBOARD_KEY_STATE_RELEASED)
+        switch (key)
+        {
+        case KEY_ESC:
+            normal_window::my_dialog.reset();
+            break;
+        }
+}
+
+auto make_dialog(normal_window* main_window) -> std::unique_ptr<dialog>
+{
+    return std::make_unique<dialog>(200, 200, main_window);
+}
+
+utility::utility(int32_t width, int32_t height) :
+    grey_window{width, height, 224},
+    mir_surface{globals::mir_shell ? mir_shell_v1_get_utility_surface(globals::mir_shell, *this) : nullptr}
+{
+    redraw();
+}
+
+utility::~utility()
+{
+    if (mir_surface)
+    {
+        mir_utility_surface_v1_destroy(mir_surface);
+    }
+}
+
+void utility::handle_keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
+{
+    grey_window::handle_keyboard_key(keyboard, serial, time, key, state);
+    if (state == WL_KEYBOARD_KEY_STATE_RELEASED)
+        switch (key)
+        {
+        case KEY_ESC:
+            normal_window::my_utility.reset();
+            break;
+        }
+}
+
+auto make_utility() -> std::unique_ptr<utility>
+{
+    return std::make_unique<utility>(200,200);
+}
+
+wl_pointer_listener const input_listener::pointer_listener =
+    {
+        .enter  = [](void* ctx, auto... args) { static_cast<input_listener*>(ctx)->handle_mouse_enter(args...); },
+        .leave  = [](void* ctx, auto... args) { static_cast<input_listener*>(ctx)->handle_mouse_leave(args...); },
+        .motion = [](void* ctx, auto... args) { static_cast<input_listener*>(ctx)->handle_mouse_motion(args...); },
+        .button = [](void* ctx, auto... args) { static_cast<input_listener*>(ctx)->handle_mouse_button(args...); },
+        .axis   = [](void* ctx, auto... args) { static_cast<input_listener*>(ctx)->handle_mouse_axis(args...); },
+    };
+
+wl_keyboard_listener const input_listener::keyboard_listener =
+    {
+        [](void* self, auto... args) { static_cast<input_listener*>(self)->handle_keyboard_keymap(args...); },
+        [](void* self, auto... args) { static_cast<input_listener*>(self)->handle_keyboard_enter(args...); },
+        [](void* self, auto... args) { static_cast<input_listener*>(self)->handle_keyboard_leave(args...); },
+        [](void* self, auto... args) { static_cast<input_listener*>(self)->handle_keyboard_key(args...); },
+        [](void* self, auto... args) { static_cast<input_listener*>(self)->handle_keyboard_modifiers(args...); },
+        [](void* self, auto... args) { static_cast<input_listener*>(self)->handle_keyboard_repeat_info(args...); },
+    };
+#pragma GCC diagnostic pop
+
+void input_listener::handle_mouse_enter(
+    wl_pointer*,
+    uint32_t serial,
+    wl_surface* surface,
+    wl_fixed_t surface_x,
+    wl_fixed_t surface_y)
+{
+    mouse_focus = globals::my_windows.window_for(surface);
+
+    (void)serial;
+    trace("Received handle_mouse_enter event: (%f, %f)",
+          wl_fixed_to_double(surface_x),
+          wl_fixed_to_double(surface_y));
+}
+
+void input_listener::handle_mouse_leave(
+    wl_pointer*,
+    uint32_t serial,
+    wl_surface* surface)
+{
+    if (mouse_focus == globals::my_windows.window_for(surface))
+        mouse_focus = nullptr;
+
+    (void)serial;
+    trace("Received mouse_exit event\n");
+}
+
+void input_listener::handle_mouse_motion(
+    wl_pointer*,
+    uint32_t time,
+    wl_fixed_t surface_x,
+    wl_fixed_t surface_y)
+{
+    trace("Received motion event: (%f, %f) @ %i",
+          wl_fixed_to_double(surface_x),
+          wl_fixed_to_double(surface_y),
+          time);
+}
+
+void input_listener::handle_mouse_button(
+    wl_pointer* pointer,
+    uint32_t serial,
+    uint32_t time,
+    uint32_t button,
+    uint32_t state)
+{
+    (void)serial;
+
+    trace("Received button event: Button %i, state %i @ %i",
+          button,
+          state,
+          time);
+
+    if (globals::my_windows.is_registered(mouse_focus))
+    {
+        mouse_focus->handle_mouse_button(pointer, serial, time, button, state);
+    }
+}
+
+void input_listener::handle_mouse_axis(
+    wl_pointer*,
+    uint32_t time,
+    uint32_t axis,
+    wl_fixed_t value)
+{
+    trace("Received axis event: axis %i, value %f @ %i",
+          axis,
+          wl_fixed_to_double(value),
+          time);
+}
+
+
+void input_listener::handle_keyboard_keymap(wl_keyboard*, uint32_t format, int32_t /*fd*/, uint32_t size)
+{
+    trace("Received keyboard_keymap: format %i, size %i", format, size);
+}
+
+void input_listener::handle_keyboard_enter(wl_keyboard*, uint32_t, wl_surface* surface, wl_array*)
+{
+    keyboard_focus = globals::my_windows.window_for(surface);
+
+    trace("Received keyboard_enter:\n");
+}
+
+void input_listener::handle_keyboard_leave(wl_keyboard*, uint32_t, wl_surface* surface)
+{
+    if (keyboard_focus == globals::my_windows.window_for(surface))
+        keyboard_focus = nullptr;
+
+    trace("Received keyboard_leave:\n");
+}
+
+void input_listener::handle_keyboard_repeat_info(wl_keyboard*, int32_t rate, int32_t delay)
+{
+    trace("Received keyboard_modifiers: rate %i, delay %i", rate, delay);
+}
+
+input_listener::input_listener() :
+    pointer{wl_seat_get_pointer(globals::seat)},
+    keyboard{wl_seat_get_keyboard(globals::seat)}
+{
+    wl_keyboard_add_listener(keyboard, &keyboard_listener, this);
+    wl_pointer_add_listener(pointer, &pointer_listener, this);
+}
+
+void
+input_listener::handle_keyboard_key(wl_keyboard* keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
+{
+    trace("Received keyboard_key: key %i, state %i", key, state);
+    if (globals::my_windows.is_registered(keyboard_focus))
+    {
+        keyboard_focus->handle_keyboard_key(keyboard, serial, time, key, state);
+    }
+}
+
+void input_listener::handle_keyboard_modifiers(
+    wl_keyboard* keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked,
+    uint32_t group)
+{
+    trace("Received keyboard_modifiers: depressed %i, latched %i, locked %i, group %i", mods_depressed, mods_latched, mods_locked, group);
+    if (globals::my_windows.is_registered(keyboard_focus))
+    {
+        keyboard_focus->handle_keyboard_modifiers(keyboard, serial, mods_depressed, mods_latched, mods_locked, group);
+    }
+}
+
+input_listener::~input_listener()
+{
+    wl_pointer_destroy(pointer);
+    wl_keyboard_destroy(keyboard);
+}
+}
+
+int main(int argc, char* argv[])
+{
+    parse_options(argc, argv);
+
+    globals::init();
+
+    {
+        input_listener input;
+
+        auto const main_window = std::make_unique<normal_window>(main_width, main_height);
+        wl_display_roundtrip(display);
+        wl_display_roundtrip(display);
+
+        wayland_runner::run(display);
+    }
+
+    wl_display_roundtrip(display);
+
+    return 0;
+}

--- a/examples/client/wayland_runner.cpp
+++ b/examples/client/wayland_runner.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "wayland_runner.h"
+
+#include <poll.h>
+#include <signal.h>
+#include <stdio.h>
+#include <sys/eventfd.h>
+
+#include <boost/throw_exception.hpp>
+
+#include <list>
+#include <mutex>
+#include <system_error>
+
+namespace
+{
+
+// We use a namespace object constructor to install our signal handler once
+struct State
+{
+    State();
+
+    void run(wl_display* display);
+    void quit();
+
+    static int shutdown_fd;
+};
+
+State state;
+int State::shutdown_fd = 0;
+
+extern "C" void signal_shutdown(int signum)
+{
+    printf("Signal %d received. Good night.\n", signum);
+    state.quit();
+}
+
+class ActionQueue
+{
+public:
+    using FdEvents = uint32_t;
+
+    ActionQueue();
+    ~ActionQueue();
+    int watch_fd() const;
+
+    void enqueue(std::function<void()> const&& action);
+
+    bool dispatch(FdEvents events);
+
+private:
+    bool consume();
+    void wake();
+    int event_fd;
+    std::mutex list_lock;
+    std::list<std::function<void()>> actions;
+};
+
+ActionQueue action_queue;
+}
+
+void State::run(wl_display* display)
+{
+    enum FdIndices {
+        display_fd = 0,
+        actions,
+        shutdown,
+        indices
+    };
+
+    struct pollfd fds[indices] = {
+        {wl_display_get_fd(display), POLLIN, 0},
+        {action_queue.watch_fd(),    POLLIN, 0},
+        {shutdown_fd,                POLLIN, 0},
+    };
+
+    while (!(fds[shutdown].revents & (POLLIN | POLLERR)))
+    {
+        while (wl_display_prepare_read(display) != 0)
+        {
+            switch (wl_display_dispatch_pending(display))
+            {
+            case -1:
+                fprintf(stderr, "Failed to dispatch Wayland events\n");
+                abort();
+            case 0:
+                break;
+            default:
+                wl_display_flush(display);
+            }
+        }
+
+        if (poll(fds, indices, -1) == -1)
+        {
+            fprintf(stderr, "Failed to poll\n");
+            wl_display_cancel_read(display);
+            break;
+        }
+
+        if (fds[display_fd].revents & (POLLIN | POLLERR))
+        {
+            if (wl_display_read_events(display))
+            {
+                fprintf(stderr, "Failed to read Wayland events\n");
+                abort();
+            }
+        }
+        else
+        {
+            wl_display_cancel_read(display);
+        }
+
+        action_queue.dispatch(fds[actions].revents);
+    }
+}
+
+State::State()
+{
+    shutdown_fd = eventfd(0, EFD_CLOEXEC);
+
+    struct sigaction sig_handler_new;
+    sigfillset(&sig_handler_new.sa_mask);
+    sig_handler_new.sa_flags = 0;
+    sig_handler_new.sa_handler = signal_shutdown;
+
+    sigaction(SIGINT, &sig_handler_new, NULL);
+    sigaction(SIGTERM, &sig_handler_new, NULL);
+    sigaction(SIGHUP, &sig_handler_new, NULL);
+}
+
+void State::quit()
+{
+    if (eventfd_write(shutdown_fd, 1) == -1)
+    {
+        printf("Failed to execute a shutdown");
+        exit(-1);
+    }
+}
+
+void mir::client::wayland_runner::run(wl_display* display)
+{
+    state.run(display);
+}
+
+void mir::client::wayland_runner::quit()
+{
+    state.quit();
+}
+
+void mir::client::wayland_runner::spawn(std::function<void()>&& function)
+{
+    action_queue.enqueue(std::move(function));
+}
+
+ActionQueue::ActionQueue()
+    : event_fd{eventfd(0, EFD_CLOEXEC|EFD_NONBLOCK|EFD_SEMAPHORE)}
+{
+    if (event_fd < 0)
+        BOOST_THROW_EXCEPTION((std::system_error{errno,
+                                                 std::system_category(),
+                                                 "Failed to create event fd for action queue"}));
+}
+
+int ActionQueue::watch_fd() const
+{
+    return event_fd;
+}
+
+void ActionQueue::enqueue(std::function<void()> const&& action)
+{
+    std::unique_lock lock(list_lock);
+    actions.push_back(action);
+    wake();
+}
+
+bool ActionQueue::dispatch(FdEvents events)
+{
+    if (events & POLLERR)
+        return false;
+
+    if (!consume())
+    {
+        // Another thread has won the race to process this event
+        // That's OK, just bail.
+        return true;
+    }
+
+    std::function<void()> action_to_process;
+
+    {
+        std::unique_lock lock(list_lock);
+        action_to_process = actions.front();
+        actions.pop_front();
+    }
+
+    action_to_process();
+
+    return true;
+}
+
+bool ActionQueue::consume()
+{
+    uint64_t num_actions;
+    if (read(event_fd, &num_actions, sizeof num_actions) != sizeof num_actions)
+    {
+        if (errno == EAGAIN)
+        {
+            return false;
+        }
+        BOOST_THROW_EXCEPTION((std::system_error{errno,
+                                                 std::system_category(),
+                                                 "Failed to consume action queue notification"}));
+    }
+    return true;
+}
+
+void ActionQueue::wake()
+{
+    uint64_t one_more{1};
+    if (write(event_fd, &one_more, sizeof one_more) != sizeof one_more)
+        BOOST_THROW_EXCEPTION((std::system_error{errno,
+                                                 std::system_category(),
+                                                 "Failed to wake action queue"}));
+}
+
+ActionQueue::~ActionQueue()
+{
+    close(event_fd);
+}

--- a/examples/client/wayland_runner.h
+++ b/examples/client/wayland_runner.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_CLIENT_WAYLAND_RUNNER_H_
+#define MIR_CLIENT_WAYLAND_RUNNER_H_
+
+#include <wayland-client.h>
+
+#include <functional>
+
+namespace mir
+{
+namespace client
+{
+namespace wayland_runner
+{
+void run(wl_display* display);
+void spawn(std::function<void()>&& function);
+void quit();
+};
+
+} // mir
+} // client
+
+#endif //MIR_CLIENT_WAYLAND_RUNNER_H_

--- a/src/server/frontend_wayland/CMakeLists.txt
+++ b/src/server/frontend_wayland/CMakeLists.txt
@@ -34,6 +34,7 @@ set(
   xdg_shell_stable.cpp          xdg_shell_stable.h
   xdg_output_v1.cpp             xdg_output_v1.h
   layer_shell_v1.cpp            layer_shell_v1.h
+  mir_shell.cpp                 mir_shell.h
   resource_lifetime_tracker.cpp resource_lifetime_tracker.h
   wl_region.cpp                 wl_region.h
   foreign_toplevel_manager_v1.cpp foreign_toplevel_manager_v1.h

--- a/src/server/frontend_wayland/mir_shell.cpp
+++ b/src/server/frontend_wayland/mir_shell.cpp
@@ -1,0 +1,323 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mir_shell.h"
+
+#include "mir/wayland/protocol_error.h"
+#include "wl_surface.h"
+
+namespace mf = mir::frontend;
+namespace mw = mir::wayland;
+
+using mir::shell::SurfaceSpecification;
+using namespace mir::geometry;
+
+namespace
+{
+mw::Resource::Version<1> version;
+
+struct Global : mw::MirShellV1::Global
+{
+    Global(struct wl_display* display) :
+        mw::MirShellV1::Global{display, Version<1>{}} {}
+
+    void bind(wl_resource* new_zmir_mir_shell_v1) override;
+};
+
+struct Instance : mw::MirShellV1
+{
+    Instance(struct wl_resource* resource) :
+        MirShellV1{resource, version} {}
+
+    void get_normal_surface(struct wl_resource* id, struct wl_resource* surface) override;
+
+    void get_utility_surface(struct wl_resource* id, struct wl_resource* surface) override;
+
+    void get_dialog_surface(struct wl_resource* id, struct wl_resource* surface) override;
+
+    void
+    get_satellite_surface(struct wl_resource* id, struct wl_resource* surface, struct wl_resource* positioner) override;
+
+    void get_freestyle_surface(
+        struct wl_resource* id, struct wl_resource* surface,
+        std::optional<struct wl_resource*> const& positioner) override;
+
+    void create_positioner(struct wl_resource* id) override;
+};
+
+template<typename MirSurface, MirWindowType type>
+struct Surface : MirSurface
+{
+    Surface(wl_resource* resource, mf::WlSurface* wl_surface) :
+        MirSurface{resource, version}
+    {
+        SurfaceSpecification spec;
+        spec.type = type;
+        wl_surface->update_surface_spec(spec);
+    }
+};
+
+template<typename MirSurface, MirWindowType type>
+struct SurfaceWithPosition : MirSurface
+{
+    SurfaceWithPosition(wl_resource* resource, mf::WlSurface* wl_surface, wl_resource* positioner) :
+        MirSurface{resource, version},
+        wl_surface{wl_surface}
+    {
+        position(positioner);
+    }
+
+    void reposition(struct wl_resource* positioner, uint32_t /*token*/) override
+    {
+        position(positioner);
+    }
+
+    void position(wl_resource* positioner) const
+    {
+        auto pspec = dynamic_cast<SurfaceSpecification*>(mw::MirPositionerV1::from(positioner));
+        auto spec = pspec ? *pspec : SurfaceSpecification{};
+
+        spec.type = type;
+        wl_surface->update_surface_spec(spec);
+    }
+
+    mf::WlSurface* const wl_surface;
+};
+
+class MirPositioner : public mw::MirPositionerV1, public SurfaceSpecification
+{
+public:
+    MirPositioner(wl_resource* new_resource);
+
+private:
+    void set_size(int32_t width, int32_t height) override;
+    void set_anchor_rect(int32_t x, int32_t y, int32_t width, int32_t height) override;
+    void set_anchor(uint32_t anchor) override;
+    void set_gravity(uint32_t gravity) override;
+    void set_constraint_adjustment(uint32_t constraint_adjustment) override;
+    void set_offset(int32_t x, int32_t y) override;
+};
+}
+
+auto mf::create_mir_shell_v1(struct wl_display* display) -> std::shared_ptr<mw::MirShellV1::Global>
+{
+    return std::make_shared<Global>(display);
+}
+
+void Global::bind(wl_resource* new_zmir_mir_shell_v1)
+{
+    new Instance{new_zmir_mir_shell_v1};
+}
+
+void Instance::get_normal_surface(struct wl_resource* id, struct wl_resource* surface)
+{
+    new Surface<mw::MirNormalSurfaceV1, mir_window_type_normal>{id, mf::WlSurface::from(surface)};
+}
+
+void Instance::get_utility_surface(struct wl_resource* id, struct wl_resource* surface)
+{
+    new Surface<mw::MirUtilitySurfaceV1, mir_window_type_utility>{id, mf::WlSurface::from(surface)};
+}
+
+void Instance::get_dialog_surface(struct wl_resource* id, struct wl_resource* surface)
+{
+    new Surface<mw::MirDialogSurfaceV1, mir_window_type_dialog>{id, mf::WlSurface::from(surface)};
+}
+
+void Instance::get_satellite_surface(wl_resource* id, wl_resource* surface, wl_resource* positioner)
+{
+    new SurfaceWithPosition<mw::MirSatelliteSurfaceV1, mir_window_type_satellite>
+        {id, mf::WlSurface::from(surface), positioner};
+}
+
+void Instance::get_freestyle_surface(
+    wl_resource* id, wl_resource* surface, std::optional<struct wl_resource*> const& positioner)
+{
+    new SurfaceWithPosition<mw::MirFreestyleSurfaceV1, mir_window_type_freestyle>
+        {id, mf::WlSurface::from(surface), positioner.value_or(nullptr)};
+}
+
+void Instance::create_positioner(struct wl_resource* id)
+{
+    new MirPositioner(id);
+}
+
+MirPositioner::MirPositioner(wl_resource* new_resource)
+    : mw::MirPositionerV1(new_resource, Version<1>())
+{
+    // specifying gravity is not required by the xdg shell protocol, but is by Mir window managers
+    surface_placement_gravity = mir_placement_gravity_center;
+    aux_rect_placement_gravity = mir_placement_gravity_center;
+    placement_hints = static_cast<MirPlacementHints>(0);
+}
+
+void MirPositioner::set_size(int32_t width, int32_t height)
+{
+    if (width <= 0 || height <= 0)
+    {
+        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+            resource,
+            mw::MirPositionerV1::Error::invalid_input,
+            "Invalid popup positioner size: %dx%d", width, height));
+    }
+    this->width = Width{width};
+    this->height = Height{height};
+}
+
+void MirPositioner::set_anchor_rect(int32_t x, int32_t y, int32_t width, int32_t height)
+{
+    if (width < 0 || height < 0)
+    {
+        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+            resource,
+            mw::MirPositionerV1::Error::invalid_input,
+            "Invalid popup anchor rect size: %dx%d", width, height));
+    }
+    aux_rect = Rectangle{{x, y}, {width, height}};
+}
+
+void MirPositioner::set_anchor(uint32_t anchor)
+{
+    MirPlacementGravity placement = mir_placement_gravity_center;
+
+    switch (anchor)
+    {
+    case Anchor::top:
+        placement = mir_placement_gravity_north;
+        break;
+
+    case Anchor::bottom:
+        placement = mir_placement_gravity_south;
+        break;
+
+    case Anchor::left:
+        placement = mir_placement_gravity_west;
+        break;
+
+    case Anchor::right:
+        placement = mir_placement_gravity_east;
+        break;
+
+    case Anchor::top_left:
+        placement = mir_placement_gravity_northwest;
+        break;
+
+    case Anchor::bottom_left:
+        placement = mir_placement_gravity_southwest;
+        break;
+
+    case Anchor::top_right:
+        placement = mir_placement_gravity_northeast;
+        break;
+
+    case Anchor::bottom_right:
+        placement = mir_placement_gravity_southeast;
+        break;
+
+    default:
+        placement = mir_placement_gravity_center;
+    }
+
+    aux_rect_placement_gravity = placement;
+}
+
+void MirPositioner::set_gravity(uint32_t gravity)
+{
+    MirPlacementGravity placement = mir_placement_gravity_center;
+
+    switch (gravity)
+    {
+    case Gravity::top:
+        placement = mir_placement_gravity_south;
+        break;
+
+    case Gravity::bottom:
+        placement = mir_placement_gravity_north;
+        break;
+
+    case Gravity::left:
+        placement = mir_placement_gravity_east;
+        break;
+
+    case Gravity::right:
+        placement = mir_placement_gravity_west;
+        break;
+
+    case Gravity::top_left:
+        placement = mir_placement_gravity_southeast;
+        break;
+
+    case Gravity::bottom_left:
+        placement = mir_placement_gravity_northeast;
+        break;
+
+    case Gravity::top_right:
+        placement = mir_placement_gravity_southwest;
+        break;
+
+    case Gravity::bottom_right:
+        placement = mir_placement_gravity_northwest;
+        break;
+
+    case Gravity::none:
+        placement = mir_placement_gravity_center;
+        break;
+
+    default:
+        BOOST_THROW_EXCEPTION(mw::ProtocolError(
+            resource,
+            mw::MirPositionerV1::Error::invalid_input,
+            "Invalid gravity value %d", gravity));
+    }
+
+    surface_placement_gravity = placement;
+}
+
+void MirPositioner::set_constraint_adjustment(uint32_t constraint_adjustment)
+{
+    uint32_t new_placement_hints{0};
+    if (constraint_adjustment & ConstraintAdjustment::slide_x)
+    {
+        new_placement_hints |= mir_placement_hints_slide_x;
+    }
+    if (constraint_adjustment & ConstraintAdjustment::slide_y)
+    {
+        new_placement_hints |= mir_placement_hints_slide_y;
+    }
+    if (constraint_adjustment & ConstraintAdjustment::flip_x)
+    {
+        new_placement_hints |= mir_placement_hints_flip_x;
+    }
+    if (constraint_adjustment & ConstraintAdjustment::flip_x)
+    {
+        new_placement_hints |= mir_placement_hints_flip_y;
+    }
+    if (constraint_adjustment & ConstraintAdjustment::resize_x)
+    {
+        new_placement_hints |= mir_placement_hints_resize_x;
+    }
+    if (constraint_adjustment & ConstraintAdjustment::resize_y)
+    {
+        new_placement_hints |= mir_placement_hints_resize_y;
+    }
+    placement_hints = static_cast<MirPlacementHints>(new_placement_hints);
+}
+
+void MirPositioner::set_offset(int32_t x, int32_t y)
+{
+    aux_rect_placement_offset_x = x;
+    aux_rect_placement_offset_y = y;
+}

--- a/src/server/frontend_wayland/mir_shell.cpp
+++ b/src/server/frontend_wayland/mir_shell.cpp
@@ -129,7 +129,19 @@ void Instance::get_normal_surface(struct wl_resource* id, struct wl_resource* su
 
 void Instance::get_utility_surface(struct wl_resource* id, struct wl_resource* surface)
 {
-    new Surface<mw::MirUtilitySurfaceV1, mir_window_type_utility>{id, mf::WlSurface::from(surface)};
+    struct Surface : mw::MirUtilitySurfaceV1
+    {
+        Surface(wl_resource* resource, mf::WlSurface* wl_surface) :
+            mw::MirUtilitySurfaceV1{resource, version}
+        {
+            SurfaceSpecification spec;
+            spec.type = mir_window_type_utility;
+            spec.depth_layer = mir_depth_layer_always_on_top;
+            wl_surface->update_surface_spec(spec);
+        }
+    };
+
+    new Surface{id, mf::WlSurface::from(surface)};
 }
 
 void Instance::get_dialog_surface(struct wl_resource* id, struct wl_resource* surface)

--- a/src/server/frontend_wayland/mir_shell.h
+++ b/src/server/frontend_wayland/mir_shell.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_FRONTEND_MIR_SHELL_H
+#define MIR_FRONTEND_MIR_SHELL_H
+
+#include "mir-shell-unstable-v1_wrapper.h"
+
+#include <memory>
+
+struct wl_display;
+
+namespace mir
+{
+namespace frontend
+{
+auto create_mir_shell_v1(struct wl_display* display) -> std::shared_ptr<wayland::MirShellV1::Global>;
+}
+}
+
+#endif //MIR_FRONTEND_MIR_SHELL_H

--- a/src/server/frontend_wayland/wayland_default_configuration.cpp
+++ b/src/server/frontend_wayland/wayland_default_configuration.cpp
@@ -15,35 +15,36 @@
  */
 
 #include "mir/default_server_configuration.h"
+
 #include "mir/frontend/wayland.h"
-
-#include "wayland_connector.h"
-#include "wl_shell.h"
-#include "xdg_shell_v6.h"
-#include "xdg_shell_stable.h"
-#include "layer_shell_v1.h"
-#include "xwayland_wm_shell.h"
-#include "wl_seat.h"
-#include "xdg_output_v1.h"
-#include "foreign_toplevel_manager_v1.h"
-#include "pointer_constraints_unstable_v1.h"
-#include "relative_pointer_unstable_v1.h"
-#include "virtual_keyboard_v1.h"
-#include "virtual_pointer_v1.h"
-#include "text_input_v3.h"
-#include "text_input_v2.h"
-#include "text_input_v1.h"
-#include "input_method_v1.h"
-#include "input_method_v2.h"
-#include "idle_inhibit_v1.h"
-#include "wlr_screencopy_v1.h"
-#include "primary_selection_v1.h"
-#include "session_lock_v1.h"
-
 #include "mir/graphics/platform.h"
+#include "mir/log.h"
 #include "mir/options/default_configuration.h"
 #include "mir/scene/session.h"
-#include "mir/log.h"
+
+#include "foreign_toplevel_manager_v1.h"
+#include "idle_inhibit_v1.h"
+#include "input_method_v1.h"
+#include "input_method_v2.h"
+#include "layer_shell_v1.h"
+#include "mir_shell.h"
+#include "pointer_constraints_unstable_v1.h"
+#include "primary_selection_v1.h"
+#include "relative_pointer_unstable_v1.h"
+#include "session_lock_v1.h"
+#include "text_input_v1.h"
+#include "text_input_v2.h"
+#include "text_input_v3.h"
+#include "virtual_keyboard_v1.h"
+#include "virtual_pointer_v1.h"
+#include "wayland_connector.h"
+#include "wl_seat.h"
+#include "wl_shell.h"
+#include "wlr_screencopy_v1.h"
+#include "xdg_output_v1.h"
+#include "xdg_shell_stable.h"
+#include "xdg_shell_v6.h"
+#include "xwayland_wm_shell.h"
 
 namespace mf = mir::frontend;
 namespace ms = mir::scene;
@@ -207,6 +208,10 @@ std::vector<ExtensionBuilder> const internal_extension_builders = {
                 *ctx.seat,
                 ctx.output_manager);
         }),
+    make_extension_builder<mw::MirShellV1>([](auto const& ctx)
+        {
+            return mf::create_mir_shell_v1(ctx.display);
+        }),
 };
 
 ExtensionBuilder const xwayland_builder {
@@ -305,7 +310,8 @@ auto mf::get_standard_extensions() -> std::vector<std::string>
         mw::XdgOutputManagerV1::interface_name,
         mw::TextInputManagerV1::interface_name,
         mw::TextInputManagerV2::interface_name,
-        mw::TextInputManagerV3::interface_name};
+        mw::TextInputManagerV3::interface_name,
+        mw::MirShellV1::interface_name};
 }
 
 auto mf::get_supported_extensions() -> std::vector<std::string>

--- a/src/server/frontend_wayland/window_wl_surface_role.cpp
+++ b/src/server/frontend_wayland/window_wl_surface_role.cpp
@@ -329,6 +329,8 @@ void mf::WindowWlSurfaceRole::commit(WlSurfaceState const& state)
         return;
     }
 
+    spec().update_from(state.surface_spec);
+
     surface.value().commit(state);
     handle_commit();
 

--- a/src/server/frontend_wayland/wl_surface.cpp
+++ b/src/server/frontend_wayland/wl_surface.cpp
@@ -469,6 +469,11 @@ auto mf::WlSurface::confine_pointer_state() const -> MirPointerConfinementState
     return mir_pointer_unconfined;
 }
 
+void mir::frontend::WlSurface::update_surface_spec(shell::SurfaceSpecification const& spec)
+{
+    pending.surface_spec.update_from(spec);
+}
+
 mf::NullWlSurfaceRole::NullWlSurfaceRole(WlSurface* surface) :
     surface{surface}
 {

--- a/src/server/frontend_wayland/wl_surface.h
+++ b/src/server/frontend_wayland/wl_surface.h
@@ -26,6 +26,7 @@
 #include "mir/geometry/size.h"
 #include "mir/geometry/point.h"
 #include "mir/geometry/rectangle.h"
+#include "mir/shell/surface_specification.h"
 
 #include <vector>
 #include <map>
@@ -76,6 +77,7 @@ struct WlSurfaceState
     // null Weak: the current buffer, if any, should be cleared
     std::optional<wayland::Weak<ResourceLifetimeTracker>> buffer;
 
+    shell::SurfaceSpecification surface_spec;
     std::optional<int> scale;
     std::optional<geometry::Displacement> offset;
     std::optional<std::optional<std::vector<geometry::Rectangle>>> input_shape;
@@ -125,6 +127,7 @@ public:
     /// one exists
     void on_scene_surface_created(SceneSurfaceCreatedCallback&& callback);
 
+    void update_surface_spec(shell::SurfaceSpecification const& spec);
     void set_role(WlSurfaceRole* role_);
     void clear_role();
     void set_pending_offset(std::optional<geometry::Displacement> const& offset);

--- a/src/wayland/CMakeLists.txt
+++ b/src/wayland/CMakeLists.txt
@@ -35,6 +35,7 @@ mir_generate_protocol_wrapper(mirwayland "zwp_" primary-selection-unstable-v1.xm
 mir_generate_protocol_wrapper(mirwayland "z" wlr-screencopy-unstable-v1.xml)
 mir_generate_protocol_wrapper(mirwayland "zwlr_" wlr-virtual-pointer-unstable-v1.xml)
 mir_generate_protocol_wrapper(mirwayland "ext_" ext-session-lock-v1.xml)
+mir_generate_protocol_wrapper(mirwayland "zmir_" mir-shell-unstable-v1.xml)
 
 target_link_libraries(mirwayland
   PUBLIC

--- a/src/wayland/symbols.map
+++ b/src/wayland/symbols.map
@@ -645,3 +645,52 @@ global:
     vtable?for?mir::wayland::InputPanelSurfaceV1;
   };
 } MIRWAYLAND_2.14;
+
+MIRWAYLAND_2.17 {
+global:
+  extern "C++" {
+    mir::wayland::MirShellV1::*;
+    non-virtual?thunk?to?mir::wayland::MirShellV1::*;
+    virtual?thunk?to?mir::wayland::MirShellV1::*;
+    typeinfo?for?mir::wayland::MirShellV1;
+    vtable?for?mir::wayland::MirShellV1;
+    typeinfo?for?mir::wayland::MirShellV1::Global;
+    vtable?for?mir::wayland::MirShellV1::Global;
+
+    mir::wayland::MirNormalSurfaceV1::*;
+    non-virtual?thunk?to?mir::wayland::MirNormalSurfaceV1::*;
+    virtual?thunk?to?mir::wayland::MirNormalSurfaceV1::*;
+    typeinfo?for?mir::wayland::MirNormalSurfaceV1;
+    vtable?for?mir::wayland::MirNormalSurfaceV1;
+
+    mir::wayland::MirUtilitySurfaceV1::*;
+    non-virtual?thunk?to?mir::wayland::MirUtilitySurfaceV1::*;
+    virtual?thunk?to?mir::wayland::MirUtilitySurfaceV1::*;
+    typeinfo?for?mir::wayland::MirUtilitySurfaceV1;
+    vtable?for?mir::wayland::MirUtilitySurfaceV1;
+
+    mir::wayland::MirDialogSurfaceV1::*;
+    non-virtual?thunk?to?mir::wayland::MirDialogSurfaceV1::*;
+    virtual?thunk?to?mir::wayland::MirDialogSurfaceV1::*;
+    typeinfo?for?mir::wayland::MirDialogSurfaceV1;
+    vtable?for?mir::wayland::MirDialogSurfaceV1;
+
+    mir::wayland::MirSatelliteSurfaceV1::*;
+    non-virtual?thunk?to?mir::wayland::MirSatelliteSurfaceV1::*;
+    virtual?thunk?to?mir::wayland::MirSatelliteSurfaceV1::*;
+    typeinfo?for?mir::wayland::MirSatelliteSurfaceV1;
+    vtable?for?mir::wayland::MirSatelliteSurfaceV1;
+
+    mir::wayland::MirFreestyleSurfaceV1::*;
+    non-virtual?thunk?to?mir::wayland::MirFreestyleSurfaceV1::*;
+    virtual?thunk?to?mir::wayland::MirFreestyleSurfaceV1::*;
+    typeinfo?for?mir::wayland::MirFreestyleSurfaceV1;
+    vtable?for?mir::wayland::MirFreestyleSurfaceV1;
+
+    mir::wayland::MirPositionerV1::*;
+    non-virtual?thunk?to?mir::wayland::MirPositionerV1::*;
+    virtual?thunk?to?mir::wayland::MirPositionerV1::*;
+    typeinfo?for?mir::wayland::MirPositionerV1;
+    vtable?for?mir::wayland::MirPositionerV1;
+  };
+} MIRWAYLAND_2.15;

--- a/wayland-protocols/mir-shell-unstable-v1.xml
+++ b/wayland-protocols/mir-shell-unstable-v1.xml
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="mir_shell_unstable_v1">
+  <copyright>
+    Copyright © 2023 Canonical Limited
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="mir_shell_v1" version="1">
+    <description summary="create surface archetypes that are recognised by the desktop">
+      Clients can use this interface to assign an archetype to wl_surfaces.
+    </description>
+
+    <request name="get_normal_surface">
+      <description summary="create a normal surface from a surface">
+        Create a normal surface archetype for an existing surface. This assigns the archetype
+        of normal_surface, or raises a protocol error if another archetype is already
+        assigned and the transisition is disallowed.
+
+        A normal surface exists in the "bottom" layer (c.f. wlr_layer_shell_unstable_v1)
+      </description>
+      <arg name="id" type="new_id" interface="mir_normal_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <request name="get_utility_surface">
+      <description summary="create a utility surface from a surface">
+        Create a utility surface for an existing surface. This assigns the archetype
+        of utility_surface, or raises a protocol error if another archetype is already
+        assigned and the transisition is disallowed.
+
+        A normal surface exists in the "top" layer (c.f. wlr_layer_shell_unstable_v1)
+        and will not be docked.
+      </description>
+      <arg name="id" type="new_id" interface="mir_utility_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <request name="get_dialog_surface">
+      <description summary="create a dialog surface from a surface">
+        Create a dialog surface for an existing surface. This assigns the archetype
+        of dialog_surface, or raises a protocol error if another archetype is already
+        assigned and the transisition is disallowed.
+
+        TODO Text describing dialog behaviour
+      </description>
+      <arg name="id" type="new_id" interface="mir_dialog_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <request name="get_satellite_surface">
+      <description summary="create a dialog surface from a surface">
+        Create a satellite surface for an existing surface. This assigns the archetype
+        of satellite_surface, or raises a protocol error if another archetype is already
+        assigned and the transisition is disallowed.
+
+        TODO Text describing satellite behaviour
+      </description>
+      <arg name="id" type="new_id" interface="mir_satellite_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="positioner" type="object" interface="mir_positioner_v1"/>
+    </request>
+
+    <request name="get_freestyle_surface">
+      <description summary="create a freestyle surface from a surface">
+        Create a freestyle surface for an existing surface. This assigns the archetype
+        of freestyle_surface, or raises a protocol error if another archetype is already
+        assigned and the transisition is disallowed.
+
+        TODO Text describing freestyle behaviour
+      </description>
+      <arg name="id" type="new_id" interface="mir_freestyle_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="positioner" type="object" interface="mir_positioner_v1" allow-null="true"/>
+      <!-- TODO optional attributes describing freestyle behaviour -->
+    </request>
+
+    <request name="create_positioner">
+      <description summary="create a positioner object">
+        Create a positioner object. A positioner object is used to position
+        surfaces relative to some parent surface. See the interface description
+        and xdg_surface.get_popup for details.
+      </description>
+      <arg name="id" type="new_id" interface="mir_positioner_v1"/>
+    </request>
+
+    <enum name="error">
+      <entry name="archetype" value="0" summary="wl_surface has another archetype that prevents this assignment"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the mir_shell object">
+        This request indicates that the client will not use the mir_shell
+        object any more. Objects that have been created through this instance
+        are not affected.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="mir_normal_surface_v1" version="1">
+    <description summary="Mir metadata interface">
+      An interface that may be implemented by a wl_surface, for surfaces that
+      are designed to be rendered in a desktop-like environment.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the normal surface">
+        This request destroys the mir surface.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="mir_utility_surface_v1" version="1">
+    <description summary="Mir metadata interface">
+      An interface that may be implemented by a wl_surface, for surfaces that
+      are designed to be rendered in a desktop-like environment.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the utility_surface">
+        This request destroys the mir surface.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="mir_dialog_surface_v1" version="1">
+    <description summary="Mir metadata interface">
+      An interface that may be implemented by a wl_surface, for surfaces that
+      are designed to be rendered in a desktop-like environment.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the dialog_surface">
+        This request destroys the mir surface.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="mir_satellite_surface_v1" version="1">
+    <description summary="Mir metadata interface">
+      An interface that may be implemented by a wl_surface, for surfaces that
+      are designed to be rendered in a desktop-like environment.
+    </description>
+
+    <request name="reposition">
+      <description summary="recalculate the satellite's location">
+        Reposition an already-mapped satellite. The satellite will be placed given the
+        details in the passed mir_positioner object, and a
+        mir_satellite_surface_v1.repositioned followed by mir_satellite_surface_v1.configure and
+        wl_surface.configure will be emitted in response. Any parameters set
+        by the previous positioner will be discarded.
+
+        The passed token will be sent in the corresponding
+        xdg_satellite.repositioned event. The new satellite position will not take
+        effect until the corresponding configure event is acknowledged by the
+        client. See xdg_satellite.repositioned for details. The token itself is
+        opaque, and has no other special meaning.
+
+        If multiple reposition requests are sent, the compositor may skip all
+        but the last one.
+
+        If the satellite is repositioned in response to a configure event for its
+        parent, the client should send an mir_positioner.set_parent_configure
+        and possibly an mir_positioner.set_parent_size request to allow the
+        compositor to properly constrain the satellite.
+
+        If the satellite is repositioned together with a parent that is being
+        resized, but not in response to a configure event, the client should
+        send an mir_positioner.set_parent_size request.
+      </description>
+      <arg name="positioner" type="object" interface="mir_positioner_v1"/>
+      <arg name="token" type="uint" summary="reposition request token"/>
+    </request>
+
+    <event name="repositioned">
+      <description summary="signal the completion of a repositioned request">
+        The repositioned event is sent as part of a satellite configuration
+        sequence, together with mir_satellite_surface_v1.configure and lastly
+        wl_surface.configure to notify the completion of a reposition request.
+
+        The repositioned event is to notify about the completion of a
+        mir_satellite_surface_v1.reposition request. The token argument is the token passed
+        in the xdg_satellite.reposition request.
+
+        Immediately after this event is emitted, mir_satellite_surface_v1.configure and
+        wl_surface.configure will be sent with the updated size and position,
+        as well as a new configure serial.
+
+        The client should optionally update the content of the satellite, but must
+        acknowledge the new satellite configuration for the new position to take
+        effect. See mir_satellite_surface_v1.ack_configure for details.
+      </description>
+      <arg name="token" type="uint" summary="reposition request token"/>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the satellite_surface">
+        This request destroys the mir surface.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="mir_freestyle_surface_v1" version="1">
+    <description summary="Mir metadata interface">
+      An interface that may be implemented by a wl_surface, for surfaces that
+      are designed to be rendered in a desktop-like environment.
+    </description>
+
+    <request name="reposition">
+      <description summary="recalculate the freestyle's location">
+        Reposition an already-mapped freestyle. The freestyle will be placed given the
+        details in the passed mir_positioner object, and a
+        mir_freestyle_surface_v1.repositioned followed by mir_freestyle_surface_v1.configure and
+        wl_surface.configure will be emitted in response. Any parameters set
+        by the previous positioner will be discarded.
+
+        The passed token will be sent in the corresponding
+        xdg_freestyle.repositioned event. The new freestyle position will not take
+        effect until the corresponding configure event is acknowledged by the
+        client. See xdg_freestyle.repositioned for details. The token itself is
+        opaque, and has no other special meaning.
+
+        If multiple reposition requests are sent, the compositor may skip all
+        but the last one.
+
+        If the freestyle is repositioned in response to a configure event for its
+        parent, the client should send an mir_positioner.set_parent_configure
+        and possibly an mir_positioner.set_parent_size request to allow the
+        compositor to properly constrain the freestyle.
+
+        If the freestyle is repositioned together with a parent that is being
+        resized, but not in response to a configure event, the client should
+        send an mir_positioner.set_parent_size request.
+      </description>
+      <arg name="positioner" type="object" interface="mir_positioner_v1"/>
+      <arg name="token" type="uint" summary="reposition request token"/>
+    </request>
+
+    <event name="repositioned">
+      <description summary="signal the completion of a repositioned request">
+        The repositioned event is sent as part of a freestyle configuration
+        sequence, together with mir_freestyle_surface_v1.configure and lastly
+        wl_surface.configure to notify the completion of a reposition request.
+
+        The repositioned event is to notify about the completion of a
+        xdg_freestyle.reposition request. The token argument is the token passed
+        in the xdg_freestyle.reposition request.
+
+        Immediately after this event is emitted, mir_freestyle_surface_v1.configure and
+        wl_surface.configure will be sent with the updated size and position,
+        as well as a new configure serial.
+
+        The client should optionally update the content of the freestyle, but must
+        acknowledge the new freestyle configuration for the new position to take
+        effect. See wl_surface.ack_configure for details.
+      </description>
+      <arg name="token" type="uint" summary="reposition request token"/>
+    </event>
+
+    <!-- TODO requests/events describing freestyle behaviour -->
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the freestyle_surface">
+        This request destroys the mir surface.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="mir_positioner_v1" version="1">
+    <description summary="child surface positioner">
+      The mir_positioner provides a collection of rules for the placement of a
+      child surface relative to a parent surface. Rules can be defined to ensure
+      the child surface remains within the visible area's borders, and to
+      specify how the child surface changes its position, such as sliding along
+      an axis, or flipping around a rectangle. These positioner-created rules are
+      constrained by the requirement that a child surface must intersect with or
+      be at least partially adjacent to its parent surface.
+
+      See the various requests for details about possible rules.
+
+      At the time of the request, the compositor makes a copy of the rules
+      specified by the mir_positioner. Thus, after the request is complete the
+      mir_positioner object can be destroyed or reused; further changes to the
+      object will have no effect on previous usages.
+
+      For an mir_positioner object to be considered complete, it must have a
+      non-zero size set by set_size, and a non-zero anchor rectangle set by
+      set_anchor_rect. Passing an incomplete mir_positioner object when
+      positioning a surface raises an invalid_positioner error.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_input" value="0" summary="invalid input provided"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the mir_positioner object">
+        Notify the compositor that the mir_positioner will no longer be used.
+      </description>
+    </request>
+
+    <request name="set_size">
+      <description summary="set the size of the to-be positioned rectangle">
+        Set the size of the surface that is to be positioned with the positioner
+        object. The size is in surface-local coordinates and corresponds to the
+        window geometry. See xdg_surface.set_window_geometry.
+
+        If a zero or negative size is set the invalid_input error is raised.
+      </description>
+      <arg name="width" type="int" summary="width of positioned rectangle"/>
+      <arg name="height" type="int" summary="height of positioned rectangle"/>
+    </request>
+
+    <request name="set_anchor_rect">
+      <description summary="set the anchor rectangle within the parent surface">
+        Specify the anchor rectangle within the parent surface that the child
+        surface will be placed relative to. The rectangle is relative to the
+        window geometry as defined by xdg_surface.set_window_geometry of the
+        parent surface.
+
+        When the mir_positioner object is used to position a child surface, the
+        anchor rectangle may not extend outside the window geometry of the
+        positioned child's parent surface.
+
+        If a negative size is set the invalid_input error is raised.
+      </description>
+      <arg name="x" type="int" summary="x position of anchor rectangle"/>
+      <arg name="y" type="int" summary="y position of anchor rectangle"/>
+      <arg name="width" type="int" summary="width of anchor rectangle"/>
+      <arg name="height" type="int" summary="height of anchor rectangle"/>
+    </request>
+
+    <enum name="anchor">
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="3"/>
+      <entry name="right" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="top_right" value="7"/>
+      <entry name="bottom_right" value="8"/>
+    </enum>
+
+    <request name="set_anchor">
+      <description summary="set anchor rectangle anchor">
+        Defines the anchor point for the anchor rectangle. The specified anchor
+        is used derive an anchor point that the child surface will be
+        positioned relative to. If a corner anchor is set (e.g. 'top_left' or
+        'bottom_right'), the anchor point will be at the specified corner;
+        otherwise, the derived anchor point will be centered on the specified
+        edge, or in the center of the anchor rectangle if no edge is specified.
+      </description>
+      <arg name="anchor" type="uint" enum="anchor"
+           summary="anchor"/>
+    </request>
+
+    <enum name="gravity">
+      <entry name="none" value="0"/>
+      <entry name="top" value="1"/>
+      <entry name="bottom" value="2"/>
+      <entry name="left" value="3"/>
+      <entry name="right" value="4"/>
+      <entry name="top_left" value="5"/>
+      <entry name="bottom_left" value="6"/>
+      <entry name="top_right" value="7"/>
+      <entry name="bottom_right" value="8"/>
+    </enum>
+
+    <request name="set_gravity">
+      <description summary="set child surface gravity">
+        Defines in what direction a surface should be positioned, relative to
+        the anchor point of the parent surface. If a corner gravity is
+        specified (e.g. 'bottom_right' or 'top_left'), then the child surface
+        will be placed towards the specified gravity; otherwise, the child
+        surface will be centered over the anchor point on any axis that had no
+        gravity specified. If the gravity is not in the ‘gravity’ enum, an
+        invalid_input error is raised.
+      </description>
+      <arg name="gravity" type="uint" enum="gravity"
+           summary="gravity direction"/>
+    </request>
+
+    <enum name="constraint_adjustment" bitfield="true">
+      <description summary="constraint adjustments">
+        The constraint adjustment value define ways the compositor will adjust
+        the position of the surface, if the unadjusted position would result
+        in the surface being partly constrained.
+
+        Whether a surface is considered 'constrained' is left to the compositor
+        to determine. For example, the surface may be partly outside the
+        compositor's defined 'work area', thus necessitating the child surface's
+        position be adjusted until it is entirely inside the work area.
+
+        The adjustments can be combined, according to a defined precedence: 1)
+        Flip, 2) Slide, 3) Resize.
+      </description>
+      <entry name="none" value="0">
+        <description summary="don't move the child surface when constrained">
+          Don't alter the surface position even if it is constrained on some
+          axis, for example partially outside the edge of an output.
+        </description>
+      </entry>
+      <entry name="slide_x" value="1">
+        <description summary="move along the x axis until unconstrained">
+          Slide the surface along the x axis until it is no longer constrained.
+
+          First try to slide towards the direction of the gravity on the x axis
+          until either the edge in the opposite direction of the gravity is
+          unconstrained or the edge in the direction of the gravity is
+          constrained.
+
+          Then try to slide towards the opposite direction of the gravity on the
+          x axis until either the edge in the direction of the gravity is
+          unconstrained or the edge in the opposite direction of the gravity is
+          constrained.
+        </description>
+      </entry>
+      <entry name="slide_y" value="2">
+        <description summary="move along the y axis until unconstrained">
+          Slide the surface along the y axis until it is no longer constrained.
+
+          First try to slide towards the direction of the gravity on the y axis
+          until either the edge in the opposite direction of the gravity is
+          unconstrained or the edge in the direction of the gravity is
+          constrained.
+
+          Then try to slide towards the opposite direction of the gravity on the
+          y axis until either the edge in the direction of the gravity is
+          unconstrained or the edge in the opposite direction of the gravity is
+          constrained.
+        </description>
+      </entry>
+      <entry name="flip_x" value="4">
+        <description summary="invert the anchor and gravity on the x axis">
+          Invert the anchor and gravity on the x axis if the surface is
+          constrained on the x axis. For example, if the left edge of the
+          surface is constrained, the gravity is 'left' and the anchor is
+          'left', change the gravity to 'right' and the anchor to 'right'.
+
+          If the adjusted position also ends up being constrained, the resulting
+          position of the flip_x adjustment will be the one before the
+          adjustment.
+        </description>
+      </entry>
+      <entry name="flip_y" value="8">
+        <description summary="invert the anchor and gravity on the y axis">
+          Invert the anchor and gravity on the y axis if the surface is
+          constrained on the y axis. For example, if the bottom edge of the
+          surface is constrained, the gravity is 'bottom' and the anchor is
+          'bottom', change the gravity to 'top' and the anchor to 'top'.
+
+          The adjusted position is calculated given the original anchor
+          rectangle and offset, but with the new flipped anchor and gravity
+          values.
+
+          If the adjusted position also ends up being constrained, the resulting
+          position of the flip_y adjustment will be the one before the
+          adjustment.
+        </description>
+      </entry>
+      <entry name="resize_x" value="16">
+        <description summary="horizontally resize the surface">
+          Resize the surface horizontally so that it is completely
+          unconstrained.
+        </description>
+      </entry>
+      <entry name="resize_y" value="32">
+        <description summary="vertically resize the surface">
+          Resize the surface vertically so that it is completely unconstrained.
+        </description>
+      </entry>
+    </enum>
+
+    <request name="set_constraint_adjustment">
+      <description summary="set the adjustment to be done when constrained">
+        Specify how the window should be positioned if the originally intended
+        position caused the surface to be constrained, meaning at least
+        partially outside positioning boundaries set by the compositor. The
+        adjustment is set by constructing a bitmask describing the adjustment to
+        be made when the surface is constrained on that axis.
+
+        If no bit for one axis is set, the compositor will assume that the child
+        surface should not change its position on that axis when constrained.
+
+        If more than one bit for one axis is set, the order of how adjustments
+        are applied is specified in the corresponding adjustment descriptions.
+
+        The default adjustment is none.
+      </description>
+      <arg name="constraint_adjustment" type="uint"
+           summary="bit mask of constraint adjustments"/>
+    </request>
+
+    <request name="set_offset">
+      <description summary="set surface position offset">
+        Specify the surface position offset relative to the position of the
+        anchor on the anchor rectangle and the anchor on the surface. For
+        example if the anchor of the anchor rectangle is at (x, y), the surface
+        has the gravity bottom|right, and the offset is (ox, oy), the calculated
+        surface position will be (x + ox, y + oy). The offset position of the
+        surface is the one used for constraint testing. See
+        set_constraint_adjustment.
+
+        An example use case is placing a popup menu on top of a user interface
+        element, while aligning the user interface element of the parent surface
+        with some user interface element placed somewhere in the popup surface.
+      </description>
+      <arg name="x" type="int" summary="surface position x offset"/>
+      <arg name="y" type="int" summary="surface position y offset"/>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
Prototype implementation of mir-shell prototcol extension.

This includes a demo client: `mir_demo_client_mir_shell`.

The client can windows from the "normal", "satellite", "dialog" and "utility" architypes.

* normal: created when running the app, closed by `Ctrl-Q`
* satellite: created by `Ctrl-T` (for "toolbar"), press again to create on another edge, closed by `esc`
* dialog: created by `Ctrl-D`, closed by `esc`
* utility: created by `Ctrl-U`, closed by `esc`

Note that while "freestyle" is mentioned in the protocol, it is underspecified and the implemention is only a placeholder.