### PR TITLE
feature: alt + grave behavior now implemented alongside alt + tick

### DIFF
--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -79,11 +79,11 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&, MirInputEventModifier)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::advise_delete_app(miral::ApplicationInfo const&)@MIRAL_5.0" 5.0.0
- (c++)"miral::MinimalWindowManager::advise_delete_window(miral::WindowInfo const&)@MIRAL_5.1" 5.0.0
+ (c++)"miral::MinimalWindowManager::advise_delete_window(miral::WindowInfo const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::advise_focus_gained(miral::WindowInfo const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::advise_focus_lost(miral::WindowInfo const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::advise_new_app(miral::ApplicationInfo&)@MIRAL_5.0" 5.0.0
- (c++)"miral::MinimalWindowManager::advise_new_window(miral::WindowInfo const&)@MIRAL_5.1" 5.0.0
+ (c++)"miral::MinimalWindowManager::advise_new_window(miral::WindowInfo const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::begin_pointer_move(miral::WindowInfo const&, MirInputEvent const*)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::begin_pointer_resize(miral::WindowInfo const&, MirInputEvent const*, MirResizeEdge const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::begin_touch_move(miral::WindowInfo const&, MirInputEvent const*)@MIRAL_5.0" 5.0.0
@@ -260,7 +260,7 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::WindowManagerTools::active_window() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowManagerTools::add_tree_to_workspace(miral::Window const&, std::shared_ptr<miral::Workspace> const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowManagerTools::ask_client_to_close(miral::Window const&)@MIRAL_5.0" 5.0.0
- (c++)"miral::WindowManagerTools::can_select_window(miral::Window const&) const@MIRAL_5.1" 5.0.0
+ (c++)"miral::WindowManagerTools::can_select_window(miral::Window const&) const@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowManagerTools::count_applications() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowManagerTools::create_workspace()@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowManagerTools::drag_active_window(mir::geometry::generic::Displacement<int>)@MIRAL_5.0" 5.0.0

--- a/debian/libmiral7.symbols
+++ b/debian/libmiral7.symbols
@@ -79,9 +79,11 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::MinimalWindowManager(miral::WindowManagerTools const&, MirInputEventModifier)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::advise_delete_app(miral::ApplicationInfo const&)@MIRAL_5.0" 5.0.0
+ (c++)"miral::MinimalWindowManager::advise_delete_window(miral::WindowInfo const&)@MIRAL_5.1" 5.0.0
  (c++)"miral::MinimalWindowManager::advise_focus_gained(miral::WindowInfo const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::advise_focus_lost(miral::WindowInfo const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::advise_new_app(miral::ApplicationInfo&)@MIRAL_5.0" 5.0.0
+ (c++)"miral::MinimalWindowManager::advise_new_window(miral::WindowInfo const&)@MIRAL_5.1" 5.0.0
  (c++)"miral::MinimalWindowManager::begin_pointer_move(miral::WindowInfo const&, MirInputEvent const*)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::begin_pointer_resize(miral::WindowInfo const&, MirInputEvent const*, MirResizeEdge const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::MinimalWindowManager::begin_touch_move(miral::WindowInfo const&, MirInputEvent const*)@MIRAL_5.0" 5.0.0
@@ -149,6 +151,8 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::StartupInternalClient::StartupInternalClient(std::function<void (wl_display*)>, std::function<void (std::weak_ptr<mir::scene::Session>)>)@MIRAL_5.0" 5.0.0
  (c++)"miral::StartupInternalClient::operator()(mir::Server&)@MIRAL_5.0" 5.0.0
  (c++)"miral::StartupInternalClient::~StartupInternalClient()@MIRAL_5.0" 5.0.0
+ (c++)"miral::WaylandExtensions::Context::Context()@MIRAL_5.0" 5.0.0
+ (c++)"miral::WaylandExtensions::Context::~Context()@MIRAL_5.0" 5.0.0
  (c++)"miral::WaylandExtensions::EnableInfo::app() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WaylandExtensions::EnableInfo::name() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WaylandExtensions::EnableInfo::user_preference() const@MIRAL_5.0" 5.0.0
@@ -256,6 +260,7 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::WindowManagerTools::active_window() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowManagerTools::add_tree_to_workspace(miral::Window const&, std::shared_ptr<miral::Workspace> const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowManagerTools::ask_client_to_close(miral::Window const&)@MIRAL_5.0" 5.0.0
+ (c++)"miral::WindowManagerTools::can_select_window(miral::Window const&) const@MIRAL_5.1" 5.0.0
  (c++)"miral::WindowManagerTools::count_applications() const@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowManagerTools::create_workspace()@MIRAL_5.0" 5.0.0
  (c++)"miral::WindowManagerTools::drag_active_window(mir::geometry::generic::Displacement<int>)@MIRAL_5.0" 5.0.0
@@ -380,6 +385,7 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"miral::equivalent_display_area(miral::Output const&, miral::Output const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::kill(std::shared_ptr<mir::scene::Session> const&, int)@MIRAL_5.0" 5.0.0
  (c++)"miral::name_of[abi:cxx11](std::shared_ptr<mir::scene::Session> const&)@MIRAL_5.0" 5.0.0
+ (c++)"miral::operator!=(miral::Window const&, std::shared_ptr<mir::scene::Surface> const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::operator<(miral::Window const&, miral::Window const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::operator==(miral::Output::PhysicalSizeMM const&, miral::Output::PhysicalSizeMM const&)@MIRAL_5.0" 5.0.0
  (c++)"miral::operator==(miral::Window const&, miral::Window const&)@MIRAL_5.0" 5.0.0
@@ -422,4 +428,5 @@ libmiral.so.7 libmiral7 #MINVER#
  (c++)"typeinfo for miral::WindowManagementPolicy@MIRAL_5.0" 5.0.0
  (c++)"vtable for miral::CanonicalWindowManagerPolicy@MIRAL_5.0" 5.0.0
  (c++)"vtable for miral::MinimalWindowManager@MIRAL_5.0" 5.0.0
+ (c++)"vtable for miral::WaylandExtensions::Context@MIRAL_5.0" 5.0.0
  (c++)"vtable for miral::WindowManagementPolicy@MIRAL_5.0" 5.0.0

--- a/include/miral/miral/minimal_window_manager.h
+++ b/include/miral/miral/minimal_window_manager.h
@@ -82,8 +82,10 @@ public:
 
     void advise_delete_app(miral::ApplicationInfo const& app_info) override;
 
+    /// \remark Since MirAL 5.0
     void advise_new_window(WindowInfo const& app_info) override;
 
+    /// \remark Since MirAL 5.0
     void advise_delete_window(WindowInfo const& app_info) override;
 
 protected:

--- a/include/miral/miral/minimal_window_manager.h
+++ b/include/miral/miral/minimal_window_manager.h
@@ -82,6 +82,10 @@ public:
 
     void advise_delete_app(miral::ApplicationInfo const& app_info) override;
 
+    void advise_new_window(WindowInfo const& app_info) override;
+
+    void advise_delete_window(WindowInfo const& app_info) override;
+
 protected:
     WindowManagerTools tools;
 

--- a/include/miral/miral/window_manager_tools.h
+++ b/include/miral/miral/window_manager_tools.h
@@ -162,6 +162,7 @@ public:
     auto window_to_select_application(const Application) const -> std::optional<Window>;
 
     /// Check if the provided window can be selected
+    /// \remark Since MirAL 5.0
     auto can_select_window(Window const&) const -> bool;
 
     /// Find the topmost window at the cursor

--- a/include/miral/miral/window_manager_tools.h
+++ b/include/miral/miral/window_manager_tools.h
@@ -161,6 +161,9 @@ public:
     /// \remark Since MirAL 3.10
     auto window_to_select_application(const Application) const -> std::optional<Window>;
 
+    /// Check if the provided window can be selected
+    auto can_select_window(Window const&) const -> bool;
+
     /// Find the topmost window at the cursor
     auto window_at(mir::geometry::Point cursor) const -> Window;
 

--- a/src/miral/application_selector.cpp
+++ b/src/miral/application_selector.cpp
@@ -93,11 +93,9 @@ void ApplicationSelector::advise_delete_window(WindowInfo const& window_info)
         return;
     }
 
-    // If we delete the selected application, we will try to select the next available one.
+    // If we delete the selected window, we will try to select the next available one
     if (*it == selected)
     {
-        auto application = it->application();
-        std::optional<Window> next_window = std::nullopt;
         auto original_it = it;
         do {
             it++;
@@ -105,16 +103,13 @@ void ApplicationSelector::advise_delete_window(WindowInfo const& window_info)
                 it = focus_list.begin();
 
             if (it == original_it)
-            {
                 break;
-            }
-        } while ((next_window = tools.window_to_select_application(application)) == std::nullopt);
-
-        if (next_window != std::nullopt)
-            selected = next_window.value();
+        } while (!tools.can_select_window(*it));
 
         if (it != original_it)
             selected = *it;
+        else
+            selected = Window();
     }
 
     focus_list.erase(it);

