### PR TITLE
Do not kill X11 apps whose pop-ups don't support WM_DELETE_WINDOW

### DIFF
--- a/src/server/frontend_xwayland/xwayland_surface.cpp
+++ b/src/server/frontend_xwayland/xwayland_surface.cpp
@@ -1025,10 +1025,9 @@ void mf::XWaylandSurface::scene_surface_close_requested()
         if (verbose_xwayland_logging_enabled())
         {
             log_debug(
-                "Killing %s because it does not support WM_DELETE_WINDOW",
+                "Not closing %s (because it does not support WM_DELETE_WINDOW)",
                 connection->window_debug_string(window).c_str());
         }
-        xcb_kill_client(*connection, window);
     }
     connection->flush();
 }


### PR DESCRIPTION
Note that Mir will hide the window anyway. It simply can't request the client delete it too.

Fixes: #3177