### PR TITLE
feature: abstract away application selector behavior  in preparation for alt-tick behavior

### DIFF
--- a/src/miral/application_selector.cpp
+++ b/src/miral/application_selector.cpp
@@ -21,71 +21,104 @@
 
 using namespace miral;
 
-namespace miral
+namespace
 {
+struct WeakApplicationSelector
+{
+    using value_t = std::weak_ptr<mir::scene::Session>;
 
-template <typename T>
-class WindowCyclingBehavior
+    WeakApplicationSelector(WindowManagerTools tools)
+        : tools{tools}
+    {}
+
+    auto equals(value_t const &first, value_t const &second) -> bool
+    {
+        return !first.owner_before(second) && !second.owner_before(first);;
+    }
+
+    auto selectable(value_t const &session) -> bool
+    {
+        return tools.window_to_select_application(session.lock()) != std::nullopt;
+    }
+
+    void
+    on_selected(value_t const &previously_selected, value_t const &newly_selected, value_t const &originally_selected)
+    {
+        auto previous_session = previously_selected.lock();
+        auto new_session = newly_selected.lock();
+        auto original_session = originally_selected.lock();
+
+        auto previous_window = tools.active_window();
+        auto new_window = tools.window_to_select_application(new_session);
+        if (previous_session == new_session || new_window == std::nullopt)
+            return;
+
+        if (new_session == original_session)
+        {
+            // Edge case: if we have gone full circle around the list back to the original app
+            // then we will wind up in a situation where the original app - now in the second z-order
+            // position - will be swapped with the final app, putting the final app in the second position.
+            for (auto const &window: tools.info_for(new_session).windows())
+                tools.send_tree_to_back(window);
+        } else
+        {
+            tools.swap_tree_order(new_window.value(), previous_window);
+        }
+
+        tools.select_active_window(new_window.value());
+    }
+
+    void on_cancelled(value_t const &session)
+    {
+        auto window_to_select = tools.window_to_select_application(session.lock());
+        if (window_to_select != std::nullopt)
+        {
+            tools.select_active_window(window_to_select.value());
+        }
+    }
+
+    void reset(value_t &session)
+    {
+        session.reset();
+    }
+
+    WindowManagerTools tools;
+};
+
+template<class SelectorBase>
+class TabOrderSelector : public SelectorBase
 {
 public:
-    WindowCyclingBehavior(
-        std::function<bool(T const&, T const&)> comparison_func,
-        std::function<bool(T const&)> can_select,
-        std::function<void(T const&, T const&, T const&)> on_raised,
-        std::function<void(T const&)> on_cancelled,
-        std::function<void(T&)> reset
-    ) : comparison_func{comparison_func},
-        can_select{can_select},
-        on_raised{on_raised},
-        on_cancelled{on_cancelled},
-        reset{reset}
-    {
-    }
+    using T = typename SelectorBase::value_t;
 
-    WindowCyclingBehavior(
-        std::function<bool(T const&, T const&)> comparison_func,
-        std::function<bool(T const&)> can_select,
-        std::function<void(T const& previously_selected, T const& newly_selected, T const& originally_selected)> on_raised,
-        std::function<void(T const&)> on_cancelled,
-        std::function<void(T&)> reset,
-        std::vector<T> focus_list,
-        T originally_selected,
-        T selected,
-        bool is_active
-    ) : comparison_func{comparison_func},
-        can_select{can_select},
-        on_raised{on_raised},
-        on_cancelled{on_cancelled},
-        reset{reset},
-        focus_list{focus_list},
-        originally_selected{originally_selected},
-        selected{selected},
-        is_active{is_active}
-    {
-    }
+    template<typename ... Args>
+    TabOrderSelector(Args &&... args): SelectorBase(std::forward<Args>(args) ...)
+    {}
 
-    WindowCyclingBehavior(WindowCyclingBehavior const&) = delete;
-    auto operator=(WindowCyclingBehavior const&) -> WindowCyclingBehavior& = delete;
+    TabOrderSelector(TabOrderSelector const &) = delete;
 
-    void add(T const& t)
+    auto operator=(TabOrderSelector const &) -> TabOrderSelector & = delete;
+
+    void add(T const &t)
     {
         focus_list.push_back(t);
     }
 
-    void remove(T const& t)
+    void remove(T const &t)
     {
         auto it = find(t);
         if (it == focus_list.end())
         {
-            mir::log_warning("WindowCyclingBehavior::remove could not find item to remove");
+            mir::log_warning("TabOrderSelector::remove could not find item to remove");
             return;
         }
 
         // If we delete the selected application, we will try to select the next available one.
-        if (comparison_func(*it, selected))
+        if (SelectorBase::equals(*it, selected))
         {
             auto original_it = it;
-            do {
+            do
+            {
                 it++;
                 if (it == focus_list.end())
                     it = focus_list.begin();
@@ -94,7 +127,7 @@ public:
                 {
                     break;
                 }
-            } while (!can_select(*it));
+            } while (!SelectorBase::selectable(*it));
 
             if (it != original_it)
                 selected = *it;
@@ -103,12 +136,12 @@ public:
         focus_list.erase(it);
     }
 
-    void focus(T const& t)
+    void focus(T const &t)
     {
         auto it = find(t);
         if (it == focus_list.end())
         {
-            mir::log_error("WindowCyclingBehavior::focus: attempting to focus an item that is not in the focus list");
+            mir::log_error("TabOrderSelector::focus: attempting to focus an item that is not in the focus list");
             return;
         }
 
@@ -122,11 +155,11 @@ public:
         selected = t;
     }
 
-    void unfocus(T const& t)
+    void unfocus(T const &t)
     {
-        if (comparison_func(t, selected))
+        if (SelectorBase::equals(t, selected))
         {
-            reset(selected);
+            SelectorBase::reset(selected);
         }
     }
 
@@ -144,7 +177,7 @@ public:
     {
         if (!is_active)
         {
-            mir::log_warning("WindowCyclingBehavior::complete: Cannot complete while not active");
+            mir::log_warning("TabOrderSelector::complete: Cannot complete while not active");
             return T();
         }
 
@@ -155,7 +188,7 @@ public:
             std::rotate(focus_list.begin(), it, it + 1);
         }
 
-        reset(originally_selected);
+        SelectorBase::reset(originally_selected);
         is_active = false;
         return *it;
     }
@@ -164,12 +197,12 @@ public:
     {
         if (!is_active)
         {
-            mir::log_warning("WindowCyclingBehavior::complete: Cannot cancel while not active");
+            mir::log_warning("TabOrderSelector::complete: Cannot cancel while not active");
             return T();
         }
 
-        on_cancelled(originally_selected);
-        reset(originally_selected);
+        SelectorBase::on_cancelled(originally_selected);
+        SelectorBase::reset(originally_selected);
         is_active = false;
         return originally_selected;
     }
@@ -179,24 +212,17 @@ public:
         return selected;
     }
 
-    auto get_originally_focused() -> T
-    {
-        return originally_selected;
-    }
-
     bool get_is_active()
     {
         return is_active;
     }
 
-    std::vector<T> const& get_focus_list() { return focus_list; }
-
 private:
-    auto find(T const& application) -> std::vector<T>::iterator
+    auto find(T const &application) -> std::vector<T>::iterator
     {
-        return std::find_if(focus_list.begin(), focus_list.end(), [&](T const& existing_application)
+        return std::find_if(focus_list.begin(), focus_list.end(), [&](T const &existing_application)
         {
-            return comparison_func(application, existing_application);
+            return SelectorBase::equals(application, existing_application);
         });
     }
 
@@ -216,19 +242,18 @@ private:
         auto it = find(selected);
         auto start_it = it;
 
-        do {
+        do
+        {
             if (reverse)
             {
                 if (it == focus_list.begin())
                 {
                     it = focus_list.end() - 1;
-                }
-                else
+                } else
                 {
                     it--;
                 }
-            }
-            else
+            } else
             {
                 it++;
                 if (it == focus_list.end())
@@ -240,17 +265,11 @@ private:
             // We made it all the way through the list but failed to find anything.
             if (it == start_it)
                 break;
-        } while (!can_select(*it));
+        } while (!SelectorBase::selectable(*it));
 
-        on_raised(*start_it, *it, originally_selected);
+        SelectorBase::on_selected(*start_it, *it, originally_selected);
         return *it;
     }
