### PR TITLE
Change placement of new floating windows

### DIFF
--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -2029,13 +2029,23 @@ auto miral::BasicWindowManager::place_new_surface(WindowSpecification parameters
 
             for (auto const& position : positions)
             {
-                if (auto const window{window_at(position)};
-                    !window ||
-                    info_for(window).state() != mir_window_state_restored ||
-                    (info_for(window).type() != mir_window_type_normal &&
-                     info_for(window).type() != mir_window_type_decoration &&
-                     info_for(window).type() != mir_window_type_freestyle) ||
-                    window.top_left() != position)
+                auto const window{window_at(position)};
+
+                static auto const ignored_state_or_type = [](WindowInfo const& info)
+                    {
+                        switch (info.type())
+                        {
+                        case mir_window_type_normal:
+                        case mir_window_type_decoration:
+                        case mir_window_type_freestyle:
+                            return info.state() != mir_window_state_restored;
+
+                        default:
+                            return true;
+                        }
+                    };
+
+                if (!window || ignored_state_or_type(info_for(window)) || window.top_left() != position)
                 {
                     parameters.top_left().value() = position;
                     break;

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -29,6 +29,8 @@
 #include <boost/throw_exception.hpp>
 
 #include <algorithm>
+#include <random>
+#include <unordered_set>
 
 using namespace mir;
 using namespace mir::geometry;
@@ -2016,6 +2018,90 @@ auto miral::BasicWindowManager::place_new_surface(WindowSpecification parameters
 
         if (parameters.top_left().value().y < display_area.top_left.y)
             parameters.top_left() = Point{parameters.top_left().value().x, display_area.top_left.y};
+
+        if (parameters.state() == mir_window_state_restored)
+        {
+            Displacement const cascading_offset{48, 48};
+            Displacement const position_tolerance{12, 12};
+
+            auto unique_window_positions{[&]()
+            {
+                struct PointHash
+                {
+                    std::size_t operator() (Point const& point) const
+                    {
+                        std::size_t seed{};
+                        boost::hash_combine(seed, point.x.as_value());
+                        boost::hash_combine(seed, point.y.as_value());
+                        return seed;
+                    }
+                };
+                std::unordered_set<Point, PointHash> unique_positions;
+                for_each_application([&](ApplicationInfo& info)
+                {
+                    for (auto const& window : info.windows())
+                    {
+                        unique_positions.insert(window.top_left());
+                    }
+                });
+                return unique_positions;
+            }()};
+
+            auto const find_near_window_position{[&](Point const& point, Displacement const& tolerance)
+            {
+                return std::find_if(
+                    unique_window_positions.begin(),
+                    unique_window_positions.end(),
+                    [&](auto const& it)
+                    {
+                        return std::abs(it.x.as_value() - point.x.as_value()) <= tolerance.dx.as_value() &&
+                               std::abs(it.y.as_value() - point.y.as_value()) <= tolerance.dy.as_value();
+                    });
+            }};
+
+            auto new_position{parameters.top_left().value()};
+
+            auto near_window_position{find_near_window_position(new_position, position_tolerance)};
+            while (near_window_position != unique_window_positions.end())
+            {
+                unique_window_positions.erase(near_window_position);
+                new_position += cascading_offset;
+                near_window_position = find_near_window_position(new_position, position_tolerance);
+            }
+
+            if (!display_area.contains(new_position + as_displacement(parameters.size().value())))
+            {
+                Rectangle const placement_region{
+                    display_area.top_left,
+                    as_size(display_area.bottom_right() -
+                        as_displacement(parameters.size().value()) -
+                        as_displacement(display_area.top_left) + Displacement{1, 1})};
+                if (placement_region.size.width.as_value() > 0 && placement_region.size.height.as_value() > 0)
+                {
+                    std::random_device rd;
+                    std::default_random_engine gen(rd());
+                    std::uniform_int_distribution<int> dist_x(0, placement_region.size.width.as_value() - 1);
+                    std::uniform_int_distribution<int> dist_y(0, placement_region.size.height.as_value() - 1);
+                    new_position = placement_region.top_left + as_displacement(Point{dist_x(gen), dist_y(gen)});
+                }
+                else
+                {
+                    if(placement_region.size.width.as_value() <= 0)
+                    {
+                        new_position = Point{display_area.left(), new_position.y};
+                        parameters.size().value().width = display_area.size.width;
+                    }
+                    if(placement_region.size.height.as_value() <= 0)
+                    {
+                        new_position = Point{new_position.x, display_area.top()};
+                        parameters.size().value().height = display_area.size.height;
+                    }
+                }
+
+            }
+
+            parameters.top_left() = new_position;
+        }
     }
 
     return parameters;

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -2029,23 +2029,19 @@ auto miral::BasicWindowManager::place_new_surface(WindowSpecification parameters
 
             for (auto const& position : positions)
             {
-                auto const window{window_at(position)};
-                auto const window_type{info_for(window).type()};
-                auto const window_state{info_for(window).state()};
-
-                if (!window ||
-                    window_state != mir_window_state_restored ||
-                    (window_type != mir_window_type_normal &&
-                     window_type != mir_window_type_decoration &&
-                     window_type != mir_window_type_freestyle) ||
-                     window.top_left() != position)
+                if (auto const window{window_at(position)};
+                    !window ||
+                    info_for(window).state() != mir_window_state_restored ||
+                    (info_for(window).type() != mir_window_type_normal &&
+                     info_for(window).type() != mir_window_type_decoration &&
+                     info_for(window).type() != mir_window_type_freestyle) ||
+                    window.top_left() != position)
                 {
                     parameters.top_left().value() = position;
                     break;
                 }
             }
         }
-
     }
 
     return parameters;


### PR DESCRIPTION
Fixes #3175 using a combination of cascading and random positioning.

Rather than replacing the original algorithm, it has been extended. If the new optically centered window shares the same top-left position as an existing window within a margin of tolerance, the new window is cascaded both vertically and horizontally. Following cascading, if any part of the window extends beyond the display area, it is randomly placed within a "feasible placement region" defined as the morphological erosion of the display region by the window region. If this region is empty, the window is resized horizontally and/or vertically to fit the display area and is also moved to the top and/or left of the display area.