### PR TITLE
Fix rawhide FTBFS

### DIFF
--- a/examples/client/wayland_client.c
+++ b/examples/client/wayland_client.c
@@ -570,7 +570,7 @@ int main(int argc, char** argv)
     struct wl_pointer* pointer = wl_seat_get_pointer(globals.seat);
     wl_pointer_add_listener(pointer, &pointer_listener, NULL);
 
-    draw_context* ctx = calloc(sizeof *ctx, 1);
+    draw_context* ctx = calloc(1, sizeof *ctx);
     ctx->display = display;
     ctx->surface = wl_compositor_create_surface(globals.compositor);
     ctx->width = 400;

--- a/src/platform/graphics/egl_buffer_copy.cpp
+++ b/src/platform/graphics/egl_buffer_copy.cpp
@@ -66,13 +66,13 @@ class GLBulkHandle
 public:
     GLBulkHandle()
     {
-        (*allocator)(1, &id);
+        allocator(1, &id);
     }
 
     ~GLBulkHandle()
     {
         if (id)
-            (*deleter)(1, &id);
+            deleter(1, &id);
     }
 
     GLBulkHandle(GLBulkHandle const&) = delete;
@@ -102,14 +102,14 @@ class GLTypedHandle
 {
 public:
     GLTypedHandle(GLenum type)
-        : id{(*allocator)(type)}
+        : id{allocator(type)}
     {
     }
 
     ~GLTypedHandle()
     {
         if (id)
-            (*deleter)(id);
+            deleter(id);
     }
 
     GLTypedHandle(GLTypedHandle const&) = delete;
@@ -139,14 +139,14 @@ class GLHandle
 {
 public:
     GLHandle()
-        : id{(*allocator)()}
+        : id{allocator()}
     {
     }
 
     ~GLHandle()
     {
         if (id)
-            (*deleter)(id);
+            deleter(id);
     }
 
     GLHandle(GLHandle const&) = delete;

--- a/src/platform/graphics/egl_buffer_copy.cpp
+++ b/src/platform/graphics/egl_buffer_copy.cpp
@@ -66,13 +66,13 @@ class GLBulkHandle
 public:
     GLBulkHandle()
     {
-        (**allocator)(1, &id);
+        (*allocator)(1, &id);
     }
 
     ~GLBulkHandle()
     {
         if (id)
-            (**deleter)(1, &id);
+            (*deleter)(1, &id);
     }
 
     GLBulkHandle(GLBulkHandle const&) = delete;
@@ -102,14 +102,14 @@ class GLTypedHandle
 {
 public:
     GLTypedHandle(GLenum type)
-        : id{(**allocator)(type)}
+        : id{(*allocator)(type)}
     {
     }
 
     ~GLTypedHandle()
     {
         if (id)
-            (**deleter)(id);
+            (*deleter)(id);
     }
 
     GLTypedHandle(GLTypedHandle const&) = delete;
@@ -139,14 +139,14 @@ class GLHandle
 {
 public:
     GLHandle()
-        : id{(**allocator)()}
+        : id{(*allocator)()}
     {
     }
 
     ~GLHandle()
     {
         if (id)
-            (**deleter)(id);
+            (*deleter)(id);
     }
 
     GLHandle(GLHandle const&) = delete;

--- a/src/server/frontend_xwayland/xcb_connection.cpp
+++ b/src/server/frontend_xwayland/xcb_connection.cpp
@@ -207,7 +207,7 @@ void mf::XCBConnection::verify_not_in_error_state() const
 
 auto mf::XCBConnection::query_name(xcb_atom_t atom) const -> std::string
 {
-    std::lock_guard{atom_name_cache_mutex};
+    std::lock_guard lock{atom_name_cache_mutex};
     auto const iter = atom_name_cache.find(atom);
 
     if (iter == atom_name_cache.end())


### PR DESCRIPTION
```
 /spread/mir/examples/client/wayland_client.c:533:39: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  533 |     draw_context* ctx = calloc(sizeof *ctx, 1);
      |                                       ^
/spread/mir/examples/client/wayland_client.c:533:39: note: earlier argument should specify number of elements, later size of each element
cc1: all warnings being treated as errors
```