### PR TITLE
platform/graphics: Allow for multiple RenderingPlatforms of each type 

### DIFF
--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -41,7 +41,6 @@
 
 #include <boost/throw_exception.hpp>
 
-#include <ranges>
 #include <sstream>
 
 namespace mg = mir::graphics;
@@ -379,16 +378,17 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
             // So don't push it into rendering_platforms until the rest are done
             auto const [egl_generic_begin, egl_generic_end] = rendering_platform_map.equal_range("mir:egl-generic");
 
-            decltype(std::ranges::subrange(rendering_platform_map.begin(), egl_generic_begin)) const ranges[] =
-                {
-                    std::ranges::subrange(rendering_platform_map.begin(), egl_generic_begin),
-                    std::ranges::subrange(egl_generic_end, rendering_platform_map.end()),
-                    std::ranges::subrange(egl_generic_begin, egl_generic_end)
-                };
-
-            for (auto const& rp: std::ranges::join_view(ranges))
+            for (auto rp = rendering_platform_map.begin(); rp != egl_generic_begin; ++rp)
             {
-                rendering_platforms.push_back(rp.second);
+                rendering_platforms.push_back(rp->second);
+            }
+            for (auto rp = egl_generic_end; rp != rendering_platform_map.end(); ++rp)
+            {
+                rendering_platforms.push_back(rp->second);
+            }
+            for (auto rp = egl_generic_begin; rp != egl_generic_end; ++rp)
+            {
+                rendering_platforms.push_back(rp->second);
             }
         }
 

--- a/src/server/graphics/default_configuration.cpp
+++ b/src/server/graphics/default_configuration.cpp
@@ -41,6 +41,7 @@
 
 #include <boost/throw_exception.hpp>
 
+#include <ranges>
 #include <sstream>
 
 namespace mg = mir::graphics;
@@ -264,7 +265,7 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
     {
         std::stringstream error_report;
         std::vector<std::pair<mg::SupportedDevice, std::shared_ptr<mir::SharedLibrary>>> platform_modules;
-        std::map<std::string, std::shared_ptr<graphics::RenderingPlatform>> rendering_platform_map;
+        std::multimap<std::string, std::shared_ptr<graphics::RenderingPlatform>> rendering_platform_map;
 
         try
         {
@@ -352,12 +353,13 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
                 }
 
                 // TODO: Do we want to be able to continue on partial failure here?
-                rendering_platform_map[description->name] =
+                rendering_platform_map.emplace(
+                    description->name,
                     create_rendering_platform(
                         device,
                         display_targets,
                         *the_options(),
-                        *the_emergency_cleanup());
+                        *the_emergency_cleanup()));
                 // Add this module to the list searched by the input stack later
                 // TODO: Come up with a more principled solution for combined input/rendering/output platforms
                 platform_libraries.push_back(platform);
@@ -372,26 +374,22 @@ auto mir::DefaultServerConfiguration::the_rendering_platforms() ->
 
         rendering_platforms.reserve(rendering_platform_map.size());
 
-        // We want to make the egl-generic platform the last resort
-        // So don't push it into rendering_platforms until the rest are done
-        std::shared_ptr<graphics::RenderingPlatform> egl_generic;
-
-        for (auto const& rp : rendering_platform_map)
         {
-            if (rp.first != "mir:egl-generic")
+            // We want to make the egl-generic platform the last resort
+            // So don't push it into rendering_platforms until the rest are done
+            auto const [egl_generic_begin, egl_generic_end] = rendering_platform_map.equal_range("mir:egl-generic");
+
+            decltype(std::ranges::subrange(rendering_platform_map.begin(), egl_generic_begin)) const ranges[] =
+                {
+                    std::ranges::subrange(rendering_platform_map.begin(), egl_generic_begin),
+                    std::ranges::subrange(egl_generic_end, rendering_platform_map.end()),
+                    std::ranges::subrange(egl_generic_begin, egl_generic_end)
+                };
+
+            for (auto const& rp: std::ranges::join_view(ranges))
             {
                 rendering_platforms.push_back(rp.second);
             }
-            else
-            {
-                egl_generic = rp.second;
-            }
-        }
-
-        // If we skipped egl-generic, add it to the end
-        if (egl_generic)
-        {
-            rendering_platforms.push_back(egl_generic);
         }
 
         if (rendering_platforms.empty())


### PR DESCRIPTION
We load one `RenderingPlatform` for each hardware device detected, and then select the best one to drive each display. If we don't keep all the `RenderingPlatform`s then we might not keep the one capable of direct-output, requiring a CPU copy to the display.

Fixes: #3205