--- a/src/miral/application_selector.cpp
+++ b/src/miral/application_selector.cpp
@@ -18,6 +18,7 @@
 #include <miral/application_info.h>
 #include <miral/application.h>
 #include <mir/log.h>
+#include <mir/scene/session.h>
 
 using namespace miral;
 
@@ -31,8 +32,7 @@ ApplicationSelector::ApplicationSelector(miral::ApplicationSelector const& other
     tools{other.tools},
     focus_list{other.focus_list},
     originally_selected{other.originally_selected},
-    selected{other.selected},
-    active_window{other.active_window}
+    selected{other.selected}
 {
 }
 
@@ -42,13 +42,12 @@ auto ApplicationSelector::operator=(ApplicationSelector const& other) -> Applica
     focus_list = other.focus_list;
     originally_selected = other.originally_selected;
     selected = other.selected;
-    active_window = other.active_window;
     return *this;
 }
 
-void ApplicationSelector::advise_new_app(Application const& application)
+void ApplicationSelector::advise_new_window(WindowInfo const& window_info)
 {
-    focus_list.push_back(application);
+    focus_list.push_back(window_info.window());
 }
 
 void ApplicationSelector::advise_focus_gained(WindowInfo const& window_info)
@@ -56,16 +55,10 @@ void ApplicationSelector::advise_focus_gained(WindowInfo const& window_info)
     auto window = window_info.window();
     if (!window)
     {
-        return;
+        mir::fatal_error("advise_focus_gained: window_info did not reference a window");
     }
 
-    auto application = window.application();
-    if (!application)
-    {
-        return;
-    }
-
-    auto it = find(application);
+    auto it = find(window);
     if (!is_active())
     {
         // If we are not active, we move the newly focused item to the front of the list.
@@ -76,8 +69,7 @@ void ApplicationSelector::advise_focus_gained(WindowInfo const& window_info)
     }
 
     // Update the current selection
-    selected = application;
-    active_window = window;
+    selected = window;
 }
 
 void ApplicationSelector::advise_focus_lost(miral::WindowInfo const& window_info)
@@ -85,24 +77,16 @@ void ApplicationSelector::advise_focus_lost(miral::WindowInfo const& window_info
     auto window = window_info.window();
     if (!window)
     {
+        mir::fatal_error("advise_focus_lost: window_info did not reference a window");
         return;
     }
 
-    auto application = window.application();
-    if (!application)
-    {
-        return;
-    }
-
-    if (selected.lock() == application)
-    {
-        selected.reset();
-    }
+    selected = Window();
 }
 
-void ApplicationSelector::advise_delete_app(Application const& application)
+void ApplicationSelector::advise_delete_window(WindowInfo const& window_info)
 {
-    auto it = find(application);
+    auto it = find(window_info.window());
     if (it == focus_list.end())
     {
         mir::log_warning("ApplicationSelector::advise_delete_app could not delete the app.");
@@ -110,8 +94,9 @@ void ApplicationSelector::advise_delete_app(Application const& application)
     }
 
     // If we delete the selected application, we will try to select the next available one.
-    if (application == selected.lock())
+    if (*it == selected)
     {
+        auto application = it->application();
         std::optional<Window> next_window = std::nullopt;
         auto original_it = it;
         do {
@@ -123,10 +108,10 @@ void ApplicationSelector::advise_delete_app(Application const& application)
             {
                 break;
             }
-        } while ((next_window = tools.window_to_select_application(it->lock())) == std::nullopt);
+        } while ((next_window = tools.window_to_select_application(application)) == std::nullopt);
 
         if (next_window != std::nullopt)
-            active_window = next_window.value();
+            selected = next_window.value();
 
         if (it != original_it)
             selected = *it;
@@ -135,21 +120,22 @@ void ApplicationSelector::advise_delete_app(Application const& application)
     focus_list.erase(it);
 }
 
-auto ApplicationSelector::next() -> Application
+auto ApplicationSelector::next(bool within_app) -> Window
 {
-    return advance(false);
+    return advance(false, within_app);
 }
 
-auto ApplicationSelector::prev() -> Application
+auto ApplicationSelector::prev(bool within_app) -> Window
 {
-    return advance(true);
+    return advance(true, within_app);
 }
 
-auto ApplicationSelector::complete() -> Application
+auto ApplicationSelector::complete() -> Window
 {
     if (!is_active())
     {
-        return nullptr;
+        mir::log_warning("complete: application selector is not active");
+        return {};
     }
 
     // Place the newly selected item at the front of the list.
@@ -159,46 +145,40 @@ auto ApplicationSelector::complete() -> Application
         std::rotate(focus_list.begin(), it, it + 1);
     }
 
-    originally_selected.reset();
-    return selected.lock();
+    originally_selected = Window();
+    is_moving = false;
+    return selected;
 }
 
 void ApplicationSelector::cancel()
 {
-    std::optional<Window> window_to_select;
-    if ((window_to_select = tools.window_to_select_application(originally_selected.lock())) != std::nullopt)
-    {
-        tools.select_active_window(window_to_select.value());
-    }
-    else
-    {
-        mir::log_warning("ApplicationSelector::cancel: Failed to select the root.");
-    }
-
-    originally_selected.reset();
+    tools.select_active_window(originally_selected);
+    originally_selected = Window();
+    is_moving = false;
 }
 
-auto ApplicationSelector::is_active() -> bool
+auto ApplicationSelector::is_active() const -> bool
 {
-    return !originally_selected.expired();
+    return is_moving;
 }
 
-auto ApplicationSelector::get_focused() -> Application
+auto ApplicationSelector::get_focused() -> Window
 {
-    return selected.lock();
+    return selected;
 }
 