-
-    std::function<bool(T const&, T const&)> comparison_func;
-    std::function<bool(T const&)> can_select;
-    std::function<void(T const&, T const&, T const&)> on_raised;
-    std::function<void(T const&)> on_cancelled;
-    std::function<void(T&)> reset;
 
     std::vector<T> focus_list;
     /// The application that was selected when next was first called
@@ -261,59 +280,30 @@ private:
 
     bool is_active = false;
 };
-
 }
 
+struct ApplicationSelector::Impl
+{
+    Impl(miral::WindowManagerTools const& _tools)
+        : tab_order_selector(_tools)
+    {
+    }
+
+    ~Impl() = default;
+
+    TabOrderSelector<WeakApplicationSelector> tab_order_selector;
+};
+
 ApplicationSelector::ApplicationSelector(miral::WindowManagerTools const& _tools) :
-    tools{_tools},
-    window_cycler{std::make_unique<WindowCyclingBehavior<WeakApplication>>(
-        get_comparison_func(),
-        get_can_select_func(tools),
-        get_on_raised_func(tools),
-        get_on_cancelled_func(tools),
-        get_reset_func()
-    )}
+    self{std::make_unique<Impl>(_tools)}
 {
 }
 
 ApplicationSelector::~ApplicationSelector() = default;
 
