### PR TITLE
Fix armhf symbols

### DIFF
--- a/debian/libmiroil5.symbols.armhf
+++ b/debian/libmiroil5.symbols.armhf
@@ -1,0 +1,108 @@
+libmiroil.so.5 libmiroil5 #MINVER#
+ MIROIL_5.0@MIROIL_5.0 2.17.0
+ (c++)"miroil::Compositor::~Compositor()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::DisplayConfigurationControllerWrapper::DisplayConfigurationControllerWrapper(std::shared_ptr<mir::shell::DisplayConfigurationController> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::DisplayConfigurationControllerWrapper::set_base_configuration(std::shared_ptr<mir::graphics::DisplayConfiguration> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::DisplayConfigurationPolicy::DisplayConfigurationPolicy()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::DisplayConfigurationPolicy::~DisplayConfigurationPolicy()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::DisplayListenerWrapper::DisplayListenerWrapper(std::shared_ptr<mir::compositor::DisplayListener> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::DisplayListenerWrapper::add_display(mir::geometry::generic::Rectangle<int> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::DisplayListenerWrapper::remove_display(mir::geometry::generic::Rectangle<int> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::DisplayListenerWrapper::~DisplayListenerWrapper()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Edid::Descriptor::string_value[abi:cxx11]() const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Edid::parse_data(std::vector<unsigned char, std::allocator<unsigned char> > const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::EventBuilder::EventBuilder()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::EventBuilder::EventInfo::store(MirInputEvent const*, unsigned long)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::EventBuilder::add_touch(MirEvent&, int, MirTouchAction, MirTouchTooltype, float, float, float, float, float, float)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::EventBuilder::find_info(unsigned long)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::EventBuilder::make_key_event(long long, std::chrono::duration<long long, std::ratio<1ll, 1000000000ll> >, MirKeyboardAction, unsigned int, int, unsigned int)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::EventBuilder::make_pointer_event(long long, std::chrono::duration<long long, std::ratio<1ll, 1000000000ll> >, unsigned int, MirPointerAction, unsigned int, float, float, float, float, float, float)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::EventBuilder::make_touch_event(long long, std::chrono::duration<long long, std::ratio<1ll, 1000000000ll> >, unsigned int)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::EventBuilder::store(MirInputEvent const*, unsigned long)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::EventBuilder::~EventBuilder()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::GLBuffer::GLBuffer(std::shared_ptr<mir::graphics::Buffer> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::GLBuffer::bind()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::GLBuffer::empty()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::GLBuffer::from_mir_buffer(std::shared_ptr<mir::graphics::Buffer> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::GLBuffer::has_alpha_channel() const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::GLBuffer::reset()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::GLBuffer::reset(std::shared_ptr<mir::graphics::Buffer> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::GLBuffer::size() const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::GLBuffer::~GLBuffer()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::InputDevice()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::InputDevice(miroil::InputDevice const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::InputDevice(miroil::InputDevice&&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::InputDevice(std::shared_ptr<mir::input::Device> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::apply_keymap(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::get_device_id()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::get_device_name[abi:cxx11]()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::is_alpha_numeric()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::is_keyboard()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::operator=(miroil::InputDevice const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::operator=(miroil::InputDevice&&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::operator==(miroil::InputDevice const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDevice::~InputDevice()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::InputDeviceObserver::~InputDeviceObserver()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirPromptSession::MirPromptSession(MirPromptSession*)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirPromptSession::MirPromptSession(miroil::MirPromptSession const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirPromptSession::MirPromptSession(miroil::MirPromptSession&&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirPromptSession::new_fds_for_prompt_providers(unsigned int, void (*)(MirPromptSession*, unsigned int, int const*, void*), void*)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirPromptSession::operator=(miroil::MirPromptSession const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirPromptSession::operator=(miroil::MirPromptSession&&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirPromptSession::operator==(miroil::MirPromptSession const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirPromptSession::~MirPromptSession()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirServerHooks::MirServerHooks()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirServerHooks::create_input_device_observer(std::shared_ptr<miroil::InputDeviceObserver>&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirServerHooks::create_named_cursor(std::function<std::shared_ptr<mir::graphics::CursorImage> (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirServerHooks::create_prompt_session_listener(std::shared_ptr<miroil::PromptSessionListener>)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirServerHooks::operator()(mir::Server&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirServerHooks::the_display_configuration_controller() const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirServerHooks::the_mir_display() const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirServerHooks::the_prompt_session_listener() const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::MirServerHooks::the_prompt_session_manager() const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::OpenGLContext::OpenGLContext(mir::graphics::GLConfig*)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::OpenGLContext::operator()(mir::Server&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::OpenGLContext::the_open_gl_config() const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PersistDisplayConfig::PersistDisplayConfig(miroil::PersistDisplayConfig const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PersistDisplayConfig::PersistDisplayConfig(std::shared_ptr<miroil::DisplayConfigurationStorage> const&, std::function<std::shared_ptr<miroil::DisplayConfigurationPolicy> (std::shared_ptr<mir::graphics::DisplayConfigurationPolicy> const&)> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PersistDisplayConfig::operator()(mir::Server&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PersistDisplayConfig::operator=(miroil::PersistDisplayConfig const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PersistDisplayConfig::~PersistDisplayConfig()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PromptSessionListener::~PromptSessionListener()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PromptSessionManager::PromptSessionManager(miroil::PromptSessionManager const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PromptSessionManager::PromptSessionManager(miroil::PromptSessionManager&&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PromptSessionManager::PromptSessionManager(std::shared_ptr<mir::scene::PromptSessionManager> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PromptSessionManager::application_for(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PromptSessionManager::operator==(miroil::PromptSessionManager const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PromptSessionManager::resume_prompt_session(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PromptSessionManager::stop_prompt_session(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PromptSessionManager::suspend_prompt_session(std::shared_ptr<mir::scene::PromptSession> const&) const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::PromptSessionManager::~PromptSessionManager()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::SetCompositor::SetCompositor(std::function<std::shared_ptr<miroil::Compositor> ()>, std::function<void (std::shared_ptr<mir::graphics::Display> const&, std::shared_ptr<miroil::Compositor> const&, std::shared_ptr<mir::compositor::DisplayListener> const&)>)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::SetCompositor::operator()(mir::Server&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::Surface(std::shared_ptr<mir::scene::Surface>)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::add_observer(std::shared_ptr<miroil::SurfaceObserver> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::buffers_ready_for_compositor(void const*) const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::configure(MirWindowAttrib, int)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::generate_renderables(void const*) const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::get_wrapped() const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::is_confined_to_window()@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::parent() const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::query(MirWindowAttrib) const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::remove_observer(std::shared_ptr<miroil::SurfaceObserver> const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::set_confine_pointer_state(MirPointerConfinementState)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::set_keymap(long long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::set_orientation(MirOrientation)@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::top_left() const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::Surface::visible() const@MIROIL_5.0" 2.17.0
+ (c++)"miroil::dispatch_input_event(miral::Window const&, MirInputEvent const*)@MIROIL_5.0" 2.17.0
+ (c++)"typeinfo for miroil::Compositor@MIROIL_5.0" 2.17.0
+ (c++)"typeinfo for miroil::DisplayConfigurationPolicy@MIROIL_5.0" 2.17.0
+ (c++)"typeinfo for miroil::EventBuilder@MIROIL_5.0" 2.17.0
+ (c++)"typeinfo for miroil::InputDeviceObserver@MIROIL_5.0" 2.17.0
+ (c++)"typeinfo for miroil::PromptSessionListener@MIROIL_5.0" 2.17.0
+ (c++)"vtable for miroil::Compositor@MIROIL_5.0" 2.17.0
+ (c++)"vtable for miroil::DisplayConfigurationPolicy@MIROIL_5.0" 2.17.0
+ (c++)"vtable for miroil::EventBuilder@MIROIL_5.0" 2.17.0
+ (c++)"vtable for miroil::InputDeviceObserver@MIROIL_5.0" 2.17.0
+ (c++)"vtable for miroil::PromptSessionListener@MIROIL_5.0" 2.17.0


### PR DESCRIPTION
Launchpad builds are failing because of size_t (for example) is a different type on 32bit builds.

This provides a POC fix