-auto ApplicationSelector::advance(bool reverse) -> Application
+auto ApplicationSelector::advance(bool reverse, bool within_app) -> Window
 {
     if (focus_list.empty())
     {
-        return nullptr;
+        return {};
     }
 
     if (!is_active())
     {
         originally_selected = focus_list.front();
         selected = originally_selected;
+        is_moving = true;
     }
 
     // Attempt to focus the next application after the selected application.
@@ -230,34 +210,47 @@ auto ApplicationSelector::advance(bool reverse) -> Application
         // We made it all the way through the list but failed to find anything.
         if (it == start_it)
             break;
-    } while ((next_window = tools.window_to_select_application(it->lock())) == std::nullopt);
+
+        if (within_app)
+        {
+            if (it->application() == originally_selected.application() && tools.can_select_window(*it))
+                next_window = *it;
+            else
+                next_window = std::nullopt;
+        }
+        else
+        {
+            next_window = tools.window_to_select_application(it->application());
+        }
+    } while (next_window == std::nullopt);
 
     if (it == start_it || next_window == std::nullopt)
     {
         // next_window will be a garbage window in this case, so let's not select it
-        return start_it->lock();
+        return *start_it;
     }
 
     // Swap the tree order first and then select the new window
-    if (it->lock() == originally_selected.lock())
+    if (*it == originally_selected)
     {
         // Edge case: if we have gone full circle around the list back to the original app
         // then we will wind up in a situation where the original app - now in the second z-order
         // position - will be swapped with the final app, putting the final app in the second position.
-        for (auto window: tools.info_for(selected).windows())
+        auto application = it->application();
+        for (auto& window: tools.info_for(application).windows())
             tools.send_tree_to_back(window);
     }
     else
-        tools.swap_tree_order(next_window.value(), active_window);
+        tools.swap_tree_order(next_window.value(), selected);
 
     tools.select_active_window(next_window.value());
-    return it->lock();
+    return *it;
 }
 
-auto ApplicationSelector::find(WeakApplication application) -> std::vector<WeakApplication>::iterator
+auto ApplicationSelector::find(Window window) -> std::vector<Window>::iterator
 {
-    return std::find_if(focus_list.begin(), focus_list.end(), [&](WeakApplication const& existing_application)
+    return std::find_if(focus_list.begin(), focus_list.end(), [&](Window const& other)
     {
-        return !existing_application.owner_before(application) && !application.owner_before(existing_application);
+        return window == other;
     });
 }

--- a/src/miral/application_selector.cpp
+++ b/src/miral/application_selector.cpp
@@ -31,7 +31,7 @@ ApplicationSelector::~ApplicationSelector() = default;
 ApplicationSelector::ApplicationSelector(miral::ApplicationSelector const& other) :
     tools{other.tools},
     focus_list{other.focus_list},
-    originally_selected{other.originally_selected},
+    originally_selected_it{other.originally_selected_it},
     selected{other.selected}
 {
 }
@@ -40,7 +40,7 @@ auto ApplicationSelector::operator=(ApplicationSelector const& other) -> Applica
 {
     tools = other.tools;
     focus_list = other.focus_list;
-    originally_selected = other.originally_selected;
+    originally_selected_it = other.originally_selected_it;
     selected = other.selected;
     return *this;
 }
@@ -63,9 +63,9 @@ void ApplicationSelector::advise_focus_gained(WindowInfo const& window_info)
     {
         // If we are not active, we move the newly focused item to the front of the list.
         if (it != focus_list.end())
-        {
             std::rotate(focus_list.begin(), it, it + 1);
-        }
+        else
+            mir::fatal_error("advise_focus_gained: window was not found in the list");
     }
 
     // Update the current selection
@@ -94,9 +94,9 @@ void ApplicationSelector::advise_delete_window(WindowInfo const& window_info)
     }
 
     // If we delete the selected window, we will try to select the next available one
+    auto original_it = it;
     if (*it == selected)
     {
-        auto original_it = it;
         do {
             it++;
             if (it == focus_list.end())
@@ -111,8 +111,10 @@ void ApplicationSelector::advise_delete_window(WindowInfo const& window_info)
         else
             selected = Window();
     }
+    else
+        selected = Window();
 
-    focus_list.erase(it);
+    focus_list.erase(original_it);
 }
 
 auto ApplicationSelector::next(bool within_app) -> Window
@@ -128,10 +130,7 @@ auto ApplicationSelector::prev(bool within_app) -> Window
 auto ApplicationSelector::complete() -> Window
 {
     if (!is_active())
-    {
-        mir::log_warning("complete: application selector is not active");
         return {};
-    }
 
     // Place the newly selected item at the front of the list.
     auto it = find(selected);
@@ -140,21 +139,27 @@ auto ApplicationSelector::complete() -> Window
         std::rotate(focus_list.begin(), it, it + 1);
     }
 
-    originally_selected = Window();
-    is_moving = false;
+    originally_selected_it = focus_list.end();
+    _is_active = false;
     return selected;
 }
 
 void ApplicationSelector::cancel()
 {
-    tools.select_active_window(originally_selected);
-    originally_selected = Window();
-    is_moving = false;
+    if (!is_active())
+    {
+        mir::log_warning("Cannot cancel while not active");
+        return;
+    }
+
+    tools.select_active_window(*originally_selected_it);
+    originally_selected_it = focus_list.end();
+    _is_active = false;
 }
 
 auto ApplicationSelector::is_active() const -> bool
 {
-    return is_moving;
+    return _is_active;
 }
 
 auto ApplicationSelector::get_focused() -> Window
@@ -171,67 +176,74 @@ auto ApplicationSelector::advance(bool reverse, bool within_app) -> Window
 
     if (!is_active())
     {
-        originally_selected = focus_list.front();
-        selected = originally_selected;
-        is_moving = true;
+        originally_selected_it = focus_list.begin();
+        selected = focus_list.front();
+        _is_active = true;
     }
 
     // Attempt to focus the next application after the selected application.
     auto it = find(selected);
-    auto start_it = it;
 
     std::optional<Window> next_window = std::nullopt;
     do {
         if (reverse)
         {
             if (it == focus_list.begin())
-            {
                 it = focus_list.end() - 1;
-            }
             else
-            {
                 it--;
-            }
         }
         else
         {
             it++;
             if (it == focus_list.end())
-            {
                 it = focus_list.begin();
-            }
         }
 
         // We made it all the way through the list but failed to find anything.
-        if (it == start_it)
-            break;
+        // This means that there is no other selectable window in the list but
+        // the currently selected one, so we don't need to select anything.
+        if (*it == selected)
+            return selected;
 
         if (within_app)
         {
-            if (it->application() == originally_selected.application() && tools.can_select_window(*it))
+            if (it->application() == (*originally_selected_it).application() && tools.can_select_window(*it))
                 next_window = *it;
             else
                 next_window = std::nullopt;
         }
         else
         {
-            next_window = tools.window_to_select_application(it->application());
+            // Check if we've already encountered this application. If so, we shouldn't try to select it again
+            bool already_encountered = false;
+            for (auto prev_it = originally_selected_it; prev_it != it; prev_it++)
+            {
+                if (prev_it == focus_list.end())
+                    prev_it = focus_list.begin();
+
+                if (prev_it->application() == it->application())
+                {
+                    next_window = std::nullopt;
+                    already_encountered = true;
+                    break;
+                }
+            }
+            if (!already_encountered)
+                next_window = tools.window_to_select_application(it->application());
         }
     } while (next_window == std::nullopt);
 