-ApplicationSelector::ApplicationSelector(miral::ApplicationSelector const& other) :
-    tools{other.tools}
-{
-    window_cycler = std::make_unique<WindowCyclingBehavior<WeakApplication>>(
-        get_comparison_func(),
-        get_can_select_func(tools),
-        get_on_raised_func(tools),
-        get_on_cancelled_func(tools),
-        get_reset_func(),
-        other.window_cycler->get_focus_list(),
-        other.window_cycler->get_originally_focused(),
-        other.window_cycler->get_focused(),
-        other.window_cycler->get_is_active()
-    );
-}
-
-auto ApplicationSelector::operator=(ApplicationSelector const& other) -> ApplicationSelector&
-{
-    tools = other.tools;
-    window_cycler = std::make_unique<WindowCyclingBehavior<WeakApplication>>(
-        get_comparison_func(),
-        get_can_select_func(tools),
-        get_on_raised_func(tools),
-        get_on_cancelled_func(tools),
-        get_reset_func(),
-        other.window_cycler->get_focus_list(),
-        other.window_cycler->get_originally_focused(),
-        other.window_cycler->get_focused(),
-        other.window_cycler->get_is_active()
-    );
-    return *this;
-}
-
 void ApplicationSelector::advise_new_app(Application const& application)
 {
-    window_cycler->add(application);
+    self->tab_order_selector.add(application);
 }
 
 void ApplicationSelector::advise_focus_gained(WindowInfo const& window_info)
@@ -321,18 +311,18 @@ void ApplicationSelector::advise_focus_gained(WindowInfo const& window_info)
     auto window = window_info.window();
     if (!window)
     {
-        mir::log_error("ApplicationSelector::advise_focus_gained: Could not find the window");
+        mir::fatal_error("ApplicationSelector::advise_focus_gained: Could not find the window");
         return;
     }
 
     auto application = window.application();
     if (!application)
     {
-        mir::log_error("ApplicationSelector::advise_focus_gained: Could not find the application");
+        mir::fatal_error("ApplicationSelector::advise_focus_gained: Could not find the application");
         return;
     }
 
-    window_cycler->focus(application);
+    self->tab_order_selector.focus(application);
 }
 
 void ApplicationSelector::advise_focus_lost(miral::WindowInfo const& window_info)
