### PR TITLE
Simplify code

### DIFF
--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -53,11 +53,11 @@ namespace
 {
 // These functions were not accepted into libinput, but we would want to use them if they were.
 // By introducing a potential overload ambiguity we will be notified that happens.
-double libinput_event_touch_get_touch_major(libinput_event_touch*, uint32_t, uint32_t)
+double libinput_event_touch_get_major_transformed(libinput_event_touch*, uint32_t, uint32_t)
 {
     return 8;
 }
-double libinput_event_touch_get_touch_minor(libinput_event_touch*, uint32_t, uint32_t)
+double libinput_event_touch_get_touch_minor_transformed(libinput_event_touch*, uint32_t, uint32_t)
 {
     return 6;
 }
@@ -406,8 +406,8 @@ void mie::LibInputDevice::update_contact_data(ContactData & data, MirTouchAction
     data.action = action;
     data.x = libinput_event_touch_get_x_transformed(touch, width);
     data.y = libinput_event_touch_get_y_transformed(touch, height);
-    data.major = libinput_event_touch_get_touch_major(touch, width, height);
-    data.minor = libinput_event_touch_get_touch_minor(touch, width, height);
+    data.major = libinput_event_touch_get_major_transformed(touch, width, height);
+    data.minor = libinput_event_touch_get_touch_minor_transformed(touch, width, height);
     data.pressure = libinput_event_touch_get_pressure(touch);
 
     info.transform_to_scene(data.x, data.y);

--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -35,7 +35,6 @@
 
 #include <libinput.h>
 #include <linux/input.h>  // only used to get constants for input reports
-#include <dlfcn.h>
 
 #include <boost/exception/diagnostic_information.hpp>
 #include <cstring>
@@ -52,36 +51,19 @@ using namespace std::literals::chrono_literals;
 
 namespace
 {
-double touch_major(libinput_event_touch*, uint32_t, uint32_t)
+// These functions were not accepted into libinput, but we would want to use them if they were.
+// By introducing a potential overload ambiguity we will be notified that happens.
+double libinput_event_touch_get_touch_major(libinput_event_touch*, uint32_t, uint32_t)
 {
     return 8;
 }
-double touch_minor(libinput_event_touch*, uint32_t, uint32_t)
+double libinput_event_touch_get_touch_minor(libinput_event_touch*, uint32_t, uint32_t)
 {
     return 6;
 }
-double pressure(libinput_event_touch*)
+double libinput_event_touch_get_pressure(libinput_event_touch*)
 {
     return 0.8;
-}
-double orientation(libinput_event_touch*)
-{
-    return 0;
-}
-
-template<typename T> auto load_function(char const* sym)
-{
-    T result{};
-    dlerror();
-    (void*&)result = dlsym(RTLD_DEFAULT, sym);
-    char const *error = dlerror();
-
-    if (error)
-        throw std::runtime_error(error);
-    if (!result)
-        throw std::runtime_error("no valid function address");
-
-    return result;
 }
 
 template<typename Tag>
@@ -125,33 +107,8 @@ auto get_axis_source(libinput_event_pointer* pointer) -> MirPointerAxisSource
 }
 }
 
-struct mie::LibInputDevice::ContactExtension
-{
-    ContactExtension()
-    {
-        constexpr const char touch_major_sym[] = "libinput_event_touch_get_major_transformed";
-        constexpr const char touch_minor_sym[] = "libinput_event_touch_get_minor_transformed";
-        constexpr const char orientation_sym[] = "libinput_event_touch_get_orientation";
-        constexpr const char pressure_sym[] = "libinput_event_touch_get_pressure";
-
-        try
-        {
-            get_touch_major = load_function<decltype(&touch_major)>(touch_major_sym);
-            get_touch_minor = load_function<decltype(&touch_minor)>(touch_minor_sym);
-            get_orientation = load_function<decltype(&orientation)>(orientation_sym);
-            get_pressure = load_function<decltype(&pressure)>(pressure_sym);
-        }
-        catch(...) {}
-    }
-
-    decltype(&touch_major) get_touch_major{&touch_major};
-    decltype(&touch_minor) get_touch_minor{&touch_minor};
-    decltype(&pressure) get_pressure{&pressure};
-    decltype(&orientation) get_orientation{&orientation};
-};
-
 mie::LibInputDevice::LibInputDevice(std::shared_ptr<mi::InputReport> const& report, LibInputDevicePtr dev)
-    : contact_extension{std::make_unique<ContactExtension>()}, report{report}, pointer_pos{0, 0}, button_state{0}
+    : report{report}, pointer_pos{0, 0}, button_state{0}
 {
     add_device_of_group(std::move(dev));
 }
@@ -449,9 +406,9 @@ void mie::LibInputDevice::update_contact_data(ContactData & data, MirTouchAction
     data.action = action;
     data.x = libinput_event_touch_get_x_transformed(touch, width);
     data.y = libinput_event_touch_get_y_transformed(touch, height);
-    data.major = contact_extension->get_touch_major(touch, width, height);
-    data.minor = contact_extension->get_touch_minor(touch, width, height);
-    data.pressure = contact_extension->get_pressure(touch);
+    data.major = libinput_event_touch_get_touch_major(touch, width, height);
+    data.minor = libinput_event_touch_get_touch_minor(touch, width, height);
+    data.pressure = libinput_event_touch_get_pressure(touch);
 
     info.transform_to_scene(data.x, data.y);
 }

--- a/src/platforms/evdev/libinput_device.h
+++ b/src/platforms/evdev/libinput_device.h
@@ -76,9 +76,6 @@ private:
     bool is_output_active() const;
     OutputInfo get_output_info() const;
 
-    struct ContactExtension;
-    std::unique_ptr<ContactExtension> contact_extension;
-
     std::shared_ptr<InputReport> report;
     std::vector<LibInputDevicePtr> devices;
 

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -897,10 +897,10 @@ TEST_F(LibInputDeviceOnTouchScreen, process_event_spurious_frame_when_down)
 TEST_F(LibInputDeviceOnTouchScreen, process_event_handles_touch_down_events)
 {
     MirTouchId slot = 0;
-    float major = 6;
-    float minor = 5;
+    float major = 8;
+    float minor = 6;
     float orientation = 0;
-    float pressure = 0.6f;
+    float pressure = 0.8f;
     float x = 100;
     float y = 7;
 
@@ -922,9 +922,9 @@ TEST_F(LibInputDeviceOnTouchScreen, process_event_handles_touch_down_events)
 TEST_F(LibInputDeviceOnTouchScreen, process_event_handles_touch_move_events)
 {
     MirTouchId slot = 0;
-    float major = 6;
-    float minor = 5;
-    float pressure = 0.6f;
+    float major = 8;
+    float minor = 6;
+    float pressure = 0.8f;
     float orientation = 0;
     float x = 100;
     float y = 7;
@@ -947,9 +947,9 @@ TEST_F(LibInputDeviceOnTouchScreen, process_event_handles_touch_move_events)
 TEST_F(LibInputDeviceOnTouchScreen, process_event_handles_touch_up_events_without_querying_properties)
 {
     MirTouchId slot = 3;
-    float major = 6;
-    float minor = 5;
-    float pressure = 0.6f;
+    float major = 8;
+    float minor = 6;
+    float pressure = 0.8f;
     float x = 30;
     float y = 20;
     float orientation = 0;


### PR DESCRIPTION
Many years ago we tried to get some `libinput_event_touch_` functions upstreamed to libinput, but they were rejected. Ubuntu no longer carries the patch that implements them.

There are simpler ways to do what this code did (e.g. resolve the possible library functions at compile time or make the function pointers global) but, as the functions are never available, it doesn't need to do it anyway.

The new version will give a compile error if the functions are introduced into libinput and we can fix the code appropriately if that happens.