-    if (it == start_it || next_window == std::nullopt)
-    {
-        // next_window will be a garbage window in this case, so let's not select it
-        return *start_it;
-    }
+    if (next_window == std::nullopt)
+        return selected;
 
-    // Swap the tree order first and then select the new window
-    if (*it == originally_selected)
+    if (it == originally_selected_it)
     {
         // Edge case: if we have gone full circle around the list back to the original app
-        // then we will wind up in a situation where the original app - now in the second z-order
-        // position - will be swapped with the final app, putting the final app in the second position.
-        auto application = it->application();
+        // then we will wind up in a situation where the original app is in the 2nd position
+        // in the list, while the last app is in the 1st position. Hence, we send the selected
+        // app to the back of the list.
+        auto application = selected.application();
         for (auto& window: tools.info_for(application).windows())
             tools.send_tree_to_back(window);
     }

--- a/src/miral/application_selector.cpp
+++ b/src/miral/application_selector.cpp
@@ -140,7 +140,7 @@ auto ApplicationSelector::complete() -> Window
     }
 
     originally_selected_it = focus_list.end();
-    _is_active = false;
+    is_active_ = false;
     return selected;
 }
 
@@ -154,12 +154,12 @@ void ApplicationSelector::cancel()
 
     tools.select_active_window(*originally_selected_it);
     originally_selected_it = focus_list.end();
-    _is_active = false;
+    is_active_ = false;
 }
 
 auto ApplicationSelector::is_active() const -> bool
 {
-    return _is_active;
+    return is_active_;
 }
 
 auto ApplicationSelector::get_focused() -> Window
@@ -178,7 +178,7 @@ auto ApplicationSelector::advance(bool reverse, bool within_app) -> Window
     {
         originally_selected_it = focus_list.begin();
         selected = focus_list.front();
-        _is_active = true;
+        is_active_ = true;
     }
 
     // Attempt to focus the next application after the selected application.
@@ -251,7 +251,7 @@ auto ApplicationSelector::advance(bool reverse, bool within_app) -> Window
         tools.swap_tree_order(next_window.value(), selected);
 
     tools.select_active_window(next_window.value());
-    return *it;
+    return next_window.value();
 }
 
 auto ApplicationSelector::find(Window window) -> std::vector<Window>::iterator

--- a/src/miral/application_selector.h
+++ b/src/miral/application_selector.h
@@ -18,7 +18,6 @@
 #define MIR_APPLICATION_SELECTOR_H
 
 #include <miral/window_manager_tools.h>
-#include <miral/application.h>
 
 namespace miral
 {
@@ -41,8 +40,8 @@ public:
     ApplicationSelector(ApplicationSelector const&);
     auto operator=(ApplicationSelector const&) -> ApplicationSelector&;
 
-    /// Called when a new application has been added to the list.
-    void advise_new_app(Application const&);
+    /// Called when a window is created
+    void advise_new_window(WindowInfo const&);
 
     /// Called when focus is given to a window.
     void advise_focus_gained(WindowInfo const&);
@@ -50,49 +49,49 @@ public:
     /// Called when focus is lost on a window.
     void advise_focus_lost(WindowInfo const&);
 
-    /// Called when an application is deleted.
-    void advise_delete_app(Application const&);
+    /// Called when a window is deleted
+    void advise_delete_window(WindowInfo const&);
 
     /// Raises the next selectable application in the list for focus selection.
-    /// \returns The raised application, or nullptr in the case of a failure
-    auto next() -> Application;
+    /// \returns The raised window
+    auto next(bool within_app) -> Window;
 
     /// Raises the previous selectable application in the list for focus selection.
-    /// \returns The raised application or nullptr in the case of a failure
-    auto prev() -> Application ;
+    /// \returns The raised window
+    auto prev(bool within_app) -> Window;
 
     /// Focuses the currently selected Application.
-    /// \returns The newly selected application, or nullptr in the case of a failure
-    auto complete() -> Application;
+    /// \returns The raised window
+    auto complete() -> Window;
 
     /// Cancel the selector if it has been triggered. This will refocus the original application.
     void cancel();
 
     /// Retrieve whether or not the selector is in progress.
     /// \return true if it is running, otherwise false
-    auto is_active() -> bool;
+    auto is_active() const -> bool;
 
     /// Retrieve the focused application.
     /// \returns The focused application
-    auto get_focused() -> Application;
+    auto get_focused() -> Window;
 
 private:
-    using WeakApplication = std::weak_ptr<mir::scene::Session>;
-    auto advance(bool reverse) -> Application;
-    auto find(WeakApplication) -> std::vector<WeakApplication>::iterator;
+    auto advance(bool reverse, bool within_app) -> Window;
+    auto find(Window) -> std::vector<Window>::iterator;
 
     WindowManagerTools tools;
 
     /// Represents the current order of focus by application. Most recently focused
     /// applications are at the beginning, while least recently focused are at the end.
-    std::vector<WeakApplication> focus_list;
+    std::vector<Window> focus_list;
 
     /// The application that was selected when next was first called
-    WeakApplication originally_selected;
+    Window originally_selected;
 
     /// The application that is currently selected.
-    WeakApplication selected;
-    Window active_window;
+    Window selected;
+
+    bool is_moving = false;
 };
 
 }

--- a/src/miral/application_selector.h
+++ b/src/miral/application_selector.h
@@ -86,12 +86,12 @@ private:
     std::vector<Window> focus_list;
 
     /// The application that was selected when next was first called
-    Window originally_selected;
+    std::vector<Window>::iterator originally_selected_it;
 
     /// The application that is currently selected.
     Window selected;
 
-    bool is_moving = false;
+    bool _is_active = false;
 };
 
 }

--- a/src/miral/application_selector.h
+++ b/src/miral/application_selector.h
@@ -91,7 +91,7 @@ private:
     /// The application that is currently selected.
     Window selected;
 
-    bool _is_active = false;
+    bool is_active_ = false;
 };
 
 }

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -898,22 +898,7 @@ auto miral::BasicWindowManager::window_to_select_application(const Application a
         if (window.application() != application)
              return true;
 
-        // Check if the previous window has to remain focused
-        auto const prev_windows_focus_mode = prev_window ? info_for(prev_window).focus_mode() : mir_focus_mode_focusable;
-        if (prev_windows_focus_mode == mir_focus_mode_grabbing)
-        {
-            return true;
-        }
-
-        // Check if the new window selection has selection disabled
-        auto& desired_window_selection = info_for(window);
-        if (desired_window_selection.focus_mode() == mir_focus_mode_disabled)
-        {
-            return true;
-        }
-
-        // Check if we can activate it at all.
-        if (desired_window_selection.can_be_active() && desired_window_selection.state() != mir_window_state_hidden)
+        if (can_select_window(window))
         {
             result = window;
             return false;
@@ -923,6 +908,25 @@ auto miral::BasicWindowManager::window_to_select_application(const Application a
     });
 
     return result;
+}
+
+auto miral::BasicWindowManager::can_select_window(miral::Window const& window) const -> bool
+{
+    auto const current_window = active_window();
+    auto const current_windows_focus_mode = current_window ? info_for(current_window).focus_mode() : mir_focus_mode_focusable;
+    if (current_windows_focus_mode == mir_focus_mode_grabbing)
+        return false;
+
+    // Check if the new window selection has selection disabled
+    auto& desired_window_selection = info_for(window);
+    if (desired_window_selection.focus_mode() == mir_focus_mode_disabled)
+        return false;
+
+    // Check if we can activate it at all.
+    if (desired_window_selection.can_be_active() && desired_window_selection.state() != mir_window_state_hidden)
+        return true;
+
+    return false;
 }
 
 auto miral::BasicWindowManager::window_at(geometry::Point cursor) const

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -173,6 +173,7 @@ public:
     void focus_prev_within_application() override;
 
     auto window_to_select_application(const Application) const -> std::optional<Window> override;