@@ -340,120 +330,51 @@ void ApplicationSelector::advise_focus_lost(miral::WindowInfo const& window_info
     auto window = window_info.window();
     if (!window)
     {
-        mir::log_error("ApplicationSelector::advise_focus_lost: Could not find the window");
+        mir::fatal_error("ApplicationSelector::advise_focus_lost: Could not find the window");
         return;
     }
 
     auto application = window.application();
     if (!application)
     {
-        mir::log_error("ApplicationSelector::advise_focus_lost: Could not find the application");
+        mir::fatal_error("ApplicationSelector::advise_focus_lost: Could not find the application");
         return;
     }
 
-    window_cycler->unfocus(application);
+    self->tab_order_selector.unfocus(application);
 }
 
 void ApplicationSelector::advise_delete_app(Application const& application)
 {
-    window_cycler->remove(application);
+    self->tab_order_selector.remove(application);
 }
 
 auto ApplicationSelector::next() -> Application
 {
-    return window_cycler->next().lock();
+    return self->tab_order_selector.next().lock();
 }
 
 auto ApplicationSelector::prev() -> Application
 {
-    return window_cycler->prev().lock();
+    return self->tab_order_selector.prev().lock();
 }
 
 auto ApplicationSelector::complete() -> Application
 {
-    return window_cycler->complete().lock();
+    return self->tab_order_selector.complete().lock();
 }
 
 void ApplicationSelector::cancel()
 {
-    window_cycler->cancel();
+    self->tab_order_selector.cancel();
 }
 
 auto ApplicationSelector::is_active() -> bool
 {
-    return window_cycler->get_is_active();
+    return self->tab_order_selector.get_is_active();
 }
 
 auto ApplicationSelector::get_focused() -> Application
 {
-    return window_cycler->get_focused().lock();
-}
-
-auto ApplicationSelector::get_comparison_func() -> std::function<bool(ApplicationSelector::WeakApplication const&, ApplicationSelector::WeakApplication const&)>
-{
-    return [](ApplicationSelector::WeakApplication const& first, ApplicationSelector::WeakApplication const& second)
-    {
-        return !first.owner_before(second) && !second.owner_before(first);;
-    };
-}
-
-auto ApplicationSelector::get_can_select_func(WindowManagerTools& tools) -> std::function<bool(ApplicationSelector::WeakApplication const&)>
-{
-    return [&](ApplicationSelector::WeakApplication const& session)
-    {
-        return tools.window_to_select_application(session.lock()) != std::nullopt;
-    };
-}
-
-auto ApplicationSelector::get_on_raised_func(WindowManagerTools& tools)
-    -> std::function<void(ApplicationSelector::WeakApplication const&, ApplicationSelector::WeakApplication const&, ApplicationSelector::WeakApplication const&)>
-{
-    return [&](ApplicationSelector::WeakApplication const& previously_selected,
-               ApplicationSelector::WeakApplication const& newly_selected,
-               ApplicationSelector::WeakApplication const& originally_selected)
-    {
-        auto previous_session = previously_selected.lock();
-        auto new_session = newly_selected.lock();
-        auto original_session = originally_selected.lock();
-
-        auto previous_window = tools.active_window();
-        auto new_window = tools.window_to_select_application(new_session);
-        if (previous_session == new_session || new_window == std::nullopt)
-            return;
-
-        if (new_session == original_session)
-        {
-            // Edge case: if we have gone full circle around the list back to the original app
-            // then we will wind up in a situation where the original app - now in the second z-order
-            // position - will be swapped with the final app, putting the final app in the second position.
-            for (auto const& window: tools.info_for(new_session).windows())
-                tools.send_tree_to_back(window);
-        }
-        else
-        {
-            tools.swap_tree_order(new_window.value(), previous_window);
-        }
-
-        tools.select_active_window(new_window.value());
-    };
-}
-
-auto ApplicationSelector::get_on_cancelled_func(WindowManagerTools& tools) -> std::function<void(ApplicationSelector::WeakApplication const&)>
-{
-    return [&](ApplicationSelector::WeakApplication const& session)
-    {
-        auto window_to_select = tools.window_to_select_application(session.lock());
-        if (window_to_select != std::nullopt)
-        {
-            tools.select_active_window(window_to_select.value());
-        }
-    };
-}
-
-auto ApplicationSelector::get_reset_func() -> std::function<void(ApplicationSelector::WeakApplication&)>
-{
-    return [](ApplicationSelector::WeakApplication& session)
-    {
-        session.reset();
-    };
+    return self->tab_order_selector.get_focused().lock();
 }

