### PR TITLE
Drive-by tidy up of libinput use

### DIFF
--- a/src/platforms/evdev/libinput_device.h
+++ b/src/platforms/evdev/libinput_device.h
@@ -61,7 +61,7 @@ public:
     void process_event(libinput_event* event);
     ::libinput_device* device() const;
     ::libinput_device_group* group();
-    void add_device_of_group(LibInputDevicePtr ptr);
+
 private:
     EventUPtr convert_event(libinput_event_keyboard* keyboard);
     EventUPtr convert_button_event(libinput_event_pointer* pointer);
@@ -76,8 +76,8 @@ private:
     bool is_output_active() const;
     OutputInfo get_output_info() const;
 
-    std::shared_ptr<InputReport> report;
-    std::vector<LibInputDevicePtr> devices;
+    std::shared_ptr<InputReport> const report;
+    LibInputDevicePtr const device_;
 
     InputSink* sink{nullptr};
     EventBuilder* builder{nullptr};

--- a/src/platforms/evdev/platform.cpp
+++ b/src/platforms/evdev/platform.cpp
@@ -420,8 +420,7 @@ void mie::Platform::device_added(libinput_device* dev)
     auto device_it = find_device(device_ptr.get());
     if (end(devices) != device_it)
     {
-        (*device_it)->add_device_of_group(std::move(device_ptr));
-        log_debug("Device %s is part of an already opened device group", libinput_device_get_sysname(dev));
+        log_debug("Device %s is an already opened device", libinput_device_get_sysname(dev));
         return;
     }
 

--- a/src/server/input/default_device.cpp
+++ b/src/server/input/default_device.cpp
@@ -64,16 +64,17 @@ mi::DefaultDevice::DefaultDevice(MirInputDevice const& config,
                                  std::function<void(Device*)> const& callback)
     : DefaultDevice(config.id(), actions, device, key_mapper, callback)
 {
-#define ATTEMPT(x) try{ x; }catch(...){}
-    ATTEMPT(if (config.has_touchpad_config())
-                set_touchpad_configuration(config.touchpad_config()));
-    ATTEMPT(if (config.has_keyboard_config())
-                set_keyboard_configuration(config.keyboard_config()));
-    ATTEMPT(if (config.has_pointer_config())
-                set_pointer_configuration(config.pointer_config()));
-    ATTEMPT(if (config.has_touchscreen_config())
-                set_touchscreen_configuration(config.touchscreen_config()));
-#undef ATTEMPT
+    if (config.has_touchpad_config())
+        set_touchpad_configuration(config.touchpad_config());
+
+    if (config.has_keyboard_config())
+        set_keyboard_configuration(config.keyboard_config());
+
+    if (config.has_pointer_config())
+        set_pointer_configuration(config.pointer_config());
+
+    if (config.has_touchscreen_config())
+        set_touchscreen_configuration(config.touchscreen_config());
 }
 
 mi::DeviceCapabilities mi::DefaultDevice::capabilities() const

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -371,38 +371,6 @@ TEST_F(LibInputDevice, start_creates_and_refs_libinput_device)
     dev.start(&mock_sink, &mock_builder);
 }
 
-TEST_F(LibInputDevice, open_device_of_group)
-{
-    auto fake_device = setup_laptop_keyboard();
-    auto second_fake_device = setup_trackpad();
-
-    InSequence seq;
-    // See previous test
-    EXPECT_CALL(env.mock_libinput, libinput_device_ref(fake_device)).Times(1);
-    EXPECT_CALL(env.mock_libinput, libinput_device_ref(second_fake_device)).Times(1);
-
-    mie::LibInputDevice dev(mir::report::null_input_report(),
-                            mie::make_libinput_device(lib, fake_device));
-    dev.add_device_of_group(mie::make_libinput_device(lib, second_fake_device));
-    dev.start(&mock_sink, &mock_builder);
-}
-
-TEST_F(LibInputDevice, input_info_combines_capabilities)
-{
-    auto fake_device = setup_laptop_keyboard();
-    auto second_fake_device = setup_trackpad();
-
-    mie::LibInputDevice dev(mir::report::null_input_report(),
-                            mie::make_libinput_device(lib, fake_device));
-    dev.add_device_of_group(mie::make_libinput_device(lib, second_fake_device));
-    auto info = dev.get_device_info();
-
-    EXPECT_THAT(info.capabilities, Eq(mi::DeviceCapability::touchpad |
-                                      mi::DeviceCapability::pointer |
-                                      mi::DeviceCapability::keyboard |
-                                      mi::DeviceCapability::alpha_numeric));
-}
-
 TEST_F(LibInputDevice, unique_id_contains_device_name)
 {
     auto fake_device = env.mock_libinput.get_next_fake_ptr<libinput_device*>();


### PR DESCRIPTION
Tidying input code that should be clearer. Mostly simplifying `mie::LibInputDevice` which is confuses about whether it represents l`ibinput_device*` or `libinput_device_group*`.

Before:

`mie::LibInputDevice` has a data member `devices` that is populated via `add_device_of_group()` that would appear to be intended to reflect the `libinput_device_group`.

However `add_device_of_group()` will only be called with the same `libinput_device` (and no code makes reference to `libinput_device_group`).

Further, most of the class is implemented based on `mie::LibInputDevice::device()` which returns the first element of `devices`.

After:

`mie::LibInputDevice` represents a single device.

Some tests of the "multiple devices in one `mie::LibInputDevice`" code dropped