+    auto can_select_window(Window const&) const -> bool override;
 
     auto window_at(mir::geometry::Point cursor) const -> Window override;
 

--- a/src/miral/minimal_window_manager.cpp
+++ b/src/miral/minimal_window_manager.cpp
@@ -164,11 +164,11 @@ bool miral::MinimalWindowManager::handle_keyboard_event(MirKeyboardEvent const* 
             return true;
 
         case KEY_TAB:
-            self->application_selector.next();
+            self->application_selector.next(false);
             return true;
 
         case KEY_GRAVE:
-            tools.focus_next_within_application();
+            self->application_selector.next(true);
             return true;
 
         default:;
@@ -181,11 +181,11 @@ bool miral::MinimalWindowManager::handle_keyboard_event(MirKeyboardEvent const* 
         switch (mir_keyboard_event_scan_code(event))
         {
         case KEY_TAB:
-            self->application_selector.prev();
+            self->application_selector.prev(false);
             return true;
 
         case KEY_GRAVE:
-            tools.focus_prev_within_application();
+            self->application_selector.prev(true);
             return true;
 
         default:;
@@ -275,9 +275,9 @@ auto miral::MinimalWindowManager::confirm_inherited_move(WindowInfo const& windo
     return {window_info.window().top_left()+movement, window_info.window().size()};
 }
 
-void miral::MinimalWindowManager::advise_new_app(miral::ApplicationInfo& app_info)
+void miral::MinimalWindowManager::advise_new_window(miral::WindowInfo const& window_info)
 {
-    self->application_selector.advise_new_app(app_info.application());
+    self->application_selector.advise_new_window(window_info);
 }
 
 void miral::MinimalWindowManager::advise_focus_gained(WindowInfo const& window_info)
@@ -286,14 +286,17 @@ void miral::MinimalWindowManager::advise_focus_gained(WindowInfo const& window_i
     self->application_selector.advise_focus_gained(window_info);
 }
 
+void miral::MinimalWindowManager::advise_new_app(miral::ApplicationInfo&){}
+void miral::MinimalWindowManager::advise_delete_app(miral::ApplicationInfo const&){}
+
 void  miral::MinimalWindowManager::advise_focus_lost(const miral::WindowInfo &window_info)
 {
     self->application_selector.advise_focus_lost(window_info);
 }
 
-void miral::MinimalWindowManager::advise_delete_app(miral::ApplicationInfo const &app_info)
+void miral::MinimalWindowManager::advise_delete_window(miral::WindowInfo const& window_info)
 {
-    self->application_selector.advise_delete_app(app_info.application());
+    self->application_selector.advise_delete_window(window_info);
 }
 
 bool miral::MinimalWindowManager::Impl::prepare_for_gesture(

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -470,3 +470,14 @@ global:
   };
 local: *;
 };
+
+MIRAL_5.1 {
+global:
+  extern "C++" {
+    miral::MinimalWindowManager::advise_new_window*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::advise_new_window*;
+    miral::MinimalWindowManager::advise_delete_window*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::advise_delete_window*;
+    miral::WindowManagerTools::can_select_window*;
+  };
+} MIRAL_5.0;

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -82,6 +82,8 @@ global:
     miral::MinimalWindowManager::handle_touch_event*;
     miral::MinimalWindowManager::handle_window_ready*;
     miral::MinimalWindowManager::place_new_window*;
+    miral::MinimalWindowManager::advise_new_window*;
+    miral::MinimalWindowManager::advise_delete_window*;
     miral::MirRunner::?MirRunner*;
     miral::MirRunner::MirRunner*;
     miral::MirRunner::add_start_callback*;
@@ -263,6 +265,7 @@ global:
     miral::WindowManagerTools::swap_tree_order*;
     miral::WindowManagerTools::window_at*;
     miral::WindowManagerTools::window_to_select_application*;
+    miral::WindowManagerTools::can_select_window*;
     miral::WindowSpecification::?WindowSpecification*;
     miral::WindowSpecification::WindowSpecification*;
     miral::WindowSpecification::application_id*;
@@ -371,6 +374,8 @@ global:
     non-virtual?thunk?to?miral::MinimalWindowManager::handle_touch_event*;
     non-virtual?thunk?to?miral::MinimalWindowManager::handle_window_ready*;
     non-virtual?thunk?to?miral::MinimalWindowManager::place_new_window*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::advise_new_window*;
+    non-virtual?thunk?to?miral::MinimalWindowManager::advise_delete_window*;
     non-virtual?thunk?to?miral::WaylandExtensions::Context::?Context*;
     non-virtual?thunk?to?miral::WindowManagementPolicy::?WindowManagementPolicy*;
     non-virtual?thunk?to?miral::WindowManagementPolicy::advise_adding_to_workspace*;
@@ -470,14 +475,3 @@ global:
   };
 local: *;
 };
-
-MIRAL_5.1 {
-global:
-  extern "C++" {
-    miral::MinimalWindowManager::advise_new_window*;
-    non-virtual?thunk?to?miral::MinimalWindowManager::advise_new_window*;
-    miral::MinimalWindowManager::advise_delete_window*;
-    non-virtual?thunk?to?miral::MinimalWindowManager::advise_delete_window*;
-    miral::WindowManagerTools::can_select_window*;
-  };
-} MIRAL_5.0;

--- a/src/miral/window_management_trace.cpp
+++ b/src/miral/window_management_trace.cpp
@@ -585,6 +585,15 @@ try {
 }
 MIRAL_TRACE_EXCEPTION
 