--- a/src/miral/application_selector.h
+++ b/src/miral/application_selector.h
@@ -23,6 +23,9 @@
 namespace miral
 {
 
+template <typename T>
+class WindowCyclingBehavior;
+
 /// Intended to be used in conjunction with a WindowManagementPolicy. Simply
 /// hook up the "advise" methods to be called at the appropriate times, and
 /// the ApplicationSelector will keep track of the rest.
@@ -78,21 +81,16 @@ public:
 
 private:
     using WeakApplication = std::weak_ptr<mir::scene::Session>;
-    auto advance(bool reverse) -> Application;
-    auto find(WeakApplication) -> std::vector<WeakApplication>::iterator;
 
     WindowManagerTools tools;
+    std::unique_ptr<WindowCyclingBehavior<WeakApplication>> window_cycler;
 
-    /// Represents the current order of focus by application. Most recently focused
-    /// applications are at the beginning, while least recently focused are at the end.
-    std::vector<WeakApplication> focus_list;
-
-    /// The application that was selected when next was first called
-    WeakApplication originally_selected;
-
-    /// The application that is currently selected.
-    WeakApplication selected;
-    Window active_window;
+    static auto get_comparison_func()-> std::function<bool(ApplicationSelector::WeakApplication const&, ApplicationSelector::WeakApplication const&)>;
+    static auto get_can_select_func(WindowManagerTools& tools) -> std::function<bool(ApplicationSelector::WeakApplication const&)>;
+    static auto get_on_raised_func(WindowManagerTools& tools)
+        -> std::function<void(ApplicationSelector::WeakApplication const&, ApplicationSelector::WeakApplication const&, ApplicationSelector::WeakApplication const&)>;
+    static auto get_on_cancelled_func(WindowManagerTools& tools) -> std::function<void(ApplicationSelector::WeakApplication const&)>;
+    static auto get_reset_func() -> std::function<void(ApplicationSelector::WeakApplication&)>;
 };
 
 }

--- a/src/miral/application_selector.h
+++ b/src/miral/application_selector.h
@@ -23,9 +23,6 @@
 namespace miral
 {
 
-template <typename T>
-class WindowCyclingBehavior;
-
 /// Intended to be used in conjunction with a WindowManagementPolicy. Simply
 /// hook up the "advise" methods to be called at the appropriate times, and
 /// the ApplicationSelector will keep track of the rest.
@@ -41,8 +38,8 @@ class ApplicationSelector
 public:
     explicit ApplicationSelector(WindowManagerTools const&);
     ~ApplicationSelector();
-    ApplicationSelector(ApplicationSelector const&);
-    auto operator=(ApplicationSelector const&) -> ApplicationSelector&;
+    ApplicationSelector(ApplicationSelector const&) = delete;
+    auto operator=(ApplicationSelector const&) -> ApplicationSelector& = delete;
 
     /// Called when a new application has been added to the list.
     void advise_new_app(Application const&);
@@ -79,18 +76,9 @@ public:
     /// \returns The focused application
     auto get_focused() -> Application;
 
-private:
-    using WeakApplication = std::weak_ptr<mir::scene::Session>;
-
-    WindowManagerTools tools;
-    std::unique_ptr<WindowCyclingBehavior<WeakApplication>> window_cycler;
-
-    static auto get_comparison_func()-> std::function<bool(ApplicationSelector::WeakApplication const&, ApplicationSelector::WeakApplication const&)>;
-    static auto get_can_select_func(WindowManagerTools& tools) -> std::function<bool(ApplicationSelector::WeakApplication const&)>;
-    static auto get_on_raised_func(WindowManagerTools& tools)
-        -> std::function<void(ApplicationSelector::WeakApplication const&, ApplicationSelector::WeakApplication const&, ApplicationSelector::WeakApplication const&)>;
-    static auto get_on_cancelled_func(WindowManagerTools& tools) -> std::function<void(ApplicationSelector::WeakApplication const&)>;
-    static auto get_reset_func() -> std::function<void(ApplicationSelector::WeakApplication&)>;
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> self;
 };
 
 }

--- a/src/miral/application_selector.h
+++ b/src/miral/application_selector.h
@@ -78,7 +78,7 @@ public:
 
   private:
     struct Impl;
-    std::unique_ptr<Impl> self;
+    std::unique_ptr<Impl> const self;
 };
 
 }


### PR DESCRIPTION
## What's new?
- Abstracted away the window cycling algorithm so that we can instead its use to be not only between applications but also _within_ applications

A follow up PR will integrate the window selection within apps.