+auto miral::WindowManagementTrace::can_select_window(miral::Window const& window) const -> bool
+try {
+    log_input();
+    mir::log_info("%s app=%s", __func__, dump_of(window).c_str());
+    trace_count++;
+    return wrapped.can_select_window(window);
+}
+MIRAL_TRACE_EXCEPTION
+
 void miral::WindowManagementTrace::raise_tree(miral::Window const& root)
 try {
     log_input();

--- a/src/miral/window_management_trace.h
+++ b/src/miral/window_management_trace.h
@@ -71,6 +71,8 @@ private:
 
     virtual auto window_to_select_application(const Application) const -> std::optional<Window> override;
 
+    virtual auto can_select_window(Window const& window) const -> bool  override;
+
     virtual void raise_tree(Window const& root) override;
 
     virtual void swap_tree_order(Window const& first, Window const& second) override;

--- a/src/miral/window_manager_tools.cpp
+++ b/src/miral/window_manager_tools.cpp
@@ -76,6 +76,9 @@ void miral::WindowManagerTools::focus_prev_within_application()
 auto miral::WindowManagerTools::window_to_select_application(const Application application) const -> std::optional<Window>
 { return tools->window_to_select_application(application); }
 
+auto miral::WindowManagerTools::can_select_window(miral::Window const& window) const -> bool
+{ return tools->can_select_window(window); }
+
 auto miral::WindowManagerTools::window_at(mir::geometry::Point cursor) const -> Window
 { return tools->window_at(cursor); }
 

--- a/src/miral/window_manager_tools_implementation.h
+++ b/src/miral/window_manager_tools_implementation.h
@@ -65,6 +65,7 @@ public:
     virtual void focus_next_within_application() = 0;
     virtual void focus_prev_within_application() = 0;
     virtual auto window_to_select_application(const Application application) const -> std::optional<Window> = 0;
+    virtual auto can_select_window(Window const&) const -> bool = 0;
     virtual auto window_at(mir::geometry::Point cursor) const -> Window = 0;
     virtual auto active_output() -> mir::geometry::Rectangle const = 0;
     virtual auto active_application_zone() -> Zone = 0;

--- a/tests/miral/application_selector.cpp
+++ b/tests/miral/application_selector.cpp
@@ -125,7 +125,7 @@ TEST_F(ApplicationSelectorTest, deleting_selected_window_makes_the_next_window_s
     application_selector.advise_focus_gained(window_manager_tools.info_for(windows[1]));
     application_selector.advise_delete_window(window_manager_tools.info_for(windows[1]));
     auto window = application_selector.get_focused();
-    EXPECT_TRUE(window == windows[0]);
+    EXPECT_EQ(window, windows[0]);
 }
 
 TEST_F(ApplicationSelectorTest, selecting_the_next_window_in_an_app_when_there_isnt_another_window_results_in_the_currently_selected_window_remaining_the_same)

--- a/tests/miral/application_selector.cpp
+++ b/tests/miral/application_selector.cpp
@@ -45,6 +45,20 @@ struct ApplicationSelectorTest : mt::TestWindowManagerTools
         return window;
     }
 
+    auto create_window_for_app(std::shared_ptr<mir::scene::Session> app) -> Window
+    {
+        mir::shell::SurfaceSpecification creation_parameters;
+        creation_parameters.type = mir_window_type_normal;
+        creation_parameters.focus_mode = MirFocusMode::mir_focus_mode_focusable;
+        creation_parameters.set_size({600, 400});
+        auto window = create_and_select_window_for_session(creation_parameters, app);
+
+        // Simulates a new application opening and gaining focus
+        application_selector.advise_new_window(window_manager_tools.info_for(window));
+        application_selector.advise_focus_gained(window_manager_tools.info_for(window));
+        return window;
+    }
+
     auto create_window_list(int num_windows) -> std::vector<Window>
     {
         std::vector<Window> window_list;
@@ -55,36 +69,48 @@ struct ApplicationSelectorTest : mt::TestWindowManagerTools
 
         return window_list;
     }
+
+    auto create_window_list_on_same_app(int num_windows) -> std::vector<Window>
+    {
+        auto session_to_add = std::make_shared<mt::StubStubSession>();
+        std::vector<Window> window_list;
+        for (int index = 0; index < num_windows; index++)
+        {
+            window_list.push_back(create_window_for_app(session_to_add));
+        }
+
+        return window_list;
+    }
 };
 
 TEST_F(ApplicationSelectorTest, focused_window_is_latest_selected)
 {
     auto windows = create_window_list(3);
-    EXPECT_TRUE(windows[2] == application_selector.get_focused());
+    EXPECT_EQ(windows[2], application_selector.get_focused());
 }
 
-TEST_F(ApplicationSelectorTest, moving_forward_once_selects_previously_selected_window)
+TEST_F(ApplicationSelectorTest, moving_forward_once_by_app_selects_previously_selected_window)
 {
     auto windows = create_window_list(3);
     auto window = application_selector.next(false);
-    EXPECT_TRUE(window == windows[1]);
+    EXPECT_EQ(window, windows[1]);
 }
 
-TEST_F(ApplicationSelectorTest, moving_backward_once_selects_least_recently_selected_window)
+TEST_F(ApplicationSelectorTest, moving_backward_once_by_app_selects_least_recently_selected_window)
 {
     auto windows = create_window_list(3);
     auto window = application_selector.prev(false);
-    EXPECT_TRUE(window == windows[0]);
+    EXPECT_EQ(window, windows[0]);
 }
 
-TEST_F(ApplicationSelectorTest, can_move_forward_through_all_windows_in_the_list_to_arrive_at_original_window)
+TEST_F(ApplicationSelectorTest, moving_forward_through_list_once_by_app_arrives_at_original_window)
 {
     int num_windows = 3;
     auto windows = create_window_list(num_windows);
     for (int i = 0; i < 3; i++)
         application_selector.next(false);
     auto window = application_selector.complete();
-    EXPECT_TRUE(window == windows[2]);
+    EXPECT_EQ(window, windows[2]);
 }
 
 TEST_F(ApplicationSelectorTest, new_selector_is_not_active)
@@ -93,10 +119,10 @@ TEST_F(ApplicationSelectorTest, new_selector_is_not_active)
     EXPECT_FALSE(application_selector.is_active());
 }
 
-TEST_F(ApplicationSelectorTest, calling_next_with_no_windows_results_in_default_window)
+TEST_F(ApplicationSelectorTest, moving_forward_once_by_app_with_no_windows_results_in_default_window)
 {
     auto window = application_selector.next(false);
-    EXPECT_TRUE(window == Window());
+    EXPECT_EQ(window, Window());
     EXPECT_FALSE(application_selector.is_active());
 }
 
@@ -106,7 +132,7 @@ TEST_F(ApplicationSelectorTest, focusing_a_new_window_while_application_selector
     application_selector.prev(false);
     auto new_window = create_window();
     auto focused = application_selector.get_focused();
-    EXPECT_TRUE(focused == new_window);
+    EXPECT_EQ(focused, new_window);
 }
 
 TEST_F(ApplicationSelectorTest, window_added_while_selection_is_active_get_added_to_end_of_list)
@@ -115,7 +141,7 @@ TEST_F(ApplicationSelectorTest, window_added_while_selection_is_active_get_added
     application_selector.next(false);
     auto new_window = create_window();
     auto window = application_selector.prev(false);
-    EXPECT_TRUE(window == windows[0]);
+    EXPECT_EQ(window, windows[0]);
 }
 
 TEST_F(ApplicationSelectorTest, deleting_selected_window_makes_the_next_window_selected)
@@ -128,10 +154,57 @@ TEST_F(ApplicationSelectorTest, deleting_selected_window_makes_the_next_window_s
     EXPECT_EQ(window, windows[0]);
 }
 
-TEST_F(ApplicationSelectorTest, selecting_the_next_window_in_an_app_when_there_isnt_another_window_results_in_the_currently_selected_window_remaining_the_same)
+TEST_F(ApplicationSelectorTest, moving_forward_once_within_an_app_when_there_isnt_another_window_results_in_the_currently_selected_window_remaining_the_same)
 {
     auto windows = create_window_list(3);
-    application_selector.next(true); // windows[1] is selected
-    auto window = application_selector.get_focused();
-    EXPECT_TRUE(window == windows[2]);
+    auto window = application_selector.next(true);
+    EXPECT_EQ(window, windows[2]);
 }
+
+TEST_F(ApplicationSelectorTest, moving_forward_once_within_an_app_selects_the_next_window)
+{
+    auto windows = create_window_list_on_same_app(3);
+    auto window = application_selector.next(true);
+    EXPECT_EQ(window, windows[1]);
+}
+
+TEST_F(ApplicationSelectorTest, moving_backward_once_within_an_app_selects_the_previous_window)
+{
+    auto windows = create_window_list_on_same_app(3);
+    auto window = application_selector.prev(true);
+    EXPECT_EQ(window, windows[0]);
+}
+
+TEST_F(ApplicationSelectorTest, moving_forward_once_within_an_app_selects_the_next_window_when_a_different_app_is_in_the_way)
+{
+    auto app = std::make_shared<mt::StubStubSession>();;
+    auto first = create_window();
+    auto second = create_window_for_app(app);
+    auto third = create_window();
+    auto fourth = create_window_for_app(app);
+    auto fifth = create_window();
+    auto sixth = create_window_for_app(app);
+
+    auto window = application_selector.next(true);
+    EXPECT_EQ(window, fourth);
+}
+
+TEST_F(ApplicationSelectorTest, moving_forward_through_all_windows_in_an_app_selects_the_original_window)
+{
+    auto app = std::make_shared<mt::StubStubSession>();;
+    auto first = create_window();
+    auto second = create_window_for_app(app);
+    auto third = create_window();
+    auto fourth = create_window_for_app(app);
+    auto fifth = create_window();
+    auto sixth = create_window_for_app(app);
+
+    for (int i = 0; i < 3; i++)
+    {
+        auto window = application_selector.next(true);
+        application_selector.advise_focus_gained(window_manager_tools.info_for(window));
+    }
+    auto window = application_selector.complete();
+    EXPECT_EQ(window, sixth);
+}
+

--- a/tests/miral/application_selector.cpp
+++ b/tests/miral/application_selector.cpp
@@ -40,21 +40,7 @@ struct ApplicationSelectorTest : mt::TestWindowManagerTools
         auto window = create_and_select_window(creation_parameters);
 
         // Simulates a new application opening and gaining focus
-        application_selector.advise_new_app(window.application());
-        application_selector.advise_focus_gained(window_manager_tools.info_for(window));
-        return window;
-    }
-
-    auto create_unfocusable_window() -> Window
-    {
-        mir::shell::SurfaceSpecification creation_parameters;
-        creation_parameters.type = mir_window_type_normal;
-        creation_parameters.focus_mode = MirFocusMode::mir_focus_mode_disabled;
-        creation_parameters.set_size({600, 400});
-        auto window = create_and_select_window(creation_parameters);
-
-        // Simulates a new application opening and gaining focus
-        application_selector.advise_new_app(window.application());
+        application_selector.advise_new_window(window_manager_tools.info_for(window));
         application_selector.advise_focus_gained(window_manager_tools.info_for(window));
         return window;
     }
@@ -71,24 +57,24 @@ struct ApplicationSelectorTest : mt::TestWindowManagerTools
     }
 };
 
-TEST_F(ApplicationSelectorTest, focused_app_is_latest_selected)
+TEST_F(ApplicationSelectorTest, focused_window_is_latest_selected)
 {
     auto windows = create_window_list(3);
-    EXPECT_TRUE(windows[2].application() == application_selector.get_focused());
+    EXPECT_TRUE(windows[2] == application_selector.get_focused());
 }
 
-TEST_F(ApplicationSelectorTest, moving_forward_once_selects_previously_selected_application)
+TEST_F(ApplicationSelectorTest, moving_forward_once_selects_previously_selected_window)
 {
     auto windows = create_window_list(3);
-    auto application = application_selector.next();
-    EXPECT_TRUE(application == windows[1].application());
+    auto window = application_selector.next(false);
+    EXPECT_TRUE(window == windows[1]);
 }
 
-TEST_F(ApplicationSelectorTest, moving_backward_once_selects_least_recently_selected_app)
+TEST_F(ApplicationSelectorTest, moving_backward_once_selects_least_recently_selected_window)
 {
     auto windows = create_window_list(3);
-    auto application = application_selector.prev();
-    EXPECT_TRUE(application == windows[0].application());
+    auto window = application_selector.prev(false);
+    EXPECT_TRUE(window == windows[0]);
 }
 
 TEST_F(ApplicationSelectorTest, can_move_forward_through_all_windows_in_the_list_to_arrive_at_original_window)
@@ -96,9 +82,9 @@ TEST_F(ApplicationSelectorTest, can_move_forward_through_all_windows_in_the_list
     int num_windows = 3;
     auto windows = create_window_list(num_windows);
     for (int i = 0; i < 3; i++)
-        application_selector.next();
-    auto application = application_selector.complete();
-    EXPECT_TRUE(application == windows[2].application());
+        application_selector.next(false);
+    auto window = application_selector.complete();
+    EXPECT_TRUE(window == windows[2]);
 }
 
 TEST_F(ApplicationSelectorTest, new_selector_is_not_active)
@@ -107,37 +93,45 @@ TEST_F(ApplicationSelectorTest, new_selector_is_not_active)
     EXPECT_FALSE(application_selector.is_active());
 }
 
-TEST_F(ApplicationSelectorTest, calling_next_with_no_windows_results_in_nullptr)
+TEST_F(ApplicationSelectorTest, calling_next_with_no_windows_results_in_default_window)
 {
-    auto application = application_selector.next();
-    EXPECT_TRUE(application == nullptr);
+    auto window = application_selector.next(false);
+    EXPECT_TRUE(window == Window());
     EXPECT_FALSE(application_selector.is_active());
 }
 
-TEST_F(ApplicationSelectorTest, focusing_a_new_window_while_application_selector_is_active_focuses_the_new_app)
+TEST_F(ApplicationSelectorTest, focusing_a_new_window_while_application_selector_is_active_focuses_the_new_window)
 {
     auto windows = create_window_list(3);
-    application_selector.prev();
+    application_selector.prev(false);
     auto new_window = create_window();
     auto focused = application_selector.get_focused();
-    EXPECT_TRUE(focused == new_window.application());
+    EXPECT_TRUE(focused == new_window);
 }
 
-TEST_F(ApplicationSelectorTest, apps_added_while_selection_is_active_get_added_to_end_of_list)
+TEST_F(ApplicationSelectorTest, window_added_while_selection_is_active_get_added_to_end_of_list)
 {
     auto windows = create_window_list(3);
-    application_selector.next();
+    application_selector.next(false);
     auto new_window = create_window();
-    auto application = application_selector.prev();
-    EXPECT_TRUE(application == windows[0].application());
+    auto window = application_selector.prev(false);
+    EXPECT_TRUE(window == windows[0]);
 }
 
-TEST_F(ApplicationSelectorTest, deleting_selected_app_makes_the_next_app_selected)
+TEST_F(ApplicationSelectorTest, deleting_selected_window_makes_the_next_window_selected)
 {
     auto windows = create_window_list(3);
-    application_selector.next(); // windows[1] is selected
+    application_selector.next(false); // windows[1] is selected
     application_selector.advise_focus_gained(window_manager_tools.info_for(windows[1]));
-    application_selector.advise_delete_app(windows[1].application());
-    auto application = application_selector.get_focused();
-    EXPECT_TRUE(application == windows[0].application());
+    application_selector.advise_delete_window(window_manager_tools.info_for(windows[1]));
+    auto window = application_selector.get_focused();
+    EXPECT_TRUE(window == windows[0]);
+}
+
+TEST_F(ApplicationSelectorTest, selecting_the_next_window_in_an_app_when_there_isnt_another_window_results_in_the_currently_selected_window_remaining_the_same)
+{
+    auto windows = create_window_list(3);
+    application_selector.next(true); // windows[1] is selected
+    auto window = application_selector.get_focused();
+    EXPECT_TRUE(window == windows[2]);
 }

--- a/tests/miral/test_window_manager_tools.cpp
+++ b/tests/miral/test_window_manager_tools.cpp
@@ -149,43 +149,6 @@ struct StubSurface : mir::test::doubles::StubSurface
     MirFocusMode focus_mode_;
 };
 
-struct StubStubSession : mir::test::doubles::StubSession
-{
-    auto create_surface(
-        std::shared_ptr<mir::scene::Session> const& /*session*/,
-        mir::wayland::Weak<mir::frontend::WlSurface> const& /*wayland_surface*/,
-        mir::shell::SurfaceSpecification const& params,
-        std::shared_ptr<mir::scene::SurfaceObserver> const& /*observer*/,
-        mir::Executor*) -> std::shared_ptr<mir::scene::Surface> override
-    {
-        auto id = mir::frontend::SurfaceId{next_surface_id.fetch_add(1)};
-        auto surface = std::make_shared<StubSurface>(
-            params.name.is_set() ? params.name.value() : "",
-            params.type.is_set() ?
-                params.type.value()
-                : mir_window_type_normal,
-            params.top_left.is_set() ?
-                params.top_left.value()
-                : mir::geometry::Point{},
-            mir::geometry::Size{
-                params.width.is_set() ? params.width.value() : mir::geometry::Width{100},
-                params.height.is_set() ? params.height.value() : mir::geometry::Height{100},
-            },
-            params.depth_layer.is_set() ?
-                params.depth_layer.value()
-                : mir_depth_layer_application,
-            params.focus_mode.is_set() ?
-                params.focus_mode.value()
-                : mir_focus_mode_focusable);
-        surfaces[id] = surface;
-        return surface;
-    }
-
-private:
-    std::atomic<int> next_surface_id;
-    std::map<mir::frontend::SurfaceId, std::shared_ptr<mir::scene::Surface>> surfaces;
-};
-
 struct MockWindowManagerPolicy : miral::CanonicalWindowManagerPolicy
 {
     using miral::CanonicalWindowManagerPolicy::CanonicalWindowManagerPolicy;
@@ -370,7 +333,14 @@ void mt::TestWindowManagerTools::notify_configuration_applied(
 }
 
 auto mt::TestWindowManagerTools::create_and_select_window(
-    mir::shell::SurfaceSpecification creation_parameters) -> miral::Window
+    mir::shell::SurfaceSpecification& creation_parameters) -> miral::Window
+{
+    return create_and_select_window_for_session(creation_parameters, std::make_shared<StubStubSession>());
+}
+
+auto mt::TestWindowManagerTools::create_and_select_window_for_session(
+    mir::shell::SurfaceSpecification& creation_parameters,
+    std::shared_ptr<scene::Session> session_to_add) -> miral::Window
 {
     miral::Window result;
 
@@ -380,7 +350,6 @@ auto mt::TestWindowManagerTools::create_and_select_window(
                 [&result](miral::WindowInfo const& window_info)
                 { result = window_info.window(); }));
 
-    auto session_to_add = std::make_shared<StubStubSession>();
     basic_window_manager.add_session(session_to_add);
     basic_window_manager.add_surface(session_to_add, creation_parameters, &create_surface);
     basic_window_manager.select_active_window(result);
@@ -389,4 +358,34 @@ auto mt::TestWindowManagerTools::create_and_select_window(
     testing::Mock::VerifyAndClearExpectations(window_manager_policy);
 
     return result;
+}
+
+auto mt::StubStubSession::create_surface(
+    std::shared_ptr<mir::scene::Session> const& /*session*/,
+    mir::wayland::Weak<mir::frontend::WlSurface> const& /*wayland_surface*/,
+    mir::shell::SurfaceSpecification const& params,
+    std::shared_ptr<mir::scene::SurfaceObserver> const& /*observer*/,
+    mir::Executor*) -> std::shared_ptr<mir::scene::Surface>
+{
+    auto id = mir::frontend::SurfaceId{next_surface_id.fetch_add(1)};
+    auto surface = std::make_shared<StubSurface>(
+        params.name.is_set() ? params.name.value() : "",
+        params.type.is_set() ?
+        params.type.value()
+                             : mir_window_type_normal,
+        params.top_left.is_set() ?
+        params.top_left.value()
+                                 : mir::geometry::Point{},
+        mir::geometry::Size{
+            params.width.is_set() ? params.width.value() : mir::geometry::Width{100},
+            params.height.is_set() ? params.height.value() : mir::geometry::Height{100},
+        },
+        params.depth_layer.is_set() ?
+        params.depth_layer.value()
+                                    : mir_depth_layer_application,
+        params.focus_mode.is_set() ?
+        params.focus_mode.value()
+                                   : mir_focus_mode_focusable);
+    surfaces[id] = surface;
+    return surface;
 }

--- a/tests/miral/test_window_manager_tools.h
+++ b/tests/miral/test_window_manager_tools.h
@@ -18,6 +18,7 @@
 #define MIRAL_TEST_WINDOW_MANAGER_TOOLS_H
 
 #include "basic_window_manager.h"
+#include <mir/test/doubles/stub_session.h>
 
 #include <miral/canonical_window_manager.h>
 #include <miral/window.h>
@@ -93,13 +94,31 @@ public:
         std::shared_ptr<graphics::DisplayConfiguration const> display_config);
 
     /// Creates a new session, adds a surface to the session, and then sets the resulting window as
-    /// the active window.z
+    /// the active window.
     /// \param creation_parameters
     /// \returns The active window
-    auto create_and_select_window(mir::shell::SurfaceSpecification creation_parameters) -> miral::Window;
+    auto create_and_select_window(mir::shell::SurfaceSpecification& creation_parameters) -> miral::Window;
+
+    /// Creates a new session, adds the provided surface to the session, and then sets the resulting window as
+    /// the active window.
+    auto create_and_select_window_for_session(mir::shell::SurfaceSpecification&, std::shared_ptr<scene::Session>) -> miral::Window;
 };
 
+struct StubStubSession : mir::test::doubles::StubSession
+{
+    auto create_surface(
+        std::shared_ptr<mir::scene::Session> const & /*session*/,
+        mir::wayland::Weak<mir::frontend::WlSurface> const & /*wayland_surface*/,
+        mir::shell::SurfaceSpecification const &params,
+        std::shared_ptr<mir::scene::SurfaceObserver> const & /*observer*/,
+        mir::Executor *) -> std::shared_ptr<mir::scene::Surface> override;
+
+private:
+    std::atomic<int> next_surface_id;
+    std::map<mir::frontend::SurfaceId, std::shared_ptr<mir::scene::Surface>> surfaces;
+};
 }
+
 }
 
 #endif //MIRAL_TEST_WINDOW_MANAGER_TOOLS_H


### PR DESCRIPTION
## What's new?
- I realized that the last PR was going to be messy, as we would have to maintain a tab order for every application _and_ every window.
- However, I realized that this list was one in the same. Basically, we just keep the order of Windows, and we choose whether or not we are jumping from App to App or from Window to Window within an app
- So much simpler, less data to keep track of, and easier to read :magic_